### PR TITLE
fix compilation error when using old GNU Make versions (V3.82).

### DIFF
--- a/mlxconfig/mlxcfg_parser.cpp
+++ b/mlxconfig/mlxcfg_parser.cpp
@@ -351,11 +351,11 @@ mlxCfgStatus MlxCfg::extractSetCfgArgs(int argc, char *argv[])
 Device_Type MlxCfg::getDeviceTypeFromString(string inStr){
     mft_utils::to_lowercase(inStr);
     if (inStr == "switch") {
-        return Device_Type::Switch;
+        return Switch;
     }else if (inStr == "hca") {
-        return Device_Type::HCA;
+        return HCA;
     }else{
-        return Device_Type::UNSUPPORTED_DEVICE;
+        return UNSUPPORTED_DEVICE;
     }
 }
 
@@ -380,7 +380,7 @@ mlxCfgStatus MlxCfg::parseArgs(int argc, char *argv[])
                 return err(true, "missing device type");
             }
             Device_Type dType = getDeviceTypeFromString(argv[i]);
-            if (dType == Device_Type::UNSUPPORTED_DEVICE) {
+            if (dType == UNSUPPORTED_DEVICE) {
                 return err(true, "Unsupported device name given, please specify \"switch\" or \"hca\" device type");
             }
             _mlxParams.deviceType = dType;

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -1100,7 +1100,7 @@ mlxCfgStatus MlxCfg::genTLVsFile()
     mlxCfgStatus rc = MLX_CFG_OK;
 
     try {
-        GenericCommander commander(NULL, _mlxParams.dbName,_mlxParams.deviceType == Device_Type::Switch);
+        GenericCommander commander(NULL, _mlxParams.dbName,_mlxParams.deviceType == Switch);
         commander.genTLVsList(tlvs);
         VECTOR_ITERATOR(string, tlvs, it) {
             sprintf(buff, "%-50s0\n", it->c_str());
@@ -1165,7 +1165,7 @@ mlxCfgStatus MlxCfg::genXMLTemplate()
     }
 
     try {
-        GenericCommander commander(NULL, _mlxParams.dbName,_mlxParams.deviceType == Device_Type::Switch);
+        GenericCommander commander(NULL, _mlxParams.dbName,_mlxParams.deviceType == Switch);
         commander.genXMLTemplate(tlvs, xmlTemplate, _mlxParams.allAttrs);
     } catch (MlxcfgException& e) {
         printf("-E- %s\n", e._err.c_str());
@@ -1199,7 +1199,7 @@ mlxCfgStatus MlxCfg::raw2XMLAux(bool isBin)
     EXIT_IF_RC_NOT_OK(rc)
 
     try {
-        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Device_Type::Switch);
+        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Switch);
         if (isBin) {
             //commander.bin2XML(buff, xmlTemplate);
         } else {
@@ -1241,7 +1241,7 @@ mlxCfgStatus MlxCfg::XML2RawAux(bool isBin)
     EXIT_IF_RC_NOT_OK(rc)
 
     try {
-        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Device_Type::Switch);
+        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Switch);
         if (isBin) {
             commander.XML2Bin(xml, binBuff, false);
         } else {
@@ -1291,7 +1291,7 @@ mlxCfgStatus MlxCfg::createConf()
     EXIT_IF_RC_NOT_OK(rc)
 
     try {
-        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Device_Type::Switch);
+        GenericCommander commander(NULL, _mlxParams.dbName, _mlxParams.deviceType == Switch);
         commander.createConf(xml, buff);
         if (!_mlxParams.privPemFile.empty() &&
             !_mlxParams.keyPairUUID.empty()) {


### PR DESCRIPTION
Description:
remove the name qualifier in mlxconfig, when using the enum "device_type"

Tested OS: ppc64
Tested devices: None
Tested flows:

git clone ...
git checkout master_devel
autogen.sh
configure
make

Known gaps (with RM ticket): None

Issue: 2848241