### PR TITLE
Remove mlxfwreset support for BF2/BF3

### DIFF
--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -1764,6 +1764,11 @@ def reset_flow_host(device, args, command):
         if psid in ["MT_0000000891", "MT_0000000929", "MT_0000000937"]:
             raise RuntimeError("Cedar device is not supported")
 
+    # Block BF2/BF3
+    devDict = getDeviceDict(devid)
+    if devDict['name'] in ['BlueField2', 'BlueField3']:
+        raise RuntimeError("%s device is not supported" % devDict['name'])
+
     # Check if other process is accessing the device (burning the device)
     # Supported on Windows OS only
     if platform.system() == "Windows":


### PR DESCRIPTION
Description: N/A

Tested OS: Linux
Tested devices: BF2, CX6
Tested flows: mlxfwreset reset/query

Known gaps (with RM ticket): N/A

Issue: 3459379
Change-Id: Ic5a958519d2926e850cf8a5df0dbf5ce2ac11900