### PR TITLE
Fix bug:1834727: Mstfwtrace prints error message related to secure-fw…

### DIFF
--- a/tracers/fwtrace/mstfwtrace.py
+++ b/tracers/fwtrace/mstfwtrace.py
@@ -241,9 +241,9 @@ def parse_cmd_line_args():
     IGNORE_OLD_EVENTS = args.ignore_old_events
 
     if IRISC_NAME != "all":
-        raise TracerException("Only 'all' irisc is compatible with secure fw")
+        raise TracerException("Only 'all' irisc is compatible with this tracer version")
     if TRACER_MODE != "MEM":
-        raise TracerException("Only 'MEM' tracer mode is compatible with secure fw")
+        raise TracerException("Only 'MEM' tracer mode is compatible with this tracer version")
 
 
 def check_secure_fw_args(devInfo):


### PR DESCRIPTION
… event the device is non-secure.

Description: error messages have been changed.
Issue: 1834727