### PR TITLE
[mlxlink][PCIE Err Inj] Un-restricting param 2 for UNEXPECTED_CPL error

### DIFF
--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -1200,7 +1200,7 @@ void MlxlinkMaps::pcieEnumMapping()
     _pcieErrType[PCIE_ERR_TYPE_POISONED_TLP] =
       PcieErrType{"POISONED_TLP", 0, 1, PCIE_MAX_DURATION, true, false, false, false, false, true, "Packet"};
     _pcieErrType[PCIE_ERR_TYPE_UNEXPECTED_CPL] =
-      PcieErrType{"UNEXPECTED_CPL", 0, 1, PCIE_MAX_DURATION, true, true, true, false, false, true, "Packet"};
+      PcieErrType{"UNEXPECTED_CPL", 0, 1, PCIE_MAX_DURATION, true, true, true, true, false, true, "Packet"};
     _pcieErrType[PCIE_ERR_TYPE_ACS_VIOLATION] =
       PcieErrType{"ACS_VIOLATION", 0, 1, PCIE_MAX_DURATION, true, false, false, false, false, false, "Packet"};
     _pcieErrType[PCIE_ERR_TYPE_SURP_LINK_DOWN] =


### PR DESCRIPTION
Parameter 2 is valid for UNEXPECTED_CPL error type:
 Bit 16: 0 – use default completion size (1).
            1 – Use completion data size from bits 15:0
Bits 15:0: Completion size in bytes.

Issue: 3233196
Signed-off-by: Mustafa Dalloul <mustafadall@nvidia.com>