### PR TITLE
[mlxconfig] - changing regex to strstr.

### DIFF
--- a/mlxconfig/mlxcfg_db_manager.h
+++ b/mlxconfig/mlxcfg_db_manager.h
@@ -87,7 +87,7 @@ public:
     void findTLVInDB(std::string mlxconfigName, u_int32_t index);
     TLVConf* getTLVByIndexAndClass(u_int32_t id, TLVClass c);
     void fillInRelevantParamsOfTlv(TLVConf* tlv, u_int32_t port, int32_t module);
-    tuple<string, int> splitMlxcfgNameAndPortOrModule(std::string mlxconfigName, SPLITBY splitBy);
+    static tuple<string, int> splitMlxcfgNameAndPortOrModule(std::string mlxconfigName, SPLITBY splitBy);
     void execSQL(sqlite3_callback f, void* obj, const char* stat, ...);
 };
 


### PR DESCRIPTION
Description:
mlxconfig - changing regex use to strstr.

Tested OS: Linux
Tested devices:CX6
Tested flows:
mlxconfig -d {device} q
mlxconfig -d {device} s LINK_TYPE_P1=2
mlxconfig -d {device} q LINK_TYPE_P1
check that it was changed
mlxconfig -d {device} i
check that physical ports look ok

Known gaps (with RM ticket): None

Issue:3114968