### PR TITLE
[mstflint] added support for AccessRegister Class 0xA and removed sup…

### DIFF
--- a/mtcr_ul/mtcr_ib.h
+++ b/mtcr_ul/mtcr_ib.h
@@ -58,6 +58,9 @@ int mib_smp_set(mfile *mf, u_int8_t *data, u_int16_t attr_id, u_int32_t attr_mod
 int mib_smp_get(mfile *mf, u_int8_t *data, u_int16_t attr_id, u_int32_t attr_mod);
 int mib_get_gmp(mfile *mf, unsigned attr_id, unsigned mod, u_int32_t *vsmad_data, size_t vsmad_data_len);
 int mib_supports_reg_access_gmp(mfile *mf, maccess_reg_method_t reg_method);
-int mib_send_gmp_access_reg_mad(mfile *mf, u_int32_t *data, u_int32_t reg_size, u_int32_t reg_id, maccess_reg_method_t reg_method);
+int mib_send_gmp_access_reg_mad(mfile *mf, u_int32_t *data,
+                                u_int32_t reg_size, u_int32_t reg_id,
+                                maccess_reg_method_t reg_method, int *reg_status);
 int mib_supports_reg_access_cls_a(mfile *mf, maccess_reg_method_t reg_method);
+int mib_send_cls_a_access_reg_mad(mfile *mf, u_int8_t *data);
 #endif

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -133,6 +133,7 @@ int tools_cmdif_unlock_semaphore_ul(mfile *mf);
 
 int mget_max_reg_size_ul(mfile *mf, maccess_reg_method_t reg_method);
 int supports_reg_access_gmp_ul(mfile *mf, maccess_reg_method_t reg_method);
+int supports_reg_access_cls_a_ul(mfile *mf, maccess_reg_method_t reg_method);
 
 int mread_buffer_ul(mfile *mf, unsigned int offset, u_int8_t *data, int byte_len);
 int mwrite_buffer_ul(mfile *mf, unsigned int offset, u_int8_t *data, int byte_len);


### PR DESCRIPTION
…port for class 0x9

Description: ported new AccessRegister class 0xA code and removed support for cancelled class 0x9.
also added VKey support and introduced latest bug fixes in mtcr.

Tested OS: linux
Tested devices: ib devices
Tested flows: tested compilation on linux platforms

Known gaps (with RM ticket): none

Issue: 2166465