### PR TITLE
Fix - When mstarchive was given a path to a new file it recognized it as a directory.

### DIFF
--- a/mlxarchive/mlxarchive.cpp
+++ b/mlxarchive/mlxarchive.cpp
@@ -110,12 +110,13 @@ void Mlxarchive::paramValidate()
         success = false;
     }
     else {
-        if(!isFile(_outFile)) {
-            fprintf(stderr, "Output file: %s is expected to be a file\n", _outFile.c_str());
-            success = false;
-        }
-        else if(fexists(_outFile)) {
-            fprintf(stderr, "Output file: %s already exists\n", _outFile.c_str());
+        if(fexists(_outFile)) {
+            if(!isFile(_outFile)) {
+                fprintf(stderr, "Output file: %s is expected to be a file\n", _outFile.c_str());
+            }
+            else {
+                fprintf(stderr, "Output file: %s already exists\n", _outFile.c_str());
+            }
             success = false;
         }
     }


### PR DESCRIPTION
Description: mstarchive will treat a new file as a file and not a
directory

Issue: 1898265