### PR TITLE
Fix - build with --enable-adb-generic-tools failed on Ubuntu, Fedora and RH

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -516,7 +516,7 @@ void MlxlinkCommander::labelToIBLocalPort()
         updateField("local_port", localPort);
         try {
             genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
-        } catch (MlxRegException) {
+        } catch (MlxRegException& exp) {
             continue; // no reason to fail when one of the ports is not supported, such as in split mode.
         }
         if (getFieldValue("ib_port", _buffer) == labelPort) {
@@ -540,7 +540,7 @@ bool MlxlinkCommander::isIBSplitReady() {
         updateField("local_port", localPort);
         try {
             genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
-        } catch (MlxRegException) {
+        } catch (MlxRegException& exp) {
             continue; // no reason to fail when one of the ports is not supported, such as in split mode.
         }
         if (getFieldValue("ib_port", _buffer) == max_port/2) {

--- a/mlxlink/modules/mlxlink_logger.cpp
+++ b/mlxlink/modules/mlxlink_logger.cpp
@@ -76,12 +76,12 @@ void MlxlinkLogger::debugLog(const char* format, ...)
 void MlxlinkLogger::printHeaderWithUnderLine(const char* title)
 {
     if (_logFile) {
-        fprintf(_logFile,_underLine);
+        fprintf(_logFile,"%s",_underLine);
         fprintf(_logFile,"\n");
         fprintf(_logFile, "FUNCTION\t\t");
-        fprintf(_logFile,title);
+        fprintf(_logFile,"%s",title);
         fprintf(_logFile, "\n");
-        fprintf(_logFile, _underLine);
+        fprintf(_logFile,"%s", _underLine);
         fprintf(_logFile, "\n");
         fflush(_logFile);
     }

--- a/mlxlink/modules/mlxlink_logger.cpp
+++ b/mlxlink/modules/mlxlink_logger.cpp
@@ -38,7 +38,7 @@ MlxlinkLogger::MlxlinkLogger(const string &filePath, LOG_LEVEL logLevel)
 {
     _logLevel = logLevel;
     _logFile = fopen (filePath.c_str(),"w");
-    memset(_underLine,LINE_PATTERN,LINE_WIDTH);
+    memset(_underLine, LINE_PATTERN, LINE_WIDTH);
 }
 
 MlxlinkLogger::~MlxlinkLogger()
@@ -76,12 +76,12 @@ void MlxlinkLogger::debugLog(const char* format, ...)
 void MlxlinkLogger::printHeaderWithUnderLine(const char* title)
 {
     if (_logFile) {
-        fprintf(_logFile,"%s",_underLine);
-        fprintf(_logFile,"\n");
-        fprintf(_logFile, "FUNCTION\t\t");
-        fprintf(_logFile,"%s",title);
+        fprintf(_logFile, "%s", _underLine);
         fprintf(_logFile, "\n");
-        fprintf(_logFile,"%s", _underLine);
+        fprintf(_logFile, "FUNCTION\t\t");
+        fprintf(_logFile, "%s", title);
+        fprintf(_logFile, "\n");
+        fprintf(_logFile, "%s", _underLine);
         fprintf(_logFile, "\n");
         fflush(_logFile);
     }


### PR DESCRIPTION
Description: mlxlink catch exception and fprintf syntax errors on different platforms fixed.

Issue: 1909668