### PR TITLE
Segmentation fault and access violation when dealing with cables on python tools

### DIFF
--- a/mtcr_py/mtcr.py
+++ b/mtcr_py/mtcr.py
@@ -51,6 +51,7 @@ class MtcrException(Exception):
 CMTCR = None
 try:
     from ctypes import *
+    ctypes.CDLL._func_restype_ = ctypes.c_ulonglong
     if platform.system() == "Windows" or os.name == "nt":
         CMTCR = CDLL("libmtcr-1.dll", use_errno=True)
     else:


### PR DESCRIPTION
Need to check if the pointer is 64bit or 32 bit before loading the dll's.

Issue: 2083458