### PR TITLE
fix compilation errors which came from PR#454 (4.18 alignment)

### DIFF
--- a/adb_parser/adb_db.cpp
+++ b/adb_parser/adb_db.cpp
@@ -73,7 +73,7 @@ adb_db_t* db_create()
  */
 int db_load(adb_db_t *db, const char *adb_file_path, int add_reserved)
 {
-    if (!((Adb*)db)->load(adb_file_path, add_reserved, NULL, false)) {
+    if (!((Adb*)db)->load(adb_file_path, add_reserved, false)) {
         sprintf(err, "Failed to load adabe project: %s", ((Adb*)db)->getLastError().c_str());
         return 1;
     }
@@ -86,7 +86,7 @@ int db_load(adb_db_t *db, const char *adb_file_path, int add_reserved)
  */
 int db_load_from_str(adb_db_t *db, const char *adb_data, int add_reserved)
 {
-    if (!((Adb*)db)->loadFromString(adb_data, add_reserved, NULL, false)) {
+    if (!((Adb*)db)->loadFromString(adb_data, add_reserved, false)) {
         sprintf(err, "Failed to load adabe project: %s", ((Adb*)db)->getLastError().c_str());
         return 1;
     }
@@ -151,7 +151,7 @@ void db_destroy_limits_map(adb_limits_map_t *limits)
 adb_node_t* db_get_node(adb_db_t *db, const char *node_name)
 {
     Adb *adb = (Adb*)db;
-    AdbInstance *node = adb->createLayout(node_name, false, NULL);
+    AdbInstance *node = adb->createLayout(node_name, false);
     if (!node) {
         sprintf(err, "Failed to create node %s: %s", node_name, adb->getLastError().c_str());
         return NULL;

--- a/adb_parser/adb_parser.h
+++ b/adb_parser/adb_parser.h
@@ -58,7 +58,6 @@ class LogFile;
 #include "adb_exceptionHolder.h"
 #include "adb_logfile.h"
 #include "adb_config.h"
-#include "adb_progress.h"
 #include "adb_instance.h"
 #include <stdio.h>
 #include <stdlib.h>
@@ -132,10 +131,10 @@ public:
     //   2- contains nodes only
     //   3- check node size vs instance size
     bool loadFromString(const char *adbContents, bool addReserved = false,
-            AdbProgress *progressObj = NULL, bool strict = true,
+            bool strict = true,
             bool enforceExtraChecks = false);
     bool load(string fname, bool addReserved = false,
-            AdbProgress *progressObj = NULL, bool strict = true,
+            bool strict = true,
             string includePath = "", string includeDir = "",
             bool enforceExtraChecks = false, bool getAllExceptions = false,
             string logFile = "");
@@ -144,8 +143,7 @@ public:
             string addPrefix = "");
 
     AdbInstance* addMissingNodes(int depth, bool allowMultipleExceptions);
-    AdbInstance* createLayout(string rootNodeName, bool isExprEval = false,
-            AdbProgress *progressObj = NULL, int depth = -1, /* -1 means instantiate full tree */
+    AdbInstance* createLayout(string rootNodeName, bool isExprEval = false, int depth = -1, /* -1 means instantiate full tree */
             bool ignoreMissingNodes = false, bool getAllExceptions = false);
     vector<string> getNodeDeps(string nodeName);
     string getLastError();
@@ -181,7 +179,7 @@ public:
 private:
     vector<AdbInstance*> createInstance(AdbField *fieldDesc,
             AdbInstance *parent, map<string, string> vars, bool isExprEval,
-            AdbProgress *progressObj, int depth,
+            int depth,
             bool ignoreMissingNodes = false, bool getAllExceptions = false);
     u_int32_t calcArrOffset(AdbField *fieldDesc, AdbInstance *parent,
             u_int32_t arrIdx);

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -1609,7 +1609,7 @@ void MlxlinkCommander::runningVersion()
     setPrintVal(_toolInfoCmd,"Firmware Version", _fwVersion, ANSI_COLOR_GREEN,true, !_prbsTestMode);
     setPrintVal(_toolInfoCmd,"amBER Version", AMBER_VERSION, ANSI_COLOR_GREEN,
                 _productTechnology >= PRODUCT_16NM, !_prbsTestMode);
-    setPrintVal(_toolInfoCmd,"MFT Version", MFT_VERSION_STR, ANSI_COLOR_GREEN,true, !_prbsTestMode);
+    setPrintVal(_toolInfoCmd,"MFT Version", MSTFLINT_VERSION_STR, ANSI_COLOR_GREEN,true, !_prbsTestMode);
 }
 
 void MlxlinkCommander::operatingInfoPage()

--- a/mlxreg/mlxreg_lib.cpp
+++ b/mlxreg/mlxreg_lib.cpp
@@ -136,7 +136,7 @@ void MlxRegLib::initAdb(string extAdbFile)
 {
     _adb = new Adb();
     if (extAdbFile != "") {
-        if (!_adb->load(extAdbFile, false, NULL, false)) {
+        if (!_adb->load(extAdbFile, false, false)) {
             throw MlxRegException("Failure in loading Adabe file. %s", _adb->getLastError().c_str());
         }
     } else {


### PR DESCRIPTION
Description:
fixed compilation errors related to --enable-adb-generic-tools configuration

Tested OS: ppc64 RH7 , Linux64 RH8
Tested devices:None
Tested flows:
clone mstflint from github
git checkout master_devel
./autogen.sh
./configure --enable-adb-generic-tools
make

Known gaps (with RM ticket): None

Issue:2839525