### PR TITLE
Title: enforce static libstdc++ for all-static flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -170,7 +170,7 @@ AM_CONDITIONAL(ENABLE_CS, [test  "x$enable_cs" = "xyes" || test "x$enable_openss
 AC_ARG_ENABLE([static_libstdcpp],
     AS_HELP_STRING([--enable-static-libstdcpp], [Enable link static to libstdc++]))
 
-AS_IF([test "x$enable_static_libstdcpp" = "xyes"], [
+AS_IF([test "x$enable_static_libstdcpp" = "xyes" -o "x$enable_all_static" = "xyes" ], [
   CXXFLAGS="$CXXFLAGS -static-libstdc++ -static-libgcc"
 ])
 


### PR DESCRIPTION
Desciption: Add CXX flags for enabling static libstdc++ when all-static
is enabled
Issue: 1703934

Signed-off-by: Samer Deeb <samerd@mellanox.com>