### PR TITLE
Fix header detection in build config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,8 @@ AC_SUBST(default_en_inband)
 
 dnl Checks for headers
 AC_CHECK_HEADER(termios.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_TERMIOS_H"])
+AC_CHECK_HEADER(infiniband/verbs.h,,AC_MSG_ERROR([cannot find infiniband/verbs.h . Make sure that the infiniband headers are installed (usually provided by rdma-core).]))
+AC_CHECK_HEADER(infiniband/mlx5dv.h,,AC_MSG_ERROR([cannot find infiniband/mlx5dv.h . Make sure that the infiniband headers are installed (usually provided by rdma-core).]))
 TOOLS_CRYPTO=""
 MAD_IFC=""
 FW_MGR_TOOLS=""


### PR DESCRIPTION
When building on a system where rdma-core is not installed (with the --disable-inband option, so that mad.h detection is not triggered) the configuration stage passes fine, but the build fails, because resourcedump_lib requires some infiniband headers. This commit fixes it, by checking for the needed headers at configuration time, so that if they are missing, the config will fail with an informative message.

This solves https://github.com/Mellanox/mstflint/issues/712.