### PR TITLE
fix undefined symbol error in mstfwtrace

### DIFF
--- a/mtcr_py/mtcr.py
+++ b/mtcr_py/mtcr.py
@@ -84,8 +84,6 @@ if CMTCR:
             self.mwrite4BlockFunc = CMTCR.mwrite4_block
             self.icmdSendCommandFunc = CMTCR.icmd_send_command
             self.mHcaResetFunc = CMTCR.mhca_reset
-            self.mreadi2cblockFunc = CMTCR.mread_i2cblock
-            self.mwritei2cblockFunc = CMTCR.mwrite_i2cblock
             self.mseti2cslaveFunc = CMTCR.mset_i2c_slave
             self.mseti2caddrwidthFunc = CMTCR.mset_i2c_addr_width
 


### PR DESCRIPTION
Description:
during cleanup in mtcr we removed 2 unimplemented functions, a call to those functions was left out and caused that error.

Issue: 2849868