### PR TITLE
bugfix, mstdump_pld doesn't dump sp2, where mlxdump mstdump do

### DIFF
--- a/mstdump/crd_lib/crdump.c
+++ b/mstdump/crd_lib/crdump.c
@@ -480,6 +480,7 @@ static int crd_set_tlv_blocks(IN mfile *mf, OUT crd_parsed_csv_t blocks[], IN u_
     {
         blocks[block_number].addr = current_tlv.address;
         blocks[block_number].len = current_tlv.size;
+        strcpy(blocks[block_number].enable_addr, CRD_EMPTY);
 
         block_number++;
         rc = crd_get_tlv_from_address(mf, current_tlv.address, &current_tlv);

--- a/mstdump/crd_main/mstdump.c
+++ b/mstdump/crd_main/mstdump.c
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     int i;
     mfile *mf;
     int rc;
-    int full = 1;
+    int full = 0;
     int cause_addr = -1, cause_off = -1;
     crd_ctxt_t *context;
     u_int32_t arr_size = 0;


### PR DESCRIPTION
Description:
sp2 addresses are not marked as enabled

Tested OS: linux
Tested devices: CX6
Tested flows: dump and check that contains the expected address list

Known gaps (with RM ticket):

Issue: 2979319
Change-Id: I8dbf4176fc69fa899021f42a62fc846830112d30