### PR TITLE
Removed unused livefish check in flint subcommands

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1487,9 +1487,6 @@ FlintStatus BinaryCompareSubCommand::executeCommand()
         }
         return FLINT_FAILED;
     }
-    //if (!_fwOps->IsLiveFishDevice()) {
-    //    printf("Device must be in livefish mode. Exiting...\n");
-    //    return FLINT_FAILED;
 
     _fwType = _fwOps->FwType();
     if (!_fwOps->FwQuery(&_devInfo)) {

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2024,21 +2024,6 @@ const char*  FwOperations::FwGetReSignMsgStr()
 {
     return (const char*)NULL;
 }
-bool FwOperations::IsLiveFishDevice()
-{
-    if (_ioAccess == NULL) {
-        return false;
-    }
-    if (!_ioAccess->is_flash()) {
-        return false;
-    }
-    mfile* mf = _ioAccess->getMfileObj();
-    if (mf == NULL) {
-        return false;
-    }
-    return (dm_is_livefish_mode(mf) == 1);
-}
-
 
 bool FwOperations::TestAndSetTimeStamp(FwOperations *imageOps)
 {

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -161,7 +161,6 @@ public:
 
     //needed for flint low level operations
     bool FwSwReset();
-    bool IsLiveFishDevice();
     virtual bool CheckCX4Device() {return true; /* deprecated always return true*/ }
     virtual bool FwCalcMD5(u_int8_t md5sum[16]) = 0;
 


### PR DESCRIPTION
Description: It was added commented out and shouldn't be part of the code.
Both function and commented out usage were deleted now.

Issue: 1913895.