### PR TITLE
resourceparse should not stop parsing if notice msg characters are in…

### DIFF
--- a/resourceparse/segments/NoticeSegment.py
+++ b/resourceparse/segments/NoticeSegment.py
@@ -74,8 +74,13 @@ class NoticeSegment(Segment):
         offset = cs.SEGMENTS_HEADER_SIZE_IN_DW
         if len(dw_data) > cs.SEGMENTS_HEADER_SIZE_IN_DW:
             # self._parsed_data['syndrome_id'] = str(hex(int('{:0b}'.format(dw_data[offset]).zfill(32)[16:32], 2)))
-            self._parsed_data['notice msg'] = MenuRecord.bin_list_to_ascii(dw_data[cs.ERROR_SEGMENT_NOTICE_MSG_START:
-                                                                                   cs.ERROR_SEGMENT_NOTICE_MSG_END])
+            try:
+                self._parsed_data['notice msg'] = MenuRecord.bin_list_to_ascii(
+                    dw_data[cs.ERROR_SEGMENT_NOTICE_MSG_START:
+                            cs.ERROR_SEGMENT_NOTICE_MSG_END])
+            except:
+                # in case that the bin is not an ascii we will not display the notice msg
+                pass
 
         return self._parsed_data
 


### PR DESCRIPTION
…valid

Description: the tool will not present translation of the notice parse all remaining segments
Issue: 2256511