### PR TITLE
Add missing shebang to Python scripts

### DIFF
--- a/mlxconfig/mstprivhost.py
+++ b/mlxconfig/mstprivhost.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 #copyright (c) 2004-2020 Mellanox Technologies LTD. All rights reserved.   
 #                                                                           
 # This software is available to you under a choice of one of two            

--- a/resourcedump/mstresourcedump.py
+++ b/resourcedump/mstresourcedump.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 #copyright (c) 2004-2020 Mellanox Technologies LTD. All rights reserved.   
 #                                                                           
 # This software is available to you under a choice of one of two            

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 # Copyright (c) 2004-2010 Mellanox Technologies LTD. All rights reserved.
 #
 # This software is available to you under a choice of one of two


### PR DESCRIPTION
`mlxconfig/mstprivhost.py` and `small_utils/mstfwreset.py` are Python
scripts that are executable, but they lack a shebang.