### PR TITLE
Fixed bug in the configure script

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,7 +326,7 @@ CXXFLAGS="$OLD_CXXFLAGS"
 
 TOOLS_BUILD_TIME=`date  +"%b %d %Y\, %H:%M:%S"`
 if test "x$SOURCE_DATE_EPOCH" != "x"; then
-    TOOLS_BUILD_TIME=`LC_ALL=C date -u -d @$SOURCE_DATE_EPOCH" +"%b %d %Y\, %H:%M:%S"`
+    TOOLS_BUILD_TIME=`LC_ALL=C date -u -d @$SOURCE_DATE_EPOCH +"%b %d %Y\, %H:%M:%S"`
 fi
 AC_SUBST(TOOLS_BUILD_TIME)
 


### PR DESCRIPTION
Description: unclosed double-quote string caused error during running configure under FreeBSD

Issue: 2231988