### PR TITLE
Title: Fix linkage of mtcr_ul when there is a conflict with ofed

### DIFF
--- a/mlxfwupdate/Makefile.am
+++ b/mlxfwupdate/Makefile.am
@@ -40,7 +40,7 @@ docdir=$(INSTALL_BASEDIR)/etc/mstflint
 dist_doc_DATA=certificate/ca-bundle.crt
 
 MTCR_UL_DIR = $(USER_DIR)/${MTCR_CONF_DIR}
-MTCR_UL_LIB = -L$(MTCR_UL_DIR) -lmtcr_ul
+MTCR_UL_LIB = $(MTCR_UL_DIR)/libmtcr_ul.a
 
 XML_FLAGS = -DUSE_XML -DLIBXML_STATIC
 XML_LIBS = -lxml2 $(ZLIB_LIB)


### PR DESCRIPTION
Description: Add mtcr_ul library from mstflint explicitly
Issue:1768555

Signed-off-by: Samer Deeb <samerd@mellanox.com>