### PR TITLE
[Huwei]MFT mlxlink cable ddm print bug - also in mstflint

### DIFF
--- a/mlxlink/modules/mlxlink_cables_commander.cpp
+++ b/mlxlink/modules/mlxlink_cables_commander.cpp
@@ -174,7 +174,7 @@ void MlxlinkCablesCommander::getDdmValuesFromPddr()
 
     _cableDdm.channels = _numOfLanes;
     _cableDdm.temperature.val = getFieldValue("temperature") / 256;
-    _cableDdm.voltage.val = getFieldValue("voltage") / 10;
+    _cableDdm.voltage.val = getFieldValue("voltage") / MILLIVOLT_UNIT;
 
     string laneStr = "";
     for (int lane = 0; lane < _cableDdm.channels; lane++) {
@@ -655,7 +655,7 @@ void MlxlinkCablesCommander::prepareDDMOutput()
     sprintf(strBuff, "%dC", (int)_cableDdm.temperature.val);
     setPrintVal(cableDDMCmd, "Temperature", strBuff, ANSI_COLOR_RESET, true);
 
-    sprintf(strBuff, "%.4fV", ((double)_cableDdm.voltage.val) / 10000);
+    sprintf(strBuff, "%.4fV", ((double)_cableDdm.voltage.val) / VOLT_UNIT);
     setPrintVal(cableDDMCmd, "Voltage", strBuff, ANSI_COLOR_RESET, true);
 
     int i = 0;

--- a/mlxlink/modules/mlxlink_cables_commander.h
+++ b/mlxlink/modules/mlxlink_cables_commander.h
@@ -79,6 +79,9 @@ typedef struct {
 #define EXTENDED_PAGES_13_14_ADDR       142
 #define EXTENDED_PAGES_13_14_MASK       0x20
 
+#define VOLT_UNIT 1000
+#define MILLIVOLT_UNIT 10
+
 typedef struct Page{
     u_int32_t page;
     u_int16_t offset;


### PR DESCRIPTION
Description:
mlxlink cable voltage incorrect, divide by 10 error

Tested OS: Centos7.9, Ubuntu 20.04
Tested devices: CX5, CX6DX

Issue: 2845430