### PR TITLE
[resourceparse] Add index1 and index2 fields to parsed segment's title

### DIFF
--- a/resourceparse/segments/CommandSegment.py
+++ b/resourceparse/segments/CommandSegment.py
@@ -54,6 +54,13 @@ class CommandSegment(Segment):
         """
         super().__init__()
         self.raw_data = data
+        self.index1 = self.raw_data[2]
+        self.index2 = self.raw_data[3]
+    
+    def additional_title_info(self):
+        """return index1 and index2 if exists in the segment.
+        """
+        return " ; index1 = {0}, index2 = {1}".format(hex(self.index1), hex(self.index2))
 
     def get_data(self):
         """get the general segment data.

--- a/resourceparse/segments/RefSegment.py
+++ b/resourceparse/segments/RefSegment.py
@@ -60,6 +60,11 @@ class RefSegment(Segment):
         self.index2 = int('{:0b}'.format(data[3]).zfill(32)[0:32], 2)
         self.num_of_obj1 = int('{:0b}'.format(data[4]).zfill(32)[0:16], 2)
         self.num_of_obj2 = int('{:0b}'.format(data[4]).zfill(32)[16:32], 2)
+    
+    def additional_title_info(self):
+        """return index1 and index2 if exists in the segment.
+        """
+        return " ; index1 = {0}, index2 = {1}".format(hex(self.index1), hex(self.index2))
 
     def get_data(self):
         """get the reference segment data.

--- a/resourceparse/segments/ResourceSegment.py
+++ b/resourceparse/segments/ResourceSegment.py
@@ -54,6 +54,13 @@ class ResourceSegment(Segment):
         super().__init__()
         self.raw_data = data
         self.resource_type = constants.RESOURCE_DUMP_SEGMENT_TYPE_RESOURCE
+        self.index1 = self.raw_data[2]
+        self.index2 = self.raw_data[3]
+    
+    def additional_title_info(self):
+        """return index1 and index2 if exists in the segment.
+        """
+        return " ; index1 = {0}, index2 = {1}".format(hex(self.index1), hex(self.index2))
 
     def get_data(self):
         """get the general segment data.

--- a/resourceparse/segments/Segment.py
+++ b/resourceparse/segments/Segment.py
@@ -53,6 +53,11 @@ class Segment(ABC):
         self.size = 0
         self._parsed_data = OrderedDict()
 
+    def additional_title_info(self):
+        """return index1 and index2 if exists in the segment.
+        """
+        return ""
+
     def get_size(self):
         return self.size
 


### PR DESCRIPTION
Description:
When printing segments with index field in it, the index will be presented next to the segment name.

Tested OS: Linux64
Tested devices: cx6, cx6lx
Tested flows: varios segments

Known gaps (with RM ticket):

Issue: 3090820