### PR TITLE
[MSTFLINT] mstflint build unused variables

### DIFF
--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -1642,6 +1642,8 @@ void GenericCommander::sign(vector<u_int32_t>& buff,
 #else
     (void)buff;
     (void)privateKeyFile;
+    (void)openssl_engine;
+    (void)openssl_key_identifier;
     throw MlxcfgException("Sign command is not implemented\n");
 #endif
 }

--- a/mlxconfig/mlxcfg_parser.cpp
+++ b/mlxconfig/mlxcfg_parser.cpp
@@ -417,7 +417,6 @@ mlxCfgStatus MlxCfg::getNumberFromString(const char* str, u_int32_t& num)
 
 mlxCfgStatus MlxCfg::parseArgs(int argc, char* argv[])
 {
-    mlxCfgStatus status = MLX_CFG_OK;
     int i = 1;
     for (; i < argc; i++)
     {


### PR DESCRIPTION
Description: Removed unused variables in mlxconfig for building with "NO_OPEN_SSL" flag

Tested OS: Linux
Tested devices: N/A
Tested flows: Build

Known gaps (with RM ticket): N/A

Issue: 3115231