### PR TITLE
Fixing PMLP field access according to the PRM

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -214,8 +214,8 @@ void MlxlinkAmBerCollector::init()
             updateField("local_port", _localPort);
             genBuffSendRegister(ACCESS_REG_PMLP, MACCESS_REG_METHOD_GET);
 
-            _moduleIndex = getFieldValue("lane0_module_mapping.module");
-            _slotIndex = getFieldValue("lane0_module_mapping.slot_index");
+            _moduleIndex = getFieldValue("module_0");
+            _slotIndex = getFieldValue("slot_index_0");
         } else {
             resetParser(ACCESS_REG_MPEIN);
             updateField("pcie_index", _pcieIndex);

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -383,7 +383,7 @@ void MlxlinkCommander::validatePortToLC()
     updateField("local_port", _localPort);
     genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
 
-    u_int32_t slotIndex = getFieldValue("lane0_module_mapping.slot_index");
+    u_int32_t slotIndex = getFieldValue("slot_index_0");
 
     try {
         regName = "MDDQ";
@@ -641,7 +641,7 @@ void MlxlinkCommander::labelToSpectLocalPort()
             continue;
         }
         splitAdjustment = 0;
-        if ((getFieldValue("lane0_module_mapping.module") + 1)  == _userInput._labelPort) {
+        if ((getFieldValue("module_0") + 1)  == _userInput._labelPort) {
             checkWidthSplit();
             if (_userInput._splitProvided) {
                 if (_devID == DeviceSpectrum3 || _devID == DeviceSpectrum4 ||
@@ -665,7 +665,7 @@ void MlxlinkCommander::labelToSpectLocalPort()
             }
             updateField("local_port", _localPort);
             genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
-            if ((getFieldValue("lane0_module_mapping.module") + 1) == _userInput._labelPort) {
+            if ((getFieldValue("module_0") + 1) == _userInput._labelPort) {
                 return;
             }
         }
@@ -888,7 +888,7 @@ void MlxlinkCommander::getCableParams()
         resetParser(regName);
         updateField("local_port", _localPort);
         genBuffSendRegister(regName, MACCESS_REG_METHOD_GET);
-        _moduleNumber = getFieldValue("lane0_module_mapping.module");
+        _moduleNumber = getFieldValue("module_0");
     } catch (const std::exception &exc) {
         _allUnhandledErrors += string("Getting cable parameters via PDDR raised the following exception: ") + string(exc.what()) + string("\n");
     }
@@ -1023,7 +1023,7 @@ int MlxlinkCommander::handleEthLocalPort(u_int32_t labelPort, bool spect2WithGb)
         if (getFieldValue("width") == 0) {
             continue;
         }
-        if (getFieldValue("lane0_module_mapping.module") + 1
+        if (getFieldValue("module_0") + 1
                 == labelPort) {
             targetLocalPort = localPort;
             fillEthPortGroupMap(localPort, labelPort, _userInput._setGroup,
@@ -1147,7 +1147,7 @@ vector<string> MlxlinkCommander::localToPortsPerGroup(vector<u_int32_t> localPor
             if (getFieldValue("width") == 0) {
                 continue;
             }
-            labelPort = (getFieldValue("lane0_module_mapping.module")) + 1;
+            labelPort = (getFieldValue("module_0")) + 1;
         } else if (_devID == DeviceQuantum || _devID == DeviceQuantum2) {
             regName = "PLIB";
             resetParser(regName);


### PR DESCRIPTION
Description:
PRM change the fields accessto array, so tool changed according that

Tested OS: Linux64
Tested devices: SPC2, SPC3
Tested flows: mlxlink commands

Known gaps (with RM ticket): NA

Issue: 2917956
Issue: 2937749

Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>