### PR TITLE
Temporary disabling boost_filesystem and boost_regex libraries dependency

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -53,10 +53,10 @@ BuildRequires: xz-devel
 
 BuildRequires: zlib-devel %{ibmadlib}
 
-%if "%{enableadbgenerictools}" == "1"
-Requires: %{boost_filesystem_lib}
-Requires: %{boost_regex_lib}
-%endif
+#%if "%{enableadbgenerictools}" == "1"
+#Requires: %{boost_filesystem_lib}
+#Requires: %{boost_regex_lib}
+#%endif
 
 
 %description


### PR DESCRIPTION
Description: Temporary disabling boost_filesystem and boost_regex libraries dependency to
preserve compatibility with SLES OS which holds a different name for
those packages.

Issue: 1916746