### PR TITLE
mtcr_ul: Adapt tools to the upstream kernel

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -678,25 +678,12 @@ static int dm_get_device_id_inner(mfile      * mf,
             }
         }
     } else {
-        if (mf->tp == MST_MLX5_CONTROL_DRIVER) {        
-            struct reg_access_hca_mgir_ext mgir;
-            memset(&mgir, 0, sizeof(mgir));
-            reg_access_status_t rc = reg_access_mgir(mf, REG_ACCESS_METHOD_GET, &mgir);
-            
-            if (rc) {
-                return GET_DEV_ID_ERROR;
-            }
-
-            *ptr_hw_dev_id = mgir.hw_info.hw_dev_id;
-            *ptr_hw_rev = mgir.hw_info.device_hw_revision;
-        } else {
-            if (mread4(mf, DEVID_ADDR, &dword) != 4) {
-                return CRSPACE_READ_ERROR;
-            }
-
-            *ptr_hw_dev_id = EXTRACT(dword, 0, 16);
-            *ptr_hw_rev = EXTRACT(dword, 16, 8);
+        if (mread4(mf, DEVID_ADDR, &dword) != 4) {
+            return CRSPACE_READ_ERROR;
         }
+
+        *ptr_hw_dev_id = EXTRACT(dword, 0, 16);
+        *ptr_hw_rev = EXTRACT(dword, 16, 8);
     }
 
     *ptr_dm_dev_id = get_entry_by_dev_rev_id(*ptr_hw_dev_id, *ptr_hw_rev)->dm_id;

--- a/include/mtcr_ul/mlx5ctl_ioctl.h
+++ b/include/mtcr_ul/mlx5ctl_ioctl.h
@@ -37,6 +37,7 @@
 int mlx5_control_access_register(int fd, void *data_in,
                                  int size_in, __u16 reg_id,
                                  int method);
+void mlx5ctl_set_device_id(mfile* mf);
 
 struct mlx5ctl_drvinfo {
 	__u32 version;

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -65,7 +65,7 @@ struct mfile_t
     MType res_tp;         /*  Will be used with HCR if need */
     DType dtype;          /*  target device to access to */
     DType itype;          /*  interface device to access via */
-    u_int32_t device_id;
+    u_int32_t device_hw_id;
     int is_i2cm;          /*  use device as I2C master */
     int is_vm;            /*  if the machine is VM    */
     int cr_access;        /* If cr access is allowed in MLNXOS devices */

--- a/mtcr_ul/mlx5ctl.c
+++ b/mtcr_ul/mlx5ctl.c
@@ -36,9 +36,11 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <asm/byteorder.h>
 #include <errno.h>
 #include <string.h>
 #include <stddef.h>
+#include "mtcr_mf.h"
 #include "mlx5ctl.h"
 #include "mlx5ctl_ioctl.h"
 
@@ -51,6 +53,21 @@ static int mlx5_cmd_ioctl(int fd, struct mlx5ctl_cmd_inout *cmd)
 }
 
 
+void mlx5ctl_set_device_id(mfile* mf)
+{
+    unsigned char register_data[1024];
+
+    memset(register_data, 0, sizeof(register_data));
+
+    int rc = mlx5_control_access_register(mf->fd, register_data,
+                                          sizeof(register_data), 0x9020, 1);
+
+    if (!rc)
+    {
+        memcpy(&mf->device_hw_id, &register_data[8], 4);
+        mf->device_hw_id = __cpu_to_be32(mf->device_hw_id);
+    }
+}
 
 
 int mlx5_control_access_register(int fd, void *data_in,


### PR DESCRIPTION
The purpose of this commit is to modify the mstflint tools to work with the latest upstream kernel (mlx5ctl). This driver will be added in the upcoming 6.7 version of the upstream kernel.
This patch modifies the device ID retrieval method to ensure smooth operation without needing VSEC access, instead relying solely on PRM access.