### PR TITLE
Fix compilation when openssl lib is missing (with configure flag --disable-openssl)

### DIFF
--- a/flint/subcommands.h
+++ b/flint/subcommands.h
@@ -43,6 +43,7 @@
 #define MAX_PASSWORD_LEN 256
 
 #include <string>
+#include <memory>
 
 #include <tools_layouts/tools_open_layouts.h>
 

--- a/mlxsign_lib/mlxsign_signer_interface.h
+++ b/mlxsign_lib/mlxsign_signer_interface.h
@@ -34,7 +34,7 @@
 #define USER_MLXSIGN_LIB_MLXSIGN_SIGNER_INTERFACE_H_
 
 #include "mlxsign_lib.h"
-#if !defined(NO_DYNAMIC_ENGINE)
+#if !defined(UEFI_BUILD) && !defined(NO_OPEN_SSL) && !defined(NO_DYNAMIC_ENGINE)
 #include "mlxsign_openssl_engine.h"
 #endif
 


### PR DESCRIPTION
Tested OS: Linux
Tested devices: N/A
Tested flows: ./autogen.sh && ./configure --disable-openssl && make -j16

Known gaps (with RM ticket): N/A

Issue: 3213043