### PR TITLE
Install wrapped python scripts non-executable

### DIFF
--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -61,7 +61,7 @@ ${MLXPRIVHOST_PYTHON_WRAPPER}: $(PYTHON_WRAPPER_SCRIPT)
 	cp $(PYTHON_WRAPPER_SCRIPT) $@
 
 mlxprivhostlibdir=$(libdir)/mstflint/python_tools/$(MLXPRIVHOST_PYTHON_WRAPPER)
-mlxprivhostlib_SCRIPTS = $(MLXPRIVHOST_PYTHON_WRAPPER).py
+mlxprivhostlib_DATA = $(MLXPRIVHOST_PYTHON_WRAPPER).py
 
 noinst_LTLIBRARIES = libmlxcfg.a
 

--- a/resourcedump/Makefile.am
+++ b/resourcedump/Makefile.am
@@ -39,8 +39,7 @@ PYTHON_WRAPPER_SCRIPT=$(USER_DIR)/common/python_wrapper
 ${PYTHON_WRAPPER}: $(PYTHON_WRAPPER_SCRIPT)
 	cp $(PYTHON_WRAPPER_SCRIPT) $@
 pythonlibdir=$(libdir)/mstflint/python_tools/mstresourcedump
-dist_pythonlib_SCRIPTS = mstresourcedump.py
-dist_pythonlib_DATA = __init__.py
+dist_pythonlib_DATA = __init__.py mstresourcedump.py
 validationpythonlibdir=$(libdir)/mstflint/python_tools/mstresourcedump/validation
 dist_validationpythonlib_DATA = validation/*.py
 utilspythonlibdir=$(libdir)/mstflint/python_tools/mstresourcedump/utils

--- a/resourceparse/Makefile.am
+++ b/resourceparse/Makefile.am
@@ -39,8 +39,7 @@ PYTHON_WRAPPER_SCRIPT=$(USER_DIR)/common/python_wrapper
 ${PYTHON_WRAPPER}: $(PYTHON_WRAPPER_SCRIPT)
 	cp $(PYTHON_WRAPPER_SCRIPT) $@
 pythonlibdir=$(libdir)/mstflint/python_tools/mstresourceparse
-dist_pythonlib_SCRIPTS = mstresourceparse.py
-dist_pythonlib_DATA = __init__.py
+dist_pythonlib_DATA = __init__.py mstresourceparse.py
 parserspythonlibdir=$(libdir)/mstflint/python_tools/mstresourceparse/parsers
 dist_parserspythonlib_DATA = parsers/*.py
 utilspythonlibdir=$(libdir)/mstflint/python_tools/mstresourceparse/utils

--- a/small_utils/Makefile.am
+++ b/small_utils/Makefile.am
@@ -80,5 +80,5 @@ mstfwresetlibdir=$(libdir)/mstflint/python_tools/$(MSTFWRESET_PYTHON_WRAPPER)
 mlxpcilibdir=$(libdir)/mstflint/python_tools/mlxpci
 mlxpcilib_DATA = binary_file.py mlxpci_lib.py
 
-mstfwresetlib_SCRIPTS = $(MSTFWRESET_PYTHON_WRAPPER).py
+mstfwresetlib_DATA = $(MSTFWRESET_PYTHON_WRAPPER).py
 


### PR DESCRIPTION
Python scripts that should not be executed directly should not be
installed executable ("DATA", as opposed to executable "SCRIPTS", in
automake's terminology).

Bug: https://github.com/Mellanox/mstflint/issues/281
Signed-off-by: Tzafrir Cohen <mellanox@cohens.org.il>