### PR TITLE
Revert "Since CX7 IB has issues with sending MAD for mgir.fw_info using mad_ifc_general_info_fw() we send regular MGIR"

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -1009,11 +1009,6 @@ reg_access_status_t FwCompsMgr::getGI(mfile *mf, mgirReg *gi)
         if (rc) {
             goto cleanup;
         }
-        if (gi->hw_info.device_id == 4129) {
-            DPRINTF(("FwCompsMgr::getGI CX7 IB device found, sending regular MGIR\n"));
-            rc = reg_access_mgir(mf, REG_ACCESS_METHOD_GET, gi);
-            goto cleanup;
-        }
         rc = (reg_access_status_t)mad_ifc_general_info_fw(mf, &gi->fw_info);
         if (rc) {
             goto cleanup;


### PR DESCRIPTION
This reverts commit 97e3f2241f43062da122e604b2a035a2c2e1f646.