### PR TITLE
Fix "C++11 requires a space between literal and string macro" warnings

### DIFF
--- a/mlxfwupdate/cmd_line_parser.cpp
+++ b/mlxfwupdate/cmd_line_parser.cpp
@@ -448,7 +448,7 @@ void CmdLineParser::initOptions()
         this->AddOptions(LIST_CONTENT_L,
                          LIST_CONTENT_S,
                          "",
-                         "List file/Directory content, used with --" USE_IMG_DIR_L " and --"USE_IMG_FILE_L " flags");
+                         "List file/Directory content, used with --" USE_IMG_DIR_L " and --" USE_IMG_FILE_L " flags");
 
         this->AddOptions(ARCHIVE_NAMES_L,
                          ARCHIVE_NAMES_S,
@@ -536,13 +536,13 @@ void CmdLineParser::initOptions()
      this->AddOptions(DNLD_DEV_L,
                       DNLD_DEV_S,
                       "Device",
-                      "Use '--"GET_DNLD_OPT_L" Device' option to view available devices for device specific downloads",
+                      "Use '--" GET_DNLD_OPT_L " Device' option to view available devices for device specific downloads",
                       false);
 
      this->AddOptions(DNLD_OS_L,
                       DNLD_OS_S,
                       "OS",
-                      "Only for self_extractor download: Use '--"GET_DNLD_OPT_L" OS' option to view available OS for sfx download",
+                      "Only for self_extractor download: Use '--" GET_DNLD_OPT_L " OS' option to view available OS for sfx download",
                       false);
 
      this->AddOptions(DNLD_TYPE_L,

--- a/mlxfwupdate/mlnx_dev.cpp
+++ b/mlxfwupdate/mlnx_dev.cpp
@@ -208,11 +208,11 @@ void MlnxDev::setGuidMac(fw_info_t &fw_query) {
         }
     } else {
         if (fw_query.fs3_info.fs3_uids_info.valid_field) {
-            sprintf(buff, "%016"U64H_FMT_GEN,
+            sprintf(buff, "%016" U64H_FMT_GEN,
                             fw_query.fs3_info.fs3_uids_info.cx4_uids.base_guid.uid);
 
         } else {
-            sprintf(buff, "%016"U64H_FMT_GEN,
+            sprintf(buff, "%016" U64H_FMT_GEN,
                             fw_query.fs3_info.fs3_uids_info.cib_uids.guids[0].uid);
         }
         if (fw_query.fs3_info.fs3_uids_info.cib_uids.guids[0].uid ||
@@ -221,14 +221,14 @@ void MlnxDev::setGuidMac(fw_info_t &fw_query) {
         }
         if (fw_query.fs3_info.fs3_uids_info.valid_field) {
 
-            sprintf(buff, "%016"U64H_FMT_GEN,
+            sprintf(buff, "%016" U64H_FMT_GEN,
                                         fw_query.fs3_info.fs3_uids_info.cx4_uids.base_mac.uid);
             if (fw_query.fs3_info.fs3_uids_info.cx4_uids.base_mac.uid) {
                 macPortOne = (string)buff;
             }
             sprintf(buff, " ");
         } else {
-        sprintf(buff, "%016"U64H_FMT_GEN,
+        sprintf(buff, "%016" U64H_FMT_GEN,
                 fw_query.fs3_info.fs3_uids_info.cib_uids.guids[1].uid);
         }
         if (fw_query.fs3_info.fs3_uids_info.cx4_uids.base_mac.uid ||

--- a/mlxfwupdate/mlxfwmanager.cpp
+++ b/mlxfwupdate/mlxfwmanager.cpp
@@ -1463,8 +1463,8 @@ bool getIniParams(config_t &config)
         return false;
     }
 
-    config.mfa_path = iniparser_getstring(ini_dict, INI_FILESYSTEM_SECTION":"INI_SRCDIR_KEY, (char*)config.mfa_path.c_str());
-    config.http_proxy = iniparser_getstring(ini_dict, INI_SERVER_SECTION":"INI_PROXY_KEY, (char*)config.http_proxy.c_str());
+    config.mfa_path = iniparser_getstring(ini_dict, INI_FILESYSTEM_SECTION ":" INI_SRCDIR_KEY, (char*)config.mfa_path.c_str());
+    config.http_proxy = iniparser_getstring(ini_dict, INI_SERVER_SECTION ":" INI_PROXY_KEY, (char*)config.http_proxy.c_str());
 
     if (ini_dict) {
         iniparser_freedict(ini_dict);


### PR DESCRIPTION
The build process failed for me with errors like "C++11 requires a space between literal and string macro", so I put that space there and now it compiles. 

For a similar issue see https://github.com/codership/galera/issues/384.