### PR TITLE
[mstflint] build broken when using --disabl-openssl

### DIFF
--- a/flint/flint.cpp
+++ b/flint/flint.cpp
@@ -181,7 +181,9 @@ map_sub_cmd_t_to_subcommand Flint::initSubcommandMap()
     cmdMap[SC_RSA_Sign] = new SignRSASubCommand();
     cmdMap[SC_Binary_Compare] = new  BinaryCompareSubCommand();
     cmdMap[SC_Import_Hsm_Key] = new  ImportHsmKeySubCommand();
+#ifndef NO_OPEN_SSL
     cmdMap[SC_Export_Public_Key] = new ExportPublicSubCommand();
+#endif
     return cmdMap;
 }
 

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -54,6 +54,15 @@
     #endif
 #endif
 
+//declaration only to enable compilation when NO_OPEN_SSL
+//of signForFwUpdateUsingHSM(...), signForSecureBootUsingHSM(...) which decelare OpensslEngineSigner in argument.
+#ifdef NO_OPEN_SSL
+namespace MlxSign
+{
+class OpensslEngineSigner;
+}
+#endif
+
 typedef f_prog_func_str VerifyCallBack;
 typedef f_prog_func ProgressCallBack;
 typedef f_prog_func_ex ProgressCallBackEx;


### PR DESCRIPTION
Description:

fixed compilation error caused by latest pull requests when compiliing with disabled openssl

Tested OS:Linux
Tested devices:None
Tested flows:
./autogen.sh
./configure --disable-openssl
make

Known gaps (with RM ticket): None

Issue:2839278