### PR TITLE
Fix 1930381- [resourcedump] version should be one line only.

### DIFF
--- a/resourcedump/mstresourcedump.py
+++ b/resourcedump/mstresourcedump.py
@@ -95,7 +95,8 @@ class MlxResDump:
     def run(self):
         # main parser
         tool_name = os.path.basename(__file__.split('.')[0])
-        parser = argparse.ArgumentParser(epilog="Use '{0} <command> -h' to read about a specific command.".format(tool_name))
+        parser = argparse.ArgumentParser(epilog="Use '{0} <command> -h' to read about a specific command.".format(tool_name),
+                                         formatter_class=argparse.RawTextHelpFormatter)
         parser.add_argument('-v', '--version', action='version', help='Shows tool version',
                             version=tools_version.GetVersionString(cs.TOOL_NAME, None))
 


### PR DESCRIPTION
Description: set the argparse to allow more than 80 characters per line at the version command.
Issue: 1930381