### PR TITLE
Removed unused class members in mstlink

### DIFF
--- a/mlxlink/modules/mlxlink_err_inj_commander.h
+++ b/mlxlink/modules/mlxlink_err_inj_commander.h
@@ -71,8 +71,6 @@ private:
 
     Json::Value &_jsonRoot;
     MlxlinkCmdPrint _errInjOutput;
-    u_int32_t _origMixerOffset0;
-    u_int32_t _origMixerOffset1;
 };
 
 #endif /* MLXLINK_ERR_INJ_COMMANDER_H */


### PR DESCRIPTION
Description:
Fixed as part of transition to clang in FreeBSD.

Issue: 2670735