### PR TITLE
depth>0 fails

### DIFF
--- a/resourcedump/fetchers/ResourceDumpFetcher.py
+++ b/resourcedump/fetchers/ResourceDumpFetcher.py
@@ -325,7 +325,7 @@ class ResourceDumpFetcher:
                     inner_inline_data.extend(
                         self._retrieve_resource_dump_inline_data(seg.reference_type, index1=seg.index1,
                                                                  index2=seg.index2, numOfObj1=seg.num_of_obj1,
-                                                                 numOfObj2=seg.num_of_obj2, vHCAid=kwargs["vHCAid"]))
+                                                                 numOfObj2=seg.num_of_obj2, vHCAid=kwargs["vHCAid"], mem=kwargs["mem"]))
 
             segments_list_last_position = len(segments_list)
             segments_list.extend(self._create_segments(inner_inline_data))


### PR DESCRIPTION
Description:
mem arg did not reach inner fetch function in the case of reference seek

Tested OS: linux
Tested devices: CX6LX
Tested flows: run mstdump with segment 1011 and depth==1

Known gaps (with RM ticket):

Issue: 3033347
Change-Id: Ib02f3971c55d288e2e7eea89f21c97d43040c765
Signed-off-by: Alon Strutsovsky <astrutsovsky@nvidia.com>