### PR TITLE
[mstlink] PCIE Error Injection

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -1699,12 +1699,12 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                             to_string(add32BitTo64(getFieldValue("plr_sync_events_high"),
                                                                    getFieldValue("plr_sync_events_low")))));
                 fields.push_back(AmberField("HiRetransmissionRate",
-                                            to_string(add32BitTo64(getFieldValue("hi_retransmission_rate_high"),
-                                                                   getFieldValue("hi_retransmission_rate_low")))));
+                                            to_string(add32BitTo64(getLocalFieldValue("hi_retransmission_rate_high"),
+                                                                   getLocalFieldValue("hi_retransmission_rate_low")))));
                 fields.push_back(
                   AmberField("PlrXmitRetryCodesWithinTSecMax",
-                             to_string(add32BitTo64(getFieldValue("plr_xmit_retry_codes_within_t_sec_max_high"),
-                                                    getFieldValue("plr_xmit_retry_codes_within_t_sec_max_low")))));
+                             to_string(add32BitTo64(getLocalFieldValue("plr_xmit_retry_codes_within_t_sec_max_high"),
+                                                    getLocalFieldValue("plr_xmit_retry_codes_within_t_sec_max_low")))));
             }
         }
         else

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -247,6 +247,21 @@
 #define PREI_SHOW_MIXERS_FLAG_SHORT ' '
 
 //------------------------------------------------------------
+//        Mlxlink PCIE Error Injection Flags
+#define MPEINJ_PCIE_ERR_INJ_FLAG "pcie_error_injection"
+#define MPEINJ_PCIE_ERR_INJ_FLAG_SHORT ' '
+#define MPEINJ_ERR_TYPE_FLAG "error_type"
+#define MPEINJ_ERR_TYPE_FLAG_SHORT ' '
+#define MPEINJ_ERR_DURATION_FLAG "error_duration"
+#define MPEINJ_ERR_DURATION_FLAG_SHORT ' '
+#define MPEINJ_INJ_DELAY_FLAG "injection_delay"
+#define MPEINJ_INJ_DELAY_FLAG_SHORT ' '
+#define MPEINJ_ERR_PARAMETERS_FLAG "error_parameters"
+#define MPEINJ_ERR_PARAMETERS_FLAG_SHORT ' '
+#define MPEINJ_DBDF_FLAG "dbdf"
+#define MPEINJ_DBDF_FLAG_SHORT ' '
+
+//------------------------------------------------------------
 //        Histogram Counters Flags
 #define PPHCR_FEC_HIST_FLAG "rx_fec_histogram"
 #define PPHCR_FEC_HIST_FLAG_SHORT ' '
@@ -308,34 +323,12 @@ enum OPTION_TYPE
     ERR_INJ_ENABLE,
     RS_FEC_HISTOGRAM,
     SLRG_TEST,
+    PCIE_ERROR_INJ,
     // Any new function's index should be added before FUNCTION_LAST in this enum
     FUNCTION_LAST
 };
 
 ///////////
-struct DPN
-{
-    DPN()
-    {
-        depth = 0;
-        pcieIndex = 0;
-        node = 0;
-    }
-
-    DPN(u_int32_t d, u_int32_t p, u_int32_t n)
-    {
-        depth = d;
-        pcieIndex = p;
-        node = n;
-    }
-
-    bool operator==(DPN dpn) { return (dpn.depth == depth && dpn.pcieIndex == pcieIndex && dpn.node == node); }
-
-    u_int32_t depth;
-    u_int32_t pcieIndex;
-    u_int32_t node;
-};
-
 struct MODULE_FIELD
 {
     string uiName;
@@ -494,7 +487,6 @@ public:
     void writeCableEEPROM();
     void readCableEEPROM();
     void performModulePrbsCommands();
-    ;
     void performControlParams();
 
     MlxlinkCmdPrint _toolInfoCmd;
@@ -502,7 +494,6 @@ public:
     MlxlinkCmdPrint _supportedInfoCmd;
     MlxlinkCmdPrint _troubInfoCmd;
     MlxlinkCmdPrint _testModeInfoCmd;
-    MlxlinkCmdPrint _pcieInfoCmd;
     MlxlinkCmdPrint _moduleInfoCmd;
     MlxlinkCmdPrint _berInfoCmd;
     MlxlinkCmdPrint _testModeBerInfoCmd;
@@ -530,6 +521,8 @@ public:
     void sendPplr();
     void sendPepc();
     void setTxGroupMapping();
+    void handleRxErrInj();
+    void handlePCIeErrInj();
 
     // Config helper functions
     bool isForceDownSupported();
@@ -569,6 +562,7 @@ public:
     u_int32_t getLaneSpeed(u_int32_t lane);
     void validateNumOfParamsForNDRGen();
     void checkSltpParamsSize();
+    bool isMpeinjSupported();
 
     // Mlxlink params
     UserInput _userInput;
@@ -581,6 +575,7 @@ public:
     u_int32_t _protoActive;
     u_int32_t _uniqueCmds;
     u_int32_t _uniqueCableCmds;
+    u_int32_t _uniquePcieCmds;
     u_int32_t _networkCmds;
     u_int32_t _anDisable;
     u_int32_t _speedBerCsv;

--- a/mlxlink/modules/mlxlink_enums.h
+++ b/mlxlink/modules/mlxlink_enums.h
@@ -43,6 +43,7 @@
 #define ACCESS_REG_MGPIR "MGPIR"
 #define ACCESS_REG_MPCNT "MPCNT"
 #define ACCESS_REG_MPEIN "MPEIN"
+#define ACCESS_REG_MPEINJ "MPEINJ"
 #define ACCESS_REG_MPIR "MPIR"
 #define ACCESS_REG_MSGI "MSGI"
 #define ACCESS_REG_MTCAP "MTCAP"
@@ -404,6 +405,97 @@
 
 #define GET MACCESS_REG_METHOD_GET
 #define SET MACCESS_REG_METHOD_SET
+
+#define PCIE_MAX_DURATION 16777215
+#define PCIE_MAX_DURATION_HW_COUNTERS 255
+#define PCIE_MAX_ERR_PARAM 4
+
+struct DPN
+{
+    DPN()
+    {
+        depth = 0;
+        pcieIndex = 0;
+        node = 0;
+        bdf = "";
+    }
+
+    DPN(u_int32_t _depth, u_int32_t _pcieIndex, u_int32_t _node, string _bdf)
+    {
+        depth = _depth;
+        pcieIndex = _pcieIndex;
+        node = _node;
+        bdf = _bdf;
+    }
+
+    bool operator==(DPN dpn) { return (dpn.depth == depth && dpn.pcieIndex == pcieIndex && dpn.node == node); }
+
+    u_int32_t depth;
+    u_int32_t pcieIndex;
+    u_int32_t node;
+    string bdf;
+};
+
+struct PcieErrType
+{
+    PcieErrType()
+    {
+        errorTypeStr = "";
+        defaultInjDelay = 0;
+        defaultErrDuration = 0;
+        maxErrDuration = 0;
+        errorDurationValid = false;
+        paramsValid[0] = false;
+        paramsValid[1] = false;
+        paramsValid[2] = false;
+        paramsValid[3] = false;
+        dbdfValid = false;
+        unit = "";
+    }
+
+    PcieErrType(string _errorTypeStr,
+                u_int32_t _defaultInjDelay,
+                u_int32_t _defaultErrDuration,
+                u_int32_t _maxErrDuration,
+                bool _errorDurationValid,
+                bool _param0Valid,
+                bool _param1Valid,
+                bool _param2Valid,
+                bool _param3Valid,
+                bool _dbdfValid,
+                string _unit)
+    {
+        errorTypeStr = _errorTypeStr;
+        defaultInjDelay = _defaultInjDelay;
+        defaultErrDuration = _defaultErrDuration;
+        maxErrDuration = _maxErrDuration;
+        errorDurationValid = _errorDurationValid;
+        paramsValid[0] = _param0Valid;
+        paramsValid[1] = _param1Valid;
+        paramsValid[2] = _param2Valid;
+        paramsValid[3] = _param3Valid;
+        dbdfValid = _dbdfValid;
+        unit = _unit;
+    }
+
+    string errorTypeStr;
+    u_int32_t defaultInjDelay;
+    u_int32_t defaultErrDuration;
+    u_int32_t maxErrDuration;
+    bool errorDurationValid;
+    bool paramsValid[4];
+    bool dbdfValid;
+    string unit;
+};
+
+struct ReqParms
+{
+    u_int8_t errorType;
+    u_int32_t errorDuration;
+    u_int32_t injectionDelay;
+    u_int16_t dbdf;
+    u_int32_t parameters[4];
+};
 
 enum FIELD_ACCESS
 {
@@ -1565,5 +1657,20 @@ typedef enum
     CABLE_CONTROL_PARAMETERS_SET_RX_POST_EMPH,
     CABLE_CONTROL_PARAMETERS_SET_RX_AMP
 } ControlParam;
+
+enum PCIE_ERR_INJ_TYPE
+{
+    PCIE_ERR_TYPE_ABORT = 0,
+    PCIE_ERR_TYPE_BAD_DLLP_LCRC,
+    PCIE_ERR_TYPE_BAD_TLP_LCRC,
+    PCIE_ERR_TYPE_BAD_TLP_ECRC,
+    PCIE_ERR_TYPE_ERR_MSG,
+    PCIE_ERR_TYPE_MALFORMED_TLP,
+    PCIE_ERR_TYPE_POISONED_TLP,
+    PCIE_ERR_TYPE_UNEXPECTED_CPL,
+    PCIE_ERR_TYPE_ACS_VIOLATION,
+    PCIE_ERR_TYPE_SURP_LINK_DOWN = 100,
+    PCIE_ERR_TYPE_RECEIVER_ERROR = 101
+};
 
 #endif /* MLXLINK_ENUMS_H */

--- a/mlxlink/modules/mlxlink_err_inj_commander.cpp
+++ b/mlxlink/modules/mlxlink_err_inj_commander.cpp
@@ -43,12 +43,9 @@ MlxlinkErrInjCommander::MlxlinkErrInjCommander(Json::Value& jsonRoot) : _jsonRoo
 
 MlxlinkErrInjCommander::~MlxlinkErrInjCommander() {}
 
-bool MlxlinkErrInjCommander::getUserConfirm()
+bool MlxlinkErrInjCommander::getUserConfirm(const string& msg)
 {
-    MlxlinkRecord::printWar("Using this feature may result degradation of "
-                            "the link or even link failure.\nFor the link to return to normal "
-                            "operation, link needs to be toggled.",
-                            _jsonRoot);
+    MlxlinkRecord::printWar(msg, _jsonRoot);
     return askUser("Do you want to continue", _force);
 }
 
@@ -85,7 +82,9 @@ void MlxlinkErrInjCommander::updateMixerOffsets()
         throw MlxRegException("Interactive mode is not available with JSON format, "
                               "use --yes flag to force the execution");
     }
-    if (getUserConfirm())
+    if (getUserConfirm("Using this feature may result degradation of "
+                       "the link or even link failure.\nFor the link to return to normal "
+                       "operation, link needs to be toggled."))
     {
         setMixersOffset();
     }
@@ -102,4 +101,264 @@ void MlxlinkErrInjCommander::showMixersOffset()
     setPrintVal(cmdOut, "mixer_offset1", valueStr, ANSI_COLOR_RESET, true);
     cmdOut.toJsonFormat(_jsonRoot);
     cout << cmdOut;
+}
+
+string MlxlinkErrInjCommander::getPcieErrInjStatus(u_int32_t errorType)
+{
+    string status = "Ready";
+
+    if (errorType)
+    {
+        status = "In Progress";
+    }
+    return status;
+}
+
+void MlxlinkErrInjCommander::showPcieErrInjState(const DPN& dpn)
+{
+    sendPrmReg(ACCESS_REG_MPEINJ, GET, "depth=%d,pcie_index=%d,node=%d,error_type=%d", dpn.depth, dpn.pcieIndex,
+               dpn.node, PCIE_ERR_TYPE_BAD_DLLP_LCRC);
+
+    u_int32_t errType = getFieldValue("error_type");
+    string errorStatus = getPcieErrInjStatus(errType);
+    string errorTypeStr = _mlxlinkMaps->_pcieErrType[errType].errorTypeStr;
+    string errorDuration = getFieldStr("error_duration");
+    errorDuration += " " + _mlxlinkMaps->_pcieErrType[errType].unit;
+    errorDuration += getFieldValue("error_duration") > 1 ? "s" : "";
+
+    MlxlinkCmdPrint cmdOut = MlxlinkCmdPrint();
+
+    setPrintTitle(cmdOut, "PCIe Error Injection Info", 4);
+
+    setPrintVal(cmdOut, "Error Injection Status", errorStatus);
+    setPrintVal(cmdOut, "Error Injection Type", errorTypeStr, ANSI_COLOR_RESET, true, errType);
+    setPrintVal(cmdOut, "Error Injection Duration", errorDuration, ANSI_COLOR_RESET, true, errType);
+
+    cmdOut.toJsonFormat(_jsonRoot);
+
+    cout << cmdOut;
+}
+
+string MlxlinkErrInjCommander::getValidErrorTypes(bool perDbdf)
+{
+    string errTypeListStr = "";
+
+    for (const auto& errType : _mlxlinkMaps->_pcieErrType)
+    {
+        if (!errType.second.errorTypeStr.empty())
+        {
+            if (errType.second.dbdfValid || !perDbdf)
+            {
+                errTypeListStr += errType.second.errorTypeStr;
+                errTypeListStr += "(" + to_string(errType.first);
+                errTypeListStr += "),";
+            }
+        }
+    }
+
+    return deleteLastChar(errTypeListStr);
+}
+
+string MlxlinkErrInjCommander::getNumOfValidParams(PcieErrType& errTypeSt)
+{
+    u_int32_t numOfParams = 0;
+
+    for (const auto& paramValid : errTypeSt.paramsValid)
+    {
+        if (paramValid)
+        {
+            numOfParams++;
+        }
+    }
+
+    if (numOfParams)
+    {
+        return "Number of valid parameters is " + to_string(numOfParams);
+    }
+    else
+    {
+        return "No valid parameters to set";
+    }
+}
+
+ReqParms MlxlinkErrInjCommander::validateErrType(const string& type,
+                                                 int duration,
+                                                 int injDelay,
+                                                 vector<string> params,
+                                                 const string& dbdf)
+{
+    ReqParms request;
+
+    // Error type validation
+    int errTypeSet = -1;
+    int dbdfIntSet = 0;
+    int paramsSet[4] = {0};
+
+    try
+    {
+        size_t cptr;
+        errTypeSet = stoi(type, &cptr, 0);
+        if (cptr != type.size())
+        {
+            errTypeSet = -1;
+        }
+    }
+    catch (...)
+    {
+        for (const auto& errType : _mlxlinkMaps->_pcieErrType)
+        {
+            if (type == errType.second.errorTypeStr)
+            {
+                errTypeSet = errType.first;
+            }
+        }
+    }
+
+    if (errTypeSet < 0)
+    {
+        string suggestion = "";
+        size_t cost = SIZE_MAX;
+        for (const auto& errType : _mlxlinkMaps->_pcieErrType)
+        {
+            if (!errType.second.errorTypeStr.empty())
+            {
+                size_t leveCost = LevStrMatch(type, errType.second.errorTypeStr);
+                if (leveCost < cost)
+                {
+                    suggestion = errType.second.errorTypeStr;
+                    cost = leveCost;
+                }
+            }
+        }
+        if (type.size() <= suggestion.size())
+        {
+            suggestion = ", do you mean \"" + suggestion + string("\"?\n");
+        }
+        else
+        {
+            suggestion = ". ";
+        }
+
+        throw MlxRegException("Invalid Error Type %s%sValid error types are [%s]", type.c_str(), suggestion.c_str(),
+                              getValidErrorTypes().c_str());
+    }
+    request.errorType = (u_int32_t)errTypeSet;
+
+    // Error duration validity check
+    PcieErrType errTypeSt = _mlxlinkMaps->_pcieErrType[errTypeSet];
+
+    request.errorDuration = errTypeSt.defaultErrDuration;
+    request.injectionDelay = errTypeSt.defaultInjDelay;
+
+    if (duration != -1 && !errTypeSt.errorDurationValid)
+    {
+        throw MlxRegException("The error_duration flag is not valid with error type %s",
+                              errTypeSt.errorTypeStr.c_str());
+    }
+    else if (duration != -1)
+    {
+        if (((u_int32_t)duration) > errTypeSt.maxErrDuration && ((u_int32_t)duration) < errTypeSt.defaultErrDuration)
+        {
+            throw MlxRegException("Invalid error duration value for %s: %d", errTypeSt.errorTypeStr.c_str(), duration);
+        }
+        request.errorDuration = (u_int32_t)duration;
+    }
+
+    // Error parameter validity check
+    if (params.size() > PCIE_MAX_ERR_PARAM)
+    {
+        throw MlxRegException("Invalid error parameters set for error type %s. %s",
+                              errTypeSt.errorTypeStr.c_str(),
+                              getNumOfValidParams(errTypeSt).c_str());
+    }
+    for (u_int32_t idx = 0; idx < params.size(); idx++)
+    {
+        if (!errTypeSt.paramsValid[idx])
+        {
+            throw MlxRegException("Invalid parameters list for error type %s, %s", errTypeSt.errorTypeStr.c_str(),
+                                  getNumOfValidParams(errTypeSt).c_str());
+        }
+        strToUint32((char*)params[idx].c_str(), (u_int32_t&)paramsSet[idx]);
+    }
+
+    if (request.errorType == PCIE_ERR_TYPE_UNEXPECTED_CPL && paramsSet[0] == 1 &&
+        paramsSet[1] > PCIE_MAX_DURATION_HW_COUNTERS)
+    {
+        throw MlxRegException("Invalid error parameter value: %d", paramsSet[1]);
+    }
+    memcpy(request.parameters, paramsSet, sizeof(paramsSet));
+
+    // dbdf validity check
+    if (dbdf.empty() && errTypeSt.dbdfValid)
+    {
+        throw MlxRegException("The dbdf flag should be specified for error type %s", errTypeSt.errorTypeStr.c_str());
+    }
+    if (!dbdf.empty() && !errTypeSt.dbdfValid)
+    {
+        throw MlxRegException("The dbdf flag is not valid with error type %s, It's valid with error types [%s]",
+                              errTypeSt.errorTypeStr.c_str(), getValidErrorTypes(true).c_str());
+    }
+    if (!dbdf.empty())
+    {
+        dbdfIntSet = getBDFInt(dbdf);
+        if (dbdfIntSet == -1)
+        {
+            throw MlxRegException("Invalid dbdf address: %s", dbdf.c_str());
+        }
+    }
+    request.dbdf = (u_int32_t)dbdfIntSet;
+
+    // Injection delay validity check
+    if (injDelay != -1)
+    {
+        if (injDelay > PCIE_MAX_DURATION)
+        {
+            throw MlxRegException("Invalid injection delay value for %s: %d", errTypeSt.errorTypeStr.c_str(), injDelay);
+        }
+        request.injectionDelay = (u_int32_t)injDelay;
+    }
+
+    return request;
+}
+
+void MlxlinkErrInjCommander::startPcieErrInj(const DPN& dpn,
+                                             const string& type,
+                                             int duration,
+                                             int injDelay,
+                                             const string& dbdf,
+                                             vector<string> params)
+{
+    MlxlinkRecord::printCmdLine("Starting PCIe Error Injection...", _jsonRoot);
+
+    ReqParms req = validateErrType(type, duration, injDelay, params, dbdf);
+
+    if (MlxlinkRecord::jsonFormat && !_force)
+    {
+        throw MlxRegException("Interactive mode is not available with JSON format, "
+                              "use --yes flag to force the execution");
+    }
+
+    if (getUserConfirm("PCIe error injection might cause a PCIe bus failures or a system hang"))
+    {
+        sendPrmReg(ACCESS_REG_MPEINJ, GET, "depth=%d,pcie_index=%d,node=%d", dpn.depth, dpn.pcieIndex, dpn.node);
+        if (getFieldValue("error_type") && req.errorType != 0)
+        {
+            throw MlxRegException("There is a PCIe error injection process in progress!");
+        }
+        else
+        {
+            try
+            {
+                sendPrmReg(ACCESS_REG_MPEINJ, SET,
+                           "depth=%d,pcie_index=%d,node=%d,error_type=%d,error_duration=%d,"
+                           "start_delay=%d,dbdf=%d,err_params[0]=%d,err_params[1]=%d,err_params[2]=%d,err_params[3]=%d",
+                           dpn.depth, dpn.pcieIndex, dpn.node, req.errorType, req.errorDuration, req.injectionDelay,
+                           req.dbdf, req.parameters[0], req.parameters[1], req.parameters[2], req.parameters[3]);
+            }
+            catch (MlxRegException& exc)
+            {
+                throw MlxRegException("Invalid PCIe error injection configuration: %s", exc.what());
+            }
+        }
+    }
 }

--- a/mlxlink/modules/mlxlink_err_inj_commander.h
+++ b/mlxlink/modules/mlxlink_err_inj_commander.h
@@ -51,14 +51,28 @@ public:
     void showMixersOffset();
     void updateMixerOffsets();
 
+    void showPcieErrInjState(const DPN& dpn);
+    void startPcieErrInj(const DPN& dpn,
+                         const string& type,
+                         int duration,
+                         int injDelay,
+                         const string& dbdf,
+                         vector<string> params);
+
     int _mixerOffset0;
     int _mixerOffset1;
     bool _force;
+    MlxlinkMaps* _mlxlinkMaps;
 
 private:
-    bool getUserConfirm();
+    bool getUserConfirm(const string& msg);
     u_int16_t getMixerOffset(u_int32_t id);
     void setMixersOffset();
+    string getNumOfValidParams(PcieErrType& errTypeSt);
+    string getDbdfUsage();
+    string getValidErrorTypes(bool perDbdf = false);
+    string getPcieErrInjStatus(u_int32_t errorType);
+    ReqParms validateErrType(const string& type, int duration, int injDelay, vector<string> params, const string& dbdf);
 
     Json::Value& _jsonRoot;
     MlxlinkCmdPrint _errInjOutput;

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -47,13 +47,6 @@ MlxlinkMaps* MlxlinkMaps::getInstance()
 
 void MlxlinkMaps::initPublicStrings()
 {
-    _berCollectTitle =
-      "Test Mode (Nominal/Corner/Drift),Protocol,Speed [Gb/s],Active FEC,Iteration Number,Device PN,FW Version,Device "
-      "ID,Port Number,Media,Cable PN,Length [m],Attenuation [dB],"
-      "Test time [Min],Raw Errors Lane 0,Raw Errors Lane 1,Raw Errors Lane 2,Raw Errors Lane 3,Raw Errors Lane 4,Raw "
-      "Errors Lane 5,Raw Errors Lane 6,Raw Errors Lane 7,Link Down,Total Raw BER,Raw BER limit,"
-      "Effective Errors,Effective BER,Result,System Voltage,Chip Start Temp,Chip End Temp,Module Start Temp,Module End "
-      "Temp,Active RTN,Device SN,Cable SN,RX End BW [Gb/s]";
     _showErrorsTitle = "Errors";
 }
 
@@ -1191,6 +1184,31 @@ void MlxlinkMaps::activeComplianceMapping()
     _activeCableCompliance[4] = "Active Cable assembly with BER < 10-6";
 }
 
+void MlxlinkMaps::pcieEnumMapping()
+{
+    _pcieErrType[PCIE_ERR_TYPE_ABORT] = PcieErrType{"ABORT", 0, 0, 0, false, false, false, false, false, false, ""};
+    _pcieErrType[PCIE_ERR_TYPE_BAD_DLLP_LCRC] = PcieErrType{
+      "BAD_DLLP_LCRC", 100000, 1, PCIE_MAX_DURATION_HW_COUNTERS, true, false, false, false, false, false, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_BAD_TLP_LCRC] = PcieErrType{
+      "BAD_TLP_LCRC", 100000, 1, PCIE_MAX_DURATION_HW_COUNTERS, true, true, false, false, false, false, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_BAD_TLP_ECRC] = PcieErrType{
+      "BAD_TLP_ECRC", 100000, 1, PCIE_MAX_DURATION_HW_COUNTERS, true, true, false, false, false, false, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_ERR_MSG] =
+      PcieErrType{"ERR_MSG", 0, 1, PCIE_MAX_DURATION, true, true, false, false, false, false, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_MALFORMED_TLP] =
+      PcieErrType{"MALFORMED_TLP", 0, 1, PCIE_MAX_DURATION, true, false, false, false, false, true, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_POISONED_TLP] =
+      PcieErrType{"POISONED_TLP", 0, 1, PCIE_MAX_DURATION, true, false, false, false, false, true, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_UNEXPECTED_CPL] =
+      PcieErrType{"UNEXPECTED_CPL", 0, 1, PCIE_MAX_DURATION, true, true, true, false, false, true, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_ACS_VIOLATION] =
+      PcieErrType{"ACS_VIOLATION", 0, 1, PCIE_MAX_DURATION, true, false, false, false, false, false, "Packet"};
+    _pcieErrType[PCIE_ERR_TYPE_SURP_LINK_DOWN] =
+      PcieErrType{"SURPRISE_LINK_DOWN", 100000, 1, PCIE_MAX_DURATION, true, true, false, false, false, false, "usec"};
+    _pcieErrType[PCIE_ERR_TYPE_RECEIVER_ERROR] =
+      PcieErrType{"RECEIVER_ERROR", 100000, 0, PCIE_MAX_DURATION, true, false, false, false, false, false, "usec"};
+}
+
 void MlxlinkMaps::initCableComplianceMapping()
 {
     qsfpComlianceMapping();
@@ -1216,6 +1234,7 @@ void MlxlinkMaps::initCableComplianceMapping()
     errorCodeResMapping();
     techMapping();
     modulePrbsMapping();
+    pcieEnumMapping();
 }
 
 void MlxlinkMaps::initCableTechnologyMapping()

--- a/mlxlink/modules/mlxlink_maps.h
+++ b/mlxlink/modules/mlxlink_maps.h
@@ -160,6 +160,7 @@ private:
     void linkPeerMaxSpeedMapping();
     void portStateMapping();
     void techMapping();
+    void pcieEnumMapping();
 
 public:
     static MlxlinkMaps* getInstance();
@@ -278,9 +279,9 @@ public:
     std::map<u_int32_t, std::string> _pllUglState;
     std::map<u_int32_t, std::string> _slrgFomMode;
     std::map<u_int32_t, std::string> _pcieDevStatus;
+    std::map<u_int32_t, PcieErrType> _pcieErrType;
 
     string _sltpHeader;
-    string _berCollectTitle;
     string _showErrorsTitle;
 };
 

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -129,4 +129,10 @@ UserInput::UserInput()
     prbsModuleAccess = MODULE_PRBS_ACCESS_BOTH;
 
     isModuleConfigParamsProvided = false;
+
+    isPcieErrInjProvided = false;
+    errorType = "";
+    errorDuration = -1;
+    injDelay = -1;
+    dbdf = "";
 }

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -146,6 +146,13 @@ public:
 
     bool isModuleConfigParamsProvided;
     vector<pair<ControlParam, string>> configParamsToSet;
+
+    bool isPcieErrInjProvided;
+    string errorType;
+    int errorDuration;
+    int injDelay;
+    string dbdf;
+    vector<string> parameters;
 };
 
 #endif /* MLXLINK_USER_INPUT_H */

--- a/mlxlink/modules/mlxlink_utils.h
+++ b/mlxlink/modules/mlxlink_utils.h
@@ -146,6 +146,9 @@ string getCableLengthStr(u_int32_t cableLength, bool cmisCable);
 string getRxTxCDRState(u_int32_t state, u_int32_t numOfLanes);
 string getModuleFwVersion(bool passive, u_int32_t moduleFWVer);
 string getVendorRev(u_int32_t rev);
+string getBDFStr(u_int32_t bdf);
+int getBDFInt(const string& bdfStr);
+size_t LevStrMatch(const string& s1, const string& s2);
 string getStrByValue(u_int32_t flags, map<u_int32_t, string> map);
 string getStrByMask(u_int32_t bitmask, map<u_int32_t, string> maskMap, const string& fieldSeparator = ",");
 string getStrByMaskFromPair(u_int32_t bitmask,


### PR DESCRIPTION
Adding support for PCIe error injection feature for ConnectX-7
The following flags were added to the tool:
--pcie_error_injection
	--error_type
	--erro_injection
	--injection_delay
	--dbdf
	--error_parameters

Issue: 3198240
Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>