### PR TITLE
[flint][mlxfwops] Enable wb command on binary FW image + encrypted verify showitoc bug fix

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -6725,7 +6725,7 @@ WbSubCommand::WbSubCommand()
                 "addr - address to write the block to\n";
 
     _example = FLINT_NAME " -d " MST_DEV_EXAMPLE1 " wb myData.bin 0x0";
-    _v = Wtv_Dev;
+    _v = Wtv_Dev_Or_Img;
     _maxCmdParamNum = 2;
     _minCmdParamNum = 2;
     _cmdType = SC_Wb;
@@ -6778,9 +6778,11 @@ FlintStatus WbSubCommand::executeCommand()
         return FLINT_FAILED;
     }
     // printf("-D- writing to addr:0x%08x %lu bytes\n",addr , data.size());
-    if (!_fwOps->FwWriteBlock(addr, data, wbCbFunc))
+    FwOperations* ops;
+    ops = (_flintParams.device_specified) ? _fwOps : _imgOps;
+    if (!ops->FwWriteBlock(addr, data, wbCbFunc))
     {
-        reportErr(true, FLINT_WB_ERROR, _fwOps->err());
+        reportErr(true, FLINT_WB_ERROR, ops->err());
         return FLINT_FAILED;
     }
     wbCbFunc(101);

--- a/mlxfwops/lib/fs3_ops.cpp
+++ b/mlxfwops/lib/fs3_ops.cpp
@@ -1545,7 +1545,7 @@ bool Fs3Operations::FwSetMFG(guid_t baseGuid, PrintCallBack callBackFunc)
     return FwSetMFG(bGuid, callBackFunc);
 }
 
-bool Fs3Operations::parseDevData(bool quickQuery, bool verbose, VerifyCallBack)
+bool Fs3Operations::parseDevData(bool quickQuery, bool verbose, VerifyCallBack, bool)
 {
     return FsIntQueryAux(false, quickQuery, false, verbose);
 }

--- a/mlxfwops/lib/fs3_ops.h
+++ b/mlxfwops/lib/fs3_ops.h
@@ -274,7 +274,7 @@ protected:
     bool Fs3MemSetSignature(fs3_section_t sectType, u_int32_t size, PrintCallBack printFunc = (PrintCallBack)NULL);
     virtual bool IsSectionExists(fs3_section_t sectType);
     virtual bool VerifyImageAfterModifications();
-    virtual bool parseDevData(bool quickQuery = true, bool verbose = false, VerifyCallBack verifyCallBackFunc = (VerifyCallBack)NULL);
+    virtual bool parseDevData(bool quickQuery = true, bool verbose = false, VerifyCallBack verifyCallBackFunc = (VerifyCallBack)NULL, bool showItoc = false);
 
     bool isOld4MBImage(FwOperations* imageOps);
     bool FwCalcSHA(MlxSign::SHAType shaType, vector<u_int8_t>& sha256, vector<u_int8_t>& fourMbImage);

--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -1073,7 +1073,7 @@ bool Fs4Operations::FwVerify(VerifyCallBack verifyCallBackFunc, bool isStripedIm
     if (image_encrypted)
     {
         //* Verify DTOC CRCs only
-        if (!parseDevData(false, false, verifyCallBackFunc))
+        if (!parseDevData(false, false, verifyCallBackFunc, showItoc))
         {
             return errmsg("%s", err());
         }
@@ -1179,7 +1179,7 @@ bool Fs4Operations::encryptedFwReadImageInfoSection()
     return true;
 }
 
-bool Fs4Operations::parseDevData(bool quickQuery, bool verbose, VerifyCallBack verifyCallBackFunc)
+bool Fs4Operations::parseDevData(bool quickQuery, bool verbose, VerifyCallBack verifyCallBackFunc, bool showItoc)
 {
     //* Initializing DTOC info
     _ioAccess->set_address_convertor(0, 0);
@@ -1197,7 +1197,7 @@ bool Fs4Operations::parseDevData(bool quickQuery, bool verbose, VerifyCallBack v
     queryOptions.readRom = false;
     queryOptions.quickQuery = quickQuery;
     DPRINTF(("Fs4Operations::parseDevData call verifyTocEntries() DTOC\n"));
-    if (!verifyTocEntries(dtoc_addr, false, true, queryOptions, verifyCallBackFunc, verbose))
+    if (!verifyTocEntries(dtoc_addr, showItoc, true, queryOptions, verifyCallBackFunc, verbose))
     {
         return false;
     }

--- a/mlxfwops/lib/fs4_ops.h
+++ b/mlxfwops/lib/fs4_ops.h
@@ -164,7 +164,8 @@ protected:
     virtual bool VerifyImageAfterModifications();
     bool parseDevData(bool quickQuery = true,
                       bool verbose = false,
-                      VerifyCallBack verifyCallBackFunc = (VerifyCallBack)NULL);
+                      VerifyCallBack verifyCallBackFunc = (VerifyCallBack)NULL,
+                      bool showItoc = false);
 
 private:
 #define PRE_CRC_OUTPUT "    "

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2125,11 +2125,6 @@ bool FwOperations::FwWriteBlock(u_int32_t addr, std::vector<u_int8_t> dataVec, P
     {
         return errmsg("no data to write.");
     }
-    // make sure we work on device
-    if (!_ioAccess->is_flash())
-    {
-        return errmsg("no flash detected.(command is only supported on flash)");
-    }
 
     // check if flash is big enough
     if ((addr + dataVec.size()) > _ioAccess->get_effective_size())


### PR DESCRIPTION
Description:
1. Enabling write block ('wb') command for FW images
2. Fixing 'verify showitoc' to display entries content as expected

Tested OS: Linux
Tested devices: N/A
Tested flows: mstflint -i <bin> wb <bin> <addr>
mstflint -i <encrypted_bin> v showitoc

Known gaps (with RM ticket): N/A

Issue: 3348079