### PR TITLE
Title: Removed openssl dependency from adb generic tools.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -206,10 +206,6 @@ if test "x$enable_openssl" = "xyes"; then
   AC_CHECK_HEADER(openssl/bio.h,,AC_MSG_ERROR([cannot find openssl/bio.h . remove --enable-openssl to remove this dependaency or install openssl]))
   AC_CHECK_HEADER(openssl/md5.h,,AC_MSG_ERROR([cannot find openssl/md5.h . remove --enable-openssl to remove this dependaency or install openssl]))
   TOOLS_CRYPTO="tools_crypto mlxsign_lib"
-else
-    if test "x$enable_adb_generic_tools" = "xyes"; then
-        AC_MSG_ERROR([Running --enable-adb-gerneric-tools with --disable-openssl is not allowed, Adabe generic tools depend on openssl.])
-    fi
 fi
 
 AC_MSG_CHECKING(--enable-all-static argument)

--- a/mlxlink/Makefile.am
+++ b/mlxlink/Makefile.am
@@ -65,7 +65,6 @@ mstlink_DEPENDENCIES = modules/libmodules_lib.a \
                       $(USER_DIR)/dev_mgt/libdev_mgt.a \
                       $(USER_DIR)/reg_access/libreg_access.a \
                       $(LAYOUTS_DIR)/libtools_layouts.a \
-                      $(USER_DIR)/tools_crypto/libtools_crypto.a \
                       $(USER_DIR)/xz_utils/libxz_utils.a \
                       $(USER_DIR)/ext_libs/minixz/libminixz.a \
                       -lboost_regex -lboost_filesystem -lboost_system \

--- a/mlxreg/Makefile.am
+++ b/mlxreg/Makefile.am
@@ -69,7 +69,6 @@ mstreg_LDADD = libmstreg_lib.a \
                 $(USER_DIR)/dev_mgt/libdev_mgt.a \
                 $(USER_DIR)/reg_access/libreg_access.a \
                 $(LAYOUTS_DIR)/libtools_layouts.a \
-                $(USER_DIR)/tools_crypto/libtools_crypto.a \
                 $(USER_DIR)/xz_utils/libxz_utils.a \
                 $(USER_DIR)/ext_libs/minixz/libminixz.a \
                 -lboost_regex -lboost_filesystem -lboost_system \


### PR DESCRIPTION
Description: There is no need for this dependency and for the coupling between openssl and adb generic tools.

Issue: 1788615.

Signed-off-by: Dan Goldberg <dang@mellanox.com>