### PR TITLE
fail downaload files from mellanox server

### DIFF
--- a/mlxfwupdate/mlxfwmanager.cpp
+++ b/mlxfwupdate/mlxfwmanager.cpp
@@ -2256,17 +2256,16 @@ int handleDownloadRequest(ServerRequest *srq, CmdLineParams &cmd_params, config_
             currentMenu->generateMenu(cmd_params, filterOPtions);
             if (currentMenu->isValid(cmd_params, filterOPtions)) {
                 std::istringstream iss(getline());
-                iss >> choice >> std::ws;
+                iss.clear();
+                iss >> choice;
                 if (!iss.eof()) {
                     sleep(1);
                     invalid = true;
                 }
-                #if !defined(__FreeBSD__) && !(defined(_MSC_VER) && defined(_ARM64_))
                 if (iss.fail()) {
                     sleep(1);
                     invalid = true;
                 }
-                #endif
                 print_out("\n");
             } else {
                 aNewmenu = currentMenu->getNextMenu(cmd_params, filterOPtions);


### PR DESCRIPTION
Description:
The parser was looking for a number followed by a whitespace.
in some OS giving just a number would count as pass but in the case of WINPE (and also windows arm)
not getting the full parse raised the error flag.

code was updated to expect a number only. (trailing whitespace are still acceptable based on testing)

Tested OS: linux (apps-104), windows ARM(winqa-arm-014)
Tested devices:None
Tested flows:
run the command "mlxfwmanager --download C:\tmp" with the following outputs:

3 - pass
a - invalid
3a - invalid
a3 - invalid
  3 - pass
3   - invalid

Known gaps (with RM ticket): None

Issue: 2883937
Change-Id: I4e8a4552abe8a0b3e42575f6ec12d372f93bb2f3
Signed-off-by: Tomer Tubi <ttubi@nvidia.com>