### PR TITLE
Removing python byte compilation from specfile

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -12,10 +12,6 @@
 %{!?enableadbgenerictools: %define enableadbgenerictools 0}
 %{!?CONF_DIR: %define CONF_DIR /etc/mstflint}
 
-# Usually, python2 is the default python on a machine,
-# so we want to ignore python2 erros caused by incompatiblity with python3 syntax
-%define _python_bytecompile_errors_terminate_build 0
-
 %define mstflint_python_tools %{_libdir}/mstflint/python_tools
 
 %define _unpackaged_files_terminate_build 0
@@ -186,6 +182,11 @@ rm -rf $RPM_BUILD_ROOT
 %{mstflint_python_tools}/dev_mgt.py
 %{mstflint_python_tools}/c_dev_mgt.so
 %{mstflint_python_tools}/mstprivhost/mstprivhost.py
+
+# Usually, python2 is the default python on a machine,
+# so we want to ignore python2 erros caused by incompatiblity with python3 syntax
+%define _python_bytecompile_errors_terminate_build 0
+
 %{mstflint_python_tools}/mstresourcedump/*.py
 %{mstflint_python_tools}/mstresourcedump/validation/*.py
 %{mstflint_python_tools}/mstresourcedump/utils/*.py

--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -12,6 +12,10 @@
 %{!?enableadbgenerictools: %define enableadbgenerictools 0}
 %{!?CONF_DIR: %define CONF_DIR /etc/mstflint}
 
+# Usually, python2 is the default python on a machine,
+# so we want to ignore python2 erros caused by incompatiblity with python3 syntax
+%define _python_bytecompile_errors_terminate_build 0
+
 %define mstflint_python_tools %{_libdir}/mstflint/python_tools
 
 %define _unpackaged_files_terminate_build 0


### PR DESCRIPTION
Description: when default python version on machine is python2 rpmbuild
fails since mstresourcedump uses python3 synatx which is incompatible with python2.
Now specfile ignore these python syntax errors related to mstresourcedump tool.

Issue: 2035716