### PR TITLE
Fix RH6.3 compliation issue when no is_relative function in boost

### DIFF
--- a/adb_parser/adb_parser.cpp
+++ b/adb_parser/adb_parser.cpp
@@ -1,13 +1,34 @@
-/*                  - Mellanox Confidential and Proprietary -
+/* 
+ * Copyright (C) Jan 2019 Mellanox Technologies Ltd. All rights reserved.
+ * 
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ * 
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
  *
- *  Copyright (C) Jan 2013, Mellanox Technologies Ltd.  ALL RIGHTS RESERVED.
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
  *
- *  Except as specifically permitted herein, no portion of the information,
- *  including but not limited to object code and source code, may be reproduced,
- *  modified, distributed, republished or otherwise exploited in any form or by
- *  any means for any purpose without the prior written permission of Mellanox
- *  Technologies Ltd. Use of software subject to the terms and conditions
- *  detailed in the file "LICENSE.txt".
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+
  *
  */
 
@@ -237,9 +258,11 @@ public:
 private:
     // METHODS
     string findFile(string fileName);
-    static void includeFile(AdbParser *adbParser, string fileName, int lineNumber = -1);
-    static void startElement(void *adbParser, const XML_Char *name, const XML_Char **atts);
-
+    static bool is_relative(const string path);
+    static void includeFile(AdbParser *adbParser, string fileName,
+        int lineNumber = -1);
+    static void startElement(void *adbParser, const XML_Char *name,
+        const XML_Char **atts);
     static void startNodesDefElement(const XML_Char **atts, AdbParser *adbParser);
     static void startEnumElement(const XML_Char **atts, AdbParser *adbParser, const int lineNumber);
     static void startConfigElement(const XML_Char **atts, AdbParser *adbParser, const int lineNumber);
@@ -248,9 +271,9 @@ private:
     static void startInstOpAttrReplaceElement(const XML_Char **atts, AdbParser *adbParser, const int lineNumber);
     static void startNodeElement(const XML_Char **atts, AdbParser *adbParser, const int lineNumber);
     static void startFieldElement(const XML_Char **atts, AdbParser *adbParser, const int lineNumber);
-
     static void endElement(void *adbParser, const XML_Char *name);
-    static void addReserved(vector<AdbField*> &reserveds, u_int32_t offset, u_int32_t size);
+    static void addReserved(vector<AdbField*> &reserveds, u_int32_t offset,
+        u_int32_t size);
     static int attrCount(const XML_Char **atts);
     static string attrValue(const XML_Char **atts, const XML_Char *attrName);
     static string attrName(const XML_Char **atts, int i);
@@ -2035,6 +2058,16 @@ string AdbException::what_s() const {
     return _msg;
 }
 
+/**
+ * Function: AdbParser::is_relative
+ **/
+bool AdbParser::is_relative(const string path) {
+    if (path[0] == '/') {
+        return false;
+    }
+    return true;
+}
+
 /*************************** AdbParser Implementation ***************************/
 /**
  * Function: AdbParser::AdbParser
@@ -2061,7 +2094,7 @@ AdbParser::AdbParser(string fileName, Adb *adbCtxt, bool addReserved,
 
         for (StringVector::iterator it = adbCtxt->includePaths.begin(); it
                 != adbCtxt->includePaths.end(); it++) {
-            if (boost::filesystem::path(*it).is_relative()) {
+            if (AdbParser::is_relative(*it)) {
                 relatives.push_back(projPath + OS_PATH_SEP + *it);
             }
         }
@@ -2429,7 +2462,7 @@ void AdbParser::includeFile(AdbParser *adbParser, string fileName,
     string filePath;
     FILE *probeFile = NULL;
 
-    if (!boost::filesystem::path(fileName).is_relative()) {
+    if (!AdbParser::is_relative(fileName)) {
         probeFile = fopen(fileName.c_str(), "r");
     }
 
@@ -2646,7 +2679,7 @@ void AdbParser::startConfigElement(const XML_Char **atts, AdbParser *adbParser, 
             for (StringVector::iterator it =
                     adbParser->_adbCtxt->includePaths.begin(); it
                     != adbParser->_adbCtxt->includePaths.end(); it++) {
-                if (boost::filesystem::path(*it).is_relative()) {
+                if (AdbParser::is_relative(*it)) {
                     relatives.push_back(projPath + OS_PATH_SEP + *it);
                 }
             }


### PR DESCRIPTION
Description: In older versions of boost library (1.41) is_relative isn't
implemented therefore we need to keep our implementation.
In addition license is fixed.

Issue: 2107652