### PR TITLE
Reverted back "NVMe" printf to subcommands.cpp

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -2947,6 +2947,7 @@ FlintStatus QuerySubCommand::printInfo(const fw_info_t& fwInfo, bool fullQuery)
     else if (_flintParams.skip_rom_query) {
         printf("Rom Info:              type=UEFI version=skipped cpu=skipped\n");
         printf("                       type=PXE  version=skipped devid=skipped cpu=skipped\n");
+        printf("                       type=NVMe version=skipped devid=skipped cpu=skipped\n")
     }
 
     if (isFs2) {


### PR DESCRIPTION
This printf was erroneously deleted several days ago. The reason why we need it is that by removing printf we affecting the tool output that may be parsed by already existed external tools.