### PR TITLE
[mstlink][Remote loopback] Removing 50G speed from the warning message

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -4388,7 +4388,7 @@ void MlxlinkCommander::checkPplrCap()
         string warMsg = "Remote loopback mode pre-request (all should be satisfied):\n";
         warMsg += "1. Remote loopback is supported only in force mode.\n";
         warMsg += "   please use the --link_mode_force flag if force mode not configured\n";
-        warMsg += "2. Remote loopback is supported for 25G/50G per lane only.\n";
+        warMsg += "2. Remote loopback is supported for 25G per lane only.\n";
         warMsg += "3. If the NIC has 2 ports, please make sure that both ports are in the same speed.";
         MlxlinkRecord::printWar(warMsg, _jsonRoot);
     }


### PR DESCRIPTION
Description:
Removing 50G speed from the warning message while configuring RM loopback for ConnectX6 and ConnectX6-DX devices.

Issue: 3272703
Hash: ee8c8d7a

Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>