### PR TITLE
mstfwreset bug fixes (2074458; 2053621; 1980064)

### DIFF
--- a/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
@@ -169,12 +169,26 @@ class CmdRegMfrl():
         else:
             return False   
 
+    def is_reset_level_support_reset_type(self, reset_level):
+        'Check if the input reset-level can be executed with reset_type (different than the default)'
+        for reset_level_ii in self._reset_levels:
+            if reset_level_ii['level'] == reset_level:
+                return reset_level_ii['support_reset_type']
+        else:
+            return False
+
+
     def default_reset_level(self):
         'Return the default reset-level (minimal supported reset-level)'
         for reset_level_ii in CmdRegMfrl.reset_levels():
             if self.is_reset_level_supported(reset_level_ii) is True:
                 return reset_level_ii
         raise Exception("There is no supported reset-level")
+
+    
+    def is_default_reset_type(self, reset_type):
+        return reset_type == self.default_reset_type()
+
 
     def send(self, reset_level=None, reset_type=None):
         'send MFRL Set command'

--- a/small_utils/mlxfwresetlib/mlxfwreset_mlnxdriver.py
+++ b/small_utils/mlxfwresetlib/mlxfwreset_mlnxdriver.py
@@ -264,7 +264,7 @@ class MlnxDriverWindows(MlnxDriver):
         if skip == True:
             super(MlnxDriverWindows, self).__init__(logger, MlnxDriver.DRIVER_IGNORE)
             return
-
+        
         seg_bus_device_list = []
         # Extract bus and device from the device_name
         for device in devices:
@@ -273,11 +273,11 @@ class MlnxDriverWindows(MlnxDriver):
             bus_num = int(seg_bus_device.split(':')[1],16)
             device_num = int(seg_bus_device.split(':')[2],16)
             seg_bus_device_list.append((seg_num, bus_num, device_num))
-
+        
         # Find the network adapters for the dus:device
         targetedAdaptersTemp = self.get_device_drivers(logger, seg_bus_device_list)
         logger.debug(targetedAdaptersTemp)
-
+     
         # Filter the network adapter thar are disabled
         self.targetedAdapters = []
         for targetedAdapter in targetedAdaptersTemp:


### PR DESCRIPTION
1. Add a check for reset-level and reset-type 
2. bluefield on PPC - remove DMA controller (NVME emulation) from list
3. wait 1 sec if wait_for_fw_ready gets exception

Issue:2098635