### PR TITLE
[Huwei]MFT mlxlink cable ddm print bug - also in mstflint

### DIFF
--- a/mlxlink/modules/mlxlink_cables_commander.cpp
+++ b/mlxlink/modules/mlxlink_cables_commander.cpp
@@ -174,7 +174,7 @@ void MlxlinkCablesCommander::getDdmValuesFromPddr()
 
     _cableDdm.channels = _numOfLanes;
     _cableDdm.temperature.val = getFieldValue("temperature") / 256;
-    _cableDdm.voltage.val = getFieldValue("voltage") / 10;
+    _cableDdm.voltage.val = getFieldValue("voltage") / 10; // convert to mVolts
 
     string laneStr = "";
     for (int lane = 0; lane < _cableDdm.channels; lane++) {
@@ -655,7 +655,7 @@ void MlxlinkCablesCommander::prepareDDMOutput()
     sprintf(strBuff, "%dC", (int)_cableDdm.temperature.val);
     setPrintVal(cableDDMCmd, "Temperature", strBuff, ANSI_COLOR_RESET, true);
 
-    sprintf(strBuff, "%.4fV", ((double)_cableDdm.voltage.val) / 10000);
+    sprintf(strBuff, "%.4fV", ((double)_cableDdm.voltage.val) / 1000); // convert to Volts
     setPrintVal(cableDDMCmd, "Voltage", strBuff, ANSI_COLOR_RESET, true);
 
     int i = 0;


### PR DESCRIPTION
Description:
mlxlink cable voltage incorrect, divide by 10 error

Tested OS: Centos7.9, Ubuntu 20.04
Tested devices: CX5, CX6DX
Tested flows: mlxlink
Known gaps (with RM ticket): NA

Issue: 284430

Change-Id: Ie6e972190e3b6777cac4322105501868b6179a95