### PR TITLE
[mstlink][PCIE] Gen2 servers does not support eye info

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -2279,6 +2279,13 @@ void MlxlinkCommander::showEye()
     if (_userInput._pcie)
     {
         checkPCIeValidity();
+
+        sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", _dpn.depth, _dpn.pcieIndex, _dpn.node);
+
+        if (getFieldValue("link_speed_active") < GEN3)
+        {
+            throw MlxRegException("Eye information available for Gen3 and above");
+        }
     }
     try
     {


### PR DESCRIPTION
Description:
PCIe Gen2 servers does not support eye information

Issue: 3142236

Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>