### PR TITLE
FIXUP: Symlink libmtcr_ul.a into the libdir

### DIFF
--- a/debian/mstflint.links
+++ b/debian/mstflint.links
@@ -1,1 +1,1 @@
-usr/lib/mstflint/mstflint/libmtcr_ul.a usr/lib/mstflint/libmtcr_ul.a
+usr/lib/mstflint/libmtcr_ul.a usr/lib/libmtcr_ul.a


### PR DESCRIPTION
Signed-off-by: Tzafrir Cohen <nvidia@cohens.org.il>