### PR TITLE
Mlxfwreset fails and throws error: "*** glibc detected *** python2: f…

### DIFF
--- a/reg_access/regaccess.py
+++ b/reg_access/regaccess.py
@@ -107,6 +107,7 @@ if REG_ACCESS:
         _fields_ = [("device_id", c_uint16),
                     ("device_hw_revision", c_uint16),
                     ("pvs", c_uint8),
+                    ("num_ports",c_uint8),                    
                     ("hw_dev_id", c_uint16),
                     ("manufacturing_base_mac_47_32", c_uint16),
                     ("manufacturing_base_mac_31_0", c_uint32),
@@ -118,15 +119,13 @@ if REG_ACCESS:
                     ("signed_fw", c_uint8),
                     ("debug_fw", c_uint8),
                     ("dev_fw", c_uint8),
+                    ("string_tlv", c_uint8),
                     ("build_id", c_uint32),
                     ("year", c_uint16),
                     ("day", c_uint8),
                     ("month", c_uint8),
                     ("hour", c_uint16),
-                    ("psid1", c_uint32),
-                    ("psid2", c_uint32),
-                    ("psid3", c_uint32),
-                    ("psid4", c_uint32),
+                    ("psid", c_uint8 * 16),
                     ("ini_file_version", c_uint32),
                     ("extended_major", c_uint32),
                     ("extended_minor", c_uint32),
@@ -145,7 +144,8 @@ if REG_ACCESS:
                     ("rom0_version", c_uint32),
                     ("rom1_version", c_uint32),
                     ("rom2_version", c_uint32),
-                    ("rom3_version", c_uint32)]
+                    ("rom3_version", c_uint32),
+                    ("dev_branch_tag", c_uint8 * 28)]
 
     class RegAccess:
 


### PR DESCRIPTION
…ree(): invalid next size (fast).

Description: Structures modifications in reg_access_hca_layouts.h.

Issue: 1972641