### PR TITLE
[mlxconfig] - sorting of dependency tlv should be also by port and m…

### DIFF
--- a/mlxconfig/mlxcfg_db_manager.cpp
+++ b/mlxconfig/mlxcfg_db_manager.cpp
@@ -258,7 +258,8 @@ void MlxcfgDBManager::getAllTLVs()
     while (j < fetchedTLVs.size() && i < fetchedParams.size())
     {
         std::shared_ptr<Param> p = fetchedParams[i];
-        if (p->_tlvName == fetchedTLVs[j]->_name)
+        if (p->_tlvName == fetchedTLVs[j]->_name && p->_port == fetchedTLVs[j]->_port &&
+            p->_module == fetchedTLVs[j]->_module)
         {
             fetchedTLVs[j]->_params.push_back(p);
             i++; // move to next parameter


### PR DESCRIPTION
…odule.

Description:
[mlxconfig] - fixing bug, that when setting a value for same varible with 2 ports, the value of the second parameter will be set for both ports. This happends beacause when checking dipendency and pulling all the tlvs and params. The params were not sorted into the relevent tlc by port and module. for fixing this issue, we will sort dependency tlv also by port and module.

Tested OS: linux
Tested devices: CX6DX
Tested flows: run  mlxconfig -d 00:07.0 -y set  PHY_FEC_OVERRIDE_P2=2 PHY_FEC_OVERRIDE_P1=DEVICE_DEFAULT and then query those parms, see that the values are diffrent.

Known gaps (with RM ticket): None

Issue: 3309748
Hash: 7302edcc