### PR TITLE
Fixing external phy error message

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -1831,8 +1831,9 @@ void MlxlinkCommander::showBerMonitorInfo()
 
 void MlxlinkCommander::showExternalPhy()
 {
-    if (_isHCA) {
-        throw MlxRegException("\"--" PEPC_SHOW_FLAG "\" option is not supported for HCA");
+    if (_isHCA || _devID == DeviceSwitchIB || _devID == DeviceSwitchIB2
+            || _devID == DeviceQuantum) {
+        throw MlxRegException("\"--" PEPC_SET_FLAG "\" option is not supported for HCA and InfiniBand switches");
     }
     try {
         string regName = "PEPC";
@@ -2880,8 +2881,9 @@ u_int32_t MlxlinkCommander::getLoopbackMode(const string &lb)
 
 void MlxlinkCommander::sendPepc()
 {
-    if (_isHCA) {
-        throw MlxRegException("\"--" PEPC_SET_FLAG "\" option is not supported for HCA");
+    if (_isHCA || _devID == DeviceSwitchIB || _devID == DeviceSwitchIB2
+            || _devID == DeviceQuantum) {
+        throw MlxRegException("\"--" PEPC_SET_FLAG "\" option is not supported for HCA and InfiniBand switches");
     }
     try {
         MlxlinkRecord::printCmdLine("Configuring External PHY");


### PR DESCRIPTION
[mstlink] Showing and setting external phy options are not supported for IB switches

Issue: 1930350

Signed-off-by: Mustafa Dalloul <mustafadall@mellanox.com>