### PR TITLE
[mstregdump] changing the default value of the full flag to true

### DIFF
--- a/mstdump/crd_main/mstdump.c
+++ b/mstdump/crd_main/mstdump.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     int i;
     mfile *mf;
     int rc;
-    int full = 0;
+    int full = 1;
     int cause_addr = -1, cause_off = -1;
     crd_ctxt_t *context;
     u_int32_t arr_size = 0;


### PR DESCRIPTION
Description:
The 'full' flag default value was changed from false to true,
causing the tool to print out the sp2 addresses as well.

Tested OS: Linux
Tested devices: ConnectX5
Tested flows:

Known gaps (with RM ticket):

Issue: 2979319