### PR TITLE
[dev_mgt] added a non-print version of dm_get_dev_id func

### DIFF
--- a/dev_mgt/tools_dev_types.h
+++ b/dev_mgt/tools_dev_types.h
@@ -160,6 +160,11 @@ int dm_get_device_id(mfile *mf,
                      u_int32_t *ptr_dev_id,
                      u_int32_t *ptr_chip_rev);
 
+int dm_get_device_id_without_prints(mfile *mf,
+                                    dm_dev_id_t *ptr_dm_dev_id,
+                                    u_int32_t *ptr_hw_dev_id,
+                                    u_int32_t *ptr_hw_rev);
+
 /**
  * Returns 0 on success and 1 on failure.
  */


### PR DESCRIPTION
to avoid unwanted error prints in mst status