### PR TITLE
Temporary disabling expat-devel library dependency

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -35,7 +35,7 @@ BuildRequires: openssl-devel
 
 %if "%{enableadbgenerictools}" == "1"
 BuildRequires: boost-devel
-BuildRequires: expat-devel
+#BuildRequires: expat-devel
 BuildRequires: xz-devel
 %endif
 


### PR DESCRIPTION
Description: Temporary disabling expat-devel library dependency to preserve compatibility with SLES OS which holds a different name for exapt-devel, which is libexpat-devel.

Issue: 1916746