### PR TITLE
mlxdump reads corrupted values when mstflint driver is loaded due to bugs in mtcr module.

### DIFF
--- a/kernel/mst.h
+++ b/kernel/mst.h
@@ -88,7 +88,7 @@ struct mst_write_block_st {
 };
 
 
-#define PCICONF_READ4_BUFFER  _IOR(MST_BLOCK_ACCESS_MAGIC, 3, struct mst_read4_st)
+#define PCICONF_READ4_BUFFER  _IOR(MST_BLOCK_ACCESS_MAGIC, 3, struct mst_read4_buffer_st)
 struct mst_read4_buffer_st {
 	unsigned int address_space;
 	unsigned int offset;

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -823,7 +823,7 @@ static int driver_mread4_block(mfile *mf, unsigned int offset, u_int32_t *data, 
                 return -1;
             }
             memcpy(dest_ptr, read4_buf.data, toread);
-            offset += toread / sizeof(u_int32_t);
+            offset += toread;
             dest_ptr += toread / sizeof(u_int32_t);
         }
         return length;

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -795,7 +795,7 @@ static int driver_mwrite4_block(mfile *mf, unsigned int offset, u_int32_t *data,
             if (ret < 0) {
                 return -1;
             }
-            offset += towrite / sizeof(u_int32_t);
+            offset += towrite;
             dest_ptr += towrite / sizeof(u_int32_t);
         }
         return length;


### PR DESCRIPTION
Description:
The bug is a combination of two issues:
1. Wrong calculation buffer offset in mtcr_ul.
2. Wrong ioctl implementation in mstflint driver.

Issue: 2172506