### PR TITLE
Add additional #include directives for C99 compatibility

### DIFF
--- a/mflash/mflash_gw.c
+++ b/mflash/mflash_gw.c
@@ -43,6 +43,8 @@
 #include "mflash_access_layer.h"
 #include "flash_int_defs.h"
 
+#include <stdlib.h>
+
 #ifdef __WIN__
 //
 // Windows (Under DDK)

--- a/mflash/mflash_new_gw.c
+++ b/mflash/mflash_new_gw.c
@@ -42,6 +42,9 @@
 #include "mflash_dev_capability.h"
 #include "mflash_access_layer.h"
 #include "flash_int_defs.h"
+
+#include <stdlib.h>
+
 #define DPRINTF(args)                            \
     do                                           \
     {                                            \

--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -37,6 +37,7 @@
 #include <tools_layouts/reg_access_hca_layouts.h>
 #include <tools_layouts/reg_access_switch_layouts.h>
 #include <tools_layouts/tools_open_layouts.h>
+#include <tools_layouts/cibfw_layouts.h>
 
 #define REG_ID_PCNR              0x5050
 #define REG_ID_PAOS              0x5006


### PR DESCRIPTION
Avoid implicit declarations of cibfw_register_mfai_pack, cibfw_register_mfai_unpack, cibfw_register_mfai_size by including <tools_layouts/cibfw_layouts.h>, and of getenv by including <stdlib.h>.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
