### PR TITLE
[mlxcfg] - Fixing bug in windows that it dosn't find the param when s…

### DIFF
--- a/mlxconfig/mlxcfg_db_manager.h
+++ b/mlxconfig/mlxcfg_db_manager.h
@@ -87,14 +87,14 @@ public:
     TLVConf* getAndCreateTLVByName(std::string tlvName, u_int32_t port, int32_t module);
     TLVConf* getTLVByParamMlxconfigName(std::string mlxconfigName, u_int32_t index, mfile* mf);
     TLVConf* findTLVInExisting(std::string mlxconfigName,
-                               std::string noPortMlxcfgName,
-                               std::string noModuleMlxcfgName,
+                               std::string noPortModuleMlxcfgName,
                                u_int32_t port,
                                u_int32_t index,
                                int32_t module);
     void findTLVInDB(std::string mlxconfigName, u_int32_t index);
     TLVConf* getTLVByIndexAndClass(u_int32_t id, TLVClass c);
     void fillInRelevantParamsOfTlv(TLVConf* tlv, u_int32_t port, int32_t module);
+    static tuple<string, int, int> getMlxconfigNamePortModule(std::string mlxconfigName, mfile* mf);
     static tuple<string, int> splitMlxcfgNameAndPortOrModule(std::string mlxconfigName, SPLITBY splitBy, mfile* mf);
     void execSQL(sqlite3_callback f, void* obj, const char* stat, ...);
 };

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -782,7 +782,7 @@ void GenericCommander::setCfg(vector<ParamView>& params, bool force)
         }
         else
         {
-            tlvMap[(*p).mlxconfigName]->updateParamByMlxconfigName(mlxconfigName, (*p).strVal);
+            tlvMap[(*p).mlxconfigName]->updateParamByMlxconfigName(mlxconfigName, (*p).strVal, _mf);
         }
     }
 

--- a/mlxconfig/mlxcfg_tlv.cpp
+++ b/mlxconfig/mlxcfg_tlv.cpp
@@ -585,12 +585,17 @@ vector<pair<ParamView, string> > TLVConf::query(mfile* mf, QueryType qT)
     return queryResult;
 }
 
-void TLVConf::updateParamByMlxconfigName(string paramMlxconfigName, string val)
+void TLVConf::updateParamByMlxconfigName(string paramMlxconfigName, string val, mfile* mf)
 {
-    std::shared_ptr<Param> p = findParamByMlxconfigName(paramMlxconfigName);
+    std::shared_ptr<Param> p = findParamByMlxconfigNamePortModule(paramMlxconfigName, this->_port, this->_module);
     if (!p)
     {
-        throw MlxcfgException("Unknown parameter: %s", paramMlxconfigName.c_str());
+        auto ret = MlxcfgDBManager::getMlxconfigNamePortModule(paramMlxconfigName, mf);
+        p = findParamByMlxconfigNamePortModule(get<0>(ret), get<1>(ret), get<2>(ret));
+        if (!p)
+        {
+            throw MlxcfgException("Unknown parameter: %s", paramMlxconfigName.c_str());
+        }
     }
     p->setVal(val);
     // check if there is a valid bit

--- a/mlxconfig/mlxcfg_tlv.h
+++ b/mlxconfig/mlxcfg_tlv.h
@@ -116,7 +116,7 @@ public:
     std::shared_ptr<Param> getValidBitParam(std::string n);
     bool checkParamValidBit(std::shared_ptr<Param> p);
     std::vector<std::pair<ParamView, std::string>> query(mfile* mf, QueryType qT);
-    void updateParamByMlxconfigName(std::string param, std::string val);
+    void updateParamByMlxconfigName(std::string param, std::string val, mfile* mf);
     void updateParamByMlxconfigName(std::string param, std::string val, u_int32_t index);
     void updateParamByName(string param, string val);
     void updateParamByName(string paramName, vector<string> vals);


### PR DESCRIPTION
…etting a value.

Description:
[mlxcfg] - Fixing bug in windows that it dosn't find the param when setting a value. This happends because it dosn't find the tlv when searching in "updateParamByMlxconfigName" function. I have added the function getMlxconfigNamePortModule that will get an mlxconfig name and will return its port, module and mlxconfig name with no port and no module. if "updateParamByMlxconfigName" function dosn't find a tlv with the mlxconfig name, it will search with the mlxconfig name with no port and module.

Tested OS: Windows
Tested devices: Bluefield2
Tested flows: mlxconfig -d mt41686_pciconf2 -y set ROCE_CC_PRIO_MASK_P1=255 ROCE_CC_PRIO_MASK_P2=255 BOOT_PKEY=0

Known gaps (with RM ticket): None

Issue: 3308358