### PR TITLE
[mlxlink] Updating to amber 2.13

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -76,24 +76,22 @@ MlxlinkAmBerCollector::MlxlinkAmBerCollector(Json::Value& jsonRoot) : _jsonRoot(
 
     _baseSheetsList[AMBER_SHEET_GENERAL] = FIELDS_COUNT{4, 4, 4};
     _baseSheetsList[AMBER_SHEET_INDEXES] = FIELDS_COUNT{2, 2, 4};
-    _baseSheetsList[AMBER_SHEET_LINK_STATUS] = FIELDS_COUNT{49, 142, 6};
-    _baseSheetsList[AMBER_SHEET_MODULE_STATUS] = FIELDS_COUNT{110, 110, 0};
+    _baseSheetsList[AMBER_SHEET_LINK_STATUS] = FIELDS_COUNT{49, 143, 6};
+    _baseSheetsList[AMBER_SHEET_MODULE_STATUS] = FIELDS_COUNT{94, 110, 0};
     _baseSheetsList[AMBER_SHEET_SYSTEM] = FIELDS_COUNT{16, 21, 11};
     _baseSheetsList[AMBER_SHEET_SERDES_16NM] = FIELDS_COUNT{376, 736, 0};
-    _baseSheetsList[AMBER_SHEET_SERDES_7NM] = FIELDS_COUNT{206, 374, 502};
+    _baseSheetsList[AMBER_SHEET_SERDES_7NM] = FIELDS_COUNT{182, 362, 406};
     _baseSheetsList[AMBER_SHEET_PORT_COUNTERS] = FIELDS_COUNT{35, 0, 50};
     _baseSheetsList[AMBER_SHEET_TROUBLESHOOTING] = FIELDS_COUNT{2, 2, 0};
     _baseSheetsList[AMBER_SHEET_PHY_OPERATION_INFO] = FIELDS_COUNT{17, 17, 15};
     _baseSheetsList[AMBER_SHEET_LINK_UP_INFO] = FIELDS_COUNT{9, 9, 0};
-    _baseSheetsList[AMBER_SHEET_LINK_DOWN_INFO] = FIELDS_COUNT{5, 5, 0};
+    _baseSheetsList[AMBER_SHEET_LINK_DOWN_INFO] = FIELDS_COUNT{4, 4, 0};
     _baseSheetsList[AMBER_SHEET_TEST_MODE_INFO] = FIELDS_COUNT{68, 136, 0};
     _baseSheetsList[AMBER_SHEET_TEST_MODE_MODULE_INFO] = FIELDS_COUNT{70, 110, 0};
     _baseSheetsList[AMBER_SHEET_PHY_DEBUG_INFO] = FIELDS_COUNT{4, 4, 0};
-    _baseSheetsList[AMBER_SHEET_EXT_MODULE_STATUS] = FIELDS_COUNT{102, 102, 0};
+    _baseSheetsList[AMBER_SHEET_EXT_MODULE_STATUS] = FIELDS_COUNT{76, 116, 0};
 
-    for_each(_baseSheetsList.begin(), _baseSheetsList.end(), [&](pair<AMBER_SHEET, FIELDS_COUNT> sheet) {
-        _sheetsList.push_back({sheet.first, sheet.second});
-    });
+    for_each(_baseSheetsList.begin(), _baseSheetsList.end(), [&](pair<AMBER_SHEET, FIELDS_COUNT> sheet) { _sheetsList.push_back({sheet.first, sheet.second}); });
 }
 
 MlxlinkAmBerCollector::~MlxlinkAmBerCollector() {}
@@ -241,10 +239,8 @@ void MlxlinkAmBerCollector::init()
                     updateField("proto_mask", _protoActive);
                     genBuffSendRegister(ACCESS_REG_PTYS, MACCESS_REG_METHOD_GET);
 
-                    _activeSpeed = _productTechnology >= PRODUCT_16NM ? getFieldValue("ext_eth_proto_oper") :
-                                                                        getFieldValue("eth_proto_oper");
-                    _numOfLanes = _productTechnology >= PRODUCT_16NM ? _mlxlinkMaps->_ExtETHSpeed2Lanes[_activeSpeed] :
-                                                                       _mlxlinkMaps->_ETHSpeed2Lanes[_activeSpeed];
+                    _activeSpeed = _productTechnology >= PRODUCT_16NM ? getFieldValue("ext_eth_proto_oper") : getFieldValue("eth_proto_oper");
+                    _numOfLanes = _productTechnology >= PRODUCT_16NM ? _mlxlinkMaps->_ExtETHSpeed2Lanes[_activeSpeed] : _mlxlinkMaps->_ETHSpeed2Lanes[_activeSpeed];
                 }
                 else
                 {
@@ -324,9 +320,7 @@ void MlxlinkAmBerCollector::initAmberSheetsToDump()
     if (!_sheetsToDump.empty())
     {
         _sheetsList.clear();
-        for_each(_sheetsToDump.begin(), _sheetsToDump.end(), [&](AMBER_SHEET& sheet) {
-            _sheetsList.push_back({sheet, _baseSheetsList[sheet]});
-        });
+        for_each(_sheetsToDump.begin(), _sheetsToDump.end(), [&](AMBER_SHEET& sheet) { _sheetsList.push_back({sheet, _baseSheetsList[sheet]}); });
     }
 }
 
@@ -373,8 +367,7 @@ string MlxlinkAmBerCollector::getNodeGUID()
         resetLocalParser(ACCESS_REG_SPZR);
         sendRegister(ACCESS_REG_SPZR, MACCESS_REG_METHOD_GET);
 
-        sprintf(charGuid, "0x%llx",
-                (unsigned long long)add32BitTo64(getFieldValue("node_guid_h"), getFieldValue("node_guid_l")));
+        sprintf(charGuid, "0x%llx", (unsigned long long)add32BitTo64(getFieldValue("node_guid_h"), getFieldValue("node_guid_l")));
         strGuid = string(charGuid);
     }
 
@@ -400,8 +393,7 @@ string MlxlinkAmBerCollector::getMACAddress()
         fieldName = "base_mac";
     }
 
-    sprintf(charMac, "0x%llx",
-            (unsigned long long)add32BitTo64(getFieldValue(fieldName + "_47_32"), getFieldValue(fieldName + "_31_0")));
+    sprintf(charMac, "0x%llx", (unsigned long long)add32BitTo64(getFieldValue(fieldName + "_47_32"), getFieldValue(fieldName + "_31_0")));
 
     strMac = string(charMac);
 
@@ -424,16 +416,14 @@ vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
 
     AmberField::_dataValid = true;
     string labelPortStr = to_string(_labelPort);
-    if ((_splitPort && _splitPort != 1) || (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) ||
-        (_devID == DeviceGB100))
+    if ((_splitPort && _splitPort != 1) || (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100))
     {
         /* For Quantum-2, the split notation will stand for the port in the cage
          * For other, only add the split notation if it's not 1
          */
         labelPortStr += "/" + to_string(_splitPort);
     }
-    if ((_secondSplit && _secondSplit != 1) &&
-        ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100)))
+    if ((_secondSplit && _secondSplit != 1) && ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100)))
     {
         labelPortStr += "/" + to_string(_secondSplit);
     }
@@ -479,8 +469,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
 
         resetLocalParser(ACCESS_REG_MGIR);
         sendRegister(ACCESS_REG_MGIR, MACCESS_REG_METHOD_GET);
-        string fwVersion =
-          getFieldStr("extended_major") + "." + getFieldStr("extended_minor") + "." + getFieldStr("extended_sub_minor");
+        string fwVersion = getFieldStr("extended_major") + "." + getFieldStr("extended_minor") + "." + getFieldStr("extended_sub_minor");
         string tech = _mlxlinkMaps->_tech[getFieldValue("technology")];
         fields.push_back(AmberField("Device_FW_Version", fwVersion));
 
@@ -498,8 +487,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
             sendRegister(ACCESS_REG_MVCR, MACCESS_REG_METHOD_GET);
             sysVol = to_string(getFieldValue("voltage_sensor_value") * 0.01) + "V";
             sysCur = getFieldStr("current_sensor_value");
-            sensNameVoltage =
-              getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
+            sensNameVoltage = getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
         }
         fields.push_back(AmberField("System_Voltage", sysVol));
         fields.push_back(AmberField("System_Current", sysCur));
@@ -513,8 +501,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
             resetLocalParser(ACCESS_REG_MTMP);
             sendRegister(ACCESS_REG_MTMP, MACCESS_REG_METHOD_GET);
             temp = getTemp(getFieldValue("temperature"), 8);
-            sensNameTemp =
-              getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
+            sensNameTemp = getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
         }
         fields.push_back(AmberField("Chip_Temp", temp));
 
@@ -543,11 +530,8 @@ string MlxlinkAmBerCollector::getClRawBer()
     double rawBerCoef = getFieldValue("raw_ber_coef");
     double rawBerMag = getFieldValue("raw_ber_magnitude");
     double rawBer = rawBerCoef * std::pow(10, -rawBerMag);
-    double timeSinceLinkUp =
-      ((double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low"))) /
-      1000.0;
-    double activeRate =
-      _protoActive == IB ? _mlxlinkMaps->_IBSpeed2gNum[_activeSpeed] : _mlxlinkMaps->_EthExtSpeed2gNum[_activeSpeed];
+    double timeSinceLinkUp = ((double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low"))) / 1000.0;
+    double activeRate = _protoActive == IB ? _mlxlinkMaps->_IBSpeed2gNum[_activeSpeed] : _mlxlinkMaps->_EthExtSpeed2gNum[_activeSpeed];
 
     double rateBerLane = (activeRate / _numOfLanes) * pow(10.0, 9);
 
@@ -587,27 +571,21 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
                                     !_isPortPCIE));
         if (_isPortIB)
         {
-            phyManagerLinkEnabledStr =
-              getStrByMask(getFieldValue("phy_manager_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
-            coreToPhyLinkEnabledStr =
-              getStrByMask(getFieldValue("core_to_phy_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
+            phyManagerLinkEnabledStr = getStrByMask(getFieldValue("phy_manager_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
+            coreToPhyLinkEnabledStr = getStrByMask(getFieldValue("core_to_phy_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
             cableProtoCapStr = getStrByMask(getFieldValue("cable_link_speed_cap"), _mlxlinkMaps->_IBSpeed2Str);
         }
         else if (_isPortETH)
         {
-            phyManagerLinkEnabledStr =
-              getStrByMask(getFieldValue("phy_manager_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
-            coreToPhyLinkEnabledStr =
-              getStrByMask(getFieldValue("core_to_phy_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
+            phyManagerLinkEnabledStr = getStrByMask(getFieldValue("phy_manager_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
+            coreToPhyLinkEnabledStr = getStrByMask(getFieldValue("core_to_phy_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
             cableProtoCapStr = getStrByMask(getFieldValue("cable_ext_eth_proto_cap"), _mlxlinkMaps->_EthExtSpeed2Str);
         }
         fields.push_back(AmberField("phy_manager_link_enabled", phyManagerLinkEnabledStr, !_isPortPCIE));
         fields.push_back(AmberField("core_to_phy_link_enabled", coreToPhyLinkEnabledStr, !_isPortPCIE));
         fields.push_back(AmberField("cable_proto_cap", cableProtoCapStr, !_isPortPCIE));
         u_int32_t phyMngrFsmState = getFieldValue("phy_mngr_fsm_state");
-        string loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ?
-                                _mlxlinkMaps->_loopbackModeList[getFieldValue("loopback_mode")].second :
-                                "-1";
+        string loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ? _mlxlinkMaps->_loopbackModeList[getFieldValue("loopback_mode")].second : "-1";
         u_int32_t fecModeRequest = (u_int32_t)log2((float)getFieldValue("fec_mode_request"));
         fields.push_back(AmberField("loopback_mode", loopbackMode, !_isPortPCIE));
         fields.push_back(AmberField("fec_mode_request", _mlxlinkMaps->_fecModeActive[fecModeRequest], !_isPortPCIE));
@@ -626,17 +604,14 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
             fields.push_back(AmberField("num_of_pfs", getFieldStr("num_of_pfs")));
             fields.push_back(AmberField("num_of_vfs", getFieldStr("num_of_vfs")));
             fields.push_back(AmberField("bdf0", getFieldStr("bdf0")));
-            fields.push_back(AmberField("max_read_request_size",
-                                        _mlxlinkMaps->_maxReadReqSize[getFieldValue("max_read_request_size")]));
+            fields.push_back(AmberField("max_read_request_size", _mlxlinkMaps->_maxReadReqSize[getFieldValue("max_read_request_size")]));
             fields.push_back(AmberField("max_payload_size", _mlxlinkMaps->_maxReadReqSize[getFieldValue("max_payload_"
                                                                                                         "size")]));
             fields.push_back(AmberField("pwr_status", _mlxlinkMaps->_pwrStatus[getFieldValue("pwr_status")]));
             fields.push_back(AmberField("port_type", _mlxlinkMaps->_portType[getFieldValue("port_type")]));
-            fields.push_back(
-              AmberField("link_peer_max_speed", _mlxlinkMaps->_linkPeerMaxSpeed[getFieldValue("link_peer_max_speed")]));
+            fields.push_back(AmberField("link_peer_max_speed", _mlxlinkMaps->_linkPeerMaxSpeed[getFieldValue("link_peer_max_speed")]));
             fields.push_back(AmberField("pci_power", getFieldStr("pci_power") + 'W'));
-            fields.push_back(
-              AmberField("device_status", getStrByMask(getFieldValue("device_status"), _mlxlinkMaps->_pcieDevStatus)));
+            fields.push_back(AmberField("device_status", getStrByMask(getFieldValue("device_status"), _mlxlinkMaps->_pcieDevStatus)));
         }
     }
     catch (const std::exception& exc)
@@ -679,28 +654,24 @@ void MlxlinkAmBerCollector::getPpcntBer(u_int32_t portType, vector<AmberField>& 
     fields.push_back(AmberField(confLevelStr, getClRawBer()));
     fields.push_back(AmberField(preTitle + "Raw_BER", berStr));
 
-    berStr =
-      to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
+    berStr = to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
     fields.push_back(AmberField(preTitle + "Effective_BER", berStr));
 
     if (_isPortETH && (portType == NETWORK_PORT_TYPE_NEAR || portType == NETWORK_PORT_TYPE_FAR))
     {
-        string effErrorsStr = to_string(
-          add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
+        string effErrorsStr = to_string(add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
 
         fields.push_back(AmberField(preTitle + "Effective_Errors", effErrorsStr));
     }
 
     if (portType != NETWORK_PORT_TYPE || (portType == NETWORK_PORT_TYPE && _isPortIB))
     {
-        berStr =
-          to_string(getFieldValue("symbol_fec_ber_coef")) + "E-" + to_string(getFieldValue("symbol_ber_magnitude"));
+        berStr = to_string(getFieldValue("symbol_fec_ber_coef")) + "E-" + to_string(getFieldValue("symbol_ber_magnitude"));
         fields.push_back(AmberField(preTitle + "Symbol_BER", berStr));
 
         if (portType != NETWORK_PORT_TYPE)
         {
-            u_int64_t symErrors =
-              add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
+            u_int64_t symErrors = add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
             fields.push_back(AmberField(preTitle + "Symbol_Errors", to_string(symErrors)));
         }
     }
@@ -733,9 +704,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             sprintf(dataRateStr, "%.2f", dataRate);
             u_int32_t ethLinkActive = getFieldValue("ext_eth_proto_oper");
             fields.push_back(AmberField("Speed_[Gb/s]", string(dataRateStr)));
-            fields.push_back(AmberField("Ethernet_Protocol_Active",
-                                        ethLinkActive ? _mlxlinkMaps->_EthExtSpeed2Str[ethLinkActive] : "N/A",
-                                        _isPortETH));
+            fields.push_back(AmberField("Ethernet_Protocol_Active", ethLinkActive ? _mlxlinkMaps->_EthExtSpeed2Str[ethLinkActive] : "N/A", _isPortETH));
 
             resetLocalParser(ACCESS_REG_PDDR);
             updateField("local_port", _localPort);
@@ -743,10 +712,8 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
 
             string linkSpeedActive = SupportedSpeeds2Str(IB, getFieldValue("link_speed_active"), true);
-            fields.push_back(
-              AmberField("Link_Speed_Active", linkSpeedActive.empty() ? "N/A" : linkSpeedActive, _isPortIB));
-            fields.push_back(
-              AmberField("Link_Width_Active", linkWidthMaskToStr(getFieldValue("link_width_active")), _isPortIB));
+            fields.push_back(AmberField("Link_Speed_Active", linkSpeedActive.empty() ? "N/A" : linkSpeedActive, _isPortIB));
+            fields.push_back(AmberField("Link_Width_Active", linkWidthMaskToStr(getFieldValue("link_width_active")), _isPortIB));
             fields.push_back(AmberField("Active_FEC", _mlxlinkMaps->_fecModeActive[getFieldValue("fec_mode_active")]));
         }
         else
@@ -767,9 +734,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             updateField("local_port", _localPort);
             updateField("grp", PPCNT_STATISTICAL_GROUP);
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-            float lastClear = (float)add32BitTo64(getFieldValue("time_since_last_clear_high"),
-                                                  getFieldValue("time_since_last_clear_low")) /
-                              60000.0;
+            float lastClear = (float)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) / 60000.0;
             char timeFrmt[64];
             sprintf(timeFrmt, "%.1f", lastClear);
             fields.push_back(AmberField("Time_since_last_clear_[Min]", string(timeFrmt)));
@@ -804,8 +769,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
                 val = "N/A";
                 if (idx < numOfBins || (skipBinLimit || !numOfBins))
                 {
-                    histBin = add32BitTo64(getFieldValue("hist[" + to_string(idx) + "]_hi"),
-                                           getFieldValue("hist[" + to_string(idx) + "]_lo"));
+                    histBin = add32BitTo64(getFieldValue("hist[" + to_string(idx) + "]_hi"), getFieldValue("hist[" + to_string(idx) + "]_lo"));
                     val = to_string(histBin);
                     if (!histBin && firstZeroHist < 0)
                     {
@@ -831,8 +795,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
                 val = "N/A";
                 if (lane < _numOfLanes)
                 {
-                    rawError = add32BitTo64(getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_high"),
-                                            getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_low"));
+                    rawError = add32BitTo64(getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_high"), getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_low"));
                     val = to_string(rawError);
                 }
                 fields.push_back(AmberField("Raw_Errors_lane" + to_string(lane), val));
@@ -842,11 +805,9 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             updateField("grp", PPCNT_STATISTICAL_GROUP);
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
 
-            string effErrorsStr = to_string(
-              add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
+            string effErrorsStr = to_string(add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
             fields.push_back(AmberField("Effective_Errors", effErrorsStr));
-            u_int64_t symErrors =
-              add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
+            u_int64_t symErrors = add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
             fields.push_back(AmberField("Symbol_Errors", to_string(symErrors)));
         }
         else
@@ -858,8 +819,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             updateField("node", _node);
             updateField("grp", MPCNT_PERFORMANCE_GROUP);
             sendRegister(ACCESS_REG_MPCNT, MACCESS_REG_METHOD_GET);
-            string berStr = to_string(getFieldValue("effective_ber_coef")) + "E-" +
-                            to_string(getFieldValue("effective_ber_magnitude"));
+            string berStr = to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
             fields.push_back(AmberField("effective_ber_pci", berStr));
             fields.push_back(AmberField("Rx_error_pci", to_string(getFieldValue("rx_errors"))));
             fields.push_back(AmberField("Tx_error_pci", to_string(getFieldValue("tx_errors"))));
@@ -873,9 +833,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
     return fields;
 }
 
-void MlxlinkAmBerCollector::fillParamsToFields(const string& title,
-                                               const vector<string>& values,
-                                               vector<AmberField>& fields)
+void MlxlinkAmBerCollector::fillParamsToFields(const string& title, const vector<string>& values, vector<AmberField>& fields)
 {
     string val = "";
     string fieldName = "";
@@ -958,46 +916,6 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesHDR()
     return fields;
 }
 
-u_int32_t MlxlinkAmBerCollector::getFomMeasurement()
-{
-    u_int32_t fomMeasurement = SLRG_EOM_NONE;
-    if (!_isPortPCIE)
-    {
-        fomMeasurement = SLRG_EOM_COMPOSITE;
-        if (!isSpeed25GPerLane(_activeSpeed, _protoActive))
-        {
-            fomMeasurement |= (SLRG_EOM_UPPER | SLRG_EOM_MIDDLE | SLRG_EOM_LOWER);
-        }
-    }
-    else
-    {
-        for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-        {
-            resetParser(ACCESS_REG_SLRG);
-            updateField("local_port", _localPort);
-            updateField("pnat", PNAT_PCIE);
-            updateField("lane", lane);
-            updateField("fom_measurment", SLRG_EOM_COMPOSITE);
-            genBuffSendRegister(ACCESS_REG_SLRG, MACCESS_REG_METHOD_GET);
-        }
-        u_int32_t it = 0;
-        while (it < SLRG_PCIE_7NM_TIMEOUT)
-        {
-            resetParser(ACCESS_REG_SLRG);
-            updateField("local_port", _localPort);
-            updateField("pnat", PNAT_PCIE);
-            genBuffSendRegister(ACCESS_REG_SLRG, MACCESS_REG_METHOD_GET);
-            if (getFieldValue("status"))
-            {
-                break;
-            }
-            it++;
-            msleep(SLRG_PCIE_7NM_SLEEP);
-        }
-    }
-    return fomMeasurement;
-}
-
 vector<AmberField> MlxlinkAmBerCollector::getSerdesNDR()
 {
     vector<AmberField> fields;
@@ -1007,43 +925,12 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesNDR()
         fields.push_back(AmberField("UPHY_version", "N/A"));
         fields.push_back(AmberField("BKV_version", "N/A"));
 
-        vector<vector<string>> slrgParams(SLRG_PARAMS_LAST, vector<string>(_maxLanes, ""));
         vector<vector<string>> sltpParams(SLTP_NDR_LAST + 1, vector<string>(_maxLanes, ""));
-        u_int32_t fomMeasurement = getFomMeasurement();
-        u_int32_t lane = 0;
-
-        // Getting 7nm SLRG information for all lanes
-        for (; lane < _numOfLanes; lane++)
-        {
-            resetLocalParser(ACCESS_REG_SLRG);
-            updateField("local_port", _localPort);
-            updateField("lane", lane);
-            updateField("pnat", _pnat);
-            updateField("fom_measurment", fomMeasurement);
-            sendRegister(ACCESS_REG_SLRG, MACCESS_REG_METHOD_GET);
-
-            slrgParams[SLRG_PARAMS_INITIAL_FOM][lane] = getFieldStr("initial_fom");
-            slrgParams[SLRG_PARAMS_FOM_MODE][lane] = getFieldStr("fom_mode");
-            slrgParams[SLRG_PARAMS_UPPER_EYE][lane] = getFieldStr("upper_eye");
-            slrgParams[SLRG_PARAMS_MID_EYE][lane] = getFieldStr("mid_eye");
-            slrgParams[SLRG_PARAMS_LOWER_EYE][lane] = getFieldStr("lower_eye");
-            slrgParams[SLRG_PARAMS_LAST_FOM][lane] = getFieldStr("last_fom");
-        }
-        fillParamsToFields("initial_fom", slrgParams[SLRG_PARAMS_INITIAL_FOM], fields);
-
-        if (!_isPortPCIE)
-        {
-            fillParamsToFields("fom_mode", slrgParams[SLRG_PARAMS_INITIAL_FOM], fields);
-            fillParamsToFields("upper_eye", slrgParams[SLRG_PARAMS_INITIAL_FOM], fields);
-            fillParamsToFields("mid_eye", slrgParams[SLRG_PARAMS_INITIAL_FOM], fields);
-            fillParamsToFields("lower_eye", slrgParams[SLRG_PARAMS_INITIAL_FOM], fields);
-        }
-        fillParamsToFields("composite_eye", slrgParams[SLRG_PARAMS_LAST_FOM], fields);
 
         if (!_isPortPCIE)
         {
             // Getting 7nm SLTP information for all lanes
-            for (lane = 0; lane < _numOfLanes; lane++)
+            for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
             {
                 resetLocalParser(ACCESS_REG_SLTP);
                 updateField("local_port", _localPort);
@@ -1136,40 +1023,31 @@ void MlxlinkAmBerCollector::getCmisComplianceCode(u_int32_t ethComplianceCode,
     }
 }
 
-void MlxlinkAmBerCollector::getEthComplianceCodes(u_int32_t cableTechnology,
-                                                  string& ethComplianceStr,
-                                                  string& extComplianceStr,
-                                                  u_int32_t cableMediaType)
+void MlxlinkAmBerCollector::getEthComplianceCodes(u_int32_t cableTechnology, string& ethComplianceStr, string& extComplianceStr, u_int32_t cableMediaType)
 {
     u_int32_t ethComplianceCode = getFieldValue("ethernet_compliance_code");
     u_int32_t extEthComplianceCode = getFieldValue("ext_ethernet_compliance_code");
 
     if (_isQsfpCable)
     {
-        ethComplianceStr =
-          ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceQsfp, true) : "N/A";
-        extComplianceStr = (extEthComplianceCode & QSFP_ETHERNET_COMPLIANCE_CODE_EXT) ?
-                             _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] :
-                             "N/A";
+        ethComplianceStr = ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceQsfp, true) : "N/A";
+        extComplianceStr = (extEthComplianceCode & QSFP_ETHERNET_COMPLIANCE_CODE_EXT) ? _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] : "N/A";
     }
     if (_isSfpCable)
     {
-        ethComplianceStr =
-          ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceSfp, true) : "N/A";
+        ethComplianceStr = ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceSfp, true) : "N/A";
         extComplianceStr = extEthComplianceCode ? _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] : "N/A";
     }
     if (_isCmisCable)
     {
-        getCmisComplianceCode(ethComplianceCode, extEthComplianceCode, ethComplianceStr, extComplianceStr,
-                              cableMediaType, cableTechnology);
+        getCmisComplianceCode(ethComplianceCode, extEthComplianceCode, ethComplianceStr, extComplianceStr, cableMediaType, cableTechnology);
     }
 }
 
 void MlxlinkAmBerCollector::getIbComplianceCodes(string& ibComplianceCodeStr)
 {
     u_int32_t ibComplianceCode = getFieldValue("ib_compliance_code");
-    ibComplianceCodeStr =
-      ibComplianceCode ? getCompliance(ibComplianceCode, _mlxlinkMaps->_cableComplianceCmisIb, true) : "N/A";
+    ibComplianceCodeStr = ibComplianceCode ? getCompliance(ibComplianceCode, _mlxlinkMaps->_cableComplianceCmisIb, true) : "N/A";
 }
 
 string MlxlinkAmBerCollector::getCableTechnologyStr(u_int32_t cableTechnology)
@@ -1239,10 +1117,7 @@ string MlxlinkAmBerCollector::getCableBreakoutStr(u_int32_t cableBreakout, u_int
     return cableBreakoutStr;
 }
 
-void MlxlinkAmBerCollector::pushModulePerLaneField(vector<AmberField>& fields,
-                                                   string fieldName,
-                                                   float valueCorrection,
-                                                   string laneSep)
+void MlxlinkAmBerCollector::pushModulePerLaneField(vector<AmberField>& fields, string fieldName, float valueCorrection, string laneSep)
 {
     float value = 0;
     u_int32_t lanes = MAX_NETWORK_LANES;
@@ -1279,8 +1154,7 @@ void MlxlinkAmBerCollector::pushModuleDpPerLane(vector<AmberField>& fields, cons
     }
 }
 
-string
-  MlxlinkAmBerCollector::getSmfLength(const u_int32_t smfLength, const u_int32_t cableTechnology, const bool optical)
+string MlxlinkAmBerCollector::getSmfLength(const u_int32_t smfLength, const u_int32_t cableTechnology, const bool optical)
 {
     string lengthStr = "N/A";
 
@@ -1392,9 +1266,7 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("cable_length", getCableLengthStr(getFieldValue("cable_length"), _isCmisCable) + 'm'));
     fields.push_back(AmberField("smf_length", getSmfLength(getFieldValue("smf_length"), cableTechnology, optical)));
     fields.push_back(AmberField("cable_identifier", getCableIdentifier(getFieldValue("cable_identifier"))));
-    fields.push_back(AmberField(
-      "cable_power_class",
-      getPowerClass(_mlxlinkMaps, cableIdentifier, getFieldValue("cable_power_class"), getFieldValue("max_power"))));
+    fields.push_back(AmberField("cable_power_class", getPowerClass(_mlxlinkMaps, cableIdentifier, getFieldValue("cable_power_class"), getFieldValue("max_power"))));
     fields.push_back(AmberField("max_power", getFieldStr("max_power")));
     fields.push_back(AmberField("cable_rx_amp", passive ? "N/A" : getFieldStr("cable_rx_amp")));
     fields.push_back(AmberField("cable_rx_pre_emphasis", passive ? "N/A" : getFieldStr("cable_rx_emphasis")));
@@ -1404,8 +1276,7 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("cable_attenuation_12g", getFieldStr("cable_attenuation_12g")));
     fields.push_back(AmberField("cable_attenuation_7g", getFieldStr("cable_attenuation_7g")));
     fields.push_back(AmberField("cable_attenuation_5g", getFieldStr("cable_attenuation_5g")));
-    fields.push_back(
-      AmberField("tx_input_freq_sync", getStrByValue(getFieldValue("tx_input_freq_sync"), _mlxlinkMaps->_txInputFreq)));
+    fields.push_back(AmberField("tx_input_freq_sync", getStrByValue(getFieldValue("tx_input_freq_sync"), _mlxlinkMaps->_txInputFreq)));
     fields.push_back(AmberField("rx_cdr_cap", _mlxlinkMaps->_rxTxCdrCap[getFieldValue("rx_cdr_cap")]));
     fields.push_back(AmberField("tx_cdr_cap", _mlxlinkMaps->_rxTxCdrCap[getFieldValue("tx_cdr_cap")]));
     fields.push_back(AmberField("rx_cdr_state", getRxTxCDRState(getFieldValue("rx_cdr_state"), _maxLanes)));
@@ -1458,8 +1329,7 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("Nominal_Bit_Rate", nbrString));
 
     fields.push_back(AmberField("Rx_Power_Type", _mlxlinkMaps->_rxPowerType[getFieldValue("rx_power_type")]));
-    fields.push_back(
-      AmberField("Date_Code", getDateCode(add32BitTo64(getFieldValue("date_code_hi"), getFieldValue("date_code_lo")))));
+    fields.push_back(AmberField("Date_Code", getDateCode(add32BitTo64(getFieldValue("date_code_hi"), getFieldValue("date_code_lo")))));
     fields.push_back(AmberField("Module_Temperature", getTemp(getFieldValue("temperature"))));
     fields.push_back(AmberField("Module_Voltage", to_string(getFieldValue("voltage") / 10.0)));
 
@@ -1630,63 +1500,34 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                 updateField("grp", PPCNT_EXT_IB_PORT_COUNTERS_GROUP);
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
 
-                fields.push_back(AmberField(
-                  "PortXmitDataExtended",
-                  to_string(add32BitTo64(getFieldValue("port_xmit_data_high"), getFieldValue("port_xmit_data_low")))));
-                fields.push_back(AmberField(
-                  "PortRcvDataExtended",
-                  to_string(add32BitTo64(getFieldValue("port_rcv_data_high"), getFieldValue("port_rcv_data_low")))));
-                fields.push_back(AmberField(
-                  "PortXmitPktsExtended",
-                  to_string(add32BitTo64(getFieldValue("port_xmit_pkts_high"), getFieldValue("port_xmit_pkts_low")))));
-                fields.push_back(AmberField(
-                  "PortRcvPktsExtended",
-                  to_string(add32BitTo64(getFieldValue("port_rcv_pkts_high"), getFieldValue("port_rcv_pkts_low")))));
+                fields.push_back(AmberField("PortXmitDataExtended", to_string(add32BitTo64(getFieldValue("port_xmit_data_high"), getFieldValue("port_xmit_data_low")))));
+                fields.push_back(AmberField("PortRcvDataExtended", to_string(add32BitTo64(getFieldValue("port_rcv_data_high"), getFieldValue("port_rcv_data_low")))));
+                fields.push_back(AmberField("PortXmitPktsExtended", to_string(add32BitTo64(getFieldValue("port_xmit_pkts_high"), getFieldValue("port_xmit_pkts_low")))));
+                fields.push_back(AmberField("PortRcvPktsExtended", to_string(add32BitTo64(getFieldValue("port_rcv_pkts_high"), getFieldValue("port_rcv_pkts_low")))));
 
                 // Getting engress counters
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_DISC_COUNTERS_GROUP);
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-                fields.push_back(AmberField(
-                  "PortSwLifetimeLimitDiscards",
-                  to_string(add32BitTo64(getFieldValue("egress_sll_high"), getFieldValue("egress_sll_low")))));
-                fields.push_back(AmberField("PortSwHOQLifetimeLimitDiscards",
-                                            to_string(add32BitTo64(getFieldValue("egress_hoq_stall_high"),
-                                                                   getFieldValue("egress_hoq_stall_low")))));
+                fields.push_back(AmberField("PortSwLifetimeLimitDiscards", to_string(add32BitTo64(getFieldValue("egress_sll_high"), getFieldValue("egress_sll_low")))));
+                fields.push_back(AmberField("PortSwHOQLifetimeLimitDiscards", to_string(add32BitTo64(getFieldValue("egress_hoq_stall_high"), getFieldValue("egress_hoq_stall_low")))));
                 // Getting PLR counters data
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_PLR_GROUP);
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-                fields.push_back(AmberField(
-                  "PlrRcvCodes",
-                  to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"), getFieldValue("plr_rcv_codes_low")))));
-                fields.push_back(AmberField("PlrRcvCodeErr",
-                                            to_string(add32BitTo64(getFieldValue("plr_rcv_code_err_high"),
-                                                                   getFieldValue("plr_rcv_code_err_low")))));
-                fields.push_back(AmberField("PlrRcvUncorrectableCode",
-                                            to_string(add32BitTo64(getFieldValue("plr_rcv_uncorrectable_code_high"),
-                                                                   getFieldValue("plr_rcv_uncorrectable_code_low")))));
-                fields.push_back(AmberField(
-                  "PlrXmitCodes",
-                  to_string(add32BitTo64(getFieldValue("plr_xmit_codes_high"), getFieldValue("plr_xmit_codes_low")))));
-                fields.push_back(AmberField("PlrXmitRetryCodes",
-                                            to_string(add32BitTo64(getFieldValue("plr_xmit_retry_codes_high"),
-                                                                   getFieldValue("plr_xmit_retry_codes_low")))));
-                fields.push_back(AmberField("PlrXmitRetryEvents",
-                                            to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"),
-                                                                   getFieldValue("plr_xmit_retry_events_low")))));
-                fields.push_back(AmberField("PlrSyncEvents",
-                                            to_string(add32BitTo64(getFieldValue("plr_sync_events_high"),
-                                                                   getFieldValue("plr_sync_events_low")))));
-                fields.push_back(AmberField("PlrCodesLoss",
-                                            to_string(add32BitTo64(getLocalFieldValue("plr_codes_loss_high"),
-                                                                   getLocalFieldValue("plr_codes_loss_low")))));
-                fields.push_back(AmberField(
-                  "PlrXmitRetryEventsWithinTSecMax",
-                  to_string(add32BitTo64(getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_high"),
-                                         getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_low")))));
+                fields.push_back(AmberField("PlrRcvCodes", to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"), getFieldValue("plr_rcv_codes_low")))));
+                fields.push_back(AmberField("PlrRcvCodeErr", to_string(add32BitTo64(getFieldValue("plr_rcv_code_err_high"), getFieldValue("plr_rcv_code_err_low")))));
+                fields.push_back(AmberField("PlrRcvUncorrectableCode", to_string(add32BitTo64(getFieldValue("plr_rcv_uncorrectable_code_high"), getFieldValue("plr_rcv_uncorrectable_code_low")))));
+                fields.push_back(AmberField("PlrXmitCodes", to_string(add32BitTo64(getFieldValue("plr_xmit_codes_high"), getFieldValue("plr_xmit_codes_low")))));
+                fields.push_back(AmberField("PlrXmitRetryCodes", to_string(add32BitTo64(getFieldValue("plr_xmit_retry_codes_high"), getFieldValue("plr_xmit_retry_codes_low")))));
+                fields.push_back(AmberField("PlrXmitRetryEvents", to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"), getFieldValue("plr_xmit_retry_events_low")))));
+                fields.push_back(AmberField("PlrSyncEvents", to_string(add32BitTo64(getFieldValue("plr_sync_events_high"), getFieldValue("plr_sync_events_low")))));
+                fields.push_back(AmberField("PlrCodesLoss", to_string(add32BitTo64(getLocalFieldValue("plr_codes_loss_high"), getLocalFieldValue("plr_codes_loss_low")))));
+                fields.push_back(
+                  AmberField("PlrXmitRetryEventsWithinTSecMax",
+                             to_string(add32BitTo64(getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_high"), getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_low")))));
             }
         }
         else
@@ -1701,17 +1542,13 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
 
             fields.push_back(AmberField("crc_error_dllp", getFieldStr("crc_error_dllp")));
             fields.push_back(AmberField("crc_error_tlp", getFieldStr("crc_error_tlp")));
-            fields.push_back(AmberField("tx_overflow_buffer_pkt",
-                                        to_string(add32BitTo64(getFieldValue("tx_overflow_buffer_pkt_hi"),
-                                                               getFieldValue("tx_overflow_buffer_pkt_lo")))));
+            fields.push_back(AmberField("tx_overflow_buffer_pkt", to_string(add32BitTo64(getFieldValue("tx_overflow_buffer_pkt_hi"), getFieldValue("tx_overflow_buffer_pkt_lo")))));
             fields.push_back(AmberField("outbound_stalled_reads", getFieldStr("outbound_stalled_reads")));
             fields.push_back(AmberField("outbound_stalled_writes", getFieldStr("outbound_stalled_writes")));
             fields.push_back(AmberField("outbound_stalled_reads_events", getFieldStr("outbound_stalled_reads_events")));
             fields.push_back(AmberField("outbound_stalled_writes_events", getFieldStr("outbound_stalled_writes_"
                                                                                       "events")));
-            fields.push_back(AmberField("tx_overflow_buffer_marked_pkt",
-                                        to_string(add32BitTo64(getFieldValue("tx_overflow_buffer_marked_pkt_hi"),
-                                                               getFieldValue("tx_overflow_buffer_marked_pkt_lo")))));
+            fields.push_back(AmberField("tx_overflow_buffer_marked_pkt", to_string(add32BitTo64(getFieldValue("tx_overflow_buffer_marked_pkt_hi"), getFieldValue("tx_overflow_buffer_marked_pkt_lo")))));
         }
     }
     catch (const std::exception& exc)
@@ -1812,9 +1649,7 @@ string MlxlinkAmBerCollector::getPrbsModeCap(u_int32_t modeSelector, u_int32_t c
 {
     string modeCapStr = "";
     u_int32_t mask = 0;
-    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin();
-         it != _mlxlinkMaps->_prbsModesList.end();
-         it++)
+    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin(); it != _mlxlinkMaps->_prbsModesList.end(); it++)
     {
         mask = PRBS31_CAP << it->first;
         if (capsMask & mask)
@@ -1849,22 +1684,16 @@ void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg, vector<ve
 
         if (prbsReg == ACCESS_REG_PPRT)
         {
-            params[PRBS_PARAMS_RX_TUNING_STATUS][lane] =
-              getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
-            params[PRBS_PARAMS_LOCK_STATUS][lane] =
-              getStrByValue(getFieldValue("prbs_lock_status"), _mlxlinkMaps->_prbsLockStatus);
+            params[PRBS_PARAMS_RX_TUNING_STATUS][lane] = getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
+            params[PRBS_PARAMS_LOCK_STATUS][lane] = getStrByValue(getFieldValue("prbs_lock_status"), _mlxlinkMaps->_prbsLockStatus);
         }
         params[PRBS_PARAMS_E][lane] = getStrByValue(getFieldValue("e"), _mlxlinkMaps->_prbsEStatus);
         params[PRBS_PARAMS_P][lane] = getStrByValue(getFieldValue("p"), _mlxlinkMaps->_prbsPStatus);
         params[PRBS_PARAMS_MODES_CAP][lane] = getPrbsModeCap(PRBS_TX, getFieldValue("prbs_modes_cap"));
-        params[PRBS_PARAMS_MODE_ADMIN][lane] =
-          getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList);
-        params[PRBS_PARAMS_MODULATION][lane] =
-          getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_prbsModulation);
-        params[PRBS_PARAMS_LANE_RATE_CAP][lane] =
-          getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_prbsLaneRateCap);
-        params[PRBS_PARAMS_LANE_RATE_ADMIN][lane] =
-          getStrByValue(getFieldValue(laneRateStr), _mlxlinkMaps->_prbsLaneRateList);
+        params[PRBS_PARAMS_MODE_ADMIN][lane] = getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList);
+        params[PRBS_PARAMS_MODULATION][lane] = getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_prbsModulation);
+        params[PRBS_PARAMS_LANE_RATE_CAP][lane] = getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_prbsLaneRateCap);
+        params[PRBS_PARAMS_LANE_RATE_ADMIN][lane] = getStrByValue(getFieldValue(laneRateStr), _mlxlinkMaps->_prbsLaneRateList);
     }
 }
 
@@ -1915,20 +1744,13 @@ void MlxlinkAmBerCollector::getTestModeModulePMPT(vector<AmberField>& fields, st
 
     string modeStr = mode == MODULE_PRBS_ACCESS_GEN ? "generator" : "checker";
 
-    fields.push_back(AmberField("prbs_" + modeStr + "_pattern_cap_" + moduleSide,
-                                getPrbsModeCap(PRBS_RX, getFieldValue("prbs_modes_cap"))));
-    fields.push_back(AmberField("prbs_" + modeStr + "_pattern_admin_" + moduleSide,
-                                getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList)));
-    fields.push_back(AmberField("prbs_" + modeStr + "_msb_lsb_swap_" + moduleSide,
-                                getStrByValue(getFieldValue("swap_admin"), _mlxlinkMaps->_modulePrbsSwapAdmin)));
-    fields.push_back(AmberField("prbs_" + modeStr + "_polarity_" + moduleSide,
-                                getStrByValue(getFieldValue("invt_admin"), _mlxlinkMaps->_modulePrbsInvAdmin)));
-    fields.push_back(AmberField("prbs_" + modeStr + "_modulation_" + moduleSide,
-                                getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_modulePrbsModulation)));
-    fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_cap_" + moduleSide,
-                                getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
-    fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_admin_" + moduleSide,
-                                getStrByValue(getFieldValue("lane_rate_admin"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_pattern_cap_" + moduleSide, getPrbsModeCap(PRBS_RX, getFieldValue("prbs_modes_cap"))));
+    fields.push_back(AmberField("prbs_" + modeStr + "_pattern_admin_" + moduleSide, getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_msb_lsb_swap_" + moduleSide, getStrByValue(getFieldValue("swap_admin"), _mlxlinkMaps->_modulePrbsSwapAdmin)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_polarity_" + moduleSide, getStrByValue(getFieldValue("invt_admin"), _mlxlinkMaps->_modulePrbsInvAdmin)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_modulation_" + moduleSide, getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_modulePrbsModulation)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_cap_" + moduleSide, getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
+    fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_admin_" + moduleSide, getStrByValue(getFieldValue("lane_rate_admin"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
 }
 
 void MlxlinkAmBerCollector::getTestModeModulePMPD(vector<AmberField>& fields, string moduleSide)
@@ -1945,10 +1767,8 @@ void MlxlinkAmBerCollector::getTestModeModulePMPD(vector<AmberField>& fields, st
         sendRegister(ACCESS_REG_PMPD, MACCESS_REG_METHOD_GET);
 
         pmpdParams[PMPD_PARAM_STATUS][lane] = getStrByValue(getFieldValue("status"), _mlxlinkMaps->_modulePMPDStatus);
-        pmpdParams[PMPD_PARAM_PRBS_BITS][lane] =
-          to_string(add32BitTo64(getFieldValue("prbs_bits_high"), getFieldValue("prbs_bits_low")));
-        pmpdParams[PMPD_PARAM_PRBS_ERRORS][lane] =
-          to_string(add32BitTo64(getFieldValue("prbs_errors_high"), getFieldValue("prbs_errors_low")));
+        pmpdParams[PMPD_PARAM_PRBS_BITS][lane] = to_string(add32BitTo64(getFieldValue("prbs_bits_high"), getFieldValue("prbs_bits_low")));
+        pmpdParams[PMPD_PARAM_PRBS_ERRORS][lane] = to_string(add32BitTo64(getFieldValue("prbs_errors_high"), getFieldValue("prbs_errors_low")));
         pmpdParams[PMPD_PARAM_SNR][lane] = getFieldStr("measured_snr") + "dB";
         pmpdParams[PMPD_PARAM_BER][lane] = getFieldStr("ber_coef") + "E-" + getFieldStr("ber_magnitude");
     }

--- a/mlxlink/modules/mlxlink_amBER_collector.h
+++ b/mlxlink/modules/mlxlink_amBER_collector.h
@@ -126,7 +126,6 @@ private:
     void getTestModeModulePMPT(vector<AmberField>& fields, string moduleSide, ModuleAccess_t mode);
     void getTestModeModulePMPD(vector<AmberField>& fields, string moduleSide);
     u_int32_t getSheetIndex(AMBER_SHEET sheet);
-    u_int32_t getFomMeasurement();
 
     void collect();
     vector<AmberField> collectSheet(AMBER_SHEET sheet);

--- a/mlxlink/modules/mlxlink_enums.h
+++ b/mlxlink/modules/mlxlink_enums.h
@@ -34,7 +34,7 @@
 #define MLXLINK_ENUMS_H
 
 // Common definitions
-#define AMBER_VERSION "2.11"
+#define AMBER_VERSION "2.13"
 
 #define ACCESS_REG_MCIA "MCIA"
 #define ACCESS_REG_MDDQ "MDDQ"


### PR DESCRIPTION
Description:
-> Module_status_4:
Changed IB lanes (column D) index to 4x.

-> Link_status_3:
Added a new field from the PPCNT.Physical_Layer_Counters: successful_recovery_events

-> Removed all SLRG readings for 7nm devices

Issue: 3408638