### PR TITLE
fix offset/size adb fields parsing

### DIFF
--- a/resourceparse/parsers/AdbParser.py
+++ b/resourceparse/parsers/AdbParser.py
@@ -288,16 +288,15 @@ class AdbParser:
         """
         hex_size = 0
         bit_size = 0
+        size_parts = size_str.split(".")
 
-        if "." in size_str:
-            # hex size is in bytes, multiply by 8 to convert to bits
-            hex_size = size_str[:size_str.index(".")]
-            bit_size = size_str[size_str.index(".")+1:]
+        if len(size_parts) == 1:
+            size_parts = size_parts[0], "0"
+        if size_parts[0] == "":
+            size_parts[0] = "0"
 
-            hex_size = 0 if len(hex_size) == 0 else int(hex_size, 16) * 8
-            bit_size = 0 if len(size_str[size_str.index("."):]) == 0 else int(bit_size, 10)
-        else:
-            bit_size = int(size_str, 10)
+        hex_size = int(size_parts[0], 16) * 8
+        bit_size = int(size_parts[1], 10)
 
         return hex_size+bit_size
 


### PR DESCRIPTION
Description:

Tested OS: linux
Tested devices: NA
Tested flows: changed offset/size fields in a rp tracked node in .adb file to all valid forms and ran the tool

Known gaps (with RM ticket):

Issue: 2937456
Change-Id: I4191b5050d10da4614bbe4b38743ab8d24ea57a3
Signed-off-by: Alon Strutsovsky <astrutsovsky@nvidia.com>