### PR TITLE
spec: Do not set "optflags"

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -16,7 +16,6 @@
 
 %define _unpackaged_files_terminate_build 0
 %define debug_package %{nil}
-%define optflags -g -O2
 
 Summary: Mellanox firmware burning application
 Name: %{name}


### PR DESCRIPTION
When "optflags" are defined in the spec file they override the flags set
by GNU Autotools and the platform's default RPM macros during rpmbuild.

On RHEL8 or OL8 this causes the rpmbuild of mstflint to fail during
cross compile checking during the "configure" phase.

On RHEL7 or OL7 this results in mstflint compiling and linking with
a different set of options than what the platform RPM macros should be
setting.

Signed-off-by: Aron Silverton <aron.silverton@oracle.com>