### PR TITLE
Spec file fixes

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -33,7 +33,19 @@ ExclusiveArch: i386 i486 i586 i686 x86_64 ia64 ppc ppc64 ppc64le arm64 aarch64
 BuildRequires: openssl-devel
 %endif
 
+%if "%{enableadbgenerictools}" == "1"
+BuildRequires: boost-devel
+BuildRequires: expat-devel
+BuildRequires: xz-devel
+%endif
+
 BuildRequires: zlib-devel %{ibmadlib}
+
+%if "%{enableadbgenerictools}" == "1"
+Requires: boost-filesystem
+Requires: boost-regex
+%endif
+
 
 %description
 This package contains firmware update tool, vpd dump and register dump tools

--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -28,6 +28,11 @@ Group: System Environment/Base
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 Source: %{name}-%{version}.tar.gz
 ExclusiveArch: i386 i486 i586 i686 x86_64 ia64 ppc ppc64 ppc64le arm64 aarch64
+
+%if "%{nopenssl}" == "0"
+BuildRequires: openssl-devel
+%endif
+
 BuildRequires: zlib-devel %{ibmadlib}
 
 %description

--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -124,6 +124,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/mstfwreset
 %{_bindir}/mstcongestion
 %{_bindir}/mstprivhost
+%{_bindir}/mstfwtrace
 %if %{enablefwmgr}
  %{_bindir}/mstfwmanager
  %{_bindir}/mstarchive


### PR DESCRIPTION
This PR includes three fixes discussed previously in email. For "spec: Add missing dependencies for ADB generic tools" we do not enable building the ADB generic tools but do conditionally include the dependencies required when building those tools (e.g., mstlink, mstreg) is enabled.