### PR TITLE
[mstlink] Fixing amber_collect for Quantum while split ready

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -134,15 +134,6 @@ void MlxlinkAmBerCollector::startCollector()
         _labelPort = it->labelPort;
         _splitPort = it->split;
         _secondSplit = it->secondSplit;
-        if (_devID == DeviceQuantum2) { // convert panel port to cage/port
-            _labelPort = _labelPort % 2 == 0 ? (_labelPort / 2)
-                                             : (_labelPort / 2) + 1;
-
-            if (_secondSplit) { // convert split panel port to cage/port/split
-                _labelPort = _labelPort % 2 == 0 ? (_labelPort / 2)
-                                                 : (_labelPort / 2) + 1;
-            }
-        }
 
         init();
         collect();
@@ -320,7 +311,7 @@ vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
          */
         labelPortStr += "/" + to_string(_splitPort);
     }
-    if (_devID == DeviceQuantum2 && _secondSplit) {
+    if ((_secondSplit && _secondSplit != 1) && _devID == DeviceQuantum2) {
         labelPortStr += "/" + to_string(_secondSplit);
     }
     fields.push_back(AmberField("Port Number", labelPortStr + "(" +
@@ -412,7 +403,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
         updateField("local_port", _localPort);
         updateField("page_select", PDDR_MODULE_INFO_PAGE);
         sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
-        fields.push_back(AmberField("Module Temp", getTemp(getFieldValue("temperature"), !_isPortPCIE)));
+        fields.push_back(AmberField("Module Temp", getTemp(getFieldValue("temperature")), !_isPortPCIE));
 
     } catch (const std::exception &exc) {
         throw MlxRegException(

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -946,7 +946,10 @@ int MlxlinkCommander::handleIBLocalPort(u_int32_t labelPort, bool ibSplitReady)
 {
     string regName = "PLIB";
     int targetLocalPort = -1;
-    if (_devID == DeviceQuantum2) {
+    if ((_devID == DeviceQuantum2 || (_devID == DeviceQuantum && ibSplitReady))) {
+        labelPort = 2 * labelPort - 1;
+    }
+    if (_devID == DeviceQuantum2 && ibSplitReady) {
         labelPort = 2 * labelPort - 1;
     }
     for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
@@ -1043,34 +1046,36 @@ void MlxlinkCommander::fillIbPortGroupMap(u_int32_t localPort,u_int32_t labelPor
         u_int32_t group, bool splitReady)
 {
     if (splitReady) {
+        labelPort = (labelPort + 1) / 2;
         if (_devID == DeviceQuantum) {
             if (isIbLocalPortValid(localPort+1)) {
                 _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
                 _localPortsPerGroup.push_back(PortGroup(localPort+1, labelPort, group, 2));
             } else {
-                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
+                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
             }
         } else if (_devID == DeviceQuantum2) {
-            labelPort = labelPort * 2; // change labelPort mapping if split ready
+            labelPort = (labelPort / 2) + 1;
             if (isIbLocalPortValid(localPort+1)) {
-                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort-1, group, 1, 1));
+                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1, 1));
                 _localPortsPerGroup.push_back(PortGroup(localPort+1, labelPort, group, 1, 2));
             } else {
-                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort-1, group, 1, 1));
+                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1, 1));
             }
             if (isIbLocalPortValid(localPort+3)) {
-                _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort+1, group, 2, 1));
-                _localPortsPerGroup.push_back(PortGroup(localPort+3, labelPort+2, group, 2, 2));
+                _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort, group, 2, 1));
+                _localPortsPerGroup.push_back(PortGroup(localPort+3, labelPort, group, 2, 2));
             } else {
-                _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort+1, group, 1, 1));
+                _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort, group, 2, 1));
             }
         }
     } else {
         if (_devID == DeviceQuantum) {
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
         } else if (_devID == DeviceQuantum2) {
+            labelPort = (labelPort / 2) + 1;
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
-            _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort+1, group, 2));
+            _localPortsPerGroup.push_back(PortGroup(localPort+2, labelPort, group, 2));
         }
     }
 }


### PR DESCRIPTION
Fixing amber_collect for Quantum switch while split ready

Tested OS: Linux64
Tested devices: Quantum
Tested flows: mstlink amber collector

Known gaps (with RM ticket): NA

Issue: 2850001