### PR TITLE
Fix illegal shift in mst_release

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -598,8 +598,10 @@ static int mst_release(struct inode* inode, struct file* file)
         goto out;
     }
 
-    slot_mask = ~(1 << (md->connectx_wa_slot_p1 - 1));
-    dev->connectx_wa_slots &= slot_mask;
+    if (md->connectx_wa_slot_pl != 0) {
+        slot_mask = ~(1 << (md->connectx_wa_slot_p1 - 1));
+        dev->connectx_wa_slots &= slot_mask;
+    }
 
     /*
      * mst_info("CONNECTX_WA: Released slot %u. Current slots: %02x\n",

--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -598,7 +598,7 @@ static int mst_release(struct inode* inode, struct file* file)
         goto out;
     }
 
-    if (md->connectx_wa_slot_pl != 0) {
+    if (md->connectx_wa_slot_p1 != 0) {
         slot_mask = ~(1 << (md->connectx_wa_slot_p1 - 1));
         dev->connectx_wa_slots &= slot_mask;
     }


### PR DESCRIPTION
UBSAN is catching an illegal shift in mst_release() and is reporting it to syslog.  The problem is that mst_release() is doing:
  slot_mask = ~(1 << (md->connectx_wa_slot_p1 - 1));
but md->connectx_wa_slot_pl is only set if the user calls the undocumented PCI_CONNECX_WA ioctl().  When the file is opened connectx_wa_slot_pl is set to 0.  If a user simply does an open() and then a close() then md->connectx_wa_slot_p1 is 0 and mst_release will try to do a shift by -1.