### PR TITLE
Fix - dm_get_device_id() return wrong hw_dev_id in case of linkx device

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -447,6 +447,7 @@ int dm_get_device_id(mfile *mf,
                 return 1;
                 break;
         }
+        *ptr_hw_dev_id = (u_int32_t)mf->linkx_chip_devid;
         return 0;
 
     }


### PR DESCRIPTION
Description: hw_dev_id wasn't assigned in case of linkx device, now
fixed.

Issue: 2080311