### PR TITLE
[mstflint] print not required error message when openssl version not supported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,13 +52,13 @@ AC_PROG_LIBTOOL
 AC_CONFIG_HEADERS( config.h )
 
 # OPENSSL_VERSION_NUMBER < 0x100020bf
-#0x100020bfL = OpenSSL 1.0.2k-fips  26 Jan 2017
-MIN_OPENSSL_VER="1.0.2k-fips"
+#0x100020bfL = OpenSSL 1.0.2k - 26 Jan 2017
+MIN_OPENSSL_VER="1.0.2k"
 AC_COMPILE_IFELSE(
       [AC_LANG_PROGRAM([[
 #include <openssl/ssl.h>
 #if OPENSSL_VERSION_NUMBER < 0x100020bf
-  ERROR: OPENSSL_VERSION_NUMBER version must be >= 0x100020bf ("OpenSSL 1.0.2k-fips  26 Jan 2017")
+  ERROR: OPENSSL_VERSION_NUMBER version must be >= 0x100020bf ("OpenSSL 1.0.2k - 26 Jan 2017")
 #endif
 ]])], [OPENSSL_VERSION_VALID=yes], [OPENSSL_VERSION_VALID=no])
 OS=$(uname -s)


### PR DESCRIPTION
Description:
the fips module is not actually required and is not part of the minimal version check.
removed the mention of fips module from the massage

Issue: 2872291