### PR TITLE
Support linking against system libjsoncpp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ AS_IF([test "x$INIPARSER_SYSTEM_AVAILABLE" = "xyes" ], [
     CXXFLAGS="$CXXFLAGS -DHAVE_INI_PARSER"
 ])
 
-AC_SEARCH_LIBS([json_object_get], [json-c jason], [JSON_SYSTEM_AVAILABLE="yes"],[
+PKG_CHECK_MODULES([JSON], [jsoncpp], [JSON_SYSTEM_AVAILABLE="yes"],[
     JSON_SYSTEM_AVAILABLE="no"
     JSON_CFLAGS='-I$(top_srcdir)/ext_libs/json'
     AC_SUBST(JSON_CFLAGS)

--- a/mlxlink/Makefile.am
+++ b/mlxlink/Makefile.am
@@ -44,15 +44,12 @@ UTILS_DIR = $(top_srcdir)/mft_utils
 MLXREG_DIR = $(top_srcdir)/mlxreg
 LAYOUTS_DIR = $(top_srcdir)/tools_layouts
 MLXLINK_MODULES_DIR = $(top_srcdir)/mlxlink
-JSON_DIR = $(top_srcdir)/ext_libs/json
-
-INCLUDES = -I. -I$(top_srcdir) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MLXLINK_MODULES_DIR) -I$(MTCR_INC_DIR) -I$(JSON_DIR)
 
 AM_CXXFLAGS = -Wall -W -DMST_UL -g -MP -MD -pipe -Werror
 
 bin_PROGRAMS = mstlink
 
-mstlink_CXXFLAGS = -DEXTERNAL
+mstlink_CXXFLAGS = -I. -I$(top_srcdir) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MLXLINK_MODULES_DIR) -I$(MTCR_INC_DIR) $(JSON_CFLAGS) -DEXTERNAL
 mstlink_SOURCES = mlxlink_main.cpp
 
 mstlink_DEPENDENCIES = modules/libmodules_lib.a \
@@ -70,7 +67,7 @@ mstlink_DEPENDENCIES = modules/libmodules_lib.a \
                       $(USER_DIR)/ext_libs/minixz/libminixz.a \
                       -lboost_regex -lboost_filesystem -lboost_system \
                       -llzma $(LIBSTD_CPP) ${LDL} -lexpat \
-                      $(JSON_DIR)/libjson.a
+                      $(JSON_LIBS)
 
 mstlink_LDADD = $(mstlink_DEPENDENCIES)
 

--- a/mlxlink/modules/Makefile.am
+++ b/mlxlink/modules/Makefile.am
@@ -41,9 +41,6 @@ MTCR_INC_DIR = $(top_srcdir)/include/mtcr_ul
 UTILS_DIR = $(top_srcdir)/mft_utils
 MLXREG_DIR = $(top_srcdir)/mlxreg
 MLXLINK_MODULES_DIR = $(top_srcdir)/mlxlink
-JSON_DIR = $(top_srcdir)/ext_libs/json
-
-INCLUDES = -I. -I$(USER_DIR) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MLXLINK_MODULES_DIR) -I$(MTCR_INC_DIR) -I$(JSON_DIR)
 
 AM_CFLAGS = -Wall -W -g -MP -MD -pipe -Werror $(COMPILER_FPIC) -DDATA_PATH=\"$(pkgdatadir)\"
 AM_CXXFLAGS = -Wall -W -g -MP -MD -pipe -Werror #$(COMPILER_FPIC)
@@ -63,5 +60,6 @@ libmodules_lib_a_SOURCES = mlxlink_commander.h \
                             mlxlink_ui.h \
                             mlxlink_ui.cpp
 
-libmodules_lib_a_LIBADD = printutil/libprint_util_lib.a  $(JSON_DIR)/libjson.a
+libmodules_lib_a_LIBADD = printutil/libprint_util_lib.a $(JSON_LIBS)
 libmodules_lib_a_CFLAGS = $(AM_CFLAGS)
+libmodules_lib_a_CXXFLAGS = -I. -I$(USER_DIR) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MLXLINK_MODULES_DIR) -I$(MTCR_INC_DIR) $(JSON_CFLAGS)

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -364,7 +364,7 @@ void MlxlinkUi::paramValidate()
 
 void MlxlinkUi::initCmdParser()
 {
-    for (u_int32_t it = SHOW_PDDR; it < FUNCTION_LAST; it++) {
+    for (u_int32_t it = SHOW_PDDR; it <= FUNCTION_LAST; it++) {
         _sendRegFuncMap.push_back(0);
     }
     AddOptions(DEVICE_FLAG, DEVICE_FLAG_SHORT, "MstDevice",

--- a/mlxlink/modules/printutil/Makefile.am
+++ b/mlxlink/modules/printutil/Makefile.am
@@ -39,9 +39,6 @@ MTCR_DIR = $(top_srcdir)/${MTCR_CONF_DIR}
 MTCR_INC_DIR = $(top_srcdir)/include/mtcr_ul
 UTILS_DIR = $(top_srcdir)/mft_utils
 MLXREG_DIR = $(top_srcdir)/mlxreg
-JSON_DIR = $(top_srcdir)/ext_libs/json
-
-INCLUDES = -I. -I$(USER_DIR) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MTCR_INC_DIR) -I$(JSON_DIR)
 
 AM_CFLAGS = -Wall -W -g -MP -MD -pipe -Werror $(COMPILER_FPIC) -DDATA_PATH=\"$(pkgdatadir)\"
 
@@ -51,5 +48,6 @@ libprint_util_lib_a_SOURCES = mlxlink_cmd_print.h \
                             mlxlink_cmd_print.cpp \
                             mlxlink_record.h \
                             mlxlink_record.cpp
-libprint_util_lib_a_LIBDADD = $(JSON_DIR)/libjson.a
+libprint_util_lib_a_CXXFLAGS = -I. -I$(USER_DIR) -I$(MTCR_DIR) -I$(MFT_EXT_LIBS_INC_DIR) -I$(UTILS_DIR) -I$(MLXREG_DIR) -I$(MTCR_INC_DIR) $(JSON_CFLAGS)
+libprint_util_lib_a_LIBADD = $(JSON_LIBS)
 libprint_util_lib_a_CFLAGS = $(AM_CFLAGS)


### PR DESCRIPTION
`jsoncpp` is used instead of `json-c`. Use pkg-config to search for the system installed jsoncpp library. Use `JSON_CFLAGS` and `JSON_LIBS` which is either set by pkg-config to the system library or by configure to the local copy of the library.

Fixes https://github.com/Mellanox/mstflint/issues/305