### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,6 +234,9 @@ AC_LANG_POP([C++])
 CXXFLAGS="$OLD_CXXFLAGS"
 
 TOOLS_BUILD_TIME=`date  +"%b %d %Y\, %H:%M:%S"`
+if test "x$SOURCE_DATE_EPOCH" != "x"; then
+    TOOLS_BUILD_TIME=`LC_ALL=C date -u -d @$SOURCE_DATE_EPOCH" +"%b %d %Y\, %H:%M:%S"`
+fi
 AC_SUBST(TOOLS_BUILD_TIME)
 
 AC_ARG_VAR(MSTFLINT_VERSION_STR, The MSTFLINT version)


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

Also use UTC to be independent of timezone.
This date call only works with GNU date.

This patch was imported from https://bugs.debian.org/886386
and successfully tested on openSUSE.

Signed-off-by: Bernhard M. Wiedemann <bwiedemann at suse com>