### PR TITLE
[mlxcfg] - fixing bug, mlxconfig fails when trying to run q with -e o…

### DIFF
--- a/mlxconfig/mlxcfg_db_manager.cpp
+++ b/mlxconfig/mlxcfg_db_manager.cpp
@@ -417,6 +417,19 @@ TLVConf* MlxcfgDBManager::getAndCreateTLVByName(string tlvName, u_int32_t port, 
     return tlv;
 }
 
+TLVConf* MlxcfgDBManager::getTLVByNameOnlyAux(string tlv_name)
+{
+    VECTOR_ITERATOR(TLVConf*, fetchedTLVs, it)
+    {
+        TLVConf* t = *it;
+        if (t->_name == tlv_name)
+        {
+            return t;
+        }
+    }
+    return NULL;
+}
+
 TLVConf* MlxcfgDBManager::getTLVByName(string tlvName, u_int32_t port, int32_t module)
 {
     TLVConf* tlv = NULL;
@@ -428,6 +441,29 @@ TLVConf* MlxcfgDBManager::getTLVByName(string tlvName, u_int32_t port, int32_t m
     }
 
     return tlv;
+}
+
+TLVConf* MlxcfgDBManager::getDependencyTLVByName(string tlvName, u_int32_t cTLVPort, int32_t cTLVModule)
+{
+    TLVConf* dependendTLV = getTLVByNameOnlyAux(tlvName);
+    if (!dependendTLV)
+    {
+        getAllTLVs();
+        dependendTLV = getTLVByNameOnlyAux(tlvName);
+        if (!dependendTLV)
+        {
+            // TLV not in DB
+            return NULL;
+        }
+    }
+    if ((dependendTLV->_tlvClass == TLVClass::Physical_Port) || (dependendTLV->_tlvClass == TLVClass::Module))
+    {
+        return getTLVByName(tlvName, cTLVPort, cTLVModule); // get TLV with same port and module as the requester TLV
+    }
+    else // this is not port / module related tlv, ignore the requeter port/module (for cross class dependency)
+    {
+        return getTLVByName(tlvName, 0, -1);
+    }
 }
 
 TLVConf* MlxcfgDBManager::getTLVByIndexAndClassAux(u_int32_t id, TLVClass c)

--- a/mlxconfig/mlxcfg_db_manager.h
+++ b/mlxconfig/mlxcfg_db_manager.h
@@ -81,9 +81,11 @@ public:
     std::vector<std::shared_ptr<Param>> fetchedParams;
     void getAllTLVs();
     TLVConf* getTLVByNameAux(std::string tlvName, u_int32_t port, int32_t module);
+    TLVConf* getTLVByNameOnlyAux(std::string tlvName);
     TLVConf* getAndSetTLVByNameAuxNotInitialized(string tlv_name, u_int32_t port, int32_t module);
     TLVConf* getTLVByIndexAndClassAux(u_int32_t id, TLVClass c);
     TLVConf* getTLVByName(std::string tlvName, u_int32_t port, int32_t module);
+    TLVConf* getDependencyTLVByName(string tlvName, u_int32_t cTLVPort, int32_t cTLVModule);
     TLVConf* getAndCreateTLVByName(std::string tlvName, u_int32_t port, int32_t module);
     TLVConf* getTLVByParamMlxconfigName(std::string mlxconfigName, u_int32_t index, mfile* mf);
     TLVConf* findTLVInExisting(std::string mlxconfigName,

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -537,32 +537,7 @@ bool GenericCommander::checkDependency(TLVConf* cTLV, string dStr)
         {
             string dTLVName = (*it).substr(0, dotPos).replace(0, 1, "");
             string dParamName = (*it).substr(dotPos + 1);
-            // to allow cross class/port dependency we need to check dependency for
-            // port 0 and for port 1 (higher port numbers will act the same)
-            int lookForPorts[] = {int(cTLV->_port), (int(cTLV->_port) == 0) ? 1 : 0};
-            TLVConf* dTLV = NULL;
-            for (int ports = 0; ports < 2; ports++)
-            {
-                try
-                {
-                    if (lookForPorts[ports] == 0)
-                    {
-                        dTLV = _dbManager->getTLVByName(dTLVName, lookForPorts[ports], cTLV->_module);
-                    }
-                    else
-                    {
-                        dTLV = _dbManager->getTLVByName(dTLVName, lookForPorts[ports], -1);
-                    }
-                    if (dTLV != NULL)
-                    {
-                        break;
-                    }
-                }
-                catch (MlxcfgTLVNotFoundException e)
-                { // if TLV not found exception continue to search
-                    continue;
-                }
-            }
+            TLVConf* dTLV = _dbManager->getDependencyTLVByName(dTLVName, cTLV->_port, cTLV->_module);
             if (dTLV == NULL)
             {
                 throw MlxcfgTLVNotFoundException(dTLVName.c_str());


### PR DESCRIPTION
…n CX6DX and CX6LX devices.

Description:
[mlxcfg] - fixing bug, mlxconfig fails when trying to run q with -e on CX6DX and CX6LX devices. Changing the way we check the dependency of devices with port and modules.

Tested OS: Linux - ppc64le
Tested devices: CX6DX
Tested flows: mlxconfig -d /dev/mst/mt4127_pciconf0 -e q and check it doesn't fail

Known gaps (with RM ticket): None

Issue: 3272124
Hash: 172eacbb