### PR TITLE
fix mlxconfig makefile to include boost when builder in order 

### DIFF
--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -78,7 +78,8 @@ libmlxcfg_a_LIBADD = $(UTILS_LIB) $(MUPARSER_LIBS) $(SQLITE_LIBS)\
 
 mstconfig_LDADD = libmlxcfg.a $(UTILS_LIB) $(MUPARSER_LIBS) $(SQLITE_LIBS)\
 				$(CMDIF_DIR)/libcmdif.a ../reg_access/libreg_access.a $(LAYOUTS_LIB) $(MTCR_DIR)/libmtcr_ul.a\
-				$(DEV_MGT_DIR)/libdev_mgt.a $(COMPS_MGR_DIR)/libfw_comps_mgr.a $(TOOLS_RES_MGMT_DIR)/libtools_res_mgmt.a $(MLNXOS_PPC_LIBS) $(LIBSTD_CPP) ${LDL}
+				$(DEV_MGT_DIR)/libdev_mgt.a $(COMPS_MGR_DIR)/libfw_comps_mgr.a $(TOOLS_RES_MGMT_DIR)/libtools_res_mgmt.a $(MLNXOS_PPC_LIBS) $(LIBSTD_CPP) ${LDL}\
+                                -lboost_regex -lboost_filesystem -lboost_system
 
 if DISABLE_XML2
 AM_CXXFLAGS += -DDISABLE_XML2


### PR DESCRIPTION
to support regex on c++11 machines