### PR TITLE
Fix compilation issue when using "enable-fw-mgr" flag at configure step

### DIFF
--- a/flint/Makefile.am
+++ b/flint/Makefile.am
@@ -85,7 +85,7 @@ else
 endif
 
 if ENABLE_FWMGR
-mstflint_LDADD += $(top_srcdir)/libmfa/libmfa.a $(top_srcdir)/ext_libs/minixz/libminixz.a $(top_srcdir)/mlxarchive/libmstarchive.a $(top_srcdir)/xz_utils/libxz_utils.a 
+mstflint_LDADD += $(top_srcdir)/libmfa/libmfa.a $(top_srcdir)/ext_libs/minixz/libminixz.a $(top_srcdir)/mlxarchive/libmstarchive.a $(top_srcdir)/xz_utils/libxz_utils.a -llzma -lm
 else
 mstflint_CXXFLAGS += -DNO_MSTARCHIVE
 endif


### PR DESCRIPTION
Description: Adding lzma lib to flint Makefile.am when "enable-fw-mgr"
flag is set.

Issue: 2037210