### PR TITLE
deprecated some of boost library usage.

### DIFF
--- a/adb_parser/Makefile.am
+++ b/adb_parser/Makefile.am
@@ -40,7 +40,8 @@ USER_DIR = ..
 INCLUDES = -I$(USER_DIR) -I$(USER_DIR)/common
 AM_CXXFLAGS = -Wall -W -g -MP -MD  -pipe $(COMPILER_FPIC)
 
-lib_LTLIBRARIES = libadb_parser.a
+lib_LTLIBRARIES = libadb_parser.a \
+                  $(USER_DIR)/common/libstring_utils.la
 
 libadb_parser_a_SOURCES = buf_ops.cpp expr.cpp adb_expr.cpp adb_parser.cpp adb_db.cpp adb_config.cpp adb_exceptionHolder.cpp adb_field.cpp adb_instance.cpp adb_logfile.cpp adb_node.cpp adb_xmlCreator.cpp adb_condVar.cpp adb_condition.cpp
 

--- a/adb_parser/adb_condition.cpp
+++ b/adb_parser/adb_condition.cpp
@@ -37,20 +37,21 @@
 #include <stdlib.h>
 #include "adb_condition.h"
 
-#if __cplusplus >= 201402L
-#include <regex>
-#else
+#ifdef BOOST_ENABLED
 #include <boost/regex.hpp>
 using namespace boost;
+#else
+#include <regex>
 #endif
 
-AdbCondition::AdbCondition() {}
+AdbCondition::AdbCondition()
+{
+}
 
 void AdbCondition::setCondition(std::string condition)
 {
     this->condition = condition;
-    if (condition != "")
-    {
+    if (condition != "") {
         splitConditionIntoVariables();
     }
 }
@@ -58,17 +59,18 @@ void AdbCondition::setCondition(std::string condition)
 void AdbCondition::splitConditionIntoVariables()
 {
     static const regex EXP_PATTERN("(\\w+)\\s*==");
-    match_results<string::const_iterator> match;
+
+    match_results < string::const_iterator > match;
     string::const_iterator start = this->condition.begin();
     string::const_iterator end = this->condition.end();
-    while (regex_search(start, end, match, EXP_PATTERN))
-    {
+
+    while (regex_search(start, end, match, EXP_PATTERN)) {
         this->varsMap[match[0]] = CondVar();
         start = match[0].second;
     }
 }
 
-map<string, CondVar>& AdbCondition::getVarsMap()
+map < string, CondVar > &AdbCondition::getVarsMap()
 {
     return this->varsMap;
 }

--- a/adb_parser/adb_db.cpp
+++ b/adb_parser/adb_db.cpp
@@ -37,8 +37,8 @@
 
 #include <vector>
 #include <stdio.h>
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
+#include <string>
+#include "common/string_utils.h"
 #include "adb_db.h"
 
 #define CHECK_FIELD(field, node_w)                                                  \
@@ -52,10 +52,9 @@
         continue;                                                                   \
     }
 
-struct node_wrapper
-{
+struct node_wrapper {
     AdbInstance* node;
-    vector<AdbInstance*>* fields;
+    vector < AdbInstance * > *fields;
 };
 
 static char err[1024] = {0};
@@ -73,8 +72,7 @@ adb_db_t* db_create()
  */
 int db_load(adb_db_t* db, const char* adb_file_path, int add_reserved)
 {
-    if (!((Adb*)db)->load(adb_file_path, add_reserved, NULL, false))
-    {
+    if (!((Adb*)db)->load(adb_file_path, add_reserved, NULL, false)) {
         sprintf(err, "Failed to load adabe project: %s", ((Adb*)db)->getLastError().c_str());
         return 1;
     }
@@ -87,8 +85,7 @@ int db_load(adb_db_t* db, const char* adb_file_path, int add_reserved)
  */
 int db_load_from_str(adb_db_t* db, const char* adb_data, int add_reserved)
 {
-    if (!((Adb*)db)->loadFromString(adb_data, add_reserved, NULL, false))
-    {
+    if (!((Adb*)db)->loadFromString(adb_data, add_reserved, NULL, false)) {
         sprintf(err, "Failed to load adabe project: %s", ((Adb*)db)->getLastError().c_str());
         return 1;
     }
@@ -101,9 +98,8 @@ int db_load_from_str(adb_db_t* db, const char* adb_data, int add_reserved)
  */
 void db_destroy(adb_db_t* db)
 {
-    if (db)
-    {
-        delete (Adb*)db;
+    if (db) {
+        delete(Adb*) db;
     }
 }
 
@@ -117,26 +113,20 @@ const char* db_get_last_err()
 
 adb_limits_map_t* db_create_limits_map(adb_db_t* db)
 {
-    map<string, string>* limits = new map<string, string>();
+    map < string, string > *limits = new map < string, string > ();
 
-    // Load defines
-    if (db)
-    {
-        for (size_t i = 0; i < ((Adb*)db)->configs.size(); i++)
-        {
+    /* Load defines */
+    if (db) {
+        for (size_t i = 0; i < ((Adb*)db)->configs.size(); i++) {
             AttrsMap::iterator attrs_map = ((Adb*)db)->configs[i]->attrs.find("define");
-            if (attrs_map != ((Adb*)db)->configs[i]->attrs.end())
-            {
-                vector<string> defVal;
-                boost::algorithm::split(defVal, attrs_map->second, boost::is_any_of(string("=")));
+            if (attrs_map != ((Adb*)db)->configs[i]->attrs.end()) {
+                vector < string > defVal;
+                string_utils::split(defVal, attrs_map->second, "=");
 
-                if (defVal.size() == 1)
-                {
-                    ((map<string, string>*)limits)->insert(pair<string, string>(defVal[0], "0"));
-                }
-                else
-                {
-                    ((map<string, string>*)limits)->insert(pair<string, string>(defVal[0], defVal[1]));
+                if (defVal.size() == 1) {
+                    ((map < string, string > *)limits)->insert(pair < string, string > (defVal[0], "0"));
+                } else {
+                    ((map < string, string > *)limits)->insert(pair < string, string > (defVal[0], defVal[1]));
                 }
             }
         }
@@ -146,10 +136,9 @@ adb_limits_map_t* db_create_limits_map(adb_db_t* db)
 
 void db_destroy_limits_map(adb_limits_map_t* limits)
 {
-    if (limits)
-    {
-        ((map<string, string>*)limits)->clear();
-        delete (map<string, string>*)limits;
+    if (limits) {
+        ((map < string, string > *)limits)->clear();
+        delete(map < string, string > *) limits;
     }
 }
 
@@ -158,23 +147,23 @@ void db_destroy_limits_map(adb_limits_map_t* limits)
  */
 adb_node_t* db_get_node(adb_db_t* db, const char* node_name)
 {
-    Adb* adb = (Adb*)db;
+    Adb        * adb = (Adb*)db;
     AdbInstance* node = adb->createLayout(node_name, false, NULL);
-    if (!node)
-    {
+
+    if (!node) {
         sprintf(err, "Failed to create node %s: %s", node_name, adb->getLastError().c_str());
         return NULL;
     }
     struct node_wrapper* node_w = (struct node_wrapper*)malloc(sizeof(struct node_wrapper));
-    if (!node_w)
-    {
+
+    if (!node_w) {
         delete node;
         sprintf(err, "Failed to allocate memory for node");
         return NULL;
     }
     memset(node_w, 0, sizeof(*node_w));
     node_w->node = node;
-    node_w->fields = new vector<AdbInstance*>;
+    node_w->fields = new vector < AdbInstance * >;
     *node_w->fields = node->getLeafFields(false);
     return node_w;
 }
@@ -185,14 +174,12 @@ adb_node_t* db_get_node(adb_db_t* db, const char* node_name)
 void db_node_destroy(adb_node_t* node)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
-    if (node_w)
-    {
-        if (node_w->node)
-        {
+
+    if (node_w) {
+        if (node_w->node) {
             delete node_w->node;
         }
-        if (node_w->fields)
-        {
+        if (node_w->fields) {
             delete node_w->fields;
         }
         free(node_w);
@@ -205,6 +192,7 @@ void db_node_destroy(adb_node_t* node)
 void db_node_name(adb_node_t* node, char name[])
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     strcpy(name, node_w->node->name.c_str());
 }
 
@@ -214,6 +202,7 @@ void db_node_name(adb_node_t* node, char name[])
 int db_node_size(adb_node_t* node)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     return node_w->node->size;
 }
 
@@ -223,6 +212,7 @@ int db_node_size(adb_node_t* node)
 int db_node_num_of_fields(adb_node_t* node)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     return (int)node_w->fields->size();
 }
 
@@ -231,13 +221,13 @@ int db_node_num_of_fields(adb_node_t* node)
  */
 adb_field_t* db_node_get_field(adb_node_t* node, int field_idx)
 {
-    if (field_idx >= db_node_num_of_fields(node))
-    {
+    if (field_idx >= db_node_num_of_fields(node)) {
         sprintf(err, "index out of range");
         return NULL;
     }
 
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     return node_w->fields->at(field_idx);
 }
 
@@ -247,28 +237,22 @@ adb_field_t* db_node_get_field(adb_node_t* node, int field_idx)
 adb_field_t* db_node_get_field_by_path(adb_node_t* node, const char* path, int is_case_sensitive)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     string fullPath(path);
 
-    if (node_w->node->isConditionalNode())
-    {
+    if (node_w->node->isConditionalNode()) {
         fullPath += ".val";
     }
-    for (size_t i = 0; i < node_w->fields->size(); i++)
-    {
-        if (is_case_sensitive)
-        {
-            if (node_w->fields->at(i)->fullName(1) == fullPath)
-            {
+    for (size_t i = 0; i < node_w->fields->size(); i++) {
+        if (is_case_sensitive) {
+            if (node_w->fields->at(i)->fullName(1) == fullPath) {
                 return node_w->fields->at(i);
             }
-        }
-        else
-        {
-            string field_name_lower = boost::algorithm::to_lower_copy(node_w->fields->at(i)->fullName(1));
-            string path_lower = boost::algorithm::to_lower_copy(fullPath);
+        } else {
+            string field_name_lower = string_utils::to_lower_copy(node_w->fields->at(i)->fullName(1));
+            string path_lower = string_utils::to_lower_copy(fullPath);
 
-            if (path_lower == field_name_lower)
-            {
+            if (path_lower == field_name_lower) {
                 return node_w->fields->at(i);
             }
         }
@@ -285,6 +269,7 @@ adb_field_t* db_node_get_field_by_path(adb_node_t* node, const char* path, int i
 bool db_node_dump(adb_node_t* node, u_int8_t buf[], dump_format_t format, FILE* stream)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     return db_node_range_dump(node, 0, node_w->node->size - 1, buf, format, stream);
 }
 
@@ -292,13 +277,14 @@ bool db_node_dump(adb_node_t* node, u_int8_t buf[], dump_format_t format, FILE* 
  * db_node_dump_with_limits
  * Returns: false on error
  */
-bool db_node_conditional_dump(adb_node_t* node,
-                              u_int8_t buf[],
-                              dump_format_t format,
-                              FILE* stream,
+bool db_node_conditional_dump(adb_node_t      * node,
+                              u_int8_t          buf[],
+                              dump_format_t     format,
+                              FILE            * stream,
                               adb_limits_map_t* values_map)
 {
     struct node_wrapper* node_w = (struct node_wrapper*)node;
+
     return db_node_conditional_range_dump(node, 0, node_w->node->size - 1, buf, format, stream, values_map);
 }
 
@@ -306,12 +292,12 @@ bool db_node_conditional_dump(adb_node_t* node,
  * db_node_range_dump
  * Returns: false on error
  */
-bool db_node_range_dump(adb_node_t* node,
-                        u_int32_t from,
-                        u_int32_t to,
-                        u_int8_t buf[],
+bool db_node_range_dump(adb_node_t  * node,
+                        u_int32_t     from,
+                        u_int32_t     to,
+                        u_int8_t      buf[],
                         dump_format_t format,
-                        FILE* stream)
+                        FILE        * stream)
 {
     return db_node_conditional_range_dump(node, from, to, buf, format, stream, NULL);
 }
@@ -320,82 +306,73 @@ bool db_node_range_dump(adb_node_t* node,
  * db_node_range_dump_with_limits
  * Returns: false on error
  */
-bool db_node_conditional_range_dump(adb_node_t* node,
-                                    u_int32_t from,
-                                    u_int32_t to,
-                                    u_int8_t buf[],
-                                    dump_format_t format,
-                                    FILE* stream,
+bool db_node_conditional_range_dump(adb_node_t      * node,
+                                    u_int32_t         from,
+                                    u_int32_t         to,
+                                    u_int8_t          buf[],
+                                    dump_format_t     format,
+                                    FILE            * stream,
                                     adb_limits_map_t* values_map)
 {
-    int i;
-    adb_field_t* field;
-    char enum_str[256];
-    char name[256];
-    int is_enum;
-    u_int32_t value;
-    u_int32_t offset;
-    u_int32_t size;
+    int                  i;
+    adb_field_t        * field;
+    char                 enum_str[256];
+    char                 name[256];
+    int                  is_enum;
+    u_int32_t            value;
+    u_int32_t            offset;
+    u_int32_t            size;
     struct node_wrapper* node_w = (struct node_wrapper*)node;
-    if (values_map)
-    {
-        // Fill values map for conditions
-        for (i = 0; i < db_node_num_of_fields(node); i++)
-        {
+
+    if (values_map) {
+        /* Fill values map for conditions */
+        for (i = 0; i < db_node_num_of_fields(node); i++) {
             field = db_node_get_field(node, i);
-            if (!field)
-            {
+            if (!field) {
                 return false;
             }
             CHECK_FIELD(field, node_w);
             db_field_full_name(field, 0, name);
             value = db_field_value(field, (u_int8_t*)buf);
-            if (node_w->node->isConditionalNode())
-            {
+            if (node_w->node->isConditionalNode()) {
                 char* p = strstr(name, ".val");
-                if (p != NULL)
-                {
+                if (p != NULL) {
                     *p = '\0';
                 }
             }
-            ((map<string, string>*)values_map)->insert(pair<string, string>(name, boost::lexical_cast<string>(value)));
+            ((map < string, string > *)values_map)->insert(pair < string,
+                                                           string > (name, to_string(value)));
         }
     }
 
-    for (i = 0; i < db_node_num_of_fields(node); i++)
-    {
+    for (i = 0; i < db_node_num_of_fields(node); i++) {
         field = db_node_get_field(node, i);
-        if (!field)
-        {
+        if (!field) {
             return false;
         }
         CHECK_FIELD(field, node_w);
 
         db_field_full_name(field, 0, name);
         value = db_field_value(field, (u_int8_t*)buf);
-        if (node_w->node->isConditionalNode())
-        {
+        if (node_w->node->isConditionalNode()) {
             char* p = strstr(name, ".val");
-            if (p != NULL)
-            {
+            if (p != NULL) {
                 *p = '\0';
             }
         }
         /*
          * Just if the node is Conditional
          */
-        if (node_w->node->isConditionalNode() && values_map != NULL)
-        {
+        if (node_w->node->isConditionalNode() && (values_map != NULL)) {
             try
             {
                 AdbInstance* parentField = node_w->node->subItems[i];
-                if (!parentField->isConditionValid(((map<string, string>*)values_map)))
-                {
-                    ((map<string, string>*)values_map)->erase(name);
+                if (!parentField->isConditionValid((((map < string), (string > *))values_map))) {
+                    ((map < string, string > *)values_map)->erase(name);
                     continue;
                 }
             }
-            catch (...)
+            catch(...)
             {
                 continue;
             }
@@ -403,22 +380,20 @@ bool db_node_conditional_range_dump(adb_node_t* node,
 
         is_enum = db_field_enum(field, value, enum_str);
         size = db_field_size(field);
-        if (stream != NULL)
-        {
-            switch (format)
-            {
-                case DB_FORMAT_STANDARD:
-                    fprintf(stream, "%-40s : 0x%x %s\n", name, value, is_enum ? enum_str : "");
-                    break;
+        if (stream != NULL) {
+            switch (format) {
+            case DB_FORMAT_STANDARD:
+                fprintf(stream, "%-40s : 0x%x %s\n", name, value, is_enum ? enum_str : "");
+                break;
 
-                case DB_FORMAT_STANDARD_NO_ENUM:
-                    fprintf(stream, "%-40s : 0x%x\n", name, value);
-                    break;
+            case DB_FORMAT_STANDARD_NO_ENUM:
+                fprintf(stream, "%-40s : 0x%x\n", name, value);
+                break;
 
-                case DB_FORMAT_FULL_DETAILS:
-                    fprintf(stream, "%-40s : 0x%x %s - address: 0x%x.%d:%d\n", name, value, is_enum ? enum_str : "",
-                            offset / 32 * 4, offset % 32, size);
-                    break;
+            case DB_FORMAT_FULL_DETAILS:
+                fprintf(stream, "%-40s : 0x%x %s - address: 0x%x.%d:%d\n", name, value, is_enum ? enum_str : "",
+                        offset / 32 * 4, offset % 32, size);
+                break;
             }
         }
     }
@@ -462,10 +437,10 @@ int db_field_size(adb_field_t* field)
  */
 u_int64_t db_field_value(adb_field_t* field, u_int8_t buf[])
 {
-    //    cout << ((AdbInstance*)field)->offset / 8 << endl;
-    //    for (unsigned i = 0; i < ((AdbInstance*)field)->offset / 8; i++) {
-    //        printf ("%02x ", buf[i]);
-    //    }
+    /*    cout << ((AdbInstance*)field)->offset / 8 << endl; */
+    /*    for (unsigned i = 0; i < ((AdbInstance*)field)->offset / 8; i++) { */
+    /*        printf ("%02x ", buf[i]); */
+    /*    } */
     return ((AdbInstance*)field)->popBuf(buf);
 }
 
@@ -483,13 +458,11 @@ void db_field_set_value(adb_field_t* field, u_int8_t buf[], u_int64_t value)
 int db_field_enum(adb_field_t* field, u_int64_t value, char enum_str[])
 {
     string s;
-    if (((AdbInstance*)field)->intToEnum(value, s))
-    {
+
+    if (((AdbInstance*)field)->intToEnum(value, s)) {
         strcpy(enum_str, s.c_str());
         return 1;
-    }
-    else
-    {
+    } else {
         strcpy(enum_str, "");
         return 0;
     }
@@ -503,8 +476,7 @@ void db_print_nodes(adb_db_t* db)
     int i = 0;
 
     printf("DB nodes list:\n");
-    for (NodesMap::iterator iter = ((Adb*)db)->nodesMap.begin(); iter != ((Adb*)db)->nodesMap.end(); iter++)
-    {
+    for (NodesMap::iterator iter = ((Adb*)db)->nodesMap.begin(); iter != ((Adb*)db)->nodesMap.end(); iter++) {
         i++;
         printf("%-5d) %s\n", i, iter->first.c_str());
     }

--- a/adb_parser/adb_field.cpp
+++ b/adb_parser/adb_field.cpp
@@ -37,8 +37,6 @@
  **/
 
 #include "adb_field.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <iostream>
@@ -59,7 +57,9 @@ AdbField::AdbField() :
 /**
  * Function: AdbField::~AdbField
  **/
-AdbField::~AdbField() {}
+AdbField::~AdbField()
+{
+}
 
 /**
  * Function: AdbField::isLeaf
@@ -80,7 +80,7 @@ bool AdbField::isStruct()
 /**
  * Function: AdbField::operator<
  **/
-bool AdbField::operator<(AdbField& other)
+bool AdbField::operator < (AdbField & other)
 {
     return offset < other.offset;
 }
@@ -90,12 +90,9 @@ bool AdbField::operator<(AdbField& other)
  **/
 bool AdbField::isArray()
 {
-    if (unlimitedArr)
-    {
+    if (unlimitedArr) {
         return true;
-    }
-    else
-    {
+    } else {
         return definedAsArr ? true : lowBound != highBound;
     }
 }
@@ -105,12 +102,9 @@ bool AdbField::isArray()
  **/
 u_int32_t AdbField::arrayLen()
 {
-    if (unlimitedArr)
-    {
+    if (unlimitedArr) {
         return 1;
-    }
-    else
-    {
+    } else {
         return (highBound - lowBound + 1);
     }
 }
@@ -136,12 +130,9 @@ bool AdbField::isDynamicArr()
  **/
 u_int32_t AdbField::eSize()
 {
-    if (unlimitedArr)
-    {
+    if (unlimitedArr) {
         return size;
-    }
-    else
-    {
+    } else {
         return size / arrayLen();
     }
 }
@@ -163,15 +154,13 @@ void AdbField::print(int indent)
 string AdbField::toXml(const string& addPrefix)
 {
     string xml = "<field name=\"" + name + "\" descr=\"" + encodeXml(descNativeToXml(desc)) + "\"";
-    if (isStruct())
-    {
+
+    if (isStruct()) {
         xml += " subnode=\"" + addPrefix + subNode + "\"";
     }
 
-    for (AttrsMap::iterator it = attrs.begin(); it != attrs.end(); it++)
-    {
-        if (it->first == "name" || it->first == "subnode" || it->first == "descr")
-        {
+    for (AttrsMap::iterator it = attrs.begin(); it != attrs.end(); it++) {
+        if ((it->first == "name") || (it->first == "subnode") || (it->first == "descr")) {
             continue;
         }
 

--- a/adb_parser/adb_instance.cpp
+++ b/adb_parser/adb_instance.cpp
@@ -36,27 +36,33 @@
  * Function: AdbInstance::AdbInstance
  **/
 
+#include <string>
 #include "adb_instance.h"
 #include "adb_node.h"
 #include "adb_field.h"
 #include "adb_expr.h"
 #include "adb_exceptionHolder.h"
 #include "buf_ops.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
+#include "common/string_utils.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#ifdef BOOST_ENABLED
+#include <boost/regex.hpp>
+using namespace boost;
+#else
+#include <regex>
+#endif
+
 string addPathSuffixForArraySupport(string path)
 {
-    if (path[path.length() - 1] == ']')
-    { // Won't add suffix if leaf is in Array
+    if (path[path.length() - 1] == ']') { /* Won't add suffix if leaf is in Array */
         return "";
     }
     size_t pos = 0;
     string suffix = "";
-    while ((pos = path.find("[")) != std::string::npos)
-    { // Add array index number in path to suffix.
+
+    while ((pos = path.find("[")) != std::string::npos) { /* Add array index number in path to suffix. */
         size_t end_pos = path.find("]");
         size_t len = end_pos - pos - 1;
         suffix = suffix + "_" + path.substr(pos + 1, len);
@@ -79,7 +85,6 @@ AdbInstance::AdbInstance() :
     unionSelector(NULL),
     isDiff(false),
     userData(NULL)
-
 {
 }
 
@@ -88,8 +93,9 @@ AdbInstance::AdbInstance() :
  **/
 AdbInstance::~AdbInstance()
 {
-    for (size_t i = 0; i < subItems.size(); i++)
+    for (size_t i = 0; i < subItems.size(); i++) {
         delete subItems[i];
+    }
 }
 
 /**
@@ -137,27 +143,22 @@ bool AdbInstance::isPartOfArray()
  **/
 string AdbInstance::fullName(int skipLevel)
 {
-    list<string> fnList;
+    list < string > fnList;
     AdbInstance* p = parent;
 
     fnList.push_front(name);
-    while (p != NULL)
-    {
+    while (p != NULL) {
         fnList.push_front(p->name);
         p = p->parent;
     }
 
-    if ((int)fnList.size() > skipLevel)
-    {
-        while (skipLevel--)
-        {
+    if ((int)fnList.size() > skipLevel) {
+        while (skipLevel--) {
             fnList.pop_front();
         }
 
-        return boost::algorithm::join(fnList, ".");
-    }
-    else
-    {
+        return string_utils::join(fnList, ".");
+    } else {
         return fnList.back();
     }
 }
@@ -189,7 +190,7 @@ u_int32_t AdbInstance::startBit()
 /**
  * Function: AdbInstance::operator<
  **/
-bool AdbInstance::operator<(const AdbInstance& other)
+bool AdbInstance::operator < (const AdbInstance& other)
 {
     return offset < other.offset;
 }
@@ -199,10 +200,9 @@ bool AdbInstance::operator<(const AdbInstance& other)
  **/
 AdbInstance* AdbInstance::getChildByPath(const string& path, bool isCaseSensitive)
 {
-    string effPath = isCaseSensitive ? path : boost::algorithm::to_lower_copy(path);
+    string effPath = isCaseSensitive ? path : string_utils::to_lower_copy(path);
 
-    if (effPath[0] == '.')
-    {
+    if (effPath[0] == '.') {
         effPath.erase(0, 1);
     }
 
@@ -210,59 +210,51 @@ AdbInstance* AdbInstance::getChildByPath(const string& path, bool isCaseSensitiv
     string childName = idx == string::npos ? effPath : effPath.substr(0, idx);
     string grandChildPath = idx == string::npos ? string() : effPath.substr(idx + 1);
 
-    if (path.empty())
-    {
+    if (path.empty()) {
         return this;
     }
 
-    // Search for childName
+    /* Search for childName */
     AdbInstance* child = NULL;
-    for (size_t i = 0; i < subItems.size(); i++)
-    {
-        string subName = isCaseSensitive ? subItems[i]->name : boost::algorithm::to_lower_copy(subItems[i]->name);
-        if (subName == childName)
-        {
+
+    for (size_t i = 0; i < subItems.size(); i++) {
+        string subName = isCaseSensitive ? subItems[i]->name : string_utils::to_lower_copy(subItems[i]->name);
+        if (subName == childName) {
             child = subItems[i];
             break;
         }
     }
 
-    if (!child)
-    {
+    if (!child) {
         return NULL;
     }
 
-    // if grandChildPath isn't empty this means we need to continue and find the desired field in grand child node
+    /* if grandChildPath isn't empty this means we need to continue and find the desired field in grand child node */
     return grandChildPath.empty() ? child : child->getChildByPath(grandChildPath, isCaseSensitive);
 }
 
 /**
  * Function: AdbInstance::findChild
  **/
-vector<AdbInstance*> AdbInstance::findChild(const string& childName, bool isCaseSensitive, bool by_inst_name)
+vector < AdbInstance * > AdbInstance::findChild(const string& childName, bool isCaseSensitive, bool by_inst_name)
 {
-    string effName = isCaseSensitive ? childName : boost::algorithm::to_lower_copy(childName);
-    vector<AdbInstance*> childList;
+    string effName = isCaseSensitive ? childName : string_utils::to_lower_copy(childName);
 
-    if (by_inst_name || isLeaf())
-    {
-        if (name == childName)
-        {
+    vector < AdbInstance * > childList;
+
+    if (by_inst_name || isLeaf()) {
+        if (name == childName) {
             childList.push_back(this);
         }
-    }
-    else
-    {
-        if (isNode() && nodeDesc->name == childName)
-        {
+    } else {
+        if (isNode() && (nodeDesc->name == childName)) {
             childList.push_back(this);
         }
     }
 
-    // do that recursively for all child items
-    for (size_t i = 0; i < subItems.size(); i++)
-    {
-        vector<AdbInstance*> l = subItems[i]->findChild(effName, true);
+    /* do that recursively for all child items */
+    for (size_t i = 0; i < subItems.size(); i++) {
+        vector < AdbInstance * > l = subItems[i]->findChild(effName, true);
         childList.insert(childList.end(), l.begin(), l.end());
     }
 
@@ -275,18 +267,14 @@ vector<AdbInstance*> AdbInstance::findChild(const string& childName, bool isCase
 string AdbInstance::getInstanceAttr(const string& attrName) const
 {
     AttrsMap::const_iterator it = instAttrsMap.find(attrName);
-    if (it == instAttrsMap.end())
-    {
-        if (fieldDesc)
-        {
+
+    if (it == instAttrsMap.end()) {
+        if (fieldDesc) {
             it = fieldDesc->attrs.find(attrName);
-            if (it == fieldDesc->attrs.end())
-            {
+            if (it == fieldDesc->attrs.end()) {
                 return string();
             }
-        }
-        else
-        {
+        } else {
             return string();
         }
     }
@@ -299,16 +287,13 @@ string AdbInstance::getInstanceAttr(const string& attrName) const
 AttrsMap::iterator AdbInstance::getInstanceAttrIterator(const string& attrName, bool& found)
 {
     AttrsMap::iterator it = instAttrsMap.find(attrName);
+
     found = false;
-    if (it != instAttrsMap.end())
-    {
+    if (it != instAttrsMap.end()) {
         found = true;
-    }
-    else if (fieldDesc)
-    {
+    } else if (fieldDesc) {
         it = fieldDesc->attrs.find(attrName);
-        if (it != fieldDesc->attrs.end())
-        {
+        if (it != fieldDesc->attrs.end()) {
             found = true;
         }
     }
@@ -337,14 +322,13 @@ void AdbInstance::copyAllInstanceAttr(AttrsMap& attsToCopy)
 AttrsMap AdbInstance::getFullInstanceAttrsMapCopy()
 {
     AttrsMap tmpCopy;
-    // copy first the fields attr map
-    for (AttrsMap::iterator it = fieldDesc->attrs.begin(); it != fieldDesc->attrs.end(); it++)
-    {
+
+    /* copy first the fields attr map */
+    for (AttrsMap::iterator it = fieldDesc->attrs.begin(); it != fieldDesc->attrs.end(); it++) {
         tmpCopy[it->first] = it->second;
     }
-    // copy the overriden variables - in instAttrsMap
-    for (AttrsMap::iterator it = instAttrsMap.begin(); it != instAttrsMap.end(); it++)
-    {
+    /* copy the overriden variables - in instAttrsMap */
+    for (AttrsMap::iterator it = instAttrsMap.begin(); it != instAttrsMap.end(); it++) {
         tmpCopy[it->first] = it->second;
     }
     return tmpCopy;
@@ -387,28 +371,25 @@ bool AdbInstance::isEnumExists()
  **/
 bool AdbInstance::enumToInt(const string& name, u_int64_t& val)
 {
-    vector<string> enumValues;
+    vector < string > enumValues;
     string enums = getInstanceAttr("enum");
-    boost::algorithm::split(enumValues, enums, boost::is_any_of(string(",")));
 
-    for (size_t i = 0; i < enumValues.size(); i++)
-    {
-        vector<string> pair;
+    string_utils::split(enumValues, enums, ",");
+
+    for (size_t i = 0; i < enumValues.size(); i++) {
+        vector < string > pair;
         string trimedEnumValues = enumValues[i];
-        boost::algorithm::trim(trimedEnumValues);
-        boost::algorithm::split(pair, trimedEnumValues, boost::is_any_of(string("=")));
+        string_utils::trim(trimedEnumValues);
+        string_utils::split(pair, trimedEnumValues, "=");
 
-        if (pair.size() != 2)
-        {
+        if (pair.size() != 2) {
             continue;
         }
 
         char* end;
-        if (pair[0] == name)
-        {
+        if (pair[0] == name) {
             val = strtoul(pair[1].c_str(), &end, 0);
-            if (*end != '\0')
-            {
+            if (*end != '\0') {
                 return false;
             }
             return true;
@@ -423,31 +404,28 @@ bool AdbInstance::enumToInt(const string& name, u_int64_t& val)
  **/
 bool AdbInstance::intToEnum(u_int64_t val, string& valName)
 {
-    vector<string> enumValues;
+    vector < string > enumValues;
     string enums = getInstanceAttr("enum");
-    boost::algorithm::split(enumValues, enums, boost::is_any_of(string(",")));
 
-    for (size_t i = 0; i < enumValues.size(); i++)
-    {
-        vector<string> pair;
+    string_utils::split(enumValues, enums, ",");
+
+    for (size_t i = 0; i < enumValues.size(); i++) {
+        vector < string > pair;
         string trimedEnumValues = enumValues[i];
-        boost::algorithm::trim(trimedEnumValues);
-        boost::algorithm::split(pair, trimedEnumValues, boost::is_any_of(string("=")));
+        string_utils::trim(trimedEnumValues);
+        string_utils::split(pair, trimedEnumValues, "=");
 
-        if (pair.size() != 2)
-        {
+        if (pair.size() != 2) {
             continue;
         }
 
-        char* end;
+        char    * end;
         u_int64_t tmp = strtoul(pair[1].c_str(), &end, 0);
-        if (*end != '\0')
-        {
+        if (*end != '\0') {
             continue;
         }
 
-        if (tmp == val)
-        {
+        if (tmp == val) {
             valName = pair[0];
             return true;
         }
@@ -459,31 +437,29 @@ bool AdbInstance::intToEnum(u_int64_t val, string& valName)
 /**
  * Function: AdbInstance::getEnumMap
  **/
-map<string, u_int64_t> AdbInstance::getEnumMap()
+map < string, u_int64_t > AdbInstance::getEnumMap()
 {
-    map<string, u_int64_t> enumMap;
-    vector<string> enumValues;
+    map < string, u_int64_t > enumMap;
+    vector < string > enumValues;
     string enums = getInstanceAttr("enum");
-    boost::algorithm::split(enumValues, enums, boost::is_any_of(string(",")));
 
-    for (size_t i = 0; i < enumValues.size(); i++)
-    {
-        vector<string> pair;
+    string_utils::split(enumValues, enums, ",");
+
+    for (size_t i = 0; i < enumValues.size(); i++) {
+        vector < string > pair;
         string trimedEnumValues = enumValues[i];
-        boost::algorithm::trim(trimedEnumValues);
-        boost::algorithm::split(pair, trimedEnumValues, boost::is_any_of(string("=")));
-        if (pair.size() != 2)
-        {
+        string_utils::trim(trimedEnumValues);
+        string_utils::split(pair, trimedEnumValues, "=");
+        if (pair.size() != 2) {
             throw AdbException("Can't parse enum: " + enumValues[i]);
-            // continue;
+            /* continue; */
         }
 
-        char* end;
+        char    * end;
         u_int64_t intVal = strtoul(pair[1].c_str(), &end, 0);
-        if (*end != '\0')
-        {
+        if (*end != '\0') {
             throw AdbException(string("Can't evaluate enum (") + pair[0].c_str() + "): " + pair[1].c_str());
-            // continue;
+            /* continue; */
         }
 
         enumMap[pair[0]] = intVal;
@@ -495,28 +471,26 @@ map<string, u_int64_t> AdbInstance::getEnumMap()
 /**
  * Function: AdbInstance::getEnumValues
  **/
-vector<u_int64_t> AdbInstance::getEnumValues()
+vector < u_int64_t > AdbInstance::getEnumValues()
 {
-    vector<u_int64_t> values;
-    vector<string> enumValues;
+    vector < u_int64_t > values;
+    vector < string > enumValues;
     string enums = getInstanceAttr("enum");
-    boost::algorithm::split(enumValues, enums, boost::is_any_of(string(",")));
 
-    for (size_t i = 0; i < enumValues.size(); i++)
-    {
-        vector<string> pair;
+    string_utils::split(enumValues, enums, ",");
+
+    for (size_t i = 0; i < enumValues.size(); i++) {
+        vector < string > pair;
         string trimedEnumValues = enumValues[i];
-        boost::algorithm::trim(trimedEnumValues);
-        boost::algorithm::split(pair, trimedEnumValues, boost::is_any_of(string("=")));
-        if (pair.size() != 2)
-        {
+        string_utils::trim(trimedEnumValues);
+        string_utils::split(pair, trimedEnumValues, "=");
+        if (pair.size() != 2) {
             continue;
         }
 
-        char* end;
+        char    * end;
         u_int64_t intVal = strtoul(pair[1].c_str(), &end, 0);
-        if (*end != '\0')
-        {
+        if (*end != '\0') {
             continue;
         }
 
@@ -531,27 +505,21 @@ vector<u_int64_t> AdbInstance::getEnumValues()
  **/
 AdbInstance* AdbInstance::getUnionSelectedNodeName(const u_int64_t& selectorVal)
 {
-    if (!isUnion())
-    {
+    if (!isUnion()) {
         throw AdbException("This is not union node (%s), can't get selected node name", fullName().c_str());
     }
 
-    if (!unionSelector)
-    {
+    if (!unionSelector) {
         throw AdbException("Can't find selector for union: " + name);
     }
 
-    map<string, u_int64_t> selectorValMap = unionSelector->getEnumMap();
-    for (map<string, u_int64_t>::iterator it = selectorValMap.begin(); it != selectorValMap.end(); it++)
-    {
-        if (it->second == selectorVal)
-        {
+    map < string, u_int64_t > selectorValMap = unionSelector->getEnumMap();
+    for (map < string, u_int64_t > ::iterator it = selectorValMap.begin(); it != selectorValMap.end(); it++) {
+        if (it->second == selectorVal) {
             const string& selectorEnum = it->first;
-            // search for the sub instance with the "selected_by" attribute == selectorEnum
-            for (size_t i = 0; i < subItems.size(); i++)
-            {
-                if (subItems[i]->getInstanceAttr("selected_by") == selectorEnum)
-                {
+            /* search for the sub instance with the "selected_by" attribute == selectorEnum */
+            for (size_t i = 0; i < subItems.size(); i++) {
+                if (subItems[i]->getInstanceAttr("selected_by") == selectorEnum) {
                     return subItems[i];
                 }
             }
@@ -561,7 +529,7 @@ AdbInstance* AdbInstance::getUnionSelectedNodeName(const u_int64_t& selectorVal)
     }
 
     throw AdbException("Union selector field (" + unionSelector->name + ") doesn't define selector value (" +
-                       boost::lexical_cast<string>(selectorVal));
+                       to_string(selectorVal));
 }
 
 /**
@@ -569,20 +537,16 @@ AdbInstance* AdbInstance::getUnionSelectedNodeName(const u_int64_t& selectorVal)
  **/
 AdbInstance* AdbInstance::getUnionSelectedNodeName(const string& selectorEnum)
 {
-    if (!isUnion())
-    {
+    if (!isUnion()) {
         throw AdbException("This is not union node (%s), can't get selected node name", fullName().c_str());
     }
 
-    if (!unionSelector)
-    {
+    if (!unionSelector) {
         throw AdbException("Can't find selector for union: " + name);
     }
 
-    for (size_t i = 0; i < subItems.size(); i++)
-    {
-        if (subItems[i]->getInstanceAttr("selected_by") == selectorEnum)
-        {
+    for (size_t i = 0; i < subItems.size(); i++) {
+        if (subItems[i]->getInstanceAttr("selected_by") == selectorEnum) {
             return subItems[i];
         }
     }
@@ -597,8 +561,7 @@ AdbInstance* AdbInstance::getUnionSelectedNodeName(const string& selectorEnum)
  **/
 bool AdbInstance::isConditionalNode()
 {
-    if (isNode())
-    {
+    if (isNode()) {
         return (getInstanceAttr("is_conditional") == "1");
     }
     return false;
@@ -608,23 +571,21 @@ bool AdbInstance::isConditionalNode()
  * Function: AdbInstance::isConditionValid
  * Throws exception: AdbException
  **/
-bool AdbInstance::isConditionValid(map<string, string>* valuesMap)
+bool AdbInstance::isConditionValid(map < string, string > * valuesMap)
 {
     u_int64_t res;
-    AdbExpr expressionChecker;
-    int status = -1;
-    char* condExp;
-    char* exp;
+    AdbExpr   expressionChecker;
+    int       status = -1;
+    char    * condExp;
+    char    * exp;
 
-    if (fieldDesc->condition.empty())
-    {
+    if (fieldDesc->condition.empty()) {
         return true;
     }
 
     condExp = new char[fieldDesc->condition.size() + 1];
     exp = condExp;
-    if (!exp)
-    {
+    if (!exp) {
         throw AdbException("Memory allocation error");
     }
     strcpy(exp, fieldDesc->condition.c_str());
@@ -634,15 +595,14 @@ bool AdbInstance::isConditionValid(map<string, string>* valuesMap)
     {
         status = expressionChecker.expr(&exp, &res);
     }
-    catch (AdbException& e)
+    catch(AdbException & e)
     {
         delete[] condExp;
         throw AdbException(string("AdbException: ") + e.what_s());
     }
     delete[] condExp;
 
-    if (status < 0)
-    {
+    if (status < 0) {
         throw AdbException(string("Error evaluating expression \"") + fieldDesc->condition.c_str() +
                            "\" : " + AdbExpr::statusStr(status));
     }
@@ -653,27 +613,19 @@ bool AdbInstance::isConditionValid(map<string, string>* valuesMap)
 /**
  * Function: AdbInstance::getLeafFields
  **/
-vector<AdbInstance*> AdbInstance::getLeafFields(bool extendenName)
+vector < AdbInstance * > AdbInstance::getLeafFields(bool extendenName)
 {
-    vector<AdbInstance*> fields;
+    vector < AdbInstance * > fields;
 
-    for (size_t i = 0; i < subItems.size(); i++)
-    {
-        if (subItems[i]->isNode())
-        {
-            vector<AdbInstance*> subFields = subItems[i]->getLeafFields(extendenName);
+    for (size_t i = 0; i < subItems.size(); i++) {
+        if (subItems[i]->isNode()) {
+            vector < AdbInstance * > subFields = subItems[i]->getLeafFields(extendenName);
             fields.insert(fields.end(), subFields.begin(), subFields.end());
-        }
-        else
-        {
-            if (extendenName && !subItems[i]->isNameBeenExtended)
-            {
-                if (subItems[i]->parent->fieldDesc->subNode == "uint64")
-                {
+        } else {
+            if (extendenName && !subItems[i]->isNameBeenExtended) {
+                if (subItems[i]->parent->fieldDesc->subNode == "uint64") {
                     subItems[i]->name = subItems[i]->parent->name + "_" + subItems[i]->name;
-                }
-                else
-                {
+                } else {
                     subItems[i]->name = subItems[i]->name + addPathSuffixForArraySupport(subItems[i]->fullName());
                 }
                 subItems[i]->isNameBeenExtended = true;
@@ -707,12 +659,13 @@ u_int64_t AdbInstance::popBuf(u_int8_t* buf)
 void AdbInstance::print(int indent)
 {
     string indentStr = indentString(indent);
+
     printf("%sfullName: %s, offset: 0x%x.%d, size: 0x%x.%d, isNode:%d, isUnion:%d\n", indentStr.c_str(),
            fullName().c_str(), (offset >> 5) << 2, offset % 32, (size >> 5) << 2, size % 32, isNode(), isUnion());
 
-    if (isNode())
-    {
-        for (size_t i = 0; i < subItems.size(); i++)
+    if (isNode()) {
+        for (size_t i = 0; i < subItems.size(); i++) {
             subItems[i]->print(indent + 1);
+        }
     }
 }

--- a/adb_parser/adb_node.cpp
+++ b/adb_parser/adb_node.cpp
@@ -41,32 +41,30 @@
 #include "adb_field.h"
 #include <iostream>
 
-#if __cplusplus >= 201402L
-#include <regex>
-#else
+#ifdef BOOST_ENABLED
 #include <boost/regex.hpp>
 using namespace boost;
+#else
+#include <regex>
 #endif
 
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
-AdbNode::AdbNode() : size(0), _maxLeafSize(0), isUnion(false), inLayout(false), lineNumber(-1), userData(0) {}
+AdbNode::AdbNode() : size(0), _maxLeafSize(0), isUnion(false), inLayout(false), lineNumber(-1), userData(0)
+{
+}
 
 /**
  *  * Function: AdbNode::~AdbNode
  *   **/
 AdbNode::~AdbNode()
 {
-    for (size_t i = 0; i < fields.size(); i++)
-    {
+    for (size_t i = 0; i < fields.size(); i++) {
         delete fields[i];
     }
     fields.clear();
-    for (size_t i = 0; i < condFields.size(); i++)
-    {
+    for (size_t i = 0; i < condFields.size(); i++) {
         delete condFields[i];
     }
     condFields.clear();
@@ -78,10 +76,9 @@ AdbNode::~AdbNode()
 string AdbNode::toXml(const string& addPrefix)
 {
     string xml = "<node name=\"" + addPrefix + name + "\" descr=\"" + encodeXml(descNativeToXml(desc)) + "\"";
-    for (AttrsMap::iterator it = attrs.begin(); it != attrs.end(); it++)
-    {
-        if (it->first == "name" || it->first == "descr")
-        {
+
+    for (AttrsMap::iterator it = attrs.begin(); it != attrs.end(); it++) {
+        if ((it->first == "name") || (it->first == "descr")) {
             continue;
         }
 
@@ -90,13 +87,12 @@ string AdbNode::toXml(const string& addPrefix)
     xml += " >\n";
 
     FieldsList allFields = fields;
-    allFields.insert(allFields.end(), condFields.begin(), condFields.end());
-    stable_sort(allFields.begin(), allFields.end(), compareFieldsPtr<AdbField>);
 
-    for (size_t i = 0; i < allFields.size(); i++)
-    {
-        if (allFields[i]->isReserved)
-        {
+    allFields.insert(allFields.end(), condFields.begin(), condFields.end());
+    stable_sort(allFields.begin(), allFields.end(), compareFieldsPtr < AdbField >);
+
+    for (size_t i = 0; i < allFields.size(); i++) {
+        if (allFields[i]->isReserved) {
             continue;
         }
 
@@ -117,6 +113,7 @@ void AdbNode::print(int indent)
          << " isUnion: " << isUnion << " Description: " << desc << endl;
 
     cout << indentString(indent) << "Fields:" << endl;
-    for (size_t i = 0; i < fields.size(); i++)
+    for (size_t i = 0; i < fields.size(); i++) {
         fields[i]->print(indent + 1);
+    }
 }

--- a/adb_parser/adb_parser.cpp
+++ b/adb_parser/adb_parser.cpp
@@ -41,18 +41,18 @@
 #include "adb_condition.h"
 #include "adb_condVar.h"
 #include "buf_ops.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
+#include "common/string_utils.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <iostream>
 #include <expat.h>
+#include <string.h>
 
-#if __cplusplus >= 201402L
-#include <regex>
-#else
+#ifdef BOOST_ENABLED
 #include <boost/regex.hpp>
 using namespace boost;
+#else
+#include <regex>
 #endif
 
 using namespace xmlCreator;
@@ -60,11 +60,11 @@ using namespace xmlCreator;
 class AdbParser
 {
 public:
-    // METHODS
+    /* METHODS */
     AdbParser(string fileName,
-              Adb* adbCtxt,
+              Adb * adbCtxt,
               bool addReserved = false,
-              AdbProgress* progressObj = NULL,
+              AdbProgress * progressObj = NULL,
               bool strict = true,
               string includePath = "",
               bool enforceExtraChecks = false,
@@ -88,7 +88,7 @@ public:
     static bool allowMultipleExceptions;
 
 private:
-    // METHODS
+    /* METHODS */
     string findFile(string fileName);
     static void addIncludePaths(Adb* adbCtxt, string includePaths);
     static void includeFile(AdbParser* adbParser, string fileName, int lineNumber = -1);
@@ -104,7 +104,7 @@ private:
     static void startFieldElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber);
 
     static void endElement(void* adbParser, const XML_Char* name);
-    static void addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_int32_t size);
+    static void addReserved(vector < AdbField* >& reserveds, u_int32_t offset, u_int32_t size);
     static int attrCount(const XML_Char** atts);
     static string attrValue(const XML_Char** atts, const XML_Char* attrName);
     static string attrName(const XML_Char** atts, int i);
@@ -113,35 +113,36 @@ private:
     static u_int32_t addr2int(string& s);
     static u_int32_t dword(u_int32_t offset);
     static u_int32_t startBit(u_int32_t offset);
-    static bool raiseException(bool allowMultipleExceptions, string exceptionTxt, string addedMsg, const string expType);
+    static bool raiseException(bool allowMultipleExceptions, string exceptionTxt, string addedMsg,
+                               const string expType);
 
 private:
-    // MEMBERS
-    Adb* _adbCtxt;
-    XML_Parser _xmlParser;
-    string _fileName;
-    string _lastError;
-    bool _addReserved;
-    int _progressCnt;
+    /* MEMBERS */
+    Adb        * _adbCtxt;
+    XML_Parser   _xmlParser;
+    string       _fileName;
+    string       _lastError;
+    bool         _addReserved;
+    int          _progressCnt;
     AdbProgress* _progressObj;
-    bool _strict;
-    bool _checkDsAlign;
-    bool skipNode;
-    string _includePath;
-    string _currentTagValue;
-    AdbNode* _currentNode;
-    AdbField* _currentField;
-    AdbConfig* _currentConfig;
-    bool _instanceOps;
-    bool _enforceExtraChecks;
-    bool _enforceGuiChecks;
-    string _nname_pattern;
-    string _fname_pattern;
-    string _enum_pattern;
-    std::set<string> field_attr_names_set;
-    std::set<string> field_spec_attr;
-    std::vector<string> field_mand_attr;
-    std::map<string, string> attr_pattern;
+    bool         _strict;
+    bool         _checkDsAlign;
+    bool         skipNode;
+    string       _includePath;
+    string       _currentTagValue;
+    AdbNode    * _currentNode;
+    AdbField   * _currentField;
+    AdbConfig  * _currentConfig;
+    bool         _instanceOps;
+    bool         _enforceExtraChecks;
+    bool         _enforceGuiChecks;
+    string       _nname_pattern;
+    string       _fname_pattern;
+    string       _enum_pattern;
+    std::set < string > field_attr_names_set;
+    std::set < string > field_spec_attr;
+    std::vector < string > field_mand_attr;
+    std::map < string, string > attr_pattern;
 
     static const string TAG_NODES_DEFINITION;
     static const string TAG_RCS_HEADERS;
@@ -160,7 +161,7 @@ private:
     static const string TAG_ATTR_DEFINE_PATTERN;
 };
 
-bool AdbParser::allowMultipleExceptions = false;
+bool         AdbParser::allowMultipleExceptions = false;
 const string AdbParser::TAG_NODES_DEFINITION = "NodesDefinition";
 const string AdbParser::TAG_RCS_HEADERS = "RCSheaders";
 const string AdbParser::TAG_CONFIG = "config";
@@ -185,15 +186,15 @@ const string AdbParser::TAG_ATTR_DEFINE_PATTERN = "([A-Za-z_]\\w*)=(\\w+)";
 /**
  * Function: AdbParser::AdbParser
  **/
-AdbParser::AdbParser(string fileName,
-                     Adb* adbCtxt,
-                     bool addReserved,
+AdbParser::AdbParser(string       fileName,
+                     Adb        * adbCtxt,
+                     bool         addReserved,
                      AdbProgress* progressObj,
-                     bool strict,
-                     string includePath,
-                     bool enforceExtraChecks,
-                     bool _checkDsAlign,
-                     bool _enforceGuiChecks) :
+                     bool         strict,
+                     string       includePath,
+                     bool         enforceExtraChecks,
+                     bool         _checkDsAlign,
+                     bool         _enforceGuiChecks) :
     _adbCtxt(adbCtxt),
     _fileName(fileName),
     _addReserved(addReserved),
@@ -212,12 +213,12 @@ AdbParser::AdbParser(string fileName,
 {
     _enforceExtraChecks = enforceExtraChecks;
 
-    // add default patterns
+    /* add default patterns */
     _nname_pattern = ".*";
     _fname_pattern = ".*";
     _enum_pattern = "(\\s*\\w+\\s*=\\s*(0x)?[0-9a-fA-f]+\\s*(,)?)+";
 
-    // add special attr names
+    /* add special attr names */
     field_spec_attr.insert("name");
     field_spec_attr.insert("offset");
     field_spec_attr.insert("size");
@@ -225,20 +226,18 @@ AdbParser::AdbParser(string fileName,
     field_spec_attr.insert("low_bound");
     field_spec_attr.insert("high_bound");
 
-    if (includePath != "")
-    {
+    if (includePath != "") {
         addIncludePaths(adbCtxt, includePath);
     }
     _xmlParser = XML_ParserCreate(0);
     XML_SetUserData(_xmlParser, this);
     XML_SetElementHandler(_xmlParser, startElement, endElement);
-    if (adbCtxt->includePaths.size() == 0)
-    {
-        // first add the opened project path
+    if (adbCtxt->includePaths.size() == 0) {
+        /* first add the opened project path */
         adbCtxt->includePaths.push_back(
-          _fileName.find(OS_PATH_SEP) == string::npos ? "." : _fileName.substr(0, _fileName.rfind(OS_PATH_SEP)));
-        vector<string> path;
-        boost::algorithm::split(path, fileName, boost::is_any_of(string(OS_PATH_SEP)));
+            _fileName.find(OS_PATH_SEP) == string::npos ? "." : _fileName.substr(0, _fileName.rfind(OS_PATH_SEP)));
+        vector < string > path;
+        string_utils::split(path, fileName, OS_PATH_SEP);
         IncludeFileInfo info = {fileName, "ROOT", 0};
         _adbCtxt->includedFiles[path[path.size() - 1]] = info;
     }
@@ -247,17 +246,15 @@ AdbParser::AdbParser(string fileName,
 
 void AdbParser::addIncludePaths(Adb* adbCtxt, string includePaths)
 {
-    vector<string> paths;
-    boost::algorithm::split(paths, includePaths, boost::is_any_of(string(";")));
+    vector < string > paths;
+    string_utils::split(paths, includePaths, ";");
     adbCtxt->includePaths.insert(adbCtxt->includePaths.end(), paths.begin(), paths.end());
 
     StringVector relatives;
-    string projPath = boost::filesystem::path(adbCtxt->mainFileName).parent_path().string();
+    string       projPath = boost::filesystem::path(adbCtxt->mainFileName).parent_path().string();
 
-    for (StringVector::iterator it = adbCtxt->includePaths.begin(); it != adbCtxt->includePaths.end(); it++)
-    {
-        if (projPath != "" && projPath != *it && boost::filesystem::path(*it).is_relative())
-        {
+    for (StringVector::iterator it = adbCtxt->includePaths.begin(); it != adbCtxt->includePaths.end(); it++) {
+        if ((projPath != "") && (projPath != *it) && boost::filesystem::path(*it).is_relative()) {
             relatives.push_back(projPath + OS_PATH_SEP + *it);
         }
     }
@@ -289,78 +286,70 @@ bool AdbParser::load(bool is_main)
 {
     FILE* file;
     char* data = NULL;
-    // Important: we open the file to read it as binary not as text.
-    // Difference in line endings style in Linux and Windows causes unexpected behavior on Windows
-    // platform when file has Windows style line endings.
-    // In case if file is opened to read it as text, "fread"-call in function below skips line
-    // ending symbols effectively reducing number of bytes read from file by amount of lines in file.
-    // Since we expect it to read the entire file at once it will fail to do that (number of bytes
-    // read is less than the size of file in bytes).
+
+    /* Important: we open the file to read it as binary not as text. */
+    /* Difference in line endings style in Linux and Windows causes unexpected behavior on Windows */
+    /* platform when file has Windows style line endings. */
+    /* In case if file is opened to read it as text, "fread"-call in function below skips line */
+    /* ending symbols effectively reducing number of bytes read from file by amount of lines in file. */
+    /* Since we expect it to read the entire file at once it will fail to do that (number of bytes */
+    /* read is less than the size of file in bytes). */
     file = fopen(_fileName.c_str(), "rb");
     _adbCtxt->_logFile->appendLogFile("Opening " + _fileName + "\n");
 
-    if (!file)
-    {
+    if (!file) {
         _lastError = "Can't open file (" + _fileName + ") for reading: " + strerror(errno);
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
     }
 
-    if (fseek(file, 0L, SEEK_END) < 0)
-    { // go to the end of the file
+    if (fseek(file, 0L, SEEK_END) < 0) { /* go to the end of the file */
         _lastError = "fseek() failed for file (" + _fileName + "): " + strerror(errno);
         fclose(file);
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
     }
 
     long fSize = ftell(file);
-    if (fSize < 0)
-    {
+
+    if (fSize < 0) {
         _lastError = "ftell() failed for file (" + _fileName + "): " + strerror(errno);
         fclose(file);
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
     }
 
     data = (char*)malloc(fSize + 1);
-    if (!data)
-    {
+    if (!data) {
         fclose(file);
         throw AdbException("Out of memory.");
     }
 
-    if (fseek(file, 0L, SEEK_SET) < 0)
-    { // go back to the start of the file
+    if (fseek(file, 0L, SEEK_SET) < 0) { /* go back to the start of the file */
         _lastError = "Failed to read file (" + _fileName + "): " + strerror(errno);
         fclose(file);
         free(data);
         data = NULL;
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
     }
 
     size_t result = fread(data, fSize, 1, file);
-    if (result != 1)
-    {
+
+    if (result != 1) {
         _lastError = "Failed to read file (" + _fileName + "): " + strerror(errno);
         fclose(file);
         free(data);
         data = NULL;
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
@@ -370,83 +359,66 @@ bool AdbParser::load(bool is_main)
     fclose(file);
 
     bool xmlStatus = true;
+
     try
     {
-        if (!XML_Parse(_xmlParser, data, strlen(data), 0))
-        {
+        if (!XML_Parse(_xmlParser, data, strlen(data), 0)) {
             enum XML_Error errNo = XML_GetErrorCode(_xmlParser);
             throw AdbException(string("XML parsing issues: ") + XML_ErrorString(errNo));
         }
 
-        if (is_main)
-        {
+        if (is_main) {
             auto root_node_it = _adbCtxt->nodesMap.find("root");
-            if (root_node_it == _adbCtxt->nodesMap.end())
-            {
+            if (root_node_it == _adbCtxt->nodesMap.end()) {
                 throw AdbException("No root found.");
-            }
-            else if (root_node_it->second->fields.size() == 0)
-            {
+            } else if (root_node_it->second->fields.size() == 0) {
                 throw AdbException("Root node doesn't contain any field. Root must contain exactly one field.");
-            }
-            else if (root_node_it->second->fields.size() > 1)
-            {
+            } else if (root_node_it->second->fields.size() > 1) {
                 throw AdbException("Only one field allowed in root node. (Check the root size and fields)");
             }
         }
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
-        if (exp.what_s().find("in file:") == string::npos)
-        {
+        if (exp.what_s().find("in file:") == string::npos) {
             int line = XML_GetCurrentLineNumber(_xmlParser);
             int column = XML_GetCurrentColumnNumber(_xmlParser);
-            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + boost::lexical_cast<string>(line) +
-                         " column: " + boost::lexical_cast<string>(column);
-        }
-        else
-        {
+            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + to_string(line) +
+                         " column: " + to_string(column);
+        } else {
             _lastError = exp.what_s();
         }
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             xmlStatus = false;
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
-        }
-        else
-        {
+        } else {
             free(data);
             return false;
         }
     }
-    catch (std::runtime_error& e)
+    catch(std::runtime_error& e)
     {
         _lastError = CHECK_RUNTIME_ERROR(e);
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             xmlStatus = false;
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
-        }
-        else
-        {
+        } else {
             free(data);
             return false;
         }
     }
-    catch (...)
+    catch(...)
     {
         int line = XML_GetCurrentLineNumber(_xmlParser);
         int column = XML_GetCurrentColumnNumber(_xmlParser);
+
         _lastError = string("An exception raised during the loading of the file: ") + _fileName +
-                     " at line: " + boost::lexical_cast<string>(line) +
-                     " column: " + boost::lexical_cast<string>(column);
-        if (allowMultipleExceptions)
-        {
+                     " at line: " + to_string(line) +
+                     " column: " + to_string(column);
+        if (allowMultipleExceptions) {
             xmlStatus = false;
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
-        }
-        else
-        {
+        } else {
             free(data);
             return false;
         }
@@ -464,23 +436,19 @@ bool AdbParser::loadFromString(const char* adbString)
     _fileName = "\"STRING\"";
     try
     {
-        if (!XML_Parse(_xmlParser, adbString, strlen(adbString), 0))
-        {
+        if (!XML_Parse(_xmlParser, adbString, strlen(adbString), 0)) {
             enum XML_Error errNo = XML_GetErrorCode(_xmlParser);
             throw AdbException(string("XML parsing issues: ") + XML_ErrorString(errNo));
         }
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
-        if (exp.what_s().find("in file:") == string::npos)
-        {
+        if (exp.what_s().find("in file:") == string::npos) {
             int line = XML_GetCurrentLineNumber(_xmlParser);
             int column = XML_GetCurrentColumnNumber(_xmlParser);
-            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + boost::lexical_cast<string>(line) +
-                         " column: " + boost::lexical_cast<string>(column);
-        }
-        else
-        {
+            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + to_string(line) +
+                         " column: " + to_string(column);
+        } else {
             _lastError = exp.what_s();
         }
 
@@ -488,18 +456,19 @@ bool AdbParser::loadFromString(const char* adbString)
                       (_adbCtxt->bigEndianArr ? "Big" : "Little") + " Endian Arrays\"";
         return false;
     }
-    catch (std::runtime_error& e)
+    catch(std::runtime_error& e)
     {
         _lastError = CHECK_RUNTIME_ERROR(e);
         return false;
     }
-    catch (...)
+    catch(...)
     {
         int line = XML_GetCurrentLineNumber(_xmlParser);
         int column = XML_GetCurrentColumnNumber(_xmlParser);
+
         _lastError = string("An exception raised during the loading of the file: ") + _fileName +
-                     " at line: " + boost::lexical_cast<string>(line) +
-                     " column: " + boost::lexical_cast<string>(column);
+                     " at line: " + to_string(line) +
+                     " column: " + to_string(column);
         return false;
     }
 
@@ -520,8 +489,8 @@ string AdbParser::getError()
 int AdbParser::attrCount(const XML_Char** atts)
 {
     int i = 0;
-    while (atts[i])
-    {
+
+    while (atts[i]) {
         i++;
     }
     return i / 2;
@@ -533,10 +502,9 @@ int AdbParser::attrCount(const XML_Char** atts)
 string AdbParser::attrValue(const XML_Char** atts, const XML_Char* attrName)
 {
     int i = 0;
-    while (atts[i])
-    {
-        if (!strcmp(atts[i], attrName))
-        {
+
+    while (atts[i]) {
+        if (!strcmp(atts[i], attrName)) {
             return string(atts[i + 1]);
         }
         i += 2;
@@ -551,10 +519,9 @@ string AdbParser::attrValue(const XML_Char** atts, const XML_Char* attrName)
 bool AdbParser::checkAttrExist(const XML_Char** atts, const XML_Char* attrName)
 {
     int i = 0;
-    while (atts[i])
-    {
-        if (!strcmp(atts[i], attrName))
-        {
+
+    while (atts[i]) {
+        if (!strcmp(atts[i], attrName)) {
             return true;
         }
         i += 2;
@@ -585,20 +552,15 @@ string AdbParser::findFile(string fileName)
 {
     FILE* f;
 
-    for (size_t i = 0; i < _adbCtxt->includePaths.size(); i++)
-    {
+    for (size_t i = 0; i < _adbCtxt->includePaths.size(); i++) {
         string filePath = _adbCtxt->includePaths[i] + OS_PATH_SEP + fileName;
         f = fopen(filePath.c_str(), "r");
-        if (f)
-        {
+        if (f) {
             fclose(f);
             return filePath;
-        }
-        else if (fileName.find(_adbCtxt->includePaths[i]) != string::npos)
-        { // includePath is part of fileName
+        } else if (fileName.find(_adbCtxt->includePaths[i]) != string::npos) { /* includePath is part of fileName */
             f = fopen(fileName.c_str(), "r");
-            if (f)
-            {
+            if (f) {
                 fclose(f);
                 return fileName;
             }
@@ -615,63 +577,54 @@ u_int32_t AdbParser::addr2int(string& s)
     try
     {
         u_int32_t res;
-        boost::algorithm::to_lower(s);
+        string_utils::to_lower(s);
         char* end;
-        vector<string> words;
-        boost::algorithm::split(words, s, boost::is_any_of(string(".")));
+        vector < string > words;
+        string_utils::split(words, s, ".");
 
-        // fix for cases like: 0x.16
-        if (words.size() && !words[0].compare("0x"))
-        {
+        /* fix for cases like: 0x.16 */
+        if (words.size() && !words[0].compare("0x")) {
             words[0] = "0";
         }
 
-        switch (words.size())
-        {
-            case 1:
-                res = strtoul(words[0].c_str(), &end, 0);
-                if (*end != '\0')
-                {
+        switch (words.size()) {
+        case 1:
+            res = strtoul(words[0].c_str(), &end, 0);
+            if (*end != '\0') {
+                throw AdbException();
+            }
+
+            res *= 8;
+            break;
+
+        case 2:
+            if (words[0].empty()) {
+                /* .DDD form */
+                res = strtoul(words[1].c_str(), &end, 0);
+                if (*end != '\0') {
                     throw AdbException();
                 }
-
+            } else {
+                /* 0xHHHHH.DDD or DDDDD.DDD form */
+                res = strtoul(words[0].c_str(), &end, 0);
+                if (*end != '\0') {
+                    throw AdbException();
+                }
                 res *= 8;
-                break;
-
-            case 2:
-                if (words[0].empty())
-                {
-                    // .DDD form
-                    res = strtoul(words[1].c_str(), &end, 0);
-                    if (*end != '\0')
-                    {
-                        throw AdbException();
-                    }
+                res += strtoul(words[1].c_str(), &end, 0);
+                if (*end != '\0') {
+                    throw AdbException();
                 }
-                else
-                {
-                    // 0xHHHHH.DDD or DDDDD.DDD form
-                    res = strtoul(words[0].c_str(), &end, 0);
-                    if (*end != '\0')
-                    {
-                        throw AdbException();
-                    }
-                    res *= 8;
-                    res += strtoul(words[1].c_str(), &end, 0);
-                    if (*end != '\0')
-                    {
-                        throw AdbException();
-                    }
-                }
-                break;
+            }
+            break;
 
-            default:
-                throw AdbException("Invalid size: " + s);
+        default:
+            throw AdbException("Invalid size: " + s);
         }
 
         return res;
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
         throw AdbException("Failed to retrieve integer from string: " + exp.what_s());
     }
@@ -703,21 +656,18 @@ string AdbParser::descXmlToNative(const string& desc)
 
 bool AdbParser::is_inst_ifdef_exist_and_correct_project(const XML_Char** atts, AdbParser* adbParser)
 {
-    bool cond = true;
+    bool   cond = true;
     string definedProject = attrValue(atts, "inst_ifdef");
-    if (!definedProject.empty())
-    {
-        bool found = false;
-        for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++)
-        {
-            AttrsMap::iterator it_def = adbParser->_adbCtxt->configs[i]->attrs.find("define");
-            if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end())
-            {
-                vector<string> defVal;
-                boost::algorithm::split(defVal, it_def->second, boost::is_any_of(string("=")));
 
-                if (defVal[0] == definedProject)
-                {
+    if (!definedProject.empty()) {
+        bool found = false;
+        for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++) {
+            AttrsMap::iterator it_def = adbParser->_adbCtxt->configs[i]->attrs.find("define");
+            if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end()) {
+                vector < string > defVal;
+                string_utils::split(defVal, it_def->second, "=");
+
+                if (defVal[0] == definedProject) {
                     found = true;
                     break;
                 }
@@ -737,43 +687,41 @@ bool AdbParser::is_inst_ifdef_exist_and_correct_project(const XML_Char** atts, A
  **/
 void AdbParser::includeFile(AdbParser* adbParser, string fileName, int lineNumber)
 {
-    // add this file to the included files map
+    /* add this file to the included files map */
     string filePath;
-    FILE* probeFile = NULL;
+    FILE * probeFile = NULL;
 
-    if (!boost::filesystem::path(fileName).is_relative())
-    {
+    if (!boost::filesystem::path(fileName).is_relative()) {
         probeFile = fopen(fileName.c_str(), "r");
     }
 
-    if (probeFile)
-    {
+    if (probeFile) {
         fclose(probeFile);
         filePath = fileName;
-    }
-    else
-    {
+    } else {
         filePath = adbParser->findFile(fileName);
     }
-    if (filePath.empty())
-    {
+    if (filePath.empty()) {
         throw AdbException(string() + "Can't find the file: " + fileName);
     }
 
-    // Update filename to be only base name with extension to prevent duplications
+    /* Update filename to be only base name with extension to prevent duplications */
     boost::filesystem::path boostPath(filePath);
     fileName = boostPath.filename().string();
 
-    if (!adbParser->_adbCtxt->includedFiles.count(fileName))
-    {
+    if (!adbParser->_adbCtxt->includedFiles.count(fileName)) {
         IncludeFileInfo info = {filePath, adbParser->_fileName, lineNumber};
         adbParser->_adbCtxt->includedFiles[fileName] = info;
 
-        // parse the included file
-        AdbParser p(filePath, adbParser->_adbCtxt, adbParser->_addReserved, adbParser->_progressObj, adbParser->_strict,
-                    "", adbParser->_enforceExtraChecks);
-        if (!p.load(false))
-        {
+        /* parse the included file */
+        AdbParser p(filePath,
+                    adbParser->_adbCtxt,
+                    adbParser->_addReserved,
+                    adbParser->_progressObj,
+                    adbParser->_strict,
+                    "",
+                    adbParser->_enforceExtraChecks);
+        if (!p.load(false)) {
             throw AdbException(p.getError());
         }
     }
@@ -784,31 +732,27 @@ void AdbParser::includeFile(AdbParser* adbParser, string fileName, int lineNumbe
  **/
 void AdbParser::includeAllFilesInDir(AdbParser* adbParser, string dirPath, int lineNumber)
 {
-    vector<string> paths;
+    vector < string > paths;
     boost::filesystem::path mainFile(adbParser->_fileName);
-    boost::algorithm::split(paths, dirPath, boost::is_any_of(string(";")));
-    for (StringVector::iterator pathIt = paths.begin(); pathIt != paths.end(); pathIt++)
-    {
-        // first look in the main file's path
+    string_utils::split(paths, dirPath, ";");
+    for (StringVector::iterator pathIt = paths.begin(); pathIt != paths.end(); pathIt++) {
+        /* first look in the main file's path */
         boost::filesystem::path fsPath(mainFile.parent_path().string() + "/" + *pathIt);
-        if (!boost::filesystem::exists(fsPath))
-        {
+        if (!boost::filesystem::exists(fsPath)) {
             fsPath = boost::filesystem::path(*pathIt);
         }
 
-        if (boost::filesystem::exists(fsPath) && boost::filesystem::is_directory(fsPath))
-        {
+        if (boost::filesystem::exists(fsPath) && boost::filesystem::is_directory(fsPath)) {
             addIncludePaths(adbParser->_adbCtxt, *pathIt);
             boost::filesystem::directory_iterator filesIter(fsPath), dirEnd;
-            for (; filesIter != dirEnd; ++filesIter)
-            {
-                if (boost::filesystem::is_regular_file(filesIter->status()) && filesIter->path().extension() == ".adb")
-                {
+            for (; filesIter != dirEnd; ++filesIter) {
+                if (boost::filesystem::is_regular_file(filesIter->status()) &&
+                    (filesIter->path().extension() == ".adb")) {
                     try
                     {
                         includeFile(adbParser, filesIter->path().string(), lineNumber);
                     }
-                    catch (AdbException& e)
+                    catch(AdbException & e)
                     {
                         throw(e);
                     }
@@ -824,25 +768,20 @@ void AdbParser::includeAllFilesInDir(AdbParser* adbParser, string dirPath, int l
 bool AdbParser::checkSpecialChars(string tagName)
 {
     smatch match;
-    regex allowedCharsExpr("[^\\w\\[\\]]"); // only alphanumeric and square brackets are allowed
-    if (regex_search(tagName, match, allowedCharsExpr))
-    {
+
+    regex allowedCharsExpr("[^\\w\\[\\]]"); /* only alphanumeric and square brackets are allowed */
+    if (regex_search(tagName, match, allowedCharsExpr)) {
         return false;
     }
-    regex checkArrayExpr("[\\[\\]]"); // this check if containing the array brackets
-    if (regex_search(tagName, match, checkArrayExpr))
-    {
+    regex checkArrayExpr("[\\[\\]]"); /* this check if containing the array brackets */
+    if (regex_search(tagName, match, checkArrayExpr)) {
         regex correctNameForArrayExpr("[_A-Za-z][\\w]*\\[[\\d]+\\]$");
-        if (!regex_search(tagName, match, correctNameForArrayExpr))
-        { // check the name if correct the square brackets (array)
+        if (!regex_search(tagName, match, correctNameForArrayExpr)) { /* check the name if correct the square brackets (array) */
             return false;
         }
-    }
-    else
-    {
+    } else {
         regex correctNameNoneArrayExpr("[_A-Za-z][\\w]*$");
-        if (!regex_search(tagName, match, correctNameNoneArrayExpr))
-        { // check the name if correct without the square brackets (not array)
+        if (!regex_search(tagName, match, correctNameNoneArrayExpr)) { /* check the name if correct without the square brackets (not array) */
             return false;
         }
     }
@@ -852,9 +791,9 @@ bool AdbParser::checkSpecialChars(string tagName)
 bool AdbParser::checkHEXFormat(string addr)
 {
     smatch match;
+
     regex correctHEXExpr("^(0x[0-9A-fa-f])?[0-9A-Fa-f]*(\\.[0-9]*)?$");
-    if (!regex_search(addr, match, correctHEXExpr))
-    {
+    if (!regex_search(addr, match, correctHEXExpr)) {
         return false;
     }
     return true;
@@ -864,11 +803,10 @@ bool AdbParser::checkBigger32(string num)
 {
     std::istringstream iss(num);
     std::string token;
+
     std::getline(iss, token, '.');
-    if (std::getline(iss, token, '.'))
-    { // the second part of the size after the . max to be 32 0x0.0
-        if (addr2int(token) / 8 >= 32)
-        {
+    if (std::getline(iss, token, '.')) { /* the second part of the size after the . max to be 32 0x0.0 */
+        if (addr2int(token) / 8 >= 32) {
             return true;
         }
     }
@@ -877,31 +815,21 @@ bool AdbParser::checkBigger32(string num)
 
 void AdbParser::startNodesDefElement(const XML_Char** atts, AdbParser* adbParser)
 {
-    if (adbParser->_adbCtxt->version == "")
-    {
-        if ((attrCount(atts) == 1) && (attrName(atts, 0) == "version"))
-        {
+    if (adbParser->_adbCtxt->version == "") {
+        if ((attrCount(atts) == 1) && (attrName(atts, 0) == "version")) {
             string adbVersion = attrValue(atts, 0);
-            if (adbVersion != "1" && adbVersion != "1.0" && adbVersion != "2")
-            {
+            if ((adbVersion != "1") && (adbVersion != "1.0") && (adbVersion != "2")) {
                 throw AdbException("Requested Adb Version (%s) is not supported. Supporting only version 1 or 2",
                                    adbVersion.c_str());
             }
-            if (adbVersion == "1.0")
-            {
+            if (adbVersion == "1.0") {
                 adbParser->_adbCtxt->version = "1";
-            }
-            else
-            {
+            } else {
                 adbParser->_adbCtxt->version = adbVersion;
             }
-        }
-        else if (attrCount(atts) == 0)
-        {
+        } else if (attrCount(atts) == 0) {
             adbParser->_adbCtxt->version = "1";
-        }
-        else
-        {
+        } else {
             throw AdbException("\"NodesDefinition\" tag can only have \"version\" attribute and only once");
         }
     }
@@ -910,277 +838,245 @@ void AdbParser::startNodesDefElement(const XML_Char** atts, AdbParser* adbParser
 void AdbParser::startEnumElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber)
 {
     bool expFound = false;
+
     if (!adbParser->_currentConfig || !adbParser->_currentConfig->attrs.count("type") ||
-        TAG_ATTR_ENUM.compare(adbParser->_currentConfig->attrs["type"]))
-    {
+        TAG_ATTR_ENUM.compare(adbParser->_currentConfig->attrs["type"])) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "\"enum\" tag must be inside relevant \"config\" tag",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::ERROR_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "\"enum\" tag must be inside relevant \"config\" tag",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::ERROR_EXCEPTION);
     }
 
     string tagName = attrValue(atts, "name");
     string value = attrValue(atts, "value");
-    if (adbParser->_enforceExtraChecks)
-    {
-        if (!AdbParser::checkSpecialChars(tagName))
-        {
+
+    if (adbParser->_enforceExtraChecks) {
+        if (!AdbParser::checkSpecialChars(tagName)) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Invalid character in enum name, in enum: \"" + tagName + "\"",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::WARN_EXCEPTION);
+                allowMultipleExceptions,
+                "Invalid character in enum name, in enum: \"" + tagName + "\"",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::WARN_EXCEPTION);
         }
     }
-    if (tagName.empty() || value.empty())
-    {
+    if (tagName.empty() || value.empty()) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "Both \"name\" and \"value\" attributes must be specified",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::ERROR_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "Both \"name\" and \"value\" attributes must be specified",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::ERROR_EXCEPTION);
     }
-    if (!expFound)
-    {
-        adbParser->_currentConfig->enums.insert(pair<string, string>(tagName, value));
+    if (!expFound) {
+        adbParser->_currentConfig->enums.insert(pair < string, string > (tagName, value));
     }
 }
 
 void AdbParser::startConfigElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber)
 {
     bool expFound = false;
-    if (adbParser->_currentConfig)
-    {
+
+    if (adbParser->_currentConfig) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "config tag can't appear within other config",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::FATAL_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "config tag can't appear within other config",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::FATAL_EXCEPTION);
     }
 
     adbParser->_currentConfig = new AdbConfig;
-    for (int i = 0; i < attrCount(atts); i++)
-    {
-        // First add this config to context
+    for (int i = 0; i < attrCount(atts); i++) {
+        /* First add this config to context */
         string aName = attrName(atts, i);
         string aValue = attrValue(atts, i);
-        adbParser->_currentConfig->attrs.insert(pair<string, string>(aName, aValue));
+        adbParser->_currentConfig->attrs.insert(pair < string, string > (aName, aValue));
 
-        // checks that was imported from the gui-parser
-        if (adbParser->_enforceGuiChecks)
-        {
-            // check if the attribute is mandatory
-            if (!aName.compare("field_mand"))
-            {
-                aValue = regex_replace(aValue, regex("\\s+"), "");
-                boost::split(adbParser->field_mand_attr, aValue, boost::is_any_of(","));
+        /* checks that was imported from the gui-parser */
+        if (adbParser->_enforceGuiChecks) {
+            /* check if the attribute is mandatory */
+            if (!aName.compare("field_mand")) {
+                string fmt = "";
+                aValue = regex_replace(aValue, regex("\\s+"), fmt);
+                string_utils::split(adbParser->field_mand_attr, aValue, ",");
             }
-
-            // check the define statement is according to format
-            else if (!aName.compare("define"))
-            {
+            /* check the define statement is according to format */
+            else if (!aName.compare("define")) {
                 smatch result;
                 regex pattern(TAG_ATTR_DEFINE_PATTERN);
-                if (!regex_match(aValue, result, pattern))
-                {
+                if (!regex_match(aValue, result, pattern)) {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("Bad define format: \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
-                }
-                else
-                {
-                    // check for define duplication
+                        allowMultipleExceptions,
+                        string("Bad define format: \"") + aName + "\" attribute value: \"" + aValue + "\"",
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
+                } else {
+                    /* check for define duplication */
                     string define_key = result[1], define_value = result[2];
 
-                    if (adbParser->_adbCtxt->defines_map.find(define_key) != adbParser->_adbCtxt->defines_map.end())
-                    {
+                    if (adbParser->_adbCtxt->defines_map.find(define_key) != adbParser->_adbCtxt->defines_map.end()) {
                         expFound = raiseException(allowMultipleExceptions,
                                                   string("Multiple definition of preprocessor variable: \"") +
-                                                    define_key + "\" attribute name: \"" + aName + "\"",
+                                                  define_key + "\" attribute name: \"" + aName + "\"",
                                                   ", in file: \"" + adbParser->_fileName +
-                                                    "\" line: " + boost::lexical_cast<string>(lineNumber),
+                                                  "\" line: " + to_string(lineNumber),
                                                   ExceptionHolder::ERROR_EXCEPTION);
-                    }
-                    else
-                    {
-                        adbParser->_adbCtxt->defines_map.insert(pair<string, string>(define_key, define_value));
+                    } else {
+                        adbParser->_adbCtxt->defines_map.insert(pair < string, string > (define_key, define_value));
                     }
                 }
-            }
-
-            else if (!expFound && !aName.compare("field_attr"))
-            {
-                // check that the field_attr is unique
-                if (adbParser->field_attr_names_set.find(aValue) != adbParser->field_attr_names_set.end())
-                {
+            } else if (!expFound && !aName.compare("field_attr")) {
+                /* check that the field_attr is unique */
+                if (adbParser->field_attr_names_set.find(aValue) != adbParser->field_attr_names_set.end()) {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("Redefinition of field_attr: \"") + aName + "\" attribute name: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
-                }
-                else
-                {
+                        allowMultipleExceptions,
+                        string("Redefinition of field_attr: \"") + aName + "\" attribute name: \"" + aValue + "\"",
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
+                } else {
                     adbParser->field_attr_names_set.insert(aValue);
                 }
 
                 string attr_type = attrValue(atts, "type");
 
-                // check that attr 'type' was provided and not empty
-                if (attr_type.empty())
-                {
+                /* check that attr 'type' was provided and not empty */
+                if (attr_type.empty()) {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("field_attr type must be specified: \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
-                }
-                else
-                {
-                    // check that type 'multival' has a 'fw_label' value
-                    if (!attr_type.compare("multival") && aValue.compare("fw_label"))
-                    {
+                        allowMultipleExceptions,
+                        string(
+                            "field_attr type must be specified: \"") + aName + "\" attribute value: \"" + aValue + "\"",
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
+                } else {
+                    /* check that type 'multival' has a 'fw_label' value */
+                    if (!attr_type.compare("multival") && aValue.compare("fw_label")) {
                         expFound =
-                          raiseException(allowMultipleExceptions,
-                                         string("Type \"multival\" is supported only for \"fw_label\" not for: \"") +
+                            raiseException(allowMultipleExceptions,
+                                           string("Type \"multival\" is supported only for \"fw_label\" not for: \"") +
                                            aName + "\" attribute value: \"" + aValue + "\"",
-                                         ", in file: \"" + adbParser->_fileName +
-                                           "\" line: " + boost::lexical_cast<string>(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                                           ", in file: \"" + adbParser->_fileName +
+                                           "\" line: " + to_string(lineNumber),
+                                           ExceptionHolder::ERROR_EXCEPTION);
                     }
                 }
 
                 string attr_used_for = attrValue(atts, "used_for");
 
-                // check that attr 'used_for' was not provided empty
-                if (checkAttrExist(atts, "used_for") && attr_used_for.empty())
-                {
+                /* check that attr 'used_for' was not provided empty */
+                if (checkAttrExist(atts, "used_for") && attr_used_for.empty()) {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("used_for is invalid: \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                        allowMultipleExceptions,
+                        string("used_for is invalid: \"") + aName + "\" attribute value: \"" + aValue + "\"",
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
                 }
 
-                // check if 'pattern' was provided
-                if (checkAttrExist(atts, "pattern"))
-                {
-                    // check if the given pattern is a valid reg expression.
+                /* check if 'pattern' was provided */
+                if (checkAttrExist(atts, "pattern")) {
+                    /* check if the given pattern is a valid reg expression. */
                     try
                     {
                         string pattern_value = attrValue(atts, "pattern");
                         regex r(pattern_value);
-                        adbParser->attr_pattern.insert(pair<string, string>(aValue, pattern_value));
+                        adbParser->attr_pattern.insert(pair < string, string > (aValue, pattern_value));
                     }
-                    catch (...)
+                    catch(...)
                     {
                         expFound = raiseException(allowMultipleExceptions,
-                                                  string("Bad attribute pattern: \"") + aValue + "\" name Pattern: \"" +
-                                                    attrValue(atts, "pattern") + "\"",
+                                                  string(
+                                                      "Bad attribute pattern: \"") + aValue + "\" name Pattern: \"" +
+                                                  attrValue(atts, "pattern") + "\"",
                                                   ", in file: \"" + adbParser->_fileName +
-                                                    "\" line: " + boost::lexical_cast<string>(lineNumber),
+                                                  "\" line: " + to_string(lineNumber),
                                                   ExceptionHolder::ERROR_EXCEPTION);
                     }
                 }
             }
-
-            // check if nname_pattern was provided
-            else if (!expFound && checkAttrExist(atts, "nname_pattern"))
-            {
-                // check if the given pattern is a valid reg expression.
+            /* check if nname_pattern was provided */
+            else if (!expFound && checkAttrExist(atts, "nname_pattern")) {
+                /* check if the given pattern is a valid reg expression. */
                 try
                 {
                     string nname_pattern = attrValue(atts, "nname_pattern");
                     regex r(nname_pattern);
                     adbParser->_nname_pattern = nname_pattern;
                 }
-                catch (...)
+                catch(...)
                 {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("Bad node name pattern: \"") + aValue + "\" pattern: \"" +
+                        allowMultipleExceptions,
+                        string("Bad node name pattern: \"") + aValue + "\" pattern: \"" +
                         attrValue(atts, "nname_pattern") + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
                 }
             }
-
-            // check if fname_pattern was provided and the name of the field is compatible with that pattern
-            else if (!expFound && checkAttrExist(atts, "fname_pattern"))
-            {
-                // check if the given pattern is a valid reg expression.
+            /* check if fname_pattern was provided and the name of the field is compatible with that pattern */
+            else if (!expFound && checkAttrExist(atts, "fname_pattern")) {
+                /* check if the given pattern is a valid reg expression. */
                 try
                 {
                     string fname_pattern = attrValue(atts, "fname_pattern");
                     regex r(fname_pattern);
                     adbParser->_fname_pattern = fname_pattern;
                 }
-                catch (...)
+                catch(...)
                 {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("Bad field name pattern: \"") + aValue + "\" pattern: \"" +
+                        allowMultipleExceptions,
+                        string("Bad field name pattern: \"") + aValue + "\" pattern: \"" +
                         attrValue(atts, "fname_pattern") + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
                 }
             }
         }
 
-        // Parse attrs that affect the parser itself
-        if (!TAG_ATTR_BIG_ENDIAN.compare(aName))
-        {
+        /* Parse attrs that affect the parser itself */
+        if (!TAG_ATTR_BIG_ENDIAN.compare(aName)) {
             try
             {
-                int val = boost::lexical_cast<int>(aValue);
+                int val = stoi(aValue);
                 adbParser->_adbCtxt->bigEndianArr = val != 0;
             }
-            catch (std::exception&)
+            catch(std::exception&)
             {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
         }
 
-        if (!TAG_ATTR_SINGLE_ENTRY_ARR.compare(aName))
-        {
+        if (!TAG_ATTR_SINGLE_ENTRY_ARR.compare(aName)) {
             try
             {
-                int val = boost::lexical_cast<int>(aValue);
+                int val = stoi(aValue);
                 adbParser->_adbCtxt->singleEntryArrSupp = val != 0;
             }
-            catch (std::exception&)
+            catch(std::exception&)
             {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
         }
 
-        if (!expFound && !TAG_ATTR_INCLUDE_PATH.compare(aName))
-        {
-            vector<string> paths;
-            boost::algorithm::split(paths, aValue, boost::is_any_of(string(";")));
+        if (!expFound && !TAG_ATTR_INCLUDE_PATH.compare(aName)) {
+            vector < string > paths;
+            string_utils::split(paths, aValue, ";");
             adbParser->_adbCtxt->includePaths.insert(adbParser->_adbCtxt->includePaths.end(), paths.begin(),
                                                      paths.end());
 
             StringVector relatives;
-            string projPath = boost::filesystem::path(adbParser->_adbCtxt->mainFileName).parent_path().string();
+            string       projPath = boost::filesystem::path(adbParser->_adbCtxt->mainFileName).parent_path().string();
 
             for (StringVector::iterator it = adbParser->_adbCtxt->includePaths.begin();
                  it != adbParser->_adbCtxt->includePaths.end();
-                 it++)
-            {
-                if (boost::filesystem::path(*it).is_relative())
-                {
+                 it++) {
+                if (boost::filesystem::path(*it).is_relative()) {
                     relatives.push_back(projPath + OS_PATH_SEP + *it);
                 }
             }
@@ -1195,6 +1091,7 @@ void AdbParser::startInfoElement(const XML_Char** atts, AdbParser* adbParser)
 {
     string docName = attrValue(atts, "source_doc_name");
     string docVer = attrValue(atts, "source_doc_version");
+
     adbParser->_adbCtxt->srcDocName = docName;
     adbParser->_adbCtxt->srcDocVer = docVer;
 }
@@ -1203,50 +1100,44 @@ void AdbParser::startIncludeElement(const XML_Char** atts, AdbParser* adbParser,
 {
     bool cond = is_inst_ifdef_exist_and_correct_project(atts, adbParser);
 
-    if (cond)
-    {
+    if (cond) {
         string includeAttr = attrName(atts, 0);
-        boost::algorithm::trim(includeAttr);
+        string_utils::trim(includeAttr);
 
         bool expFound = false;
-        if (includeAttr == "file")
-        {
+        if (includeAttr == "file") {
             string fname = attrValue(atts, "file");
-            boost::algorithm::trim(fname);
-            if (fname.empty())
-            {
+            string_utils::trim(fname);
+            if (fname.empty()) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  string() + "File attribute isn't given within " + TAG_INCLUDE + " tag",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::FATAL_EXCEPTION);
+                    allowMultipleExceptions,
+                    string() + "File attribute isn't given within " + TAG_INCLUDE + " tag",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::FATAL_EXCEPTION);
             }
-            if (!expFound)
+            if (!expFound) {
                 includeFile(adbParser, fname, lineNumber);
-        }
-        else if (includeAttr == "dir")
-        {
+            }
+        } else if (includeAttr == "dir") {
             string includeAllDirPath = attrValue(atts, "dir");
-            boost::algorithm::trim(includeAllDirPath);
-            if (includeAllDirPath.empty())
-            {
+            string_utils::trim(includeAllDirPath);
+            if (includeAllDirPath.empty()) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  string() + "Directory to include isn't given within " + TAG_INCLUDE + " tag",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::FATAL_EXCEPTION);
+                    allowMultipleExceptions,
+                    string() + "Directory to include isn't given within " + TAG_INCLUDE + " tag",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::FATAL_EXCEPTION);
             }
 
-            if (!expFound)
+            if (!expFound) {
                 includeAllFilesInDir(adbParser, includeAllDirPath, lineNumber);
-        }
-        else
-        {
+            }
+        } else {
             expFound = raiseException(
-              allowMultipleExceptions,
-              string() + "Include is called without file or dir attribute.",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::ERROR_EXCEPTION);
+                allowMultipleExceptions,
+                string() + "Include is called without file or dir attribute.",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::ERROR_EXCEPTION);
         }
     }
 }
@@ -1254,33 +1145,30 @@ void AdbParser::startIncludeElement(const XML_Char** atts, AdbParser* adbParser,
 void AdbParser::startInstOpAttrReplaceElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber)
 {
     bool expFound = false;
-    if (!adbParser->_instanceOps)
-    {
+
+    if (!adbParser->_instanceOps) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "Operation attr_replace must be defined within <instance_ops> element only.",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::FATAL_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "Operation attr_replace must be defined within <instance_ops> element only.",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::FATAL_EXCEPTION);
     }
 
     string path = attrValue(atts, "path");
-    if (path.empty())
-    {
+
+    if (path.empty()) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "path attribute is missing in attr_replace operation",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::ERROR_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "path attribute is missing in attr_replace operation",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::ERROR_EXCEPTION);
     }
 
-    if (!expFound)
-    {
+    if (!expFound) {
         adbParser->_adbCtxt->instAttrs[path] = AttrsMap();
-        for (int i = 0; i < attrCount(atts); i++)
-        {
+        for (int i = 0; i < attrCount(atts); i++) {
             string attrN = attrName(atts, i);
-            if (attrN == "path")
-            {
+            if (attrN == "path") {
                 continue;
             }
 
@@ -1292,98 +1180,86 @@ void AdbParser::startInstOpAttrReplaceElement(const XML_Char** atts, AdbParser* 
 
 void AdbParser::startNodeElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber)
 {
-    if (adbParser->_currentNode || adbParser->skipNode)
-    {
+    if (adbParser->_currentNode || adbParser->skipNode) {
         raiseException(allowMultipleExceptions,
                        "Nested nodes are not allowed",
-                       ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
+                       ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
                        ExceptionHolder::FATAL_EXCEPTION);
     }
     bool cond = is_inst_ifdef_exist_and_correct_project(atts, adbParser);
 
-    if (cond)
-    {
+    if (cond) {
         string nodeName = attrValue(atts, "name");
-        boost::algorithm::trim(nodeName);
+        string_utils::trim(nodeName);
         string size = attrValue(atts, "size");
 
-        if (adbParser->_enforceGuiChecks)
-        {
-            // check the node name is compatible with the nname_pattern
-            if (!regex_match(nodeName, regex(adbParser->_nname_pattern)))
-            {
+        if (adbParser->_enforceGuiChecks) {
+            /* check the node name is compatible with the nname_pattern */
+            if (!regex_match(nodeName, regex(adbParser->_nname_pattern))) {
                 raiseException(allowMultipleExceptions,
                                "Illegal node name: \"" + nodeName + "\" doesn't match the given node name pattern: \"",
                                adbParser->_nname_pattern + "\", in file: \"" + adbParser->_fileName +
-                                 "\" line: " + boost::lexical_cast<string>(lineNumber),
+                               "\" line: " + to_string(lineNumber),
                                ExceptionHolder::WARN_EXCEPTION);
             }
         }
 
-        if (adbParser->_enforceExtraChecks)
-        {
-            if (!AdbParser::checkSpecialChars(nodeName))
-            {
+        if (adbParser->_enforceExtraChecks) {
+            if (!AdbParser::checkSpecialChars(nodeName)) {
                 raiseException(
-                  allowMultipleExceptions,
-                  "Invalid character in node name, in Node: \"" + nodeName + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid character in node name, in Node: \"" + nodeName + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (AdbParser::checkBigger32(size))
-            { // the second part of the size after the . max to be 32 0x0.0
+            if (AdbParser::checkBigger32(size)) { /* the second part of the size after the . max to be 32 0x0.0 */
                 raiseException(
-                  allowMultipleExceptions,
-                  "Invalid size format, valid format 0x0.0 not allowed to be more than 0x0.31",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid size format, valid format 0x0.0 not allowed to be more than 0x0.31",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (!AdbParser::checkHEXFormat(size))
-            {
+            if (!AdbParser::checkHEXFormat(size)) {
                 raiseException(
-                  allowMultipleExceptions,
-                  "Invalid size format",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid size format",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (addr2int(size) == 0)
-            {
+            if (addr2int(size) == 0) {
                 raiseException(
-                  allowMultipleExceptions,
-                  "Node Size is not allowed to be 0, in Node: \"" + nodeName + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Node Size is not allowed to be 0, in Node: \"" + nodeName + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
         }
         string desc = descXmlToNative(attrValue(atts, "descr"));
 
-        // Check for mandatory attrs
-        if (nodeName.empty())
-        {
+        /* Check for mandatory attrs */
+        if (nodeName.empty()) {
             raiseException(
-              allowMultipleExceptions,
-              "Missing node name",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Missing node name",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
-        if (size.empty())
-        {
+        if (size.empty()) {
             raiseException(
-              allowMultipleExceptions,
-              "Missing node size",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Missing node size",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
-        // Check for duplications
-        if (adbParser->_adbCtxt->nodesMap.count(nodeName))
-        {
+        /* Check for duplications */
+        if (adbParser->_adbCtxt->nodesMap.count(nodeName)) {
             raiseException(
-              allowMultipleExceptions,
-              "node \"" + nodeName + "\" is already defined in file: \"" +
+                allowMultipleExceptions,
+                "node \"" + nodeName + "\" is already defined in file: \"" +
                 adbParser->_adbCtxt->nodesMap[nodeName]->fileName +
-                "\" line: " + boost::lexical_cast<string>(adbParser->_adbCtxt->nodesMap[nodeName]->lineNumber),
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                "\" line: " + to_string(adbParser->_adbCtxt->nodesMap[nodeName]->lineNumber),
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
         adbParser->_currentNode = new AdbNode;
@@ -1391,27 +1267,22 @@ void AdbParser::startNodeElement(const XML_Char** atts, AdbParser* adbParser, co
         adbParser->_currentNode->size = addr2int(size);
         adbParser->_currentNode->desc = desc;
         string unionAttrVal = attrValue(atts, "attr_is_union");
-        adbParser->_currentNode->isUnion = !unionAttrVal.empty() && boost::lexical_cast<int>(unionAttrVal) != 0;
+        adbParser->_currentNode->isUnion = !unionAttrVal.empty() && stoi(unionAttrVal) != 0;
         adbParser->_currentNode->fileName = adbParser->_fileName;
         adbParser->_currentNode->lineNumber = lineNumber;
 
-        if (adbParser->_strict && adbParser->_currentNode->isUnion && adbParser->_currentNode->size % 32)
-        {
-            // throw AdbException("union must be dword aligned");
+        if (adbParser->_strict && adbParser->_currentNode->isUnion && adbParser->_currentNode->size % 32) {
+            /* throw AdbException("union must be dword aligned"); */
         }
 
-        // Add all node attributes
-        for (int i = 0; i < attrCount(atts); i++)
-        {
-            if (attrValue(atts, i) == "")
-            {
+        /* Add all node attributes */
+        for (int i = 0; i < attrCount(atts); i++) {
+            if (attrValue(atts, i) == "") {
                 continue;
             }
             adbParser->_currentNode->attrs[attrName(atts, i)] = attrValue(atts, i);
         }
-    }
-    else
-    {
+    } else {
         adbParser->skipNode = true;
     }
 }
@@ -1419,88 +1290,78 @@ void AdbParser::startNodeElement(const XML_Char** atts, AdbParser* adbParser, co
 void AdbParser::startFieldElement(const XML_Char** atts, AdbParser* adbParser, const int lineNumber)
 {
     bool expFound = false;
-    if (!adbParser->_currentNode && !adbParser->skipNode)
-    {
+
+    if (!adbParser->_currentNode && !adbParser->skipNode) {
         expFound =
-          raiseException(allowMultipleExceptions,
-                         "Field definition outside of node",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                         ExceptionHolder::FATAL_EXCEPTION);
+            raiseException(allowMultipleExceptions,
+                           "Field definition outside of node",
+                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                           ExceptionHolder::FATAL_EXCEPTION);
     }
 
-    if (!adbParser->skipNode)
-    {
-        if (adbParser->_currentField)
-        {
+    if (!adbParser->skipNode) {
+        if (adbParser->_currentField) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Nested fields are not allowed",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Nested fields are not allowed",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
         string fieldName = attrValue(atts, "name");
-        boost::algorithm::trim(fieldName);
+        string_utils::trim(fieldName);
         string offset = attrValue(atts, "offset");
         string size = attrValue(atts, "size");
 
-        if (adbParser->_enforceExtraChecks)
-        {
-            if (addr2int(size) % 32 == 0 && !AdbParser::checkHEXFormat(size))
-            {
+        if (adbParser->_enforceExtraChecks) {
+            if ((addr2int(size) % 32 == 0) && !AdbParser::checkHEXFormat(size)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid size format",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid size format",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (!AdbParser::checkHEXFormat(offset))
-            {
+            if (!AdbParser::checkHEXFormat(offset)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid offset format",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid offset format",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (!AdbParser::checkSpecialChars(fieldName))
-            {
+            if (!AdbParser::checkSpecialChars(fieldName)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid character in field name, in Field: \"" + fieldName + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid character in field name, in Field: \"" + fieldName + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (!expFound && adbParser->_currentNode->isUnion && addr2int(offset) != 0)
-            {
+            if (!expFound && adbParser->_currentNode->isUnion && (addr2int(offset) != 0)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Offset must be 0x0.0 in Union fields",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Offset must be 0x0.0 in Union fields",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (AdbParser::checkBigger32(size))
-            { // the second part of the size after the . max to be 32 0x0.0
+            if (AdbParser::checkBigger32(size)) { /* the second part of the size after the . max to be 32 0x0.0 */
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid size format, valid format 0x0.0 not allowed to be more than 0x0.31",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid size format, valid format 0x0.0 not allowed to be more than 0x0.31",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (AdbParser::checkBigger32(offset))
-            { // the second part of the size after the . max to be 32 0x0.0
+            if (AdbParser::checkBigger32(offset)) { /* the second part of the size after the . max to be 32 0x0.0 */
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid offset format, valid format 0x0.0 not allowed to be more than 0x0.31",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid offset format, valid format 0x0.0 not allowed to be more than 0x0.31",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
-            if (addr2int(size) == 0)
-            {
+            if (addr2int(size) == 0) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Field Size is not allowed to be 0, in Field: \"" + fieldName + "\"",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Field Size is not allowed to be 0, in Field: \"" + fieldName + "\"",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
         }
 
@@ -1508,125 +1369,105 @@ void AdbParser::startFieldElement(const XML_Char** atts, AdbParser* adbParser, c
         string lowBound = attrValue(atts, "low_bound");
         string highBound = attrValue(atts, "high_bound");
 
-        if (lowBound != "" && highBound != "")
-        {
+        if ((lowBound != "") && (highBound != "")) {
             int low = atoi(lowBound.c_str());
             int high = 0;
-            if (highBound != "VARIABLE" && highBound != "DYNAMIC")
-            {
+            if ((highBound != "VARIABLE") && (highBound != "DYNAMIC")) {
                 high = atoi(highBound.c_str());
             }
             int isize = addr2int(size);
             int entrySize = isize / (high - low + 1);
-            if (entrySize % 8 != 0 && entrySize > 8)
-            {
+            if ((entrySize % 8 != 0) && (entrySize > 8)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Invalid size of array entries",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Invalid size of array entries",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
-            if (entrySize < 8 && entrySize != 4 && entrySize != 2 && entrySize != 1 &&
-                ((isize > 32 && highBound != "VARIABLE" && highBound != "DYNAMIC") || highBound == "VARIABLE" ||
-                 highBound == "DYNAMIC"))
-            {
+            if ((entrySize < 8) && (entrySize != 4) && (entrySize != 2) && (entrySize != 1) &&
+                (((isize > 32) && (highBound != "VARIABLE") && (highBound != "DYNAMIC")) ||
+                 (highBound == "VARIABLE") ||
+                 (highBound == "DYNAMIC"))) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Array with entry size 3, 5, 6 or 7 bits and array size is larger than 32bit",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Array with entry size 3, 5, 6 or 7 bits and array size is larger than 32bit",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
-        }
-        else if (adbParser->_enforceGuiChecks && !(lowBound == "" && highBound == ""))
-        {
+        } else if (adbParser->_enforceGuiChecks && !((lowBound == "") && (highBound == ""))) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Field: \"" + adbParser->_currentField->name + "\": both low_bound or high_bound must be specified",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::WARN_EXCEPTION);
+                allowMultipleExceptions,
+                "Field: \"" + adbParser->_currentField->name + "\": both low_bound or high_bound must be specified",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::WARN_EXCEPTION);
         }
 
         string subNode = attrValue(atts, "subnode");
 
-        // Check for mandatory attrs
-        if (fieldName.empty())
-        {
+        /* Check for mandatory attrs */
+        if (fieldName.empty()) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Missing field name",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Missing field name",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
-        if (size.empty())
-        {
+        if (size.empty()) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Missing field size",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Missing field size",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
-        // Create new fields
+        /* Create new fields */
         adbParser->_currentField = new AdbField;
 
-        // Fill the new fields
+        /* Fill the new fields */
         adbParser->_currentField->name = fieldName;
         adbParser->_currentField->desc = desc;
         adbParser->_currentField->size = addr2int(size);
-        if (adbParser->_adbCtxt->singleEntryArrSupp)
-        {
+        if (adbParser->_adbCtxt->singleEntryArrSupp) {
             int low = -1;
             int high = -1;
-            if (!lowBound.empty())
-            {
+            if (!lowBound.empty()) {
                 low = atoi(lowBound.c_str());
             }
-            if (!highBound.empty())
-            {
+            if (!highBound.empty()) {
                 high = atoi(highBound.c_str());
             }
             adbParser->_currentField->definedAsArr = (low == high) && (low >= 0);
-        }
-        else
-        {
+        } else {
             adbParser->_currentField->definedAsArr = false;
         }
 
-        adbParser->_currentField->lowBound = lowBound.empty() ? 0 : boost::lexical_cast<u_int32_t>(lowBound);
-        if (highBound == "VARIABLE")
-        {
+        adbParser->_currentField->lowBound = lowBound.empty() ? 0 : stoi(lowBound);
+        if (highBound == "VARIABLE") {
             adbParser->_currentField->highBound = 0;
             adbParser->_currentField->unlimitedArr = true;
-        }
-        else
-        {
-            if (highBound == "DYNAMIC")
-            {
+        } else {
+            if (highBound == "DYNAMIC") {
                 adbParser->_currentField->highBound = 0;
                 adbParser->_currentField->dynamicArr = true;
                 string conditionalSize = attrValue(atts, "size_condition");
-                if (conditionalSize == "")
-                {
+                if (conditionalSize == "") {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      "Missing size_condition attribute",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::FATAL_EXCEPTION);
+                        allowMultipleExceptions,
+                        "Missing size_condition attribute",
+                        ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::FATAL_EXCEPTION);
                 }
-            }
-            else
-            {
-                adbParser->_currentField->highBound = highBound.empty() ? 0 : boost::lexical_cast<u_int32_t>(highBound);
+            } else {
+                adbParser->_currentField->highBound = highBound.empty() ? 0 : stoi(highBound);
             }
         }
         adbParser->_currentField->subNode = subNode;
 
-        // Check array element size
+        /* Check array element size */
         if (adbParser->_currentField->isArray() && !adbParser->_currentField->isUnlimitedArr() &&
             !adbParser->_currentField->isDynamicArr() &&
-            adbParser->_currentField->size % (adbParser->_currentField->arrayLen()))
-        {
+            adbParser->_currentField->size % (adbParser->_currentField->arrayLen())) {
             char exceptionTxt[1000];
             sprintf(exceptionTxt, "In field \"%s\" invalid array element size\"%0.2f\" in file: \"%s\" line: %d",
                     fieldName.c_str(),
@@ -1635,170 +1476,145 @@ void AdbParser::startFieldElement(const XML_Char** atts, AdbParser* adbParser, c
 
             expFound = raiseException(allowMultipleExceptions, exceptionTxt, "", ExceptionHolder::FATAL_EXCEPTION);
         }
-        if (offset.empty())
-        {
-            if (adbParser->_currentNode->fields.empty())
-            {
+        if (offset.empty()) {
+            if (adbParser->_currentNode->fields.empty()) {
                 adbParser->_currentField->offset = 0;
-            }
-            else
-            {
+            } else {
                 AdbField* lastField = adbParser->_currentNode->fields.back();
                 adbParser->_currentField->offset = lastField->offset + lastField->size;
             }
-        }
-        else
-        {
+        } else {
             adbParser->_currentField->offset = addr2int(offset);
         }
 
-        // Very tricky but works well for big endian arrays support - on endElement we will fix the address again
-        if (!expFound && adbParser->_adbCtxt->bigEndianArr)
-        {
+        /* Very tricky but works well for big endian arrays support - on endElement we will fix the address again */
+        if (!expFound && adbParser->_adbCtxt->bigEndianArr) {
             u_int32_t offset = adbParser->_currentField->offset;
             u_int32_t size = adbParser->_currentField->eSize();
 
             adbParser->_currentField->offset =
-              ((offset >> 5) << 5) + ((MIN(32, adbParser->_currentNode->size) - ((offset + size) % 32)) % 32);
+                ((offset >> 5) << 5) + ((MIN(32, adbParser->_currentNode->size) - ((offset + size) % 32)) % 32);
         }
 
-        // For DS alignment check
+        /* For DS alignment check */
         u_int32_t esize = adbParser->_currentField->eSize();
-        if ((adbParser->_currentField->isLeaf() || adbParser->_currentField->subNode == "uint64") &&
-            (esize == 16 || esize == 32 || esize == 64) && esize > adbParser->_currentNode->_maxLeafSize)
-        {
+        if ((adbParser->_currentField->isLeaf() || (adbParser->_currentField->subNode == "uint64")) &&
+            ((esize == 16) || (esize == 32) || (esize == 64)) && (esize > adbParser->_currentNode->_maxLeafSize)) {
             adbParser->_currentNode->_maxLeafSize = esize;
         }
 
-        if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion && adbParser->_currentField->isLeaf())
-        {
+        if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion &&
+            adbParser->_currentField->isLeaf()) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Fields are not allowed in unions (only subnodes)",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Fields are not allowed in unions (only subnodes)",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
-        if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion && adbParser->_currentField->size % 32)
-        {
+        if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion &&
+            adbParser->_currentField->size % 32) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Union is allowed to contains only dword aligned subnodes",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Union is allowed to contains only dword aligned subnodes",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
         if (!expFound && adbParser->_currentNode->isUnion &&
-            adbParser->_currentField->size > adbParser->_currentNode->size)
-        {
+            (adbParser->_currentField->size > adbParser->_currentNode->size)) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Field size is greater than the parent node size",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Field size is greater than the parent node size",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
         if (!expFound && adbParser->_strict && !adbParser->_currentField->isArray() &&
-            adbParser->_currentField->isLeaf() && adbParser->_currentField->size > 32)
-        {
+            adbParser->_currentField->isLeaf() && (adbParser->_currentField->size > 32)) {
             expFound = raiseException(
-              allowMultipleExceptions,
-              "Leaf fields can't be > 32 bits",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-              ExceptionHolder::FATAL_EXCEPTION);
+                allowMultipleExceptions,
+                "Leaf fields can't be > 32 bits",
+                ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                ExceptionHolder::FATAL_EXCEPTION);
         }
 
-        if (!expFound && adbParser->_checkDsAlign)
-        {
+        if (!expFound && adbParser->_checkDsAlign) {
             u_int32_t esize = adbParser->_currentField->eSize();
-            if ((adbParser->_currentField->isLeaf() || adbParser->_currentField->subNode == "uint64") &&
-                (esize == 16 || esize == 32 || esize == 64) && adbParser->_currentField->offset % esize != 0)
-            {
+            if ((adbParser->_currentField->isLeaf() || (adbParser->_currentField->subNode == "uint64")) &&
+                ((esize == 16) || (esize == 32) || (esize == 64)) && (adbParser->_currentField->offset % esize != 0)) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Field: " + adbParser->_currentField->name + " in Node: " + adbParser->_currentNode->name +
-                    " offset(" + boost::lexical_cast<string>(adbParser->_currentField->offset) +
-                    ") is not aligned to size(" + boost::lexical_cast<string>(esize) + ")",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Field: " + adbParser->_currentField->name + " in Node: " + adbParser->_currentNode->name +
+                    " offset(" + to_string(adbParser->_currentField->offset) +
+                    ") is not aligned to size(" + to_string(esize) + ")",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
         }
 
-        if (adbParser->_enforceGuiChecks)
-        {
-            // check if all mandatory attributes were supplied
-            for (unsigned int i = 0; i < adbParser->field_mand_attr.size(); i++)
-            {
-                if (!checkAttrExist(atts, adbParser->field_mand_attr[i].c_str()))
-                {
+        if (adbParser->_enforceGuiChecks) {
+            /* check if all mandatory attributes were supplied */
+            for (unsigned int i = 0; i < adbParser->field_mand_attr.size(); i++) {
+                if (!checkAttrExist(atts, adbParser->field_mand_attr[i].c_str())) {
                     expFound = raiseException(
-                      allowMultipleExceptions,
-                      "Atrribute: \"" + adbParser->field_mand_attr[i] + "\" for field must be specified.",
-                      " in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                        allowMultipleExceptions,
+                        "Atrribute: \"" + adbParser->field_mand_attr[i] + "\" for field must be specified.",
+                        " in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                        ExceptionHolder::ERROR_EXCEPTION);
                 }
             }
 
-            // check if the field name is compatible with the fname pattern
-            if (!regex_match(adbParser->_currentField->name, regex(adbParser->_fname_pattern)))
-            {
+            /* check if the field name is compatible with the fname pattern */
+            if (!regex_match(adbParser->_currentField->name, regex(adbParser->_fname_pattern))) {
                 expFound = raiseException(
-                  allowMultipleExceptions,
-                  "Illegal field name: \"" + adbParser->_currentField->name +
+                    allowMultipleExceptions,
+                    "Illegal field name: \"" + adbParser->_currentField->name +
                     "\" doesn't match the given field name pattern",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::WARN_EXCEPTION);
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
+                    ExceptionHolder::WARN_EXCEPTION);
             }
         }
 
-        // Add all field attributes
-        if (!expFound)
-        {
-            for (int i = 0; i < attrCount(atts); i++)
-            {
-                if (adbParser->_enforceGuiChecks)
-                {
+        /* Add all field attributes */
+        if (!expFound) {
+            for (int i = 0; i < attrCount(atts); i++) {
+                if (adbParser->_enforceGuiChecks) {
                     string aName = attrName(atts, i);
                     string aValue = attrValue(atts, i);
 
-                    // check if the field contains illegal attribute
+                    /* check if the field contains illegal attribute */
                     if (!aName.compare("inst_if") && !aName.compare("inst_ifdef") && !aName.compare("subnode") &&
-                        adbParser->field_attr_names_set.find(aName) != adbParser->field_attr_names_set.end() &&
-                        adbParser->field_spec_attr.find(aName) != adbParser->field_spec_attr.end())
-                    {
+                        (adbParser->field_attr_names_set.find(aName) != adbParser->field_attr_names_set.end()) &&
+                        (adbParser->field_spec_attr.find(aName) != adbParser->field_spec_attr.end())) {
                         expFound =
-                          raiseException(allowMultipleExceptions,
-                                         "Unknown attribute: " + aName + " at field: " + adbParser->_currentField->name,
-                                         ", in file: \"" + adbParser->_fileName +
-                                           "\" line: " + boost::lexical_cast<string>(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                            raiseException(allowMultipleExceptions,
+                                           "Unknown attribute: " + aName + " at field: " + adbParser->_currentField->name,
+                                           ", in file: \"" + adbParser->_fileName +
+                                           "\" line: " + to_string(lineNumber),
+                                           ExceptionHolder::ERROR_EXCEPTION);
                     }
 
-                    if (!aName.compare("enum"))
-                    {
-                        // check the enum attribute is compatible with the enum pattern
-                        if (!regex_match(aValue, regex(adbParser->_enum_pattern)))
-                        {
+                    if (!aName.compare("enum")) {
+                        /* check the enum attribute is compatible with the enum pattern */
+                        if (!regex_match(aValue, regex(adbParser->_enum_pattern))) {
                             expFound = raiseException(
-                              allowMultipleExceptions,
-                              "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
-                              "doesn't match the given attribute pattern, in file: \"" + adbParser->_fileName +
-                                "\" line: " + boost::lexical_cast<string>(lineNumber),
-                              ExceptionHolder::WARN_EXCEPTION);
+                                allowMultipleExceptions,
+                                "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
+                                "doesn't match the given attribute pattern, in file: \"" + adbParser->_fileName +
+                                "\" line: " + to_string(lineNumber),
+                                ExceptionHolder::WARN_EXCEPTION);
                         }
-                    }
-                    else
-                    {
-                        // check the attribute name is compatible with the attribute pattern
-                        if (adbParser->attr_pattern.find(aName) != adbParser->attr_pattern.end() &&
-                            !regex_match(aValue, regex(adbParser->attr_pattern[aName])))
-                        {
+                    } else {
+                        /* check the attribute name is compatible with the attribute pattern */
+                        if ((adbParser->attr_pattern.find(aName) != adbParser->attr_pattern.end()) &&
+                            !regex_match(aValue, regex(adbParser->attr_pattern[aName]))) {
                             expFound = raiseException(
-                              allowMultipleExceptions,
-                              "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
-                              "doesn't match the given attribute pattern, in file: \"" + adbParser->_fileName +
-                                "\" line: " + boost::lexical_cast<string>(lineNumber),
-                              ExceptionHolder::WARN_EXCEPTION);
+                                allowMultipleExceptions,
+                                "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
+                                "doesn't match the given attribute pattern, in file: \"" + adbParser->_fileName +
+                                "\" line: " + to_string(lineNumber),
+                                ExceptionHolder::WARN_EXCEPTION);
                         }
                     }
                 }
@@ -1813,63 +1629,39 @@ void AdbParser::startFieldElement(const XML_Char** atts, AdbParser* adbParser, c
  **/
 void AdbParser::startElement(void* _adbParser, const XML_Char* name, const XML_Char** atts)
 {
-    AdbParser* adbParser = static_cast<AdbParser*>(_adbParser);
+    AdbParser* adbParser = static_cast < AdbParser * > (_adbParser);
+    int        lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
 
-    int lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
     adbParser->_currentTagValue = "";
 
-    if (TAG_NODES_DEFINITION == name)
-    {
+    if (TAG_NODES_DEFINITION == name) {
         startNodesDefElement(atts, adbParser);
-    }
-    else if (TAG_ENUM == name)
-    {
+    } else if (TAG_ENUM == name) {
         startEnumElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_CONFIG == name)
-    {
+    } else if (TAG_CONFIG == name) {
         startConfigElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_INFO == name)
-    {
+    } else if (TAG_INFO == name) {
         startInfoElement(atts, adbParser);
-    }
-    else if (TAG_INCLUDE == name)
-    {
+    } else if (TAG_INCLUDE == name) {
         startIncludeElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_INSTANCE_OPS == name)
-    {
+    } else if (TAG_INSTANCE_OPS == name) {
         adbParser->_instanceOps = true;
-    }
-    else if (TAG_INSTANCE_OP_ATTR_REPLACE == name)
-    {
+    } else if (TAG_INSTANCE_OP_ATTR_REPLACE == name) {
         startInstOpAttrReplaceElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_NODE == name)
-    {
+    } else if (TAG_NODE == name) {
         startNodeElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_FIELD == name)
-    {
+    } else if (TAG_FIELD == name) {
         startFieldElement(atts, adbParser, lineNumber);
-    }
-    else if (TAG_RCS_HEADERS == name)
-    {
-        // DO NOTHING
-    }
-    else
-    {
+    } else if (TAG_RCS_HEADERS == name) {
+        /* DO NOTHING */
+    } else {
         string exceptionTxt = "Unsupported tag: " + string(name);
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                           "\" line: " + boost::lexical_cast<string>(lineNumber);
+                           "\" line: " + to_string(lineNumber);
             ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, exceptionTxt);
             return;
-        }
-        else
-        {
+        } else {
             throw AdbException(exceptionTxt);
         }
     }
@@ -1878,15 +1670,14 @@ void AdbParser::startElement(void* _adbParser, const XML_Char* name, const XML_C
 /**
  * Function: AdbParser::addReserved
  **/
-void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_int32_t size)
+void AdbParser::addReserved(vector < AdbField* >& reserveds, u_int32_t offset, u_int32_t size)
 {
     u_int32_t numOfDwords = (dword(offset + size - 1) - dword(offset)) / 4 + 1;
 
-    // printf("==> %s\n", formatAddr(offset, size).c_str());
-    // printf("numOfDwords = %d\n", numOfDwords);
+    /* printf("==> %s\n", formatAddr(offset, size).c_str()); */
+    /* printf("numOfDwords = %d\n", numOfDwords); */
 
-    if (numOfDwords == 1 || ((offset % 32) == 0 && ((offset + size) % 32) == 0))
-    {
+    if ((numOfDwords == 1) || (((offset % 32) == 0) && (((offset + size) % 32) == 0))) {
         AdbField* f1 = new AdbField;
         f1->name = "reserved";
         f1->offset = offset;
@@ -1894,10 +1685,8 @@ void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_in
         f1->size = size;
 
         reserveds.push_back(f1);
-        // printf("case1: reserved0: %s\n", formatAddr(f1->offset, f1->size).c_str());
-    }
-    else if (numOfDwords == 2)
-    {
+        /* printf("case1: reserved0: %s\n", formatAddr(f1->offset, f1->size).c_str()); */
+    } else if (numOfDwords == 2) {
         AdbField* f1 = new AdbField;
         f1->name = "reserved";
         f1->offset = offset;
@@ -1912,11 +1701,9 @@ void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_in
         reserveds.push_back(f1);
         reserveds.push_back(f2);
         /*printf("case2: reserved0: %s, reserved1: %s\n",
-         formatAddr(f1->offset, f1->size).c_str(),
-         formatAddr(f2->offset, f2->size).c_str());*/
-    }
-    else
-    {
+         *  formatAddr(f1->offset, f1->size).c_str(),
+         *  formatAddr(f2->offset, f2->size).c_str());*/
+    } else {
         AdbField* f1 = new AdbField;
         f1->name = "reserved";
         f1->offset = offset;
@@ -1929,32 +1716,26 @@ void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_in
         f2->isReserved = true;
         f2->size = (numOfDwords - 2) * 32;
 
-        if (!((offset + size) % 32))
-        {
+        if (!((offset + size) % 32)) {
             f2->size = (numOfDwords - 1) * 32;
             reserveds.push_back(f1);
             reserveds.push_back(f2);
             /*printf("case3.1: reserved0: %s, reserved1: %s\n",
-             formatAddr(f1->offset, f1->size).c_str(),
-             formatAddr(f2->offset, f2->size).c_str());*/
+             *  formatAddr(f1->offset, f1->size).c_str(),
+             *  formatAddr(f2->offset, f2->size).c_str());*/
             return;
-        }
-        else
-        {
-            if (!(f1->size % 32))
-            {
+        } else {
+            if (!(f1->size % 32)) {
                 f1->size = (numOfDwords - 1) * 32;
                 f2->size = size - f1->size;
                 f2->offset = f1->offset + f1->size;
                 reserveds.push_back(f1);
                 reserveds.push_back(f2);
                 /*printf("case3.2: reserved0: %s, reserved1: %s\n",
-                 formatAddr(f1->offset, f1->size).c_str(),
-                 formatAddr(f2->offset, f2->size).c_str());*/
+                 *  formatAddr(f1->offset, f1->size).c_str(),
+                 *  formatAddr(f2->offset, f2->size).c_str());*/
                 return;
-            }
-            else
-            {
+            } else {
                 f2->size = (numOfDwords - 2) * 32;
                 AdbField* f3 = new AdbField;
                 f3->name = "reserved";
@@ -1965,9 +1746,9 @@ void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_in
                 reserveds.push_back(f2);
                 reserveds.push_back(f3);
                 /*printf("case3.3: reserved0: %s, reserved1: %s, reserved2: %s\n",
-                 formatAddr(f1->offset, f1->size).c_str(),
-                 formatAddr(f2->offset, f2->size).c_str(),
-                 formatAddr(f3->offset, f3->size).c_str());*/
+                 *  formatAddr(f1->offset, f1->size).c_str(),
+                 *  formatAddr(f2->offset, f2->size).c_str(),
+                 *  formatAddr(f3->offset, f3->size).c_str());*/
                 return;
             }
         }
@@ -1979,14 +1760,14 @@ void AdbParser::addReserved(vector<AdbField*>& reserveds, u_int32_t offset, u_in
  **/
 void AdbParser::endElement(void* _adbParser, const XML_Char* name)
 {
-    AdbParser* adbParser = static_cast<AdbParser*>(_adbParser);
-    int lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
+    AdbParser* adbParser = static_cast < AdbParser * > (_adbParser);
+    int        lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
+
     /*
      * Config
      * ----
      */
-    if (TAG_CONFIG == name)
-    {
+    if (TAG_CONFIG == name) {
         adbParser->_adbCtxt->configs.push_back(adbParser->_currentConfig);
         adbParser->_currentConfig = NULL;
     }
@@ -1994,61 +1775,48 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
      * Instance Operations
      * ----
      */
-    else if (TAG_INSTANCE_OPS == name)
-    {
+    else if (TAG_INSTANCE_OPS == name) {
         adbParser->_instanceOps = false;
     }
     /*
      * Node
      * ----
      */
-    else if (TAG_NODE == name)
-    {
-        // Sort the fields by offset
-        if (adbParser->skipNode)
-        {
+    else if (TAG_NODE == name) {
+        /* Sort the fields by offset */
+        if (adbParser->skipNode) {
             adbParser->skipNode = false;
-        }
-        else
-        {
-            if (!adbParser->_currentNode->isUnion)
-            {
+        } else {
+            if (!adbParser->_currentNode->isUnion) {
                 stable_sort(adbParser->_currentNode->fields.begin(),
                             adbParser->_currentNode->fields.end(),
-                            compareFieldsPtr<AdbField>);
+                            compareFieldsPtr < AdbField >);
             }
 
-            // Check overlapping
-            vector<AdbField*> reserveds;
+            /* Check overlapping */
+            vector < AdbField * > reserveds;
             AdbField prevFieldDummy;
             prevFieldDummy.offset = 0;
             prevFieldDummy.size = 0;
             AdbField* prevField = &prevFieldDummy;
-            if (!adbParser->_currentNode->isUnion)
-            {
-                for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++)
-                {
+            if (!adbParser->_currentNode->isUnion) {
+                for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++) {
                     AdbField* field = adbParser->_currentNode->fields[i];
-                    long int delta = (long)field->offset - (long)(prevField->offset + prevField->size);
+                    long int  delta = (long)field->offset - (long)(prevField->offset + prevField->size);
 
-                    if (delta < 0)
-                    { // Overlapping
+                    if (delta < 0) { /* Overlapping */
                         string exceptionTxt = "Field: " + field->name + " " + formatAddr(field->offset, field->size) +
                                               " overlaps with Field: " + prevField->name + " " +
                                               formatAddr(prevField->offset, prevField->size);
-                        if (allowMultipleExceptions)
-                        {
+                        if (allowMultipleExceptions) {
                             exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                                           "\" line: " + boost::lexical_cast<string>(lineNumber);
+                                           "\" line: " + to_string(lineNumber);
                             ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                        }
-                        else
-                        {
+                        } else {
                             throw AdbException(exceptionTxt);
                         }
                     }
-                    if (delta > 0 && adbParser->_addReserved)
-                    { // Need reserved
+                    if ((delta > 0) && adbParser->_addReserved) { /* Need reserved */
                         addReserved(reserveds, prevField->offset + prevField->size, delta);
                     }
 
@@ -2056,27 +1824,22 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
                 }
             }
 
-            // Add reserved filler at end of union/node
-            // special case if node is empty, we need to add reserved anyway
-            if (adbParser->_addReserved /*|| adbParser->_currentNode->fields.empty()*/)
-            {
-                if (adbParser->_currentNode->isUnion)
-                {
+            /* Add reserved filler at end of union/node */
+            /* special case if node is empty, we need to add reserved anyway */
+            if (adbParser->_addReserved /*|| adbParser->_currentNode->fields.empty()*/) {
+                if (adbParser->_currentNode->isUnion) {
                     addReserved(reserveds, 0, adbParser->_currentNode->size);
-                }
-                else
-                {
+                } else {
                     long delta = (long)adbParser->_currentNode->size - (long)(prevField->offset + prevField->size);
                     /*if (adbParser->_currentNode->name == "miss_machine_slice_info")
-                    {
-                    printf("Adding filler\n");
-                    printf("node offs: %s, prevField: %s\n", formatAddr(0, adbParser->_currentNode->size).c_str(),
-                    formatAddr(prevField->offset, prevField->size).c_str());
-                    printf("delta: %ld\n", delta);
-                    }*/
+                     *  {
+                     *  printf("Adding filler\n");
+                     *  printf("node offs: %s, prevField: %s\n", formatAddr(0, adbParser->_currentNode->size).c_str(),
+                     *  formatAddr(prevField->offset, prevField->size).c_str());
+                     *  printf("delta: %ld\n", delta);
+                     *  }*/
 
-                    if (delta > 0)
-                    {
+                    if (delta > 0) {
                         addReserved(reserveds, prevField->offset + prevField->size, delta);
                     }
                 }
@@ -2085,49 +1848,46 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
                                                        reserveds.end());
             }
 
-            if (adbParser->_checkDsAlign && adbParser->_currentNode->_maxLeafSize != 0 &&
-                adbParser->_currentNode->_maxLeafSize != 0 &&
-                adbParser->_currentNode->size % adbParser->_currentNode->_maxLeafSize != 0)
-            {
+            if (adbParser->_checkDsAlign && (adbParser->_currentNode->_maxLeafSize != 0) &&
+                (adbParser->_currentNode->_maxLeafSize != 0) &&
+                (adbParser->_currentNode->size % adbParser->_currentNode->_maxLeafSize != 0)) {
                 raiseException(
-                  allowMultipleExceptions,
-                  "Node: " + adbParser->_currentNode->name + " size(" +
-                    boost::lexical_cast<string>(adbParser->_currentNode->size) + ") is not aligned with largest leaf(" +
-                    boost::lexical_cast<string>(adbParser->_currentNode->_maxLeafSize) + ")",
-                  ", in file: \"" + adbParser->_fileName + "\" line: " + boost::lexical_cast<string>(lineNumber),
-                  ExceptionHolder::ERROR_EXCEPTION);
+                    allowMultipleExceptions,
+                    "Node: " + adbParser->_currentNode->name + " size(" +
+                    to_string(adbParser->_currentNode->size) + ") is not aligned with largest leaf(" +
+                    to_string(adbParser->_currentNode->_maxLeafSize) + ")",
+                    ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(
+                        lineNumber),
+                    ExceptionHolder::ERROR_EXCEPTION);
             }
 
-            // Re-fix fields offset
-            if (adbParser->_adbCtxt->bigEndianArr)
-            {
-                for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++)
-                {
+            /* Re-fix fields offset */
+            if (adbParser->_adbCtxt->bigEndianArr) {
+                for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++) {
                     u_int32_t offset = adbParser->_currentNode->fields[i]->offset;
                     u_int32_t size = adbParser->_currentNode->fields[i]->eSize();
 
                     adbParser->_currentNode->fields[i]->offset =
-                      ((offset >> 5) << 5) + ((MIN(32, adbParser->_currentNode->size) - ((offset + size) % 32)) % 32);
+                        ((offset >> 5) <<
+                            5) + ((MIN(32, adbParser->_currentNode->size) - ((offset + size) % 32)) % 32);
                 }
             }
 
-            // Resort the fields by offset (since we changed offset to workaround big endian issues and added reserved)
-            if (!adbParser->_currentNode->isUnion)
-            {
+            /* Resort the fields by offset (since we changed offset to workaround big endian issues and added reserved) */
+            if (!adbParser->_currentNode->isUnion) {
                 stable_sort(adbParser->_currentNode->fields.begin(),
                             adbParser->_currentNode->fields.end(),
-                            compareFieldsPtr<AdbField>);
+                            compareFieldsPtr < AdbField >);
             }
 
-            // Add this node to AdbCtxt
+            /* Add this node to AdbCtxt */
             adbParser->_adbCtxt->nodesMap.insert(
-              pair<string, AdbNode*>(adbParser->_currentNode->name, adbParser->_currentNode));
+                pair < string, AdbNode * > (adbParser->_currentNode->name, adbParser->_currentNode));
             adbParser->_currentNode = 0;
 
-            // Call progress_func callback
-            if (adbParser->_progressObj && !(adbParser->_progressCnt++ % PROGRESS_NODE_CNT))
-            {
-                adbParser->_progressObj->progress(); // TODO - call with real parameters
+            /* Call progress_func callback */
+            if (adbParser->_progressObj && !(adbParser->_progressCnt++ % PROGRESS_NODE_CNT)) {
+                adbParser->_progressObj->progress(); /* TODO - call with real parameters */
             }
         }
     }
@@ -2135,33 +1895,26 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
      * Field
      * ----
      */
-    else if (TAG_FIELD == name)
-    {
-        // Add this field to current node
-        if (!adbParser->skipNode)
-        {
-            if (adbParser->_currentNode->name == "root")
-            {
+    else if (TAG_FIELD == name) {
+        /* Add this field to current node */
+        if (!adbParser->skipNode) {
+            if (adbParser->_currentNode->name == "root") {
                 adbParser->_adbCtxt->rootNode = adbParser->_currentField->subNode;
             }
 
-            // Check conditions
-            bool cond = true;
+            /* Check conditions */
+            bool               cond = true;
             AttrsMap::iterator it;
             it = adbParser->_currentField->attrs.find("inst_ifdef");
-            if (it != adbParser->_currentField->attrs.end())
-            {
+            if (it != adbParser->_currentField->attrs.end()) {
                 bool found = false;
-                for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++)
-                {
+                for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++) {
                     AttrsMap::iterator it_def = adbParser->_adbCtxt->configs[i]->attrs.find("define");
-                    if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end())
-                    {
-                        vector<string> defVal;
-                        boost::algorithm::split(defVal, it_def->second, boost::is_any_of(string("=")));
+                    if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end()) {
+                        vector < string > defVal;
+                        string_utils::split(defVal, it_def->second, "=");
 
-                        if (defVal[0] == it->second)
-                        {
+                        if (defVal[0] == it->second) {
                             found = true;
                             break;
                         }
@@ -2170,36 +1923,29 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
                 cond = found;
             }
 
-            //
+            /* */
             it = adbParser->_currentField->attrs.find("inst_if");
-            if (cond && it != adbParser->_currentField->attrs.end())
-            {
-                // Prepare vars
-                map<string, string> vars;
-                for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++)
-                {
+            if (cond && (it != adbParser->_currentField->attrs.end())) {
+                /* Prepare vars */
+                map < string, string > vars;
+                for (size_t i = 0; i < adbParser->_adbCtxt->configs.size(); i++) {
                     AttrsMap::iterator it_def = adbParser->_adbCtxt->configs[i]->attrs.find("define");
-                    if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end())
-                    {
-                        vector<string> defVal;
-                        boost::algorithm::split(defVal, it_def->second, boost::is_any_of(string("=")));
+                    if (it_def != adbParser->_adbCtxt->configs[i]->attrs.end()) {
+                        vector < string > defVal;
+                        string_utils::split(defVal, it_def->second, "=");
 
-                        if (defVal.size() == 1)
-                        {
+                        if (defVal.size() == 1) {
                             vars[defVal[0]] = "0";
-                        }
-                        else
-                        {
+                        } else {
                             vars[defVal[0]] = defVal[1];
                         }
                     }
                 }
 
                 AdbExpr adbExpr;
-                char* expOrg = new char[it->second.size() + 1];
-                char* exp = expOrg;
-                if (!exp)
-                {
+                char  * expOrg = new char[it->second.size() + 1];
+                char  * exp = expOrg;
+                if (!exp) {
                     throw AdbException("Memory allocation error");
                 }
                 strcpy(exp, it->second.c_str());
@@ -2210,58 +1956,44 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
                 delete[] expOrg;
                 string statusStr;
 
-                if (status < 0)
-                {
+                if (status < 0) {
                     string exceptionTxt = string("Error evaluating expression \"") + it->second.c_str() +
                                           "\" : " + AdbExpr::statusStr(status);
-                    if (allowMultipleExceptions)
-                    {
+                    if (allowMultipleExceptions) {
                         exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                                       "\" line: " + boost::lexical_cast<string>(lineNumber);
+                                       "\" line: " + to_string(lineNumber);
                         ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                    }
-                    else
-                    {
+                    } else {
                         throw AdbException(exceptionTxt);
                     }
                 }
                 cond = !!res;
             }
 
-            if (cond)
-            {
-                // Name should be unique
-                if (adbParser->_strict)
-                {
-                    for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++)
-                    {
-                        if (!adbParser->_currentNode->fields[i]->name.compare(adbParser->_currentField->name))
-                        {
+            if (cond) {
+                /* Name should be unique */
+                if (adbParser->_strict) {
+                    for (size_t i = 0; i < adbParser->_currentNode->fields.size(); i++) {
+                        if (!adbParser->_currentNode->fields[i]->name.compare(adbParser->_currentField->name)) {
                             string exceptionTxt =
-                              "The field \"" + adbParser->_currentField->name + "\" isn't unique in node";
-                            if (allowMultipleExceptions)
-                            {
+                                "The field \"" + adbParser->_currentField->name + "\" isn't unique in node";
+                            if (allowMultipleExceptions) {
                                 exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                                               "\" line: " + boost::lexical_cast<string>(lineNumber);
+                                               "\" line: " + to_string(lineNumber);
                                 ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                            }
-                            else
-                            {
+                            } else {
                                 throw AdbException(exceptionTxt);
                             }
                         }
                     }
                 }
                 it = adbParser->_currentField->attrs.find("condition");
-                if (it != adbParser->_currentField->attrs.end())
-                {
+                if (it != adbParser->_currentField->attrs.end()) {
                     adbParser->_currentField->condition = string(it->second);
                 }
 
                 adbParser->_currentNode->fields.push_back(adbParser->_currentField);
-            }
-            else
-            {
+            } else {
                 adbParser->_currentNode->condFields.push_back(adbParser->_currentField);
             }
             adbParser->_currentField = 0;
@@ -2272,15 +2004,13 @@ void AdbParser::endElement(void* _adbParser, const XML_Char* name)
 /**
  * Function: AdbParser::raiseException
  **/
-bool AdbParser::raiseException(bool allowMultipleExceptions, string exceptionTxt, string addedMsg, const string expType)
+bool AdbParser::raiseException(bool allowMultipleExceptions, string exceptionTxt, string addedMsg,
+                               const string expType)
 {
-    if (allowMultipleExceptions)
-    {
+    if (allowMultipleExceptions) {
         ExceptionHolder::insertNewException(expType, exceptionTxt + addedMsg);
         return false;
-    }
-    else
-    {
+    } else {
         throw AdbException(exceptionTxt);
     }
 }
@@ -2303,7 +2033,7 @@ int main()
 
     try
     {
-        //adb.print(0);
+        /*adb.print(0); */
         cout << "Root node: " << adb.rootNode << endl;
         AdbInstance *root = adb.createLayout(adb.rootNode, false, NULL);
         AdbInstance *child = root->getChildByPath("packetA.x");
@@ -2314,7 +2044,7 @@ int main()
 
         printf("Child name: %s, addr: %s\n", child->name.c_str(), formatAddr(child->offset, child->size).c_str());
 
-        string n1, n2;
+        string    n1, n2;
         u_int64_t v1, v2;
         child->intToEnum(0, n1);
         child->intToEnum(1, n2);
@@ -2322,16 +2052,16 @@ int main()
         child->enumToInt("GET", v2);
 
         printf("enumName(0) = %s, enumName(1) = %s, value(SET) = %d, value(GET) = %d", n1.c_str(), n2.c_str(), v1, v2);
-        //root->print();
+        /*root->print(); */
     }
-    catch (AdbException &exp)
+    catch(AdbException & exp)
     {
         printf("-E- %s\n", exp.what());
         return 1;
     }
 
     cout << endl;
-    //adb.print(0);
+    /*adb.print(0); */
     return 0;
 }
 #endif
@@ -2346,14 +2076,17 @@ Adb::Adb() : bigEndianArr(false), singleEntryArrSupp(false), _checkDsAlign(false
  **/
 Adb::~Adb()
 {
-    // Free configs
-    for (size_t i = 0; i < configs.size(); i++)
+    /* Free configs */
+    for (size_t i = 0; i < configs.size(); i++) {
         delete configs[i];
+    }
 
-    // Free nodes
+    /* Free nodes */
     NodesMap::iterator iter;
-    for (iter = nodesMap.begin(); iter != nodesMap.end(); iter++)
+
+    for (iter = nodesMap.begin(); iter != nodesMap.end(); iter++) {
         delete iter->second;
+    }
 
     delete _logFile;
 }
@@ -2363,12 +2096,9 @@ Adb::~Adb()
  **/
 void Adb::raiseException(bool allowMultipleExceptions, string exceptionTxt, const string expType)
 {
-    if (allowMultipleExceptions)
-    {
+    if (allowMultipleExceptions) {
         ExceptionHolder::insertNewException(expType, exceptionTxt);
-    }
-    else
-    {
+    } else {
         throw AdbException(exceptionTxt);
     }
     return;
@@ -2380,19 +2110,16 @@ void Adb::raiseException(bool allowMultipleExceptions, string exceptionTxt, cons
  **/
 void Adb::fetchAdbExceptionsMap(ExceptionsMap otherMap)
 {
-    vector<string> fatals = otherMap[ExceptionHolder::FATAL_EXCEPTION];
-    for (vector<string>::iterator it = fatals.begin(); it != fatals.end(); ++it)
-    {
+    vector < string > fatals = otherMap[ExceptionHolder::FATAL_EXCEPTION];
+    for (vector < string > ::iterator it = fatals.begin(); it != fatals.end(); ++it) {
         insertNewException(ExceptionHolder::FATAL_EXCEPTION, *it);
     }
-    vector<string> errors = otherMap[ExceptionHolder::ERROR_EXCEPTION];
-    for (vector<string>::iterator it = errors.begin(); it != errors.end(); ++it)
-    {
+    vector < string > errors = otherMap[ExceptionHolder::ERROR_EXCEPTION];
+    for (vector < string > ::iterator it = errors.begin(); it != errors.end(); ++it) {
         insertNewException(ExceptionHolder::ERROR_EXCEPTION, *it);
     }
-    vector<string> warnings = otherMap[ExceptionHolder::WARN_EXCEPTION];
-    for (vector<string>::iterator it = warnings.begin(); it != warnings.end(); ++it)
-    {
+    vector < string > warnings = otherMap[ExceptionHolder::WARN_EXCEPTION];
+    for (vector < string > ::iterator it = warnings.begin(); it != warnings.end(); ++it) {
         insertNewException(ExceptionHolder::WARN_EXCEPTION, *it);
     }
 }
@@ -2414,19 +2141,17 @@ void Adb::insertNewException(const string exceptionType, string exceptionTxt)
 string Adb::printAdbExceptionMap()
 {
     string errorStr = "";
-    vector<string> fatals = adbExceptionMap[ExceptionHolder::FATAL_EXCEPTION];
-    for (vector<string>::iterator it = fatals.begin(); it != fatals.end(); ++it)
-    {
+
+    vector < string > fatals = adbExceptionMap[ExceptionHolder::FATAL_EXCEPTION];
+    for (vector < string > ::iterator it = fatals.begin(); it != fatals.end(); ++it) {
         errorStr += "-" + ExceptionHolder::FATAL_EXCEPTION + "- " + *it + ";";
     }
-    vector<string> errors = adbExceptionMap[ExceptionHolder::ERROR_EXCEPTION];
-    for (vector<string>::iterator it = errors.begin(); it != errors.end(); ++it)
-    {
+    vector < string > errors = adbExceptionMap[ExceptionHolder::ERROR_EXCEPTION];
+    for (vector < string > ::iterator it = errors.begin(); it != errors.end(); ++it) {
         errorStr += "-" + ExceptionHolder::ERROR_EXCEPTION + "- " + *it + ";";
     }
-    vector<string> warnings = adbExceptionMap[ExceptionHolder::WARN_EXCEPTION];
-    for (vector<string>::iterator it = warnings.begin(); it != warnings.end(); ++it)
-    {
+    vector < string > warnings = adbExceptionMap[ExceptionHolder::WARN_EXCEPTION];
+    for (vector < string > ::iterator it = warnings.begin(); it != warnings.end(); ++it) {
         errorStr += "-" + ExceptionHolder::WARN_EXCEPTION + "- " + "- " + *it + ";";
     }
     return errorStr;
@@ -2435,24 +2160,23 @@ string Adb::printAdbExceptionMap()
 /**
  * Function: Adb::load
  **/
-bool Adb::load(string fname,
-               bool addReserved,
+bool Adb::load(string       fname,
+               bool         addReserved,
                AdbProgress* progressObj,
-               bool strict,
-               string includePath,
-               string includeDir,
-               bool enforceExtraChecks,
-               bool allowMultipleExceptions,
-               string logFileStr,
-               bool checkDsAlign,
-               bool enforceGuiChecks)
+               bool         strict,
+               string       includePath,
+               string       includeDir,
+               bool         enforceExtraChecks,
+               bool         allowMultipleExceptions,
+               string       logFileStr,
+               bool         checkDsAlign,
+               bool         enforceGuiChecks)
 {
     try
     {
         bool status = true;
         mainFileName = fname;
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             AdbParser::setAllowMultipleExceptionsTrue();
         }
         _logFile->init(logFileStr, allowMultipleExceptions);
@@ -2460,41 +2184,34 @@ bool Adb::load(string fname,
                     enforceGuiChecks);
         _checkDsAlign = checkDsAlign;
         _enforceGuiChecks = enforceGuiChecks;
-        if (!p.load())
-        {
+        if (!p.load()) {
             _lastError = p.getError();
             status = false;
         }
-        if (status && includeDir != "")
-        {
+        if (status && (includeDir != "")) {
             AdbParser::includeAllFilesInDir(&p, includeDir);
         }
-        if (status && !nodesMap.size())
-        {
+        if (status && !nodesMap.size()) {
             _lastError = "Empty project, no nodes were found";
-            if (allowMultipleExceptions)
-            {
+            if (allowMultipleExceptions) {
                 insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
             }
             status = false;
         }
-        if (status)
-        {
+        if (status) {
             bool checkSizeConsistency = strict ? checkInstSizeConsistency(allowMultipleExceptions) : true;
             status = status && checkSizeConsistency;
         }
-        if (allowMultipleExceptions && ExceptionHolder::getNumberOfExceptions() > 0)
-        {
+        if (allowMultipleExceptions && (ExceptionHolder::getNumberOfExceptions() > 0)) {
             fetchAdbExceptionsMap(ExceptionHolder::getAdbExceptionsMap());
             status = false;
         }
         return status;
     }
-    catch (AdbException& e)
+    catch(AdbException & e)
     {
         _lastError = e.what_s();
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return false;
@@ -2504,31 +2221,29 @@ bool Adb::load(string fname,
 /**
  * Function: Adb::loadFromString
  **/
-bool Adb::loadFromString(const char* adbContents,
-                         bool addReserved,
+bool Adb::loadFromString(const char * adbContents,
+                         bool         addReserved,
                          AdbProgress* progressObj,
-                         bool strict,
-                         bool enforceExtraChecks)
+                         bool         strict,
+                         bool         enforceExtraChecks)
 {
     try
     {
         AdbParser p(string(), this, addReserved, progressObj, strict, "", enforceExtraChecks);
         mainFileName = OS_PATH_SEP;
-        if (!p.loadFromString(adbContents))
-        {
+        if (!p.loadFromString(adbContents)) {
             _lastError = p.getError();
             return false;
         }
 
-        if (!nodesMap.size())
-        {
+        if (!nodesMap.size()) {
             _lastError = "Empty project, no nodes were found";
             return false;
         }
 
         return strict ? checkInstSizeConsistency() : true;
     }
-    catch (AdbException& e)
+    catch(AdbException & e)
     {
         _lastError = e.what_s();
         return false;
@@ -2538,53 +2253,42 @@ bool Adb::loadFromString(const char* adbContents,
 /**
  * Function: Adb::toXml
  **/
-string Adb::toXml(vector<string> nodeNames, bool addRootNode, string rootName, string addPrefix)
+string Adb::toXml(vector < string > nodeNames, bool addRootNode, string rootName, string addPrefix)
 {
     try
     {
-        vector<string> nodeDeps;
-        for (vector<string>::iterator it = nodeNames.begin(); it != nodeNames.end(); it++)
-        {
-            vector<string> tmp = getNodeDeps(*it);
+        vector < string > nodeDeps;
+        for (vector < string > ::iterator it = nodeNames.begin(); it != nodeNames.end(); it++) {
+            vector < string > tmp = getNodeDeps(*it);
             nodeDeps.insert(nodeDeps.end(), tmp.begin(), tmp.end());
         }
         stable_sort(nodeDeps.begin(), nodeDeps.end());
         nodeDeps.erase(unique(nodeDeps.begin(), nodeDeps.end()), nodeDeps.end());
 
         string xml;
-        if (this->version == "2")
-        {
+        if (this->version == "2") {
             xml = "<NodesDefinition version=\"2\">\n";
-        }
-        else
-        {
+        } else {
             xml = "<NodesDefinition>\n";
         }
-        for (ConfigList::iterator it = configs.begin(); it != configs.end(); it++)
-        {
+        for (ConfigList::iterator it = configs.begin(); it != configs.end(); it++) {
             xml += (*it)->toXml() + "\n";
         }
 
-        // Add source info
+        /* Add source info */
         xml += "<info source_doc_name=\"" + encodeXml(descNativeToXml(srcDocName)) + "\" source_doc_version=\"" +
                encodeXml(descNativeToXml(srcDocVer)) + "\" />\n";
 
-        if (nodeNames.empty())
-        {
-            for (NodesMap::iterator it = nodesMap.begin(); it != nodesMap.end(); it++)
-            {
+        if (nodeNames.empty()) {
+            for (NodesMap::iterator it = nodesMap.begin(); it != nodesMap.end(); it++) {
                 AdbNode* node = it->second;
                 xml += node->toXml(addPrefix);
             }
-        }
-        else
-        {
+        } else {
             u_int32_t maxSize = 0;
-            for (size_t i = 0; i < nodeDeps.size(); i++)
-            {
+            for (size_t i = 0; i < nodeDeps.size(); i++) {
                 NodesMap::iterator it = nodesMap.find(nodeDeps[i]);
-                if (it == nodesMap.end())
-                {
+                if (it == nodesMap.end()) {
                     _lastError = "Can't find node definition for: " + nodeDeps[i];
                     return "";
                 }
@@ -2595,8 +2299,7 @@ string Adb::toXml(vector<string> nodeNames, bool addRootNode, string rootName, s
                 maxSize = TOOLS_MAX(node->size, maxSize);
             }
 
-            if (addRootNode)
-            {
+            if (addRootNode) {
                 stringstream buf;
                 buf << "<node name=\"root\" size=\"0x" << hex << ((maxSize >> 5) << 2) << "." << dec << (maxSize % 32)
                     << "\" descr=\"\" >\n";
@@ -2607,8 +2310,7 @@ string Adb::toXml(vector<string> nodeNames, bool addRootNode, string rootName, s
 
                 buf << "<node name=\"" + addPrefix + rootName + "\" size=\"0x" << hex << ((maxSize >> 5) << 2) << "."
                     << dec << (maxSize % 32) << "\" attr_is_union=\"1\" descr=\"\" >\n";
-                for (size_t i = 0; i < nodeNames.size(); i++)
-                {
+                for (size_t i = 0; i < nodeNames.size(); i++) {
                     AdbNode* node = nodesMap[nodeNames[i]];
                     buf << "\t<field name=\"" << node->name << "\" offset=\"0x0.0\" size=\"0x" << hex
                         << ((node->size >> 5) << 2) << "." << dec << (node->size % 32)
@@ -2622,7 +2324,7 @@ string Adb::toXml(vector<string> nodeNames, bool addRootNode, string rootName, s
         xml += "</NodesDefinition>\n";
         return xml;
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
         _lastError = exp.what_s();
         return "";
@@ -2638,20 +2340,15 @@ AdbInstance* Adb::addMissingNodes(int depth, bool allowMultipleExceptions)
     try
     {
         NodesMap::iterator it;
-        for (it = nodesMap.begin(); it != nodesMap.end(); it++)
-        {
+        for (it = nodesMap.begin(); it != nodesMap.end(); it++) {
             AdbNode* nodeDesc = it->second;
-            for (size_t i = 0; (depth == -1 || depth > 0) && i < nodeDesc->fields.size(); i++)
-            {
+            for (size_t i = 0; (depth == -1 || depth > 0) && i < nodeDesc->fields.size(); i++) {
                 AdbField* fieldDesc = nodeDesc->fields[i];
-                for (u_int32_t i = 0; i < fieldDesc->arrayLen(); i++)
-                {
-                    if (fieldDesc->isStruct())
-                    {
+                for (u_int32_t i = 0; i < fieldDesc->arrayLen(); i++) {
+                    if (fieldDesc->isStruct()) {
                         NodesMap::iterator it2 = nodesMap.find(fieldDesc->subNode);
-                        if (it2 == nodesMap.end())
-                        {
-                            // If in ignore missing nodes mode, it should create temporary node with placeholder
+                        if (it2 == nodesMap.end()) {
+                            /* If in ignore missing nodes mode, it should create temporary node with placeholder */
                             AdbNode* tmpNode = new AdbNode;
                             tmpNode->name = fieldDesc->subNode;
                             tmpNode->size = fieldDesc->eSize();
@@ -2665,23 +2362,22 @@ AdbInstance* Adb::addMissingNodes(int depth, bool allowMultipleExceptions)
                             tmpField->size = tmpNode->size;
                             tmpField->offset = 0;
                             tmpNode->fields.push_back(tmpField);
-                            nodesMap.insert(pair<string, AdbNode*>(tmpNode->name, tmpNode));
+                            nodesMap.insert(pair < string, AdbNode * > (tmpNode->name, tmpNode));
                         }
                     }
                 }
             }
         }
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
         _lastError = exp.what_s();
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return NULL;
     }
-    catch (...)
+    catch(...)
     {
         _lastError = "Unknown error occurred";
         return NULL;
@@ -2694,8 +2390,7 @@ AdbInstance* Adb::addMissingNodes(int depth, bool allowMultipleExceptions)
  **/
 void Adb::cleanInstAttrs()
 {
-    for (InstanceAttrs::iterator it = instAttrs.begin(); it != instAttrs.end(); it++)
-    {
+    for (InstanceAttrs::iterator it = instAttrs.begin(); it != instAttrs.end(); it++) {
         it->second.clear();
     }
     instAttrs.clear();
@@ -2704,20 +2399,19 @@ void Adb::cleanInstAttrs()
 /**
  * Function: Adb::createLayout
  **/
-AdbInstance* Adb::createLayout(string rootNodeName,
-                               bool isExprEval,
+AdbInstance* Adb::createLayout(string       rootNodeName,
+                               bool         isExprEval,
                                AdbProgress* progressObj,
-                               int depth,
-                               bool ignoreMissingNodes,
-                               bool allowMultipleExceptions)
+                               int          depth,
+                               bool         ignoreMissingNodes,
+                               bool         allowMultipleExceptions)
 {
     try
     {
-        // find root in nodes map
+        /* find root in nodes map */
         NodesMap::iterator it;
         it = nodesMap.find(rootNodeName);
-        if (it == nodesMap.end())
-        {
+        if (it == nodesMap.end()) {
             raiseException(allowMultipleExceptions,
                            "Can't find definition for node \"" + rootNodeName + "\"",
                            ExceptionHolder::FATAL_EXCEPTION);
@@ -2734,43 +2428,35 @@ AdbInstance* Adb::createLayout(string rootNodeName,
         rootItem->size = nodeDesc->size;
         rootItem->copyAllInstanceAttr(nodeDesc->attrs);
 
-        map<string, string> emptyVars;
+        map < string, string > emptyVars;
         _unionSelectorEvalDeffered.clear();
         _conditionInstances.clear();
         _conditionalArrays.clear();
-        if (ignoreMissingNodes)
-        {
+        if (ignoreMissingNodes) {
             addMissingNodes(depth, allowMultipleExceptions);
         }
 
-        for (size_t i = 0; (depth == -1 || depth > 0) && i < nodeDesc->fields.size(); i++)
-        {
-            vector<AdbInstance*> subItems =
-              createInstance(nodeDesc->fields[i], rootItem, emptyVars, isExprEval, progressObj,
-                             depth == -1 ? -1 : depth - 1, ignoreMissingNodes, allowMultipleExceptions);
+        for (size_t i = 0; (depth == -1 || depth > 0) && i < nodeDesc->fields.size(); i++) {
+            vector < AdbInstance * > subItems =
+                createInstance(nodeDesc->fields[i], rootItem, emptyVars, isExprEval, progressObj,
+                               depth == -1 ? -1 : depth - 1, ignoreMissingNodes, allowMultipleExceptions);
             rootItem->subItems.insert(rootItem->subItems.end(), subItems.begin(), subItems.end());
         }
 
-        // Now set the instance attributes (override field attrs), only if this is root node instantiation
-        if (rootNodeName == rootNode && depth == -1)
-        {
-            for (InstanceAttrs::iterator it = instAttrs.begin(); it != instAttrs.end(); it++)
-            {
-                size_t idx = it->first.find(".");
-                string path = idx == string::npos ? string() : it->first.substr(idx + 1);
-
+        /* Now set the instance attributes (override field attrs), only if this is root node instantiation */
+        if ((rootNodeName == rootNode) && (depth == -1)) {
+            for (InstanceAttrs::iterator it = instAttrs.begin(); it != instAttrs.end(); it++) {
+                size_t       idx = it->first.find(".");
+                string       path = idx == string::npos ? string() : it->first.substr(idx + 1);
                 AdbInstance* inst = rootItem->getChildByPath(path);
-                if (!inst)
-                {
+                if (!inst) {
                     raiseException(allowMultipleExceptions,
                                    "Can't find instance path (" + it->first + ") defined in <instance_ops> section",
                                    ExceptionHolder::ERROR_EXCEPTION);
                 }
 
-                for (AttrsMap::iterator it2 = it->second.begin(); it2 != it->second.end(); it2++)
-                {
-                    if (allowMultipleExceptions && !inst)
-                    {
+                for (AttrsMap::iterator it2 = it->second.begin(); it2 != it->second.end(); it2++) {
+                    if (allowMultipleExceptions && !inst) {
                         break;
                     }
                     inst->setInstanceAttr(it2->first, it2->second);
@@ -2779,58 +2465,48 @@ AdbInstance* Adb::createLayout(string rootNodeName,
         }
 
         /* Evaluate unions selector fields*/
-        for (list<AdbInstance*>::iterator it = _unionSelectorEvalDeffered.begin();
+        for (list < AdbInstance * > ::iterator it = _unionSelectorEvalDeffered.begin();
              it != _unionSelectorEvalDeffered.end();
-             it++)
-        {
+             it++) {
             bool foundSelector = true;
-            vector<string> path;
+            vector < string > path;
             AdbInstance* inst = *it;
             AdbInstance* curInst = inst;
             const string splitVal = inst->getInstanceAttr("union_selector");
-            boost::algorithm::split(path, splitVal, boost::is_any_of(string(".")));
-            for (size_t i = 0; i < path.size(); i++)
-            {
-                if (path[i] == "#(parent)" || path[i] == "$(parent)")
-                {
+            string_utils::split(path, splitVal, ".");
+            for (size_t i = 0; i < path.size(); i++) {
+                if ((path[i] == "#(parent)") || (path[i] == "$(parent)")) {
                     curInst = curInst->parent;
-                    if (curInst == NULL || i == path.size() - 1)
-                    {
+                    if ((curInst == NULL) || (i == path.size() - 1)) {
                         foundSelector = false;
-                        if (rootNodeName == rootNode)
-                        { // give this warning only if this root instantiation
-                            if (allowMultipleExceptions)
+                        if (rootNodeName == rootNode) { /* give this warning only if this root instantiation */
+                            if (allowMultipleExceptions) {
                                 cout << "allow multiple";
+                            }
                             raiseException(allowMultipleExceptions,
                                            "Invalid union selector (" + inst->fullName() +
-                                             "), must be a leaf field, cannot be a parent of root",
+                                           "), must be a leaf field, cannot be a parent of root",
                                            ExceptionHolder::ERROR_EXCEPTION);
                         }
                         break;
                     }
-                }
-                else
-                {
+                } else {
                     size_t j;
-                    bool inPath = false;
-                    for (j = 0; j < curInst->subItems.size(); j++)
-                    {
-                        if (curInst->subItems[j]->name == path[i])
-                        {
+                    bool   inPath = false;
+                    for (j = 0; j < curInst->subItems.size(); j++) {
+                        if (curInst->subItems[j]->name == path[i]) {
                             curInst = curInst->subItems[j];
                             inPath = true;
                             break;
                         }
                     }
 
-                    if (j == curInst->subItems.size() && !inPath)
-                    {
+                    if ((j == curInst->subItems.size()) && !inPath) {
                         foundSelector = false;
-                        if (rootNodeName == rootNode)
-                        { // give this warning only if this root instantiation
+                        if (rootNodeName == rootNode) { /* give this warning only if this root instantiation */
                             raiseException(allowMultipleExceptions,
                                            "Failed to find union selector for union (" + inst->fullName() +
-                                             ") Can't find field (" + path[i] + ") under (" + curInst->fullName() + ")",
+                                           ") Can't find field (" + path[i] + ") under (" + curInst->fullName() + ")",
                                            ExceptionHolder::ERROR_EXCEPTION);
                         }
                         break;
@@ -2838,56 +2514,48 @@ AdbInstance* Adb::createLayout(string rootNodeName,
                 }
             }
 
-            if (foundSelector)
-            {
+            if (foundSelector) {
                 inst->unionSelector = curInst;
-                for (size_t i = 0; i < inst->subItems.size(); i++)
-                {
-                    // printf("Field %s, isResered=%d\n", inst->subItems[i]->fullName().c_str(),
-                    // inst->subItems[i]->isReserved());
-                    if (inst->subItems[i]->isReserved())
-                    {
+                for (size_t i = 0; i < inst->subItems.size(); i++) {
+                    /* printf("Field %s, isResered=%d\n", inst->subItems[i]->fullName().c_str(), */
+                    /* inst->subItems[i]->isReserved()); */
+                    if (inst->subItems[i]->isReserved()) {
                         continue;
                     }
 
-                    // make sure all union subnodes define "selected_by" attribute
-                    bool found = false;
-                    AttrsMap::iterator selectorValIt = inst->subItems[i]->getInstanceAttrIterator("selected_by", found);
-                    if (!found)
-                    {
+                    /* make sure all union subnodes define "selected_by" attribute */
+                    bool               found = false;
+                    AttrsMap::iterator selectorValIt =
+                        inst->subItems[i]->getInstanceAttrIterator("selected_by", found);
+                    if (!found) {
                         raiseException(allowMultipleExceptions,
                                        "In union (" + inst->fullName() + ") the union subnode (" +
-                                         inst->subItems[i]->name + ") doesn't define selection value",
+                                       inst->subItems[i]->name + ") doesn't define selection value",
                                        ExceptionHolder::ERROR_EXCEPTION);
                     }
 
-                    // make sure that all union subnodes selector values are defined in the selector field enum
-                    if (selectorValIt->second == "")
-                    {
+                    /* make sure that all union subnodes selector values are defined in the selector field enum */
+                    if (selectorValIt->second == "") {
                         continue;
                     }
 
-                    if (!inst->unionSelector->isEnumExists())
-                    {
+                    if (!inst->unionSelector->isEnumExists()) {
                         string exceptionTxt = "In union (" + inst->fullName() + ") the union selector (" +
                                               inst->unionSelector->fullName() + ") is not an enum";
                         raiseException(allowMultipleExceptions, exceptionTxt, ExceptionHolder::ERROR_EXCEPTION);
                         break;
                     }
 
-                    map<string, u_int64_t>::iterator it;
-                    map<string, u_int64_t> selectorValMap = inst->unionSelector->getEnumMap();
-                    for (it = selectorValMap.begin(); it != selectorValMap.end(); it++)
-                    {
-                        if (it->first == selectorValIt->second)
-                        {
+                    map < string, u_int64_t > ::iterator it;
+                    map < string, u_int64_t > selectorValMap = inst->unionSelector->getEnumMap();
+                    for (it = selectorValMap.begin(); it != selectorValMap.end(); it++) {
+                        if (it->first == selectorValIt->second) {
                             break;
                         }
                     }
 
-                    // if not found in map throw exeption
-                    if (it == selectorValMap.end())
-                    {
+                    /* if not found in map throw exeption */
+                    if (it == selectorValMap.end()) {
                         string exceptionTxt = "In union (" + inst->fullName() + ") the union subnode (" +
                                               inst->subItems[i]->name + ") uses a selector value (" +
                                               selectorValIt->second + ") which isn't defined in the selector field (" +
@@ -2898,66 +2566,57 @@ AdbInstance* Adb::createLayout(string rootNodeName,
             }
         }
 
-        // if the layout item has a conditional array
-        for (list<AdbInstance*>::iterator it = _conditionalArrays.begin(); it != _conditionalArrays.end(); it++)
-        {
+        /* if the layout item has a conditional array */
+        for (list < AdbInstance * > ::iterator it = _conditionalArrays.begin(); it != _conditionalArrays.end(); it++) {
             string condSize = (*it)->getInstanceAttr("size_condition");
 
-            if (!condSize.substr(0, 10).compare("$(parent)."))
-            {
+            if (!condSize.substr(0, 10).compare("$(parent).")) {
                 condSize.erase(0, 10);
             }
 
-            if ((*it)->parent->getChildByPath(condSize) == NULL)
-            {
+            if ((*it)->parent->getChildByPath(condSize) == NULL) {
                 raiseException(allowMultipleExceptions,
                                "The size_condition path doesn't exist. In instance: \"" + (*it)->name + "\"" +
-                                 "field name: \"" + (*it)->fieldDesc->name + "\"",
+                               "field name: \"" + (*it)->fieldDesc->name + "\"",
                                ExceptionHolder::FATAL_EXCEPTION);
-            }
-            else
-            {
+            } else {
                 (*it)->conditionalSize.setCondition(condSize);
             }
         }
 
-        // initialize condition variables objects
-        for (list<AdbInstance*>::iterator it = _conditionInstances.begin(); it != _conditionInstances.end(); it++)
-        {
-            map<string, CondVar> variables = (*it)->condition.getVarsMap();
-            for (map<string, CondVar>::iterator it2 = variables.begin(); it2 != variables.end(); it2++)
-            {
-                string currentName = it2->first;
+        /* initialize condition variables objects */
+        for (list < AdbInstance * > ::iterator it = _conditionInstances.begin(); it != _conditionInstances.end();
+             it++) {
+            map < string, CondVar > variables = (*it)->condition.getVarsMap();
+            for (map < string, CondVar > ::iterator it2 = variables.begin(); it2 != variables.end(); it2++) {
+                string   currentName = it2->first;
                 CondVar* currentVar = &(it2->second);
-                map<string, string>::iterator currentDefine = defines_map.find(currentName);
-                if (currentDefine != defines_map.end())
-                {
+                map < string, string > ::iterator currentDefine = defines_map.find(currentName);
+                if (currentDefine != defines_map.end()) {
                     currentVar->setScalar(std::stoi(currentDefine->second));
                 }
-                // else // if it's a conditional variable
-                // {
-                //     //TODO: to be evaluated later!
-                // }
+                /* else // if it's a conditional variable */
+                /* { */
+                /*     //TODO: to be evaluated later! */
+                /* } */
             }
         }
 
-        if (allowMultipleExceptions && ExceptionHolder::getNumberOfExceptions() > 0)
-        {
+        if (allowMultipleExceptions && (ExceptionHolder::getNumberOfExceptions() > 0)) {
             fetchAdbExceptionsMap(ExceptionHolder::getAdbExceptionsMap());
             rootItem = NULL;
         }
         return rootItem;
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
         _lastError = exp.what_s();
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             insertNewException(ExceptionHolder::FATAL_EXCEPTION, _lastError);
         }
         return NULL;
     }
-    catch (...)
+    catch(...)
     {
         _lastError = "Unknown error occurred";
         return NULL;
@@ -2967,23 +2626,22 @@ AdbInstance* Adb::createLayout(string rootNodeName,
 /**
  * Function: Adb::getNodeDeps
  **/
-vector<string> Adb::getNodeDeps(string nodeName)
+vector < string > Adb::getNodeDeps(string nodeName)
 {
     NodesMap::iterator it = nodesMap.find(nodeName);
-    if (it == nodesMap.end())
-    {
+
+    if (it == nodesMap.end()) {
         throw AdbException("Can't find node definition for: " + nodeName);
     }
 
     AdbNode* node = it->second;
-    vector<string> deps(1, node->name);
 
-    for (size_t i = 0; i < node->fields.size(); i++)
-    {
-        if (node->fields[i]->isStruct())
-        {
+    vector < string > deps(1, node->name);
+
+    for (size_t i = 0; i < node->fields.size(); i++) {
+        if (node->fields[i]->isStruct()) {
             deps.push_back(node->fields[i]->subNode);
-            vector<string> subDeps = getNodeDeps(node->fields[i]->subNode);
+            vector < string > subDeps = getNodeDeps(node->fields[i]->subNode);
             deps.insert(deps.end(), subDeps.begin(), subDeps.end());
         }
     }
@@ -2996,102 +2654,88 @@ vector<string> Adb::getNodeDeps(string nodeName)
 /**
  * Function: Adb::createInstance
  **/
-vector<AdbInstance*> Adb::createInstance(AdbField* field,
-                                         AdbInstance* parent,
-                                         map<string, string> vars,
-                                         bool isExprEval,
-                                         AdbProgress* progressObj,
-                                         int depth,
-                                         bool ignoreMissingNodes,
-                                         bool allowMultipleExceptions)
+vector < AdbInstance * > Adb::createInstance(AdbField * field,
+                                             AdbInstance * parent,
+                                             map < string, string > vars,
+                                             bool isExprEval,
+                                             AdbProgress * progressObj,
+                                             int depth,
+                                             bool ignoreMissingNodes,
+                                             bool allowMultipleExceptions)
 {
     static const regex EXP_PATTERN("\\s*([a-zA-Z0-9_]+)=((\\$\\(.*?\\)|\\S+|$)*)\\s*");
-    if (progressObj)
-    {
+
+    if (progressObj) {
         progressObj->progress();
     }
 
-    // if array create instance for each item. else - create 1
-    vector<AdbInstance*> instList;
-    for (u_int32_t i = 0; i < field->arrayLen(); i++)
-    {
+    /* if array create instance for each item. else - create 1 */
+    vector < AdbInstance * > instList;
+    for (u_int32_t i = 0; i < field->arrayLen(); i++) {
         AdbInstance* inst = new AdbInstance;
         inst->fieldDesc = field;
 
-        // if field is struct - find field->subNode in nodes map and addto instance not desc
+        /* if field is struct - find field->subNode in nodes map and addto instance not desc */
 
-        if (field->isStruct())
-        {
+        if (field->isStruct()) {
             NodesMap::iterator it = nodesMap.find(field->subNode);
-            if (it == nodesMap.end())
-            {
+            if (it == nodesMap.end()) {
                 delete inst;
                 raiseException(allowMultipleExceptions,
                                "Can't find the definition for subnode: " + field->subNode + " of field: " + field->name,
                                ExceptionHolder::ERROR_EXCEPTION);
                 return instList;
-            }
-            else
-            {
+            } else {
                 inst->nodeDesc = it->second;
             }
         }
 
-        if (inst)
-        {
+        if (inst) {
             inst->name = field->name;
             inst->arrIdx = 0;
             inst->size = field->eSize();
             inst->parent = parent;
         }
 
-        if (field->offset == 0xffffffff)
-        {
-            if (parent->subItems.size() > 0)
-            {
+        if (field->offset == 0xffffffff) {
+            if (parent->subItems.size() > 0) {
                 field->offset = parent->subItems.back()->offset;
-            }
-            else
-            {
+            } else {
                 field->offset = parent->offset;
             }
         }
         inst->offset = calcArrOffset(field, parent, i);
-        if (field->isArray())
-        {
-            inst->name += "[" + boost::lexical_cast<string>(i + field->lowBound) + "]";
+        if (field->isArray()) {
+            inst->name += "[" + to_string(i + field->lowBound) + "]";
             inst->arrIdx = i;
         }
-        // printf("field: %s, offset: %s (%d)\n", inst->name.c_str(),formatAddr(inst->offset, inst->size).c_str(),
-        // inst->offset);
+        /* printf("field: %s, offset: %s (%d)\n", inst->name.c_str(),formatAddr(inst->offset, inst->size).c_str(), */
+        /* inst->offset); */
 
-        if (isExprEval)
-        {
+        if (isExprEval) {
             try
             {
-                // First add the special variables
+                /* First add the special variables */
                 char tmpStr[32];
                 vars["NAME"] = inst->name;
-                vars["ARR_IDX"] = boost::lexical_cast<string>(inst->arrIdx);
+                vars["ARR_IDX"] = to_string(inst->arrIdx);
                 sprintf(tmpStr, "[%d:%d]", inst->offset % 32 + inst->size - 1, inst->offset % 32);
                 vars["BN"] = tmpStr;
-                vars["parent"] = "#(parent)"; // special internal name
+                vars["parent"] = "#(parent)"; /* special internal name */
 
-                // Get variables attribute value
+                /* Get variables attribute value */
                 AttrsMap::iterator it = field->attrs.find("variables");
-                string varStr = (it == field->attrs.end() ? string() : it->second);
-                boost::algorithm::trim(varStr);
+                string             varStr = (it == field->attrs.end() ? string() : it->second);
+                string_utils::trim(varStr);
 
-                // build var_name->value map from varAttrStr
+                /* build var_name->value map from varAttrStr */
                 AttrsMap curVars;
-                if (!varStr.empty())
-                {
-                    match_results<string::const_iterator> what;
+                if (!varStr.empty()) {
+                    match_results < string::const_iterator > what;
                     string::const_iterator start = varStr.begin();
                     string::const_iterator end = varStr.end();
 
-                    while (regex_search(start, end, what, EXP_PATTERN))
-                    {
+                    while (regex_search(start, end, what, EXP_PATTERN)) {
                         string var(what[1].first, what[1].second);
                         string exp(what[2].first, what[2].second);
 #if 0
@@ -3102,14 +2746,12 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
                         curVars[var] = exp;
                     }
 
-                    for (AttrsMap::iterator it = curVars.begin(); it != curVars.end(); it++)
-                    {
+                    for (AttrsMap::iterator it = curVars.begin(); it != curVars.end(); it++) {
                         vars[it->first] = it->second;
                     }
 
-                    // evaluate the variables themselves
-                    for (AttrsMap::iterator it = curVars.begin(); it != curVars.end(); it++)
-                    {
+                    /* evaluate the variables themselves */
+                    for (AttrsMap::iterator it = curVars.begin(); it != curVars.end(); it++) {
                         vars[it->first] = evalExpr(it->second, &vars);
                     }
                 }
@@ -3121,11 +2763,9 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
                 }
 #endif
 
-                // evaluate other attrs
-                for (AttrsMap::iterator it = field->attrs.begin(); it != field->attrs.end(); it++)
-                {
-                    if (it->first == "variables")
-                    {
+                /* evaluate other attrs */
+                for (AttrsMap::iterator it = field->attrs.begin(); it != field->attrs.end(); it++) {
+                    if (it->first == "variables") {
                         continue;
                     }
 
@@ -3133,57 +2773,50 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
                 }
                 inst->setVarsMap(vars);
             }
-            catch (AdbException& exp)
+            catch(AdbException & exp)
             {
                 string exceptionTxt =
-                  "Failed to evaluate expression for field (" + inst->fullName() + "): " + exp.what_s();
-                if (allowMultipleExceptions)
-                {
+                    "Failed to evaluate expression for field (" + inst->fullName() + "): " + exp.what_s();
+
+                if (allowMultipleExceptions) {
                     insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                }
-                else
-                {
+                } else {
                     throw AdbException(exceptionTxt);
                 }
             }
         }
-        // else {
-        //     inst->copyAllInstanceAttr(field->attrs);
-        // }
+        /* else { */
+        /*     inst->copyAllInstanceAttr(field->attrs); */
+        /* } */
 
         /* if union and uses selecotr field add it to _unionSelectorEvalDeffered in order to defferred evaluation */
         bool found = false;
         inst->getInstanceAttrIterator("union_selector", found);
-        if (inst->isUnion() && found)
-        {
+        if (inst->isUnion() && found) {
             _unionSelectorEvalDeffered.push_back(inst);
         }
 
-        // if the field has a condition attribute
+        /* if the field has a condition attribute */
         found = false;
         inst->getInstanceAttrIterator("condition", found);
         AdbInstance* parent = inst->parent;
-        if (found && parent->getInstanceAttr("is_conditional") == "1")
-        {
+        if (found && (parent->getInstanceAttr("is_conditional") == "1")) {
             const string condition = inst->getInstanceAttr("condition");
             inst->condition.setCondition(condition);
             _conditionInstances.push_back(inst);
         }
 
-        // if the layout item has a conditional array
+        /* if the layout item has a conditional array */
         found = false;
         inst->getInstanceAttrIterator("size_condition", found);
-        if (found)
-        {
+        if (found) {
             _conditionalArrays.push_back(inst);
         }
 
         checkInstanceOffsetValidity(inst, parent, allowMultipleExceptions);
 
-        if (field->isStruct() && !inst->nodeDesc->fields.empty() && (depth == -1 || depth > 0))
-        {
-            if (inst->nodeDesc->inLayout)
-            {
+        if (field->isStruct() && !inst->nodeDesc->fields.empty() && ((depth == -1) || (depth > 0))) {
+            if (inst->nodeDesc->inLayout) {
                 delete inst;
                 raiseException(false,
                                "Cyclic definition of nodes, node: " + field->name + " was already added to the layout",
@@ -3191,60 +2824,52 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
             }
             inst->nodeDesc->inLayout = true;
 
-            // validation 2
-            if (inst->size != inst->nodeDesc->size)
-            {
+            /* validation 2 */
+            if (inst->size != inst->nodeDesc->size) {
                 inst->nodeDesc->size = inst->size;
                 /*throw AdbException("Node +(" + inst->name + ") size (" + boost::lexical_cast<string>(inst->size)) +
-                 " isn't the same as its instance (" + inst->nodeDesc->name +
-                 ") (" +  boost::lexical_cast<string>(inst->nodeDesc->size) + ")";*/
+                 *  " isn't the same as its instance (" + inst->nodeDesc->name +
+                 *  ") (" +  boost::lexical_cast<string>(inst->nodeDesc->size) + ")";*/
             }
 
-            vector<AdbField*>::iterator it;
-            for (it = inst->nodeDesc->fields.begin(); it != inst->nodeDesc->fields.end(); it++)
-            {
-                map<string, string> varsCopy = vars;
-                vector<AdbInstance*> subItems =
-                  createInstance(*it, inst, vars, isExprEval, progressObj, depth == -1 ? -1 : depth - 1,
-                                 ignoreMissingNodes, allowMultipleExceptions);
-                if (subItems.size() > 0)
-                {
+            vector < AdbField * > ::iterator it;
+            for (it = inst->nodeDesc->fields.begin(); it != inst->nodeDesc->fields.end(); it++) {
+                map < string, string > varsCopy = vars;
+                vector < AdbInstance * > subItems =
+                    createInstance(*it, inst, vars, isExprEval, progressObj, depth == -1 ? -1 : depth - 1,
+                                   ignoreMissingNodes, allowMultipleExceptions);
+                if (subItems.size() > 0) {
                     inst->subItems.insert(inst->subItems.end(), subItems.begin(), subItems.end());
-                    if (subItems[0]->maxLeafSize > inst->maxLeafSize)
-                    {
+                    if (subItems[0]->maxLeafSize > inst->maxLeafSize) {
                         inst->maxLeafSize = subItems[0]->maxLeafSize;
                     }
                 }
             }
             inst->nodeDesc->inLayout = false;
 
-            if (_checkDsAlign && inst->maxLeafSize != 0 && inst->size % inst->maxLeafSize != 0)
-            {
+            if (_checkDsAlign && (inst->maxLeafSize != 0) && (inst->size % inst->maxLeafSize != 0)) {
                 raiseException(allowMultipleExceptions,
-                               "Node: " + inst->nodeDesc->name + " size(" + boost::lexical_cast<string>(inst->size) +
-                                 ") is not aligned with largest leaf(" +
-                                 boost::lexical_cast<string>(inst->maxLeafSize) + ")",
+                               "Node: " + inst->nodeDesc->name + " size(" + to_string(inst->size) +
+                               ") is not aligned with largest leaf(" +
+                               to_string(inst->maxLeafSize) + ")",
                                ExceptionHolder::ERROR_EXCEPTION);
             }
 
-            if (!inst->isUnion() && inst->subItems.size() > 0)
-            {
-                stable_sort(inst->subItems.begin(), inst->subItems.end(), compareFieldsPtr<AdbInstance>);
+            if (!inst->isUnion() && (inst->subItems.size() > 0)) {
+                stable_sort(inst->subItems.begin(), inst->subItems.end(), compareFieldsPtr < AdbInstance >);
 
-                for (size_t j = 0; j < inst->subItems.size() - 1; j++)
-                {
-                    // printf("field: %s, offset: %s\n",
-                    // inst->subItems[j+1]->name.c_str(),formatAddr(inst->subItems[j+1]->offset,
-                    // inst->subItems[j+1]->size).c_str()); printf("field: %s, offset: %s\n",
-                    // inst->subItems[j]->name.c_str(),formatAddr(inst->subItems[j]->offset,
-                    // inst->subItems[j]->size).c_str());
-                    if (inst->subItems[j + 1]->offset < inst->subItems[j]->offset + inst->subItems[j]->size)
-                    {
+                for (size_t j = 0; j < inst->subItems.size() - 1; j++) {
+                    /* printf("field: %s, offset: %s\n", */
+                    /* inst->subItems[j+1]->name.c_str(),formatAddr(inst->subItems[j+1]->offset, */
+                    /* inst->subItems[j+1]->size).c_str()); printf("field: %s, offset: %s\n", */
+                    /* inst->subItems[j]->name.c_str(),formatAddr(inst->subItems[j]->offset, */
+                    /* inst->subItems[j]->size).c_str()); */
+                    if (inst->subItems[j + 1]->offset < inst->subItems[j]->offset + inst->subItems[j]->size) {
                         string exceptionTxt =
-                          "Field (" + inst->subItems[j + 1]->name + ") (" +
-                          formatAddr(inst->subItems[j + 1]->offset, inst->subItems[j + 1]->size).c_str() +
-                          ") overlaps with (" + inst->subItems[j]->name + ") (" +
-                          formatAddr(inst->subItems[j]->offset, inst->subItems[j]->size).c_str() + ")";
+                            "Field (" + inst->subItems[j + 1]->name + ") (" +
+                            formatAddr(inst->subItems[j + 1]->offset, inst->subItems[j + 1]->size).c_str() +
+                            ") overlaps with (" + inst->subItems[j]->name + ") (" +
+                            formatAddr(inst->subItems[j]->offset, inst->subItems[j]->size).c_str() + ")";
                         raiseException(allowMultipleExceptions, exceptionTxt, ExceptionHolder::ERROR_EXCEPTION);
                     }
                 }
@@ -3252,14 +2877,13 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
         }
 
         u_int32_t esize = inst->fieldDesc->size;
-        if ((field->isLeaf() || field->subNode == "uint64") && (esize == 16 || esize == 32 || esize == 64)) // A leaf
-        {
+        if ((field->isLeaf() || (field->subNode == "uint64")) && ((esize == 16) || (esize == 32) || (esize == 64))) { /* A leaf */
             inst->maxLeafSize = esize;
         }
         instList.push_back(inst);
     }
 
-    stable_sort(instList.begin(), instList.end(), compareFieldsPtr<AdbInstance>);
+    stable_sort(instList.begin(), instList.end(), compareFieldsPtr < AdbInstance >);
     return instList;
 }
 
@@ -3268,17 +2892,13 @@ vector<AdbInstance*> Adb::createInstance(AdbField* field,
  **/
 void Adb::checkInstanceOffsetValidity(AdbInstance* inst, AdbInstance* parent, bool allowMultipleExceptions)
 {
-    if (inst->offset + inst->size > parent->offset + parent->size)
-    {
+    if (inst->offset + inst->size > parent->offset + parent->size) {
         string exceptionTxt = "Field (" + inst->name + ") " + formatAddr(inst->offset, inst->size) +
                               " crosses its parent node (" + parent->name + ") " +
                               formatAddr(parent->offset, parent->size) + " boundaries";
-        if (allowMultipleExceptions)
-        {
+        if (allowMultipleExceptions) {
             insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-        }
-        else
-        {
+        } else {
             throw AdbException(exceptionTxt);
         }
     }
@@ -3291,30 +2911,22 @@ u_int32_t Adb::calcArrOffset(AdbField* fieldDesc, AdbInstance* parent, u_int32_t
 {
     int offs;
 
-    if (fieldDesc->eSize() >= 32)
-    {
-        // Make sure this is dword aligned
-        if (fieldDesc->eSize() % 32 || parent->offset % 32 || fieldDesc->offset % 32)
-        {
+    if (fieldDesc->eSize() >= 32) {
+        /* Make sure this is dword aligned */
+        if (fieldDesc->eSize() % 32 || parent->offset % 32 || fieldDesc->offset % 32) {
             throw AdbException("Field " + fieldDesc->name + " isn't dword aligned");
         }
         offs = parent->offset + fieldDesc->offset + fieldDesc->eSize() * arrIdx;
-    }
-    else
-    {
-        if (bigEndianArr)
-        {
+    } else {
+        if (bigEndianArr) {
             offs = (int)parent->offset + (int)fieldDesc->offset - (int)fieldDesc->eSize() * arrIdx;
 
             int dwordDelta = abs((dword(parent->offset + fieldDesc->offset) - dword(offs))) / 4;
 
-            if (dwordDelta)
-            {
+            if (dwordDelta) {
                 offs += 32 * 2 * dwordDelta;
             }
-        }
-        else
-        {
+        } else {
             offs = parent->offset + fieldDesc->offset + fieldDesc->eSize() * arrIdx;
         }
     }
@@ -3327,108 +2939,96 @@ u_int32_t Adb::calcArrOffset(AdbField* fieldDesc, AdbInstance* parent, u_int32_t
  **/
 string Adb::evalExpr(string expr, AttrsMap* vars)
 {
-    if (expr.find('$') == string::npos)
-    {
+    if (expr.find('$') == string::npos) {
         return expr;
     }
 
     smatch what, what2;
+
     regex singleExpr("^([^\\$]*)(\\$\\(([^)]+)\\))(.*)$");
-    while (regex_search(expr, what, singleExpr))
-    {
+    while (regex_search(expr, what, singleExpr)) {
         string vname = what[3].str();
         string vvalue;
         regex singleVar("^[a-zA-Z_][a-zA-Z0-9_]*$");
 
-        // Need to change to array-like initialization when we'll move to c++11
-        vector<string> specialVars;
+        /* Need to change to array-like initialization when we'll move to c++11 */
+        vector < string > specialVars;
         specialVars.push_back("NAME");
         specialVars.push_back("ARR_IDX");
         specialVars.push_back("BN");
         specialVars.push_back("parent");
 
-        if (regex_search(vname, what2, singleVar))
-        {
-            if (find(specialVars.begin(), specialVars.end(), vname) == specialVars.end())
-            {
+        if (regex_search(vname, what2, singleVar)) {
+            if (find(specialVars.begin(), specialVars.end(), vname) == specialVars.end()) {
                 return expr;
-            }
-            else
-            {
+            } else {
                 AttrsMap::iterator it = vars->find(vname);
-                if (it == vars->end())
-                {
+                if (it == vars->end()) {
                     throw AdbException("Can't find the variable: " + vname);
                 }
                 vvalue = it->second;
             }
-        }
-        else
-        {
+        } else {
             string vnameCopy = vname;
             regex singleVarInExpr("[a-zA-Z_][a-zA-Z0-9_]*");
             smatch matches;
-            while (regex_search(vnameCopy, matches, singleVarInExpr))
-            {
-                if (find(specialVars.begin(), specialVars.end(), matches[0]) == specialVars.end())
-                {
+            while (regex_search(vnameCopy, matches, singleVarInExpr)) {
+                if (find(specialVars.begin(), specialVars.end(), matches[0]) == specialVars.end()) {
                     return expr;
                 }
                 vnameCopy = matches.suffix();
             }
 
-            char exp[vname.size() + 1];
+            char  exp[vname.size() + 1];
             char* expPtr = exp;
             strcpy(exp, vname.c_str());
             u_int64_t res;
             _adbExpr.setVars(vars);
-            int status = _adbExpr.expr(&expPtr, &res);
+            int    status = _adbExpr.expr(&expPtr, &res);
             string statusStr;
 
-            // printf("-D- Eval expr \"%s\" = %ul.\n", vname.ascii(), (u_int32_t)res);
+            /* printf("-D- Eval expr \"%s\" = %ul.\n", vname.ascii(), (u_int32_t)res); */
 
-            if (status < 0)
-            {
-                switch (status)
-                {
-                    case Expr::ERR_RPAR_EXP:
-                        statusStr = "Right parentheses expected";
-                        break;
+            if (status < 0) {
+                switch (status) {
+                case Expr::ERR_RPAR_EXP:
+                    statusStr = "Right parentheses expected";
+                    break;
 
-                    case Expr::ERR_VALUE_EXP:
-                        statusStr = "Value expected";
-                        break;
+                case Expr::ERR_VALUE_EXP:
+                    statusStr = "Value expected";
+                    break;
 
-                    case Expr::ERR_BIN_EXP:
-                        statusStr = "Binary operation expected ";
-                        break;
+                case Expr::ERR_BIN_EXP:
+                    statusStr = "Binary operation expected ";
+                    break;
 
-                    case Expr::ERR_DIV_ZERO:
-                        statusStr = "Divide zero attempt";
-                        break;
+                case Expr::ERR_DIV_ZERO:
+                    statusStr = "Divide zero attempt";
+                    break;
 
-                    case Expr::ERR_BAD_NUMBER:
-                        statusStr = "Bad constant syntax";
-                        break;
+                case Expr::ERR_BAD_NUMBER:
+                    statusStr = "Bad constant syntax";
+                    break;
 
-                    case Expr::ERR_BAD_NAME:
-                        statusStr = "Variable Name not resolved";
-                        break;
+                case Expr::ERR_BAD_NAME:
+                    statusStr = "Variable Name not resolved";
+                    break;
 
-                    default:
-                        statusStr = "Unknown error";
+                default:
+                    statusStr = "Unknown error";
                 }
 
                 throw AdbException("Error evaluating expression " + expr + " : " + statusStr);
             }
 
-            vvalue = boost::lexical_cast<string>(res);
+            vvalue = to_string(res);
         }
 
         /*printf("what[0] - %s, what[1] - %s, what[2] - %s,  what[3] - %s, what[4] - %s\n",
-         what[0].str().c_str(), what[1].str().c_str(),
-         what[2].str().c_str(), what[3].str().c_str(),
-         what[4].str().c_str());*/
+         *  what[0].str().c_str(), what[1].str().c_str(),
+         *  what[2].str().c_str(), what[3].str().c_str(),
+         *  what[4].str().c_str());*/
 
         expr = what[1].str() + vvalue + what[4].str();
     }
@@ -3442,38 +3042,31 @@ string Adb::evalExpr(string expr, AttrsMap* vars)
 bool Adb::checkInstSizeConsistency(bool allowMultipleExceptions)
 {
     bool status = true;
-    for (NodesMap::iterator it = nodesMap.begin(); it != nodesMap.end(); it++)
-    {
-        for (size_t i = 0; i < it->second->fields.size(); i++)
-        {
-            if (it->second->fields[i]->isStruct())
-            {
+
+    for (NodesMap::iterator it = nodesMap.begin(); it != nodesMap.end(); it++) {
+        for (size_t i = 0; i < it->second->fields.size(); i++) {
+            if (it->second->fields[i]->isStruct()) {
                 NodesMap::iterator iter = nodesMap.find(it->second->fields[i]->subNode);
-                if (iter == nodesMap.end())
-                {
+                if (iter == nodesMap.end()) {
                     continue;
                     /*
-                     _lastError = "Can't find definition of subnode \"" + it->second->fields[i]->subNode +
-                     "\" instantiated from node \"" + it->first + "\"";
-                     return false;
+                     *  _lastError = "Can't find definition of subnode \"" + it->second->fields[i]->subNode +
+                     *  "\" instantiated from node \"" + it->first + "\"";
+                     *  return false;
                      */
                 }
                 AdbNode* node = nodesMap[it->second->fields[i]->subNode];
-                if (node->size != it->second->fields[i]->size / it->second->fields[i]->arrayLen())
-                {
+                if (node->size != it->second->fields[i]->size / it->second->fields[i]->arrayLen()) {
                     char tmp[256];
                     sprintf(tmp, "Node (%s) size 0x%x.%d is not consistent with the instance (%s->%s) size 0x%x.%d",
                             node->name.c_str(), (node->size >> 5) << 2, node->size % 32, it->second->name.c_str(),
                             it->second->fields[i]->name.c_str(), (it->second->fields[i]->size >> 5) << 2,
                             it->second->fields[i]->size % 32);
                     _lastError = tmp;
-                    if (allowMultipleExceptions)
-                    {
+                    if (allowMultipleExceptions) {
                         status = false;
                         insertNewException(ExceptionHolder::ERROR_EXCEPTION, tmp);
-                    }
-                    else
-                    {
+                    } else {
                         return false;
                     }
                 }
@@ -3498,18 +3091,22 @@ string Adb::getLastError()
 void Adb::print(int indent)
 {
     cout << indentString(indent) << "Include paths: " << endl;
-    for (size_t i = 0; i < includePaths.size(); i++)
+    for (size_t i = 0; i < includePaths.size(); i++) {
         cout << indentString(indent + 1) << includePaths[i] << endl;
+    }
 
     cout << indentString(indent) << "Is Big Endian Arrays: " << bigEndianArr << endl;
     cout << "-------------------------------------" << endl;
     cout << indentString(indent) << "Configs: " << endl;
-    for (size_t i = 0; i < configs.size(); i++)
+    for (size_t i = 0; i < configs.size(); i++) {
         configs[i]->print(indent + 1);
+    }
 
     cout << "-------------------------------------" << endl;
     cout << indentString(indent) << "Nodes" << endl;
     NodesMap::iterator iter;
-    for (iter = nodesMap.begin(); iter != nodesMap.end(); iter++)
+
+    for (iter = nodesMap.begin(); iter != nodesMap.end(); iter++) {
         iter->second->print(indent + 1);
+    }
 }

--- a/adb_parser/adb_xmlCreator.cpp
+++ b/adb_parser/adb_xmlCreator.cpp
@@ -33,16 +33,15 @@
  */
 
 #include "adb_xmlCreator.h"
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
+#include "common/string_utils.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 
 string xmlCreator::indentString(int i)
 {
     string s;
-    while (i--)
-    {
+
+    while (i--) {
         s += "\t";
     }
     return s;
@@ -50,8 +49,7 @@ string xmlCreator::indentString(int i)
 
 int xmlCreator::dword(int bits)
 {
-    if (bits < 0)
-    {
+    if (bits < 0) {
         bits -= 31;
     }
 
@@ -66,47 +64,47 @@ int xmlCreator::startBit(int bits)
 string xmlCreator::formatAddr(u_int32_t offs, u_int32_t size)
 {
     char str[64];
+
     sprintf(str, "0x%x.%u:%u", dword(offs), startBit(offs), size);
     return str;
 }
 
 /*template <class AdbInstance>
-bool xmlCreator::compareFieldsPtr(AdbInstance *f1, AdbInstance *f2)
-{
-  return (*f1) < (*f2);
-}*/
+ *  bool xmlCreator::compareFieldsPtr(AdbInstance *f1, AdbInstance *f2)
+ *  {
+ *  return (*f1) < (*f2);
+ *  }*/
 
 string xmlCreator::encodeXml(const string& data)
 {
     std::string buffer;
+
     buffer.reserve(data.size());
-    for (size_t pos = 0; pos != data.size(); ++pos)
-    {
-        switch (data[pos])
-        {
-            case '&':
-                buffer.append("&amp;");
-                break;
+    for (size_t pos = 0; pos != data.size(); ++pos) {
+        switch (data[pos]) {
+        case '&':
+            buffer.append("&amp;");
+            break;
 
-            case '\"':
-                buffer.append("&quot;");
-                break;
+        case '\"':
+            buffer.append("&quot;");
+            break;
 
-            case '\'':
-                buffer.append("&apos;");
-                break;
+        case '\'':
+            buffer.append("&apos;");
+            break;
 
-            case '<':
-                buffer.append("&lt;");
-                break;
+        case '<':
+            buffer.append("&lt;");
+            break;
 
-            case '>':
-                buffer.append("&gt;");
-                break;
+        case '>':
+            buffer.append("&gt;");
+            break;
 
-            default:
-                buffer.append(1, data.at(pos));
-                break;
+        default:
+            buffer.append(1, data.at(pos));
+            break;
         }
     }
 
@@ -115,5 +113,5 @@ string xmlCreator::encodeXml(const string& data)
 
 string xmlCreator::descNativeToXml(const string& desc)
 {
-    return boost::replace_all_copy(desc, "\n", "\\;");
+    return string_utils::replace_all_copy(desc, "\n", "\\;");
 }

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -36,6 +36,9 @@ noinst_HEADERS=compatibility.h bit_slice.h tools_utils.h tools_utils.h tools_ver
 
 commonincludedir = $(includedir)/mstflint/common/
 
+lib_LTLIBRARIES = libstring_utils.la
+libstring_utils_la_SOURCES = string_utils.cpp string_utils.h
+
 commoninclude_HEADERS = compatibility.h
 
 update_prefix = sed -e 's,[@]MST_LIB_DIR[@]${CONF_DISABLE_PATH_UPDATE},$(libdir),g'\

--- a/common/string_utils.cpp
+++ b/common/string_utils.cpp
@@ -9,57 +9,40 @@
  * This software product is governed by the End User License Agreement
  * provided with the software product.
  */
-#include <fstream>
-#include <sstream>
 #include <algorithm>
+#include <cctype>
+#include <fstream>
 #include <iostream>
 #include <iterator>
+#include <memory>
 #include <stdio.h>
 #include <string.h>
-#include <memory>
-#include <cctype>
-#include <algorithm>
 #include <string>
+#include <sstream>
 #include "string_utils.h"
 
 namespace string_utils
 {
-    std::string& ltrim(std::string& s)
+    void trim(std::string& s)
     {
-        auto it =
-            std::find_if(s.begin(), s.end(), [] (char c) { return !std::isspace < char > (c, std::locale::classic());
-                         });
+        std::string whitespace = " ";
+        const auto  first_non_whitespace = s.find_first_not_of(whitespace);
 
-        s.erase(s.begin(), it);
-        return s;
-    }
+        if (first_non_whitespace == std::string::npos) {
+            s.erase(0, s.length());
+        }
+        const auto last_non_whitespace = s.find_last_not_of(whitespace);
 
-    std::string& rtrim(std::string& s)
-    {
-        auto it =
-            std::find_if(s.rbegin(), s.rend(), [] (char c) { return !std::isspace < char > (c, std::locale::classic());
-                         });
-
-        s.erase(it.base(), s.end());
-        return s;
-    }
-
-    std::string& trim(std::string& s)
-    {
-    #if defined(_WIN32) || defined(_WIN64) /* Windows */
-        s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
-        return s;
-    #else
-        ltrim(rtrim(s));
-        return s;
-    #endif
+        s.erase(last_non_whitespace + 1, s.length()); /* remove trailing whitespaces */
+        s.erase(0, first_non_whitespace);             /* remove leading whitespaces */
     }
 
     std::string trim_copy(const std::string& s)
     {
         std::string out = s;
 
-        return trim(out);
+        trim(out);
+        return out;
     }
 
     void to_lower(std::string& s)
@@ -68,12 +51,12 @@ namespace string_utils
                   });
     }
 
-    std::string to_lower_copy(std::string s)
+    std::string to_lower_copy(const std::string s)
     {
         std::string out = "";
 
         std::transform(s.begin(), s.end(), std::back_inserter(out),
-                       [] (unsigned char c) { return std::tolower(static_cast < unsigned char > (c));
+                       [] (unsigned char c) { return std::tolower(c);
                        });
         return out;
     }
@@ -83,7 +66,7 @@ namespace string_utils
         std::string out = "";
 
         transform(s.begin(), s.end(), back_inserter(out),
-                  [] (unsigned char c) { return toupper(static_cast < unsigned char > (c));
+                  [] (unsigned char c) { return toupper(c);
                   });
         return out;
     }

--- a/common/string_utils.cpp
+++ b/common/string_utils.cpp
@@ -24,13 +24,38 @@
 
 namespace string_utils
 {
-    std::string& trim(std::string& s)
+    std::string& ltrim(std::string& s)
     {
-        s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+        auto it =
+            std::find_if(s.begin(), s.end(), [] (char c) { return !std::isspace < char > (c, std::locale::classic());
+                         });
+
+        s.erase(s.begin(), it);
         return s;
     }
 
-    std::string trim_copy(std::string& s)
+    std::string& rtrim(std::string& s)
+    {
+        auto it =
+            std::find_if(s.rbegin(), s.rend(), [] (char c) { return !std::isspace < char > (c, std::locale::classic());
+                         });
+
+        s.erase(it.base(), s.end());
+        return s;
+    }
+
+    std::string& trim(std::string& s)
+    {
+    #if defined(_WIN32) || defined(_WIN64) /* Windows */
+        s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+        return s;
+    #else
+        ltrim(rtrim(s));
+        return s;
+    #endif
+    }
+
+    std::string trim_copy(const std::string& s)
     {
         std::string out = s;
 
@@ -113,9 +138,9 @@ namespace string_utils
         return result;
     }
 
-    std::string join(list < std::string >& lst, const char* delim)
+    std::string join(std::list < std::string >& lst, const char* delim)
     {
-        vector < std::string > strings(lst.begin(), lst.end());
+        std::vector < std::string > strings(lst.begin(), lst.end());
         std::string result;
 
         switch (strings.size()) {
@@ -129,14 +154,14 @@ namespace string_utils
 
         default:
             std::ostringstream os;
-            copy(strings.begin(), strings.end() - 1, ostream_iterator < std::string > (os, delim));
+            copy(strings.begin(), strings.end() - 1, std::ostream_iterator < std::string > (os, delim));
             os << *strings.rbegin();
             result = os.str();
         }
         return result;
     }
 
-    void split(vector < std::string >& result, std::string s, const char* separator)
+    void split(std::vector < std::string >& result, std::string s, const char* separator)
     {
         if (s.size() == 0) {
             result.push_back(std::string(""));

--- a/common/string_utils.cpp
+++ b/common/string_utils.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2020-2022 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Nvidia Corporation and its affiliates
+ * (the "Company") and all right, title, and interest in and to the software
+ * product, including all associated intellectual property rights, are and
+ * shall remain exclusively with the Company.
+ *
+ * This software product is governed by the End User License Agreement
+ * provided with the software product.
+ */
+#include <fstream>
+#include <sstream>
+#include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <stdio.h>
+#include <string.h>
+#include <memory>
+#include <cctype>
+#include <algorithm>
+#include <string>
+#include "string_utils.h"
+
+namespace string_utils
+{
+    std::string& trim(std::string& s)
+    {
+        s.erase(std::remove_if(s.begin(), s.end(), ::isspace), s.end());
+        return s;
+    }
+
+    std::string trim_copy(std::string& s)
+    {
+        std::string out = s;
+
+        return trim(out);
+    }
+
+    void to_lower(std::string& s)
+    {
+        transform(s.begin(), s.end(), s.begin(), [] (unsigned char c) { return std::tolower(c);
+                  });
+    }
+
+    std::string to_lower_copy(std::string s)
+    {
+        std::string out = "";
+
+        std::transform(s.begin(), s.end(), std::back_inserter(out),
+                       [] (unsigned char c) { return std::tolower(static_cast < unsigned char > (c));
+                       });
+        return out;
+    }
+
+    std::string to_upper_copy(std::string s)
+    {
+        std::string out = "";
+
+        transform(s.begin(), s.end(), back_inserter(out),
+                  [] (unsigned char c) { return toupper(static_cast < unsigned char > (c));
+                  });
+        return out;
+    }
+
+    void replace_all(std::string& s, std::string const& to_replace, std::string const& replace_with)
+    {
+        std::string buffer;
+        size_t      pos = 0;
+        size_t      prev_pos;
+
+        /* Reserves rough estimate of final size of std::string. */
+        buffer.reserve(s.size());
+
+        while (true) {
+            prev_pos = pos;
+            pos = s.find(to_replace, pos);
+            if (pos == std::string::npos) {
+                break;
+            }
+            buffer.append(s, prev_pos, pos - prev_pos);
+            buffer += replace_with;
+            pos += to_replace.size();
+        }
+
+        buffer.append(s, prev_pos, s.size() - prev_pos);
+        s.swap(buffer);
+    }
+
+    std::string replace_all_copy(const std::string& s, std::string const& to_replace, std::string const& replace_with)
+    {
+        std::string buffer;
+        std::string result = s;
+        size_t      pos = 0;
+        size_t      prev_pos;
+
+        /* Reserves rough estimate of final size of std::string. */
+        buffer.reserve(s.size());
+
+        while (true) {
+            prev_pos = pos;
+            pos = result.find(to_replace, pos);
+            if (pos == std::string::npos) {
+                break;
+            }
+            buffer.append(result, prev_pos, pos - prev_pos);
+            buffer += replace_with;
+            pos += to_replace.size();
+        }
+
+        buffer.append(result, prev_pos, result.size() - prev_pos);
+        result.swap(buffer);
+        return result;
+    }
+
+    std::string join(list < std::string >& lst, const char* delim)
+    {
+        vector < std::string > strings(lst.begin(), lst.end());
+        std::string result;
+
+        switch (strings.size()) {
+        case 0:
+            result = "";
+            break;
+
+        case 1:
+            result = strings[0];
+            break;
+
+        default:
+            std::ostringstream os;
+            copy(strings.begin(), strings.end() - 1, ostream_iterator < std::string > (os, delim));
+            os << *strings.rbegin();
+            result = os.str();
+        }
+        return result;
+    }
+
+    void split(vector < std::string >& result, std::string s, const char* separator)
+    {
+        if (s.size() == 0) {
+            result.push_back(std::string(""));
+            return;
+        }
+        /* Pointer to point the word returned by the strtok() function. */
+        char * p;
+        size_t size = strlen(s.c_str()) + 1;
+        char * str = new char[size];
+
+        strcpy(str, s.c_str());
+
+        if (strncmp(separator, str, strlen(separator)) == 0) {
+            /* if (separator[0] == str[0]) */
+            result.push_back(std::string(""));
+        }
+        p = strtok(str, separator);
+        while (p != NULL) {
+            result.push_back(std::string(p));
+            p = strtok(NULL, separator);
+        }
+        int         separator_len = strlen(separator);
+        std::string suffix = s.substr(s.length() - separator_len);
+
+        if (strncmp(separator, suffix.c_str(), separator_len) == 0) {
+            result.push_back(std::string(""));
+        }
+        delete[] str;
+    }
+} /* namespace string_utils */

--- a/common/string_utils.h
+++ b/common/string_utils.h
@@ -19,11 +19,9 @@
 
 namespace string_utils
 {
-    std::string& ltrim(std::string& s);
-    std::string& rtrim(std::string& s);
-    std::string& trim(std::string& s);
+    void trim(std::string& s);
     std::string trim_copy(const std::string& s);
-    std::string to_lower_copy(std::string s);
+    std::string to_lower_copy(const std::string s);
     void to_lower(std::string& s);
     std::string to_upper_copy(std::string s);
     void replace_all(std::string& s, std::string const& to_replace, std::string const& replace_with);

--- a/common/string_utils.h
+++ b/common/string_utils.h
@@ -14,19 +14,20 @@
 #include <vector>
 #include <list>
 #include <string>
-using namespace std;
 
 #pragma once
 
 namespace string_utils
 {
-    string& trim(string& s);
-    string trim_copy(string& s);
-    string to_lower_copy(string s);
-    void to_lower(string& s);
-    string to_upper_copy(string s);
-    void replace_all(string& s, string const& to_replace, string const& replace_with);
-    string replace_all_copy(const string& s, string const& to_replace, string const& replace_with);
-    string join(list < string >& lst, const char* delim);
-    void split(vector < string >& result, string s, const char* separator);
+    std::string& ltrim(std::string& s);
+    std::string& rtrim(std::string& s);
+    std::string& trim(std::string& s);
+    std::string trim_copy(const std::string& s);
+    std::string to_lower_copy(std::string s);
+    void to_lower(std::string& s);
+    std::string to_upper_copy(std::string s);
+    void replace_all(std::string& s, std::string const& to_replace, std::string const& replace_with);
+    std::string replace_all_copy(const std::string& s, std::string const& to_replace, std::string const& replace_with);
+    std::string join(std::list < std::string >& lst, const char* delim);
+    void split(std::vector < std::string >& result, std::string s, const char* separator);
 } /* namespace string_utils */

--- a/common/string_utils.h
+++ b/common/string_utils.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * This software product is a proprietary product of Nvidia Corporation and its affiliates
+ * (the "Company") and all right, title, and interest in and to the software
+ * product, including all associated intellectual property rights, are and
+ * shall remain exclusively with the Company.
+ *
+ * This software product is governed by the End User License Agreement
+ * provided with the software product.
+ */
+
+#include <string>
+#include <vector>
+#include <list>
+#include <string>
+using namespace std;
+
+#pragma once
+
+namespace string_utils
+{
+    string& trim(string& s);
+    string trim_copy(string& s);
+    string to_lower_copy(string s);
+    void to_lower(string& s);
+    string to_upper_copy(string s);
+    void replace_all(string& s, string const& to_replace, string const& replace_with);
+    string replace_all_copy(const string& s, string const& to_replace, string const& replace_with);
+    string join(list < string >& lst, const char* delim);
+    void split(vector < string >& result, string s, const char* separator);
+} /* namespace string_utils */

--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,12 @@ AC_SUBST(MTCR_CONF_DIR)
 AC_SUBST(LDL)
 AC_SUBST(default_en_inband)
 
+dnl Enable boost only when gcc version is below 4.9
+AS_IF(
+    [test "$(gcc -dumpversion)" -ge "4.9"], [BOOST_ENABLED=false],
+    [AC_DEFINE_UNQUOTED([BOOST_ENABLED], [true], [Symbol that defined whether boost libraray is used])]
+)
+
 dnl Checks for headers
 AC_CHECK_HEADER(termios.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_TERMIOS_H"])
 TOOLS_CRYPTO=""
@@ -142,8 +148,10 @@ if test "x$enable_fw_mgr" = "xyes"; then
     AC_CHECK_HEADER(zlib.h,,AC_MSG_ERROR([cannot find zlib.h . this header is needed for compiling fw manager tool]))
     AC_CHECK_LIB(z, uncompress,, AC_MSG_ERROR([cannot find zlib uncompress() function.]))
     AC_CHECK_HEADER(lzma.h,,AC_MSG_ERROR([Cannot find lzma.h.]))
-    AC_CHECK_LIB(boost_regex, regcompA,, AC_MSG_ERROR([cannot find boost_regex regcompA() function. Try re-installing the library...]))
     CURL_INC_DIR=/usr/include/curl/
+    if test x$BOOST_ENABLED = xtrue; then
+        AC_CHECK_LIB(boost_regex, regcompA,, AC_MSG_ERROR([cannot find boost_regex regcompA() function. Try re-installing the library...]))
+    fi
 fi
 
 # Adabe

--- a/mlxarchive/mlxarchive.cpp
+++ b/mlxarchive/mlxarchive.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (C) Jan 2013 Mellanox Technologies Ltd. All rights reserved.
  * Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
@@ -43,17 +42,17 @@
 #include <vector>
 #include <iostream>
 #include <compatibility.h>
-#if __cplusplus >= 201402L || defined(_MSC_VER)
-#include <regex>
-#else
+#ifdef BOOST_ENABLED
 #include <boost/regex.hpp>
 using namespace boost;
+#else
+#include <regex>
 #endif
 #include "mlxarchive_mfa2_package_gen.h"
 #include <cmdparser/cmdparser.h>
 #include "mlxarchive.h"
 
-#define IDENT "    "
+#define IDENT  "    "
 #define IDENT2 IDENT IDENT
 #define IDENT3 "\t\t"
 
@@ -66,21 +65,21 @@ using namespace boost;
 /************************************
  * * FLAGS Constants
  * ************************************/
-#define HELP_FLAG "help"
-#define HELP_FLAG_SHORT 'h'
-#define BINS_DIR_FLAG "bins-dir"
-#define BINS_DIR_FLAG_SHORT 'b'
-#define OUT_FILE_FLAG "out-file"
-#define OUT_FILE_FLAG_SHORT 'o'
-#define DATE_FLAG "date"
-#define DATE_FLAG_SHORT 'd'
-#define VERSION_FLAG "version"
-#define VERSION_FLAG_SHORT 'v'
-#define MFA2_FILE_FLAG "mfa2-file"
+#define HELP_FLAG            "help"
+#define HELP_FLAG_SHORT      'h'
+#define BINS_DIR_FLAG        "bins-dir"
+#define BINS_DIR_FLAG_SHORT  'b'
+#define OUT_FILE_FLAG        "out-file"
+#define OUT_FILE_FLAG_SHORT  'o'
+#define DATE_FLAG            "date"
+#define DATE_FLAG_SHORT      'd'
+#define VERSION_FLAG         "version"
+#define VERSION_FLAG_SHORT   'v'
+#define MFA2_FILE_FLAG       "mfa2-file"
 #define MFA2_FILE_FLAG_SHORT 'm'
 
 using namespace mlxarchive;
-bool writeToFile(const string&, const vector<u_int8_t>&);
+bool writeToFile(const string&, const vector < u_int8_t >&);
 
 /************************************
  * * Function: Mlxarchive
@@ -104,10 +103,10 @@ void Mlxarchive::initCmdParser()
                    "binary files of a given firmware for different adapter cards.");
     AddOptions(HELP_FLAG, HELP_FLAG_SHORT, "", "Show help message and exit");
     AddOptions(
-      VERSION_FLAG,
-      VERSION_FLAG_SHORT,
-      "version",
-      "MFA2 version in the following format: x.x.x, if creating MFA2 file or existing MFA2 file for print its version");
+        VERSION_FLAG,
+        VERSION_FLAG_SHORT,
+        "version",
+        "MFA2 version in the following format: x.x.x, if creating MFA2 file or existing MFA2 file for print its version");
     AddOptions(OUT_FILE_FLAG, OUT_FILE_FLAG_SHORT, "out_file", "Output file");
     AddOptions(BINS_DIR_FLAG, BINS_DIR_FLAG_SHORT, "bins_dir", "Directory with the binaries files");
     AddOptions(MFA2_FILE_FLAG, MFA2_FILE_FLAG_SHORT, "mfa2_file", "Mfa2 file to parse");
@@ -119,131 +118,96 @@ void Mlxarchive::paramValidate()
     std::string err = "Missing mandatory parameter: %s\n";
     std::string big_err = "Missing mandatory parameters: %s %s %s\n";
     std::string err_regex = "Bad format in: %s(%s), the format should be like: %s\n";
-    smatch match;
-    bool status_match;
-    bool success = true;
-    if (!_mfa2file.empty())
-    {
-        if (!(_binsDir.empty() && _outFile.empty() && _version.empty()))
-        {
+    smatch      match;
+    bool        status_match;
+    bool        success = true;
+
+    if (!_mfa2file.empty()) {
+        if (!(_binsDir.empty() && _outFile.empty() && _version.empty())) {
             fprintf(stderr, "Cannot use any parameter when using mfa2_file parameter!\n");
             exit(1);
         }
         return;
     }
 
-    if (_binsDir.empty() && _outFile.empty())
-    {
-        if (!_version.empty())
-        {
+    if (_binsDir.empty() && _outFile.empty()) {
+        if (!_version.empty()) {
             _printMiniDump = true;
             _mfa2file = _version;
             _version.clear();
-        }
-        else
-        { // all three options are empty!
+        } else { /* all three options are empty! */
             fprintf(stderr, big_err.c_str(), "bins_dir", "out_file", "version");
             success = false;
         }
-    }
-    else
-    {
-        if (_binsDir.empty())
-        {
+    } else {
+        if (_binsDir.empty()) {
             fprintf(stderr, err.c_str(), "bins_dir");
             success = false;
         }
-        if (_outFile.empty())
-        {
+        if (_outFile.empty()) {
             fprintf(stderr, err.c_str(), "out_file");
             success = false;
-        }
-        else
-        {
-            if (fexists(_outFile))
-            {
-                if (!isFile(_outFile))
-                {
+        } else {
+            if (fexists(_outFile)) {
+                if (!isFile(_outFile)) {
                     fprintf(stderr, "Output file: %s is expected to be a file\n", _outFile.c_str());
-                }
-                else
-                {
+                } else {
                     fprintf(stderr, "Output file: %s already exists\n", _outFile.c_str());
                 }
                 success = false;
             }
         }
-        if (_version.empty())
-        {
+        if (_version.empty()) {
             fprintf(stderr, err.c_str(), "version");
             success = false;
-        }
-        else
-        {
+        } else {
             regex version_expression("^[0-9].[0-9].[0-9]$");
             status_match = regex_match(_version, match, version_expression);
-            if (!status_match)
-            {
+            if (!status_match) {
                 fprintf(stderr, err_regex.c_str(), "version", _version.c_str(), "x.x.x");
                 success = false;
             }
         }
     }
-    if (!success)
-    {
+    if (!success) {
         exit(1);
     }
 }
 
 ParseStatus Mlxarchive::HandleOption(string name, string value)
 {
-    if (name == HELP_FLAG)
-    {
+    if (name == HELP_FLAG) {
         cout << _cmdParser.GetUsage();
         return PARSE_OK_WITH_EXIT;
-    }
-    else if (name == VERSION_FLAG)
-    {
-        if (_version.empty() == false)
-        {
+    } else if (name == VERSION_FLAG) {
+        if (_version.empty() == false) {
             cout << "Version flag cannot be specified more than once" << endl;
             return PARSE_ERROR;
         }
         _version = value;
         return PARSE_OK;
-    }
-    else if (name == OUT_FILE_FLAG)
-    {
-        if (_outFile.empty() == false)
-        {
+    } else if (name == OUT_FILE_FLAG) {
+        if (_outFile.empty() == false) {
             cout << "Output file flag cannot be specified more than once" << endl;
             return PARSE_ERROR;
         }
         _outFile = value;
         return PARSE_OK;
-    }
-    else if (name == BINS_DIR_FLAG)
-    {
-        if (_binsDir.empty() == false)
-        {
+    } else if (name == BINS_DIR_FLAG) {
+        if (_binsDir.empty() == false) {
             cout << "Binary directory flag cannot be specified more than once" << endl;
             return PARSE_ERROR;
         }
         _binsDir = value;
         return PARSE_OK;
-    }
-    else if (name == MFA2_FILE_FLAG)
-    {
-        if (_mfa2file.empty() == false)
-        {
+    } else if (name == MFA2_FILE_FLAG) {
+        if (_mfa2file.empty() == false) {
             cout << "MFA2 file flag cannot be specified more than once" << endl;
             return PARSE_ERROR;
         }
         _mfa2file = value;
         return PARSE_OK;
-    }
-    else
-    {
+    } else {
         cout << "Unknown flag specified" << endl;
         return PARSE_ERROR;
     }
@@ -253,53 +217,41 @@ ParseStatus Mlxarchive::HandleOption(string name, string value)
 int Mlxarchive::run(int argc, char** argv)
 {
     ParseStatus rc = _cmdParser.ParseOptions(argc, argv);
-    if (rc == PARSE_OK_WITH_EXIT)
-    {
+
+    if (rc == PARSE_OK_WITH_EXIT) {
         return 0;
-    }
-    else if (rc == PARSE_ERROR)
-    {
+    } else if (rc == PARSE_ERROR) {
         cerr << "Failed to parse arguments: " << _cmdParser.GetErrDesc() << endl;
         return 1;
-    }
-    else if (rc == PARSE_ERROR_SHOW_USAGE)
-    {
+    } else if (rc == PARSE_ERROR_SHOW_USAGE) {
         cerr << "Failed to parse arguments: " << _cmdParser.GetErrDesc() << endl;
         return 1;
     }
     paramValidate();
-    if (_mfa2file.empty())
-    {
+    if (_mfa2file.empty()) {
         string outputFile = _outFile;
         string content = "";
-        vector<u_int8_t> buff;
+        vector < u_int8_t > buff;
         MFA2PackageGen mfa2PackageGen;
-        string dir = _binsDir;
-        string version = _version;
+        string         dir = _binsDir;
+        string         version = _version;
 
         buff.clear();
         mfa2PackageGen.generateBinFromFWDirectory(dir, version, buff);
-        // Save output to a file
-        if (!writeToFile(outputFile, buff))
-        {
+        /* Save output to a file */
+        if (!writeToFile(outputFile, buff)) {
             fprintf(stderr, "-E- Cannot write to the file %s\n", outputFile.c_str());
             exit(1);
         }
-    }
-    else
-    {
+    } else {
         MFA2* mfa2Pkg = MFA2::LoadMFA2Package(_mfa2file);
-        if (!mfa2Pkg)
-        {
+        if (!mfa2Pkg) {
             fprintf(stderr, "-E- Failed to parse mfa2 file %s\n", _mfa2file.c_str());
             exit(1);
         }
-        if (_printMiniDump)
-        {
+        if (_printMiniDump) {
             mfa2Pkg->minidump();
-        }
-        else
-        {
+        } else {
             mfa2Pkg->dump();
         }
         delete mfa2Pkg;
@@ -308,20 +260,20 @@ int Mlxarchive::run(int argc, char** argv)
     return 0;
 }
 
-Mlxarchive::~Mlxarchive(){};
+Mlxarchive::~Mlxarchive()
+{
+};
 
-bool writeToFile(const string& fname, const vector<u_int8_t>& data)
+bool writeToFile(const string& fname, const vector < u_int8_t >& data)
 {
     FILE* fh;
 
-    if ((fh = fopen(fname.c_str(), "wb")) == NULL)
-    {
+    if ((fh = fopen(fname.c_str(), "wb")) == NULL) {
         return false;
     }
 
-    // Write output
-    if (fwrite(data.data(), 1, data.size(), fh) != data.size())
-    {
+    /* Write output */
+    if (fwrite(data.data(), 1, data.size(), fh) != data.size()) {
         fclose(fh);
         return false;
     }
@@ -334,5 +286,6 @@ bool writeToFile(const string& fname, const vector<u_int8_t>& data)
 int main(int argc, char* argv[])
 {
     Mlxarchive mlxarch;
+
     return mlxarch.run(argc, argv);
 }


### PR DESCRIPTION
Description:
1. removed <boost/algorithm/string.hpp> dependency.
2. when running on setups with gcc > 4.8 the c++ standard library regex library will be used instead of boost/regex.

Tested OS:linux
Tested devices:n/a
Tested flows:compilation

Known gaps (with RM ticket):n/a

Issue:3461492