### PR TITLE
Restoring markhaywood #302 PR code changes after mstflint-4.14.0-1 release

### DIFF
--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -364,7 +364,7 @@ void MlxlinkUi::paramValidate()
 
 void MlxlinkUi::initCmdParser()
 {
-    for (u_int32_t it = SHOW_PDDR; it < FUNCTION_LAST; it++) {
+    for (u_int32_t it = SHOW_PDDR; it <= FUNCTION_LAST; it++) {
         _sendRegFuncMap.push_back(0);
     }
     AddOptions(DEVICE_FLAG, DEVICE_FLAG_SHORT, "MstDevice",


### PR DESCRIPTION
Description: This fix wasn't tested as part of mstflint-4.14.0-1
release, therefore it was temporarily removed and now restored.

Issue: PR #302