### PR TITLE
burn-tools 2 bug fixes related to encrypted image burning

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -2786,10 +2786,12 @@ int mf_update_boot_addr(mflash *mfl, u_int32_t boot_addr)
     case DeviceQuantum2:
         boot_cr_space_address = 0xf1000;
         offset_in_address = 0;
+        break;
     case DeviceConnectX7:
     case DeviceBlueField3:
         boot_cr_space_address = 0xf2000;
         offset_in_address = 0;
+        break;
     default:
         return MFE_UNSUPPORTED_DEVICE;
     }

--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -2120,7 +2120,7 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
     }
 
     //* Get image size without signature
-    total_img_size += imgBuff.size() - FS3_FW_SIGNATURE_SIZE;
+    total_img_size += imgBuff.size();
     DPRINTF(("Fs4Operations::burnEncryptedImage - image size to burn = 0x%x\n", (u_int32_t)imgBuff.size()));
 
     //* Burn
@@ -2141,6 +2141,7 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
     {
         return errmsg("Failed to burn encrypted image\n");
     }
+    alreadyWrittenSz += imgBuff.size() - FS3_FW_SIGNATURE_SIZE;
 
     if (burnParams.useImgDevData) {
         //* Burning DTOC
@@ -2204,6 +2205,8 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
     {
         return errmsg("Failed to burn encrypted image signature\n");
     }
+    alreadyWrittenSz += FS3_FW_SIGNATURE_SIZE;
+
     return DoAfterBurnJobs(_fs4_magic_pattern, burnParams, (Flash*)(this->_ioAccess),
                            new_image_start_addr, log2_chunk_size);
 }

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -413,7 +413,6 @@ protected:
     #define FS3_IND_ADDR 0x24
     #define FS4_IND_ADDR 0x10
     #define ARR_SIZE(arr) sizeof(arr) / sizeof(arr[0])
-    #define RESTORING_MSG "Restoring signature"
 
     struct FwImgInfo {
         fw_info_com_t ext_info;


### PR DESCRIPTION
1. Fix burning progress percentage
2. Remove false warning message for Quantum2 and CX7