### PR TITLE
[mstlink] Changing SLTP default params for Spectrum-4

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -4201,7 +4201,8 @@ void MlxlinkCommander::validateNumOfParamsForNDRGen()
     u_int32_t params;
     string errMsg = "Invalid set of Transmitter Parameters, ";
     errMsg += "valid parameters for the active speed are: ";
-    if (isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
+    if ((!_activeSpeed && _devID == DeviceSpectrum4) ||
+        isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
     {
         params = SLTP_NDR_LAST;
         errMsg += "fir_pre3,fir_pre2,fir_pre1,fir_main,fir_post1";
@@ -4291,7 +4292,8 @@ string MlxlinkCommander::updateSltpNdrFields()
     char paramBuff[128] = "";
     string sltpParamsCmd = "";
 
-    if (isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
+    if ((!_activeSpeed && _devID == DeviceSpectrum4) ||
+        isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
     {
         snprintf(ndrParamBuff, 64, ",fir_pre3=%d,fir_pre2=%d", _userInput._sltpParams[SLTP_NDR_FIR_PRE3],
                  _userInput._sltpParams[SLTP_NDR_FIR_PRE2]);

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -1465,7 +1465,7 @@ bool isSpeed100GPerLane(u_int32_t speed, u_int32_t protocol)
     bool valid = true;
     if ((protocol == IB && speed != IB_LINK_SPEED_NDR) ||
         (protocol == ETH && (speed != ETH_LINK_SPEED_EXT_100GAUI_1 && speed != ETH_LINK_SPEED_EXT_200GAUI_2 &&
-                             speed != ETH_LINK_SPEED_EXT_400GAUI_4)))
+                             speed != ETH_LINK_SPEED_EXT_400GAUI_4 && speed != ETH_LINK_SPEED_EXT_800GAUI_8)))
     {
         valid = false;
     }


### PR DESCRIPTION
Description:
Changing SLTP default params for Spectrum-4 if the port is down to use the NDR serdes params

Issue: 3430786