### PR TITLE
remove shebang line from mstfwtrace.py

### DIFF
--- a/tracers/fwtrace/mstfwtrace.py
+++ b/tracers/fwtrace/mstfwtrace.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# --
-# 
 # Copyright (c) 2019-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # 
 # This software is available to you under a choice of one of two
@@ -30,7 +27,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
 # --
 
 


### PR DESCRIPTION
script should run from python wrapper which decide on what python version to run