### PR TITLE
Skip MAIN CRCs removal in case MAIN doesn't exist for fw update sign flow

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -471,13 +471,16 @@ bool Fs4Operations::verifyTocHeader(u_int32_t tocAddr, bool isDtoc, VerifyCallBa
 */
 void Fs4Operations::RemoveCRCsFromMainSection(vector<u_int8_t>& img) {
     //* Get MAIN section ITOC entry
-    struct fs4_toc_info *main_itoc_entry = NULL;
+    struct fs4_toc_info* main_itoc_entry = NULL;
     fs4_toc_info *itoc_entries = _fs4ImgInfo.itocArr.tocArr;
     for (int i = 0; i < _fs4ImgInfo.itocArr.numOfTocs; i++) {
         if (itoc_entries[i].toc_entry.type == FS3_MAIN_CODE) {
             main_itoc_entry = &(itoc_entries[i]);
             break;
         }
+    }
+    if (main_itoc_entry == NULL) {
+        return;
     }
 
     u_int32_t main_addr = main_itoc_entry->toc_entry.flash_addr << 2; // addr in entry is in DW


### PR DESCRIPTION
Description: In case of minimized image we don't have MAIN section, so
we need to skip RemoveCRCsFromMainSection

Tested OS: N/A
Tested devices: N/A
Tested flows: N/A

Known gaps (with RM ticket): N/A

Issue: 2928610
Change-Id: I5033eb48ea9ce0b0e8c6fd24f586320ddbf0c02e

Signed-off-by: Matan Eliyahu <matanel@nvidia.com>