### PR TITLE
Fix [mstfwreset]: Bad output printed when mstfwreset on secure boot s…

### DIFF
--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -2046,6 +2046,4 @@ if __name__ == '__main__':
     except Exception as e:
         print("-E- %s." % str(e))
         rc = 1
-        import traceback
-        traceback.print_exc()
     sys.exit(rc)


### PR DESCRIPTION
…etup

Description: Remove prints

Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue:24842511