### PR TITLE
[mstflint] [--enable-adb-generic-tools] build broken

### DIFF
--- a/adb_parser/adb_parser.cpp
+++ b/adb_parser/adb_parser.cpp
@@ -850,8 +850,6 @@ void AdbParser::startConfigElement(const XML_Char **atts, AdbParser *adbParser, 
                                   ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
                                   ExceptionHolder::FATAL_EXCEPTION);
     }
-    return true;
-}
 
     adbParser->_currentConfig = new AdbConfig;
     for (int i = 0; i < attrCount(atts); i++)


### PR DESCRIPTION
Description:

fixed an error with the merge of previous pull requests which caused the compilation of adb_parser to fail.

Tested OS:linux
Tested devices:none
Tested flows:

./autogen.sh
./configure --enable-adb-generic-tools
make

Known gaps (with RM ticket): None

Issue:2839525