### PR TITLE
getpagesize (get memory page size) is deprecated.

### DIFF
--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -177,8 +177,6 @@ MTCR_API int MWRITE4_SEMAPHORE(mfile* mf, int offset, int value);
 
 MTCR_API int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr);
 
-int allocate_kernel_memory_page(mfile *mf, mtcr_alloc_page* user_alloc_page);
-
 void set_increase_poll_time(int new_value);
 
 #ifdef __cplusplus

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -3314,7 +3314,7 @@ int allocate_kernel_memory_page(mfile* mf, struct mtcr_page_info* page_info,
                                 int page_amount)
 {
  #if !defined(__VMKERNEL_UW_NATIVE__)
-    int page_size = getpagesize();
+    int page_size = sysconf(_SC_PAGESIZE);
     int i;
     int current_offest = 0;
   


### PR DESCRIPTION
Portable applications should employ sysconf(_SC_PAGESIZE) instead of getpagesize().