### PR TITLE
[mstregdump] - bugfix seg-fault due to null instead empty string

### DIFF
--- a/mstdump/crd_main/mstdump.c
+++ b/mstdump/crd_main/mstdump.c
@@ -185,7 +185,7 @@ int main(int argc, char* argv[])
         }
     }
     rc = CRD_OK;
-    rc = crd_init(&context, mf, full, cause_addr, cause_off, NULL, NULL);
+    rc = crd_init(&context, mf, full, cause_addr, cause_off, NULL, "");
     if (rc)
     {
         mclose(mf);


### PR DESCRIPTION
Description:

Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 3338471