### PR TITLE
issue: Bug SW #1791446: [Mstfwtrace] doesn't print output in a file w…

### DIFF
--- a/tracers/fwtrace/mstfwtrace.py
+++ b/tracers/fwtrace/mstfwtrace.py
@@ -50,7 +50,8 @@ sys.path.append(os.path.join("..", "..", "cmdif"))
 import mtcr  # noqa
 import cmdif  # noqa
 
-sys.stdout = os.fdopen(sys.stdout.fileno(), 'w')
+sys.stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
+
 EXEC_NAME = "mstfwtrace"
 proc = None
 


### PR DESCRIPTION
…hen the stdout=file when running it with subprocess in python