### PR TITLE
[mstlink] Adding some fixes and updates

### DIFF
--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -340,6 +340,7 @@ public:
     u_int32_t getFieldValue(const string &field_name, std::vector<u_int32_t>& buff);
     string getFieldStr(const string &field);
     void checkRegCmd();
+    void checkLocalPortDPNMapping(u_int32_t localPort);
     int getLocalPortFromMPIR(DPN& dpn);
 
     void checkValidFW();

--- a/mlxlink/modules/mlxlink_maps.h
+++ b/mlxlink/modules/mlxlink_maps.h
@@ -361,6 +361,11 @@ enum IB_LINK_SPEED {
     IB_LINK_SPEED_HDR   = 0x40,
 };
 
+enum PRBS_MODULATION {
+    PRBS_NRZ = 0,
+    PRBS_PAM4_ENCODING = 1
+};
+
 class MlxlinkMaps{
 private:
     MlxlinkMaps();

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -94,8 +94,7 @@ void MlxlinkUi::printSynopsisQueries()
 
     MlxlinkRecord::printFlagLine(DEVICE_DATA_FLAG_SHORT, DEVICE_DATA_FLAG, "", "General Device Info");
     MlxlinkRecord::printFlagLine(BER_MONITOR_INFO_FLAG_SHORT, BER_MONITOR_INFO_FLAG, "", "Show BER Monitor Info (not supported for HCA)");
-    MlxlinkRecord::printFlagLine(PEPC_SHOW_FLAG_SHORT, PEPC_SHOW_FLAG, "", "Show External PHY Info");
-
+    MlxlinkRecord::printFlagLine(PEPC_SHOW_FLAG_SHORT, PEPC_SHOW_FLAG, "", "Show External PHY Info (for Ethernet switches only)");
 }
 
 void MlxlinkUi::printSynopsisCommands()
@@ -147,7 +146,7 @@ void MlxlinkUi::printSynopsisCommands()
     MlxlinkRecord::printFlagLine(PPCNT_CLEAR_FLAG_SHORT, PPCNT_CLEAR_FLAG, "",
                   "Clear Counters");
     MlxlinkRecord::printFlagLine(PEPC_SET_FLAG_SHORT, PEPC_SET_FLAG, "",
-                  "Set External PHY (not supported for HCA)");
+                  "Set External PHY (for Ethernet switches only)");
     printf(IDENT);
     MlxlinkRecord::printFlagLine(PEPC_FORCE_MODE_FLAG_SHORT, PEPC_FORCE_MODE_FLAG, "twisted_pair_force_mode",
                   "Twisted Pair Force Mode [MA(Master)/SL(Slave)]");
@@ -240,10 +239,10 @@ void MlxlinkUi::paramValidate()
            }
         }
         if (_mlxlinkCommander->_userInput._specifiedPort) {
-            if (!(_mlxlinkCommander->_userInput._sendNode &&
-                    _mlxlinkCommander->_userInput._sendDepth &&
-                    _mlxlinkCommander->_userInput._sendPcieIndex)) {
-                throw MlxRegException("For PCIE, the port flag is valid only with depth, pcie_index and node flags");
+            if (_mlxlinkCommander->_userInput._sendNode ||
+                    _mlxlinkCommander->_userInput._sendDepth ||
+                    _mlxlinkCommander->_userInput._sendPcieIndex) {
+                throw MlxRegException("For PCIE port, either port flag or depth, pcie_index and node flags should be specified");
            }
         }
     } else if (_mlxlinkCommander->_userInput._sendNode ||
@@ -712,10 +711,8 @@ int MlxlinkUi::run(int argc, char **argv)
         throw MlxRegException("Device is not supported");
     }
     MlxRegLib::isAccessRegisterSupported(_mlxlinkCommander->_mf);
-
-    bool onlyKnownRegs = false;
     _mlxlinkCommander->_mlxLinkLib = new MlxRegLib(_mlxlinkCommander->_mf,
-            _mlxlinkCommander->_extAdbFile, onlyKnownRegs, _mlxlinkCommander->_useExtAdb);
+            _mlxlinkCommander->_extAdbFile, _mlxlinkCommander->_useExtAdb);
     if (_mlxlinkCommander->_mlxLinkLib->isIBDevice() &&
             !_mlxlinkCommander->_mlxLinkLib->isAccessRegisterGMPSupported(
                     MACCESS_REG_METHOD_GET)) {

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -205,11 +205,17 @@ string EthExtSupportedSpeeds2Str(u_int32_t int_mask)
     if (int_mask & ETH_LINK_SPEED_EXT_200GAUI_4) {
         maskStr += "200G,";
     }
-    if ((int_mask & ETH_LINK_SPEED_EXT_100GAUI_2) || (int_mask & ETH_LINK_SPEED_EXT_CAUI_4)) {
-        maskStr += "100G,";
+    if (int_mask & ETH_LINK_SPEED_EXT_100GAUI_2) {
+        maskStr += "100G_2X,";
     }
-    if ((int_mask & ETH_LINK_SPEED_EXT_50GAUI_1) || (int_mask & ETH_LINK_SPEED_EXT_50GAUI_2)) {
-        maskStr += "50G,";
+    if (int_mask & ETH_LINK_SPEED_EXT_CAUI_4) {
+        maskStr += "100G_4X,";
+    }
+    if (int_mask & ETH_LINK_SPEED_EXT_50GAUI_1) {
+        maskStr += "50G_1X,";
+    }
+    if (int_mask & ETH_LINK_SPEED_EXT_50GAUI_2) {
+        maskStr += "50G_2X,";
     }
     if (int_mask & ETH_LINK_SPEED_EXT_XLAUI_4) {
         maskStr += "40G,";
@@ -269,28 +275,45 @@ string getOui(u_int32_t oui)
 
 int ptysSpeedToExtMaskETH(const string & speed)
 {
-    if(speed == "100M")
+    if (speed == "100M") {
         return (ETH_LINK_SPEED_EXT_SGMII_100M);
-    if(speed == "1G")
+    }
+    if (speed == "1G") {
         return (ETH_LINK_SPEED_EXT_1000BASE_X);
-    if(speed == "2.5G")
+    }
+    if (speed == "2.5G") {
         return (ETH_LINK_SPEED_EXT_2_5GBASE_X);
-    if(speed == "5G")
+    }
+    if (speed == "5G") {
         return (ETH_LINK_SPEED_EXT_5GBASE_R);
-    if(speed == "10G")
+    }
+    if (speed == "10G") {
         return (ETH_LINK_SPEED_EXT_XFI);
-    if(speed == "25G")
+    }
+    if (speed == "25G") {
         return (ETH_LINK_SPEED_EXT_25GAUI_1);
-    if(speed == "40G")
+    }
+    if (speed == "40G") {
         return (ETH_LINK_SPEED_EXT_XLAUI_4);
-    if(speed == "50G")
-        return (ETH_LINK_SPEED_EXT_50GAUI_1 | ETH_LINK_SPEED_EXT_50GAUI_2);
-    if(speed == "100G")
-        return (ETH_LINK_SPEED_EXT_100GAUI_2 | ETH_LINK_SPEED_EXT_CAUI_4);
-    if(speed == "200G")
+    }
+    if (speed == "50G_2X") {
+        return (ETH_LINK_SPEED_EXT_50GAUI_2);
+    }
+    if (speed == "50G_1X") {
+        return (ETH_LINK_SPEED_EXT_50GAUI_1);
+    }
+    if (speed =="100G_4X") {
+        return (ETH_LINK_SPEED_EXT_CAUI_4);
+    }
+    if (speed =="100G_2X") {
+        return (ETH_LINK_SPEED_EXT_100GAUI_2);
+    }
+    if (speed == "200G") {
         return ETH_LINK_SPEED_EXT_200GAUI_4;
-    if(speed == "400G")
+    }
+    if (speed == "400G") {
         return ETH_LINK_SPEED_EXT_400GAUI_8;
+    }
     return 0x0;
 }
 
@@ -595,10 +618,14 @@ int prbsLaneRateToMask(const string &rate)
     if (rate == "IB-FDR" || rate == "FDR" || rate == "14G" || rate == "14GbE") {
         return PRBS_FDR;
     }
-    if (rate == "IB-EDR" || rate == "EDR" || rate == "25G" || rate == "25GbE" || rate == "50G" || rate == "50GbE" || rate == "100G" || rate == "100GbE") {
+    if (rate == "IB-EDR" || rate == "EDR" || rate == "25G" || rate == "25GbE"
+            || rate == "50G" || rate == "50GbE" || rate == "100G" || rate == "100GbE"
+            || rate == "50G_2X" || rate == "50GbE_2X" || rate == "100G_4X" || rate == "100GbE_4X") {
         return PRBS_EDR;
     }
-    if (rate == "IB-HDR" || rate == "HDR" || rate == "200GbE" || rate == "200G" || rate == "400G" || rate == "400GbE") {
+    if (rate == "IB-HDR" || rate == "HDR" || rate == "200GbE" || rate == "200G"
+            || rate == "50G_1X" || rate == "50GbE_1X" || rate == "100G_2X"
+            || rate == "100GbE_2X" || rate == "400G" || rate == "400GbE") {
         return PRBS_HDR;
     }
     if (rate == "1G" || rate == "1GbE") {
@@ -665,10 +692,14 @@ int prbsLaneRateCapToMask(const string &rate)
     if (rate == "IB-FDR" || rate == "FDR" || rate == "14G" || rate == "14GbE") {
         return LANE_RATE_FDR_CAP;
     }
-    if (rate == "IB-EDR" || rate == "EDR" || rate == "25G" || rate == "25GbE" || rate == "50G" || rate == "50GbE" || rate == "100G" || rate == "100GbE") {
+    if (rate == "IB-EDR" || rate == "EDR" || rate == "25G" || rate == "25GbE"
+            || rate == "50G" || rate == "50GbE" || rate == "100G" || rate == "100GbE"
+            || rate == "50G_2X" || rate == "50GbE_2X" || rate == "100G_4X" || rate == "100GbE_4X") {
         return LANE_RATE_EDR_CAP;
     }
-    if (rate == "IB-HDR" || rate == "HDR" || rate == "200G" || rate == "200GbE" || rate == "400G" || rate == "400GbE") {
+    if (rate == "IB-HDR" || rate == "HDR" || rate == "200GbE" || rate == "200G"
+            || rate == "50G_1X" || rate == "50GbE_1X" || rate == "100G_2X"
+            || rate == "100GbE_2X" || rate == "400G" || rate == "400GbE") {
         return LANE_RATE_HDR_CAP;
     }
     if (rate == "1G" || rate == "1GbE") {
@@ -735,10 +766,12 @@ bool prbsLaneRateCheck(const string &rate)
     if (rate == "FDR" || rate == "IB-FDR" || rate == "14G") {
         return true;
     }
-    if (rate == "EDR" || rate == "IB-EDR" || rate == "25G" || rate == "50G" || rate == "100G") {
+    if (rate == "EDR" || rate == "IB-EDR" || rate == "25G" || rate == "50G"
+            || rate == "100G"|| rate == "50G_2X" || rate == "100G_4X") {
         return true;
     }
-    if (rate == "HDR" || rate == "IB-HDR" || rate == "200G") {
+    if (rate == "HDR" || rate == "IB-HDR" || rate == "200G"
+            || rate == "50G_1X" || rate == "100G_2X") {
         return true;
     }
     if (rate == "1G") {

--- a/mlxlink/modules/printutil/mlxlink_cmd_print.cpp
+++ b/mlxlink/modules/printutil/mlxlink_cmd_print.cpp
@@ -69,8 +69,12 @@ void MlxlinkCmdPrint::toJsonFormat(Json::Value& jsonRoot)
                     subObject[JSON_MASK_TITLE] = mask;
                 }
                 if (!val.empty()) {
-                    std::vector<std::string> vals =
-                            MlxlinkRecord::split(val, ',');
+                    std::vector<std::string> vals;
+                    if (title == HEADER_FEC_INFO) {
+                        vals = MlxlinkRecord::split(val, ", ");
+                    } else {
+                      vals = MlxlinkRecord::split(val, ",");
+                    }
                     for (std::vector<std::string>::iterator it = vals.begin() ;
                             it != vals.end(); ++it) {
                         subObject[JSON_VALUES_TITLE].append(*it);

--- a/mlxlink/modules/printutil/mlxlink_record.cpp
+++ b/mlxlink/modules/printutil/mlxlink_record.cpp
@@ -49,15 +49,23 @@ MlxlinkRecord::MlxlinkRecord() {
 MlxlinkRecord::~MlxlinkRecord() {
 }
 
-std::vector<std::string> MlxlinkRecord::split(const std::string& str, char delim)
+
+std::vector<std::string> MlxlinkRecord::split(const std::string& str, const std::string &delim)
 {
     std::vector<std::string> list;
-    std::stringstream ss(str);
+    std::string tmp = str;
     std::string token;
-    while (std::getline(ss, token, delim)) {
-        MlxlinkRecord::trim(token);
-        list.push_back(token);
+    std::size_t found = tmp.find(delim);
+    while (found != std::string::npos) {
+        token = tmp.substr(0, found);
+        if (!token.empty()) {
+            MlxlinkRecord::trim(token);
+            list.push_back(token);
+        }
+        tmp = tmp.substr(found + delim.length());
+        found = tmp.find(delim);
     }
+    list.push_back(tmp);
     return list;
 }
 

--- a/mlxlink/modules/printutil/mlxlink_record.h
+++ b/mlxlink/modules/printutil/mlxlink_record.h
@@ -285,7 +285,7 @@ public:
     static void printCmdLine(const std::string &line, Json::Value &jsonRoot);
     static void printErr(const std::string &err);
     static void printWar(const std::string &war, Json::Value &jsonRoot);
-    static std::vector<std::string> split(const std::string& str, char delim = ' ');
+    static std::vector<std::string> split(const std::string& str, const std::string &delim = " ");
     static void trim(std::string& str, const std::string& chars = "\t\n\v\f\r ");
 };
 


### PR DESCRIPTION
Fixes and Changes:
- Adding support to use PAM4 RX/TX rates(50G_1X, 100G_2X) in PRBS mode
- Adding support to work with PAM4/NRZ speeds for new devices
- Fixing JSON format issues
- Updating PAOS failed message
- Fixing ambiguous else if statements
- Fixing split issues for Spectrum switch
- Updating some of the help messages
- Validating the Firmware version while working on PCIe port
- Adding support to access the PCIe port by "--port" flag
- Adding RX and TX modulation for HDR speeds
- Fixing lane width for 50G PAM4 speed

Signed-off-by: Mustafa Dalloul <mustafadall@mellanox.com>