### PR TITLE
[mstlink][NDR_GEN] Supporting amBER collection for 16/7nm devices

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -78,6 +78,7 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _isPam4Speed = false;
     _ignorePortType = true;
     _lanesLockStatus = false;
+    _ignorePortStatus = true;
     _protoAdmin = 0;
     _protoAdminEx = 0;
     _speedBerCsv = 0;
@@ -847,6 +848,11 @@ int MlxlinkCommander::handleEthLocalPort(u_int32_t labelPort, bool spect2WithGb)
 void MlxlinkCommander::fillEthPortGroupMap(u_int32_t localPort,u_int32_t labelPort,
         u_int32_t group, u_int32_t width, bool spect2WithGb)
 {
+    if(_ignorePortStatus) {
+        if (!width) {
+            _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
+        }
+    }
     if (spect2WithGb) {
         switch (width) {
         case 2:
@@ -937,24 +943,23 @@ vector<string> MlxlinkCommander::localToPortsPerGroup(vector<u_int32_t> localPor
     return labelPortsStr;
 }
 
-void MlxlinkCommander::handleLabelPorts(std::vector<string> labelPortsStr)
+void MlxlinkCommander::handleLabelPorts(std::vector<string> labelPortsStr, bool skipException)
 {
     u_int32_t labelPort = 0;
     int localPort = -1;
-    if (labelPortsStr.size() > maxLocalPort()) {
+    if (labelPortsStr.size() > maxLocalPort() && !skipException) {
         throw MlxRegException("The number of ports is invalid");
     }
     bool ibSplitReady = (_devID == DeviceQuantum || _devID == DeviceQuantum2)? isIBSplitReady() : false;
     bool spect2WithGb = (_devID == DeviceSpectrum2)? isSpect2WithGb() : false;
-    for (vector<string>::iterator it = labelPortsStr.begin();
-            it != labelPortsStr.end(); ++it) {
+    for (vector<string>::iterator it = labelPortsStr.begin(); it != labelPortsStr.end(); ++it) {
         strToUint32((char *)(*it).c_str(), labelPort);
         if (_devID == DeviceSpectrum2 || _devID == DeviceSpectrum3) {
             localPort = handleEthLocalPort(labelPort, spect2WithGb);
         } else if (_devID == DeviceQuantum || _devID == DeviceQuantum2) {
             localPort = handleIBLocalPort(labelPort, ibSplitReady);
         }
-        if (localPort < 0) {
+        if (localPort < 0 && !skipException) {
             throw MlxRegException("Invalid port number %d!\n", labelPort);
         }
     }
@@ -1397,8 +1402,8 @@ string MlxlinkCommander::getComplianceLabel(u_int32_t compliance,
                         getCompliance(compliance, _mlxlinkMaps->_cableComplianceQsfp, true);
                 if (ignoreExtBitChk ||
                         (compliance & QSFP_ETHERNET_COMPLIANCE_CODE_EXT)) {
-                    complianceLabel +=
-                            getCompliance(extCompliance, _mlxlinkMaps->_cableComplianceExt);
+                    complianceLabel += !complianceLabel.empty() ? "," : "";
+                    complianceLabel += getCompliance(extCompliance, _mlxlinkMaps->_cableComplianceExt);
                 }
             } else if (ignoreExtBitChk) {
                 complianceLabel =
@@ -1479,6 +1484,15 @@ void MlxlinkCommander::strToInt32(char *str, u_int32_t &value)
     if (*endp) {
         throw MlxRegException("Argument: %s is invalid.", str);
     }
+}
+
+void MlxlinkCommander::runningVersion()
+{
+    setPrintTitle(_toolInfoCmd,"Tool Information", TOOL_INFORMAITON_INFO_LAST, !_prbsTestMode);
+    setPrintVal(_toolInfoCmd,"Firmware Version", _fwVersion, ANSI_COLOR_GREEN,true, !_prbsTestMode);
+    setPrintVal(_toolInfoCmd,"amBER Version", AMBER_VERSION, ANSI_COLOR_GREEN,
+                _productTechnology >= PRODUCT_16NM, !_prbsTestMode);
+    setPrintVal(_toolInfoCmd,"MSTFLINT Version", MSTFLINT_VERSION_STR, ANSI_COLOR_GREEN,true, !_prbsTestMode);
 }
 
 void MlxlinkCommander::operatingInfoPage()
@@ -1663,12 +1677,14 @@ void MlxlinkCommander::showPddr()
         operatingInfoPage();
         supportedInfoPage();
         troubInfoPage();
+        runningVersion();
         if (_prbsTestMode) {
             showTestMode();
         } else {
             std::cout << _operatingInfoCmd;
             std::cout << _supportedInfoCmd;
             std::cout << _troubInfoCmd;
+            std::cout << _toolInfoCmd;
         }
     } catch (const std::exception &exc) {
         throw MlxRegException(string("Showing PDDR raised the following exception: \n") + string(exc.what()));
@@ -2503,9 +2519,52 @@ void MlxlinkCommander::showPcieState(DPN& dpn)
     cout << _pcieInfoCmd;
 }
 
+void MlxlinkCommander::collectAMBER()
+{
+    try {
+        if (_productTechnology >= PRODUCT_16NM) {
+            initAmBerCollector();
+
+            if (!_isHCA) {
+                // If port provided, collect one port only
+                if (_userInput._specifiedPort) {
+                    PortGroup pg {_localPort, _userInput._labelPort, 0, _userInput._splitPort};
+                    _amberCollector->_localPorts.push_back(pg);
+                } else {
+                    // collect all ports info if the port flag wasn't provided
+                    string regName = "MGPIR";
+                    resetParser(regName);
+                    genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
+                    u_int32_t numOfPorts = getFieldValue("num_of_modules");
+                    vector<string> labelPorts;
+                    _ignorePortStatus = false;
+                    for (u_int32_t labelPort = 1; labelPort <= numOfPorts; labelPort ++) {
+                        labelPorts.push_back(to_string(labelPort));
+                    }
+                    handleLabelPorts(labelPorts, true);
+                    _amberCollector->_localPorts = _localPortsPerGroup;
+                }
+            }
+
+            _amberCollector->startCollector();
+        } else {
+            throw MlxRegException(AMBER_COLLECT_FLAG " is not available for "\
+                  "this device, please use " BER_COLLECT_FLAG " flag instead");
+        }
+    } catch (const std::exception &exc) {
+        _allUnhandledErrors += string("Collecting AMBER raised the following exception: \n") +
+                                      string(exc.what()) + string("\n");
+    }
+}
+
 void MlxlinkCommander::collectBER()
 {
     try {
+        if (_productTechnology >= PRODUCT_16NM) {
+            throw MlxRegException(BER_COLLECT_FLAG " is not available for "\
+                  "this device, please use " AMBER_COLLECT_FLAG " flag instead");
+        }
+
         const char *fileName = _userInput._csvBer.c_str();
         ifstream ifile(fileName);
         ofstream berFile;
@@ -2564,7 +2623,8 @@ void MlxlinkCommander::collectBER()
         berFile << endl;
         berFile.close();
     } catch (const std::exception &exc) {
-        _allUnhandledErrors += string("Collecting BER and producing report raised the following exception: ") + string(exc.what()) + string("\n");
+        _allUnhandledErrors += string(
+                "Collecting BER and producing report raised the following exception: \n") + string(exc.what()) + string("\n");
     }
 }
 
@@ -4274,6 +4334,7 @@ void MlxlinkCommander::prepareJsonOut()
     _operatingInfoCmd.toJsonFormat(_jsonRoot);
     _supportedInfoCmd.toJsonFormat(_jsonRoot);
     _troubInfoCmd.toJsonFormat(_jsonRoot);
+    _toolInfoCmd.toJsonFormat(_jsonRoot);
     _testModeInfoCmd.toJsonFormat(_jsonRoot);
     _pcieInfoCmd.toJsonFormat(_jsonRoot);
     _moduleInfoCmd.toJsonFormat(_jsonRoot);

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -142,6 +142,8 @@
 #define BER_LIMIT_FLAG_SHORT               ' '
 #define ITERATION_FLAG                     "iteration"
 #define ITERATION_FLAG_SHORT               ' '
+#define AMBER_COLLECT_FLAG                 "amber_collect"
+#define AMBER_COLLECT_FLAG_SHORT           ' '
 #define PPCNT_CLEAR_FLAG                   "pc"
 #define PPCNT_CLEAR_FLAG_SHORT             ' '
 #define PEPC_SET_FLAG                      "set_external_phy"
@@ -225,45 +227,7 @@
 #define REG_ACCESS_UNION_NODE "access_reg_summary"
 
 //------------------------------------------------------------
-//        Mlxlink Values definition
-#define SWID                        0
-#define PPRT_PPTT_ENABLE            1
-#define PPRT_PPTT_START_TUNING      1
-#define PHY_TEST_MODE_STATUS        1
-
-#define PDDR_STATUS_MESSAGE_LENGTH_HCA  236
-#define PDDR_STATUS_MESSAGE_LENGTH_SWITCH 59
-#define BIT_MASK_ALL_DWORD          0xffffffff
-
-#define OB_TAP_SUM                  120
-#define OB_TAP_DIFF                 10
-#define OB_BIAS_LOW_THRESHOLD       15
-#define OB_BIAS_MID_1_THRESHOLD     31
-#define OB_BIAS_MID_2_THRESHOLD     48
-#define OB_BIAS_HIGH_THRESHOLD      63
-
-#define MAX_LOCAL_PORT_ETH          64
-#define MAX_LOCAL_PORT_IB           36
-#define MAX_LOCAL_PORT_QUANTUM      82
-#define MAX_LOCAL_PORT_QUANTUM2     128
-#define MAX_LOCAL_PORT_SPECTRUM2    128
-
-#define DBN_TO_LOCAL_PORT_BASE      60
-
-#define MAX_LANES_NUMBER            4
-#define MAX_DWORD_BLOCK_SIZE        32
-#define MAX_TX_GROUP_COUNT          10
-
-#define PCAM_FORCE_DOWN_CAP_MASK    0x2000
-
-#define OPERATIONAL_ERROR_STR       "ME_ICMD_OPERATIONAL_ERROR"
-
-#define MAX_SBYTE                   127
-#define MIN_SBYTE                   -128
-#define MAX_LABEL_PORT_LENGTH       5
-
-//------------------------------------------------------------
-//        Mlxlink enumerations
+//        Mlxlink commands enumerations
 enum OPTION_TYPE {
     SHOW_PDDR = 1,
     SHOW_PCIE,
@@ -284,6 +248,7 @@ enum OPTION_TYPE {
     CABLE_EEPROM_WRITE,
     CABLE_EEPROM_READ,
     SEND_BER_COLLECT,
+    SEND_AMBER_COLLECT,
     SEND_PAOS,
     SEND_PTYS,
     SEND_PPLM,
@@ -374,13 +339,14 @@ public:
             u_int32_t width, bool spect2WithGb);
     int handleIBLocalPort(u_int32_t labelPort, bool ibSplitReady);
     int handleEthLocalPort(u_int32_t labelPort, bool spect2WithGb);
-    void handleLabelPorts(std::vector<string> labelPortsStr);
+    void handleLabelPorts(std::vector<string> labelPortsStr, bool skipException = false);
     vector<string> localToPortsPerGroup(vector<u_int32_t> localPorts);
     u_int32_t getPortGroup(u_int32_t localPort);
 
     //Mlxlink query functions
     virtual void showModuleInfo();
     void prepareBerModuleInfoNdr(bool valid);
+    virtual void runningVersion();
     virtual void operatingInfoPage();
     virtual void supportedInfoPage();
     virtual void troubInfoPage();
@@ -397,6 +363,7 @@ public:
     virtual void showExternalPhy();
     void showPcie();
     void showPcieLinks();
+    void collectAMBER();
     void collectBER();
     virtual void showTxGroupMapping();
 
@@ -471,6 +438,7 @@ public:
     void writeCableEEPROM();
     void readCableEEPROM();
 
+    MlxlinkCmdPrint _toolInfoCmd;
     MlxlinkCmdPrint _operatingInfoCmd;
     MlxlinkCmdPrint _supportedInfoCmd;
     MlxlinkCmdPrint _troubInfoCmd;
@@ -588,6 +556,7 @@ public:
     bool _isPam4Speed;
     bool _ignorePortType;
     bool _lanesLockStatus;
+    bool _ignorePortStatus;
     std::vector<std::string> _ptysSpeeds;
     std::vector<PortGroup> _localPortsPerGroup;
     std::vector<DPN> _validDpns;

--- a/mlxlink/modules/printutil/mlxlink_record.h
+++ b/mlxlink/modules/printutil/mlxlink_record.h
@@ -94,6 +94,7 @@ enum STATUS_DDM_FLAGS_TYPE {
 /*
  * Records size
  */
+#define TOOL_INFORMAITON_INFO_LAST      4
 #define PDDR_OPERATIONAL_INFO_LAST      7
 #define PDDR_SUPPORTED_INFO_LAST        2
 #define PDDR_TRUOBLESHOOTING_INFO_LAST  4
@@ -106,7 +107,7 @@ enum STATUS_DDM_FLAGS_TYPE {
 #define TEST_MODE_BER_INFO_LAST         4
 #define MPCNT_PERFORMANCE_INFO_LAST     4
 #define MPCNT_TIMER_INFO_LAST           1
-#define EYE_OPENING_INFO_LAST           3
+#define EYE_OPENING_INFO_LAST           8
 #define FEC_CAP_INFO_LASE               5
 #define DEVICE_INFO_LAST                5
 #define BER_MONITOR_INFO_LAST           2


### PR DESCRIPTION
Description:
Adding new flag (amber_collect) for 16 and 7 nm devices.
This flag will be used instead of (ber_collect) for these devices

Issue: 2633033
Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>