### PR TITLE
The mlxfwreset tool supports resetting the Cedar and Bluefield devices

### DIFF
--- a/small_utils/mlxfwresetlib/mlnx_peripheral_components.py
+++ b/small_utils/mlxfwresetlib/mlnx_peripheral_components.py
@@ -45,7 +45,7 @@ from .mlxfwreset_utils import cmdExec
 
 class MlnxPeripheralComponents(object):
 
-    SD_SUPPORTED_DID = [0x21e, 0x218, 0x216, 0x212, 0x20f, 0x20d, 0x209, 0x20b]  # Connectx8,Connectx7,Connectx6LX,Connectx6DX,Connectx6,Connectx5 (SD device) ,Connectx4/Connectx4Lx (MH device connected as SD)
+    SD_SUPPORTED_DID = [0x21e, 0x218, 0x216, 0x212, 0x20f, 0x20d, 0x209, 0x20b, 0x21c]  # Connectx8,Connectx7,Connectx6LX,Connectx6DX,Connectx6,Connectx5 (SD device) ,Connectx4/Connectx4Lx (MH device connected as SD), BF-3
 
     def __init__(self):
         self.pci_devices = []

--- a/small_utils/mlxfwresetlib/pci_device.py
+++ b/small_utils/mlxfwresetlib/pci_device.py
@@ -95,12 +95,10 @@ class PciDevice(object):
 
     def get_manufacturing_base_mac(self):
         # Be-careful : The logic won't work for all devices
-
         mst_device = MstDevice(self.aliases[0])
         try:
             reg_access = RegAccess(mst_device)
             manufacturing_base_mac = reg_access.getManufacturingBaseMac()
         finally:
             mst_device.close()
-
         return manufacturing_base_mac

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
-# licenses.  You may choose to be licensed under the terms of the GNUf
+# licenses.  You may choose to be licensed under the terms of the GNU
 # General Public License (GPL) Version 2, available from the file
 # COPYING in the main directory of this source tree, or the
 # OpenIB.org BSD license below:
@@ -115,6 +115,7 @@ MLNX_DEVICES = [
     dict(name="Spectrum-2", devid=0x24E, status_config_not_done=(0x100010, 0)),
     dict(name="Spectrum-3", devid=0x250, status_config_not_done=(0x100010, 0)),
     dict(name="Spectrum-4", devid=0x254, status_config_not_done=(0x100010, 0)),
+
 ]
 
 # Supported devices.
@@ -173,7 +174,8 @@ FWResetStatusChecker = None
 # Global options
 SkipMstRestart = False
 SkipMultihostSync = False
-
+is_cedar = False
+is_bluefield = False
 logger = None
 device_global = None
 
@@ -405,34 +407,48 @@ def getLinuxKernelVersion():
 class MlnxPciOp(object):
     """ Abstract Class that provides a unified way to perform pci operations
     """
+
     def __init__(self):
         self.bridgeAddr = None
+
     def read(self, devAddr, addr, width="L"):
         raise NotImplementedError("read() is not implemented")
+
     def write(self, devAddr, addr, val, width="L"):
         raise NotImplementedError("write() is not implemented")
+
     def isMellanoxDevice(self, devAddr):
         raise NotImplementedError("isMellanoxDevice() is not implemented")
+
     def getPciBridgeAddr(self, devAddr):
         raise NotImplementedError("getPciBridgeAddr() is not implemented")
+
     def getPcieCapAddr(self, bridgeDev):
         raise NotImplementedError("getPcieCapAddr() is not implemented")
+
     def getMFDeviceList(self, devAddr):
         raise NotImplementedError("getMFDeviceList() is not implemented")
+
     def savePCIConfigurationSpace(self, devAddr, pci_device):
         raise NotImplementedError(
             "savePCIConfigurationSpace() is not implemented")
+
     def loadPCIConfigurationSpace(self, devAddr, pci_device, full=True):
         raise NotImplementedError(
             "loadPCIConfigurationSpace() is not implemented")
+
     def waitForDevice(self, devAddr):
         pass  # TODO need to implement for FreeBSD
+
     def getAllBuses(self, devices):
         raise NotImplementedError("getAllBuses() is not implemented")
+
     def removeDevice(self, devAddr):
         raise NotImplementedError("removeDevice() is not implemented")
+
     def rescan(self):
         raise NotImplementedError("rescan() is not implemented")
+
     def setPciBridgeAddr(self, bridgeAddr):
         self.bridgeAddr = bridgeAddr
 
@@ -453,7 +469,8 @@ class MlnxPciOpLinux(MlnxPciOp):
     def __init__(self):
         super(MlnxPciOpLinux, self).__init__()
         self.pciConfSpaceMap = {}
-        self.device_control_register_old = {}  # key is dbdf, value is configuration of "device_control_register"
+        # key is dbdf, value is configuration of "device_control_register"
+        self.device_control_register_old = {}
 
     def savePciConfOptimalValues(self, devAddr):
         logger.debug("Saving device control register for device: %s" % devAddr)
@@ -474,7 +491,8 @@ class MlnxPciOpLinux(MlnxPciOp):
 
         assert devAddr in self.device_control_register_old, 'loadPciConfOptimalValues: {0} is not in dictionay'.format(
             devAddr)
-        device_control_register_new = self.read(devAddr, 0x68, 'w')  # Reading "Device Control Register" (after pci 'rescan')
+        # Reading "Device Control Register" (after pci 'rescan')
+        device_control_register_new = self.read(devAddr, 0x68, 'w')
         device_control_register_updated = (device_control_register_new & MASK__) | (
             self.device_control_register_old[devAddr] & MASK)
         self.write(devAddr, 0x68, device_control_register_updated,
@@ -561,7 +579,8 @@ class MlnxPciOpLinux(MlnxPciOp):
         domainBus = ":".join(devAddr.split(":")[:2])
 
         if "ppc64" in platform.machine():
-            cmd = "lspci -d 15b3: -s {0}: -D | grep -v DMA".format(domainBus)  # list without NVME emulation (on bluefield)
+            # list without NVME emulation (on bluefield)
+            cmd = "lspci -d 15b3: -s {0}: -D | grep -v DMA".format(domainBus)
             (rc, out, _) = cmdExec(cmd)
             if rc != 0:
                 raise RuntimeError("failed to execute: {0}".format(cmd))
@@ -636,7 +655,7 @@ class MlnxPciOpFreeBSD(MlnxPciOp):
         self.pciConfSpaceMap = {}
 
     def read(self, devAddr, addr, width="L"):
-        if not(devAddr.startswith("pci")):
+        if not (devAddr.startswith("pci")):
             devAddr = "pci" + devAddr
         cmd = "pciconf -r %s 0x%x" % (devAddr, addr)
         (rc, out, _) = cmdExec(cmd)
@@ -646,7 +665,7 @@ class MlnxPciOpFreeBSD(MlnxPciOp):
         return int(out, 16)
 
     def write(self, devAddr, addr, val, width="L"):
-        if not(devAddr.startswith("pci")):
+        if not (devAddr.startswith("pci")):
             devAddr = "pci" + devAddr
         cmd = "pciconf -w %s 0x%x 0x%x" % (devAddr, addr, val)
         (rc, out, _) = cmdExec(cmd)
@@ -677,10 +696,10 @@ class MlnxPciOpFreeBSD(MlnxPciOp):
             raise NoPciBridgeException(
                 "Failed to get Bridge Device for the given PCI device! You might be running on a Virtual Machine!")
         linesCount = len(out.splitlines())
-        if(linesCount == 0):
+        if (linesCount == 0):
             raise RuntimeError(
                 "There is no secbus with the value: %s" % busNum)
-        if(linesCount > 1):
+        if (linesCount > 1):
             raise RuntimeError(
                 "Found more than one secbus with the value: %s" % busNum)
         hostBridge = "pcib%s" % (out.split("pcib.")[1].split(".")[0])
@@ -692,7 +711,8 @@ class MlnxPciOpFreeBSD(MlnxPciOp):
             raise RuntimeError(
                 "Failed to extract PCI bridge address ({0})".format(cmd))
         try:
-            bridgeDevAddr = out.split()[0].split('@')[1][:-1]  # Extract the pci device from the output
+            # Extract the pci device from the output
+            bridgeDevAddr = out.split()[0].split('@')[1][:-1]
         except BaseException:
             raise RuntimeError(
                 "Failed to extract PCI bridge address ({0})".format(out))
@@ -829,7 +849,7 @@ def mstRestart(busId):
         raise RuntimeError("The device is not appearing in lspci output!")
 
     ignore_signals()
-    cmd = "/etc/systemd/system/mst.service restart %s" % MstFlags
+    cmd = "/etc/init.d/mst restart %s" % MstFlags
     logger.debug('Execute {0}'.format(cmd))
     (rc, stdout, stderr) = cmdExec(cmd)
     if rc != 0:
@@ -1079,10 +1099,12 @@ def resetPciAddr(device, devicesSD, driverObj, cmdLineArgs):
             for root_pci_device in root_pci_devices:
                 logger.info('root_pci_device={0}'.format(root_pci_device.dbdf))
 
-    if isWindows is False:  # relevant for ppc(p7) TODO check power8/9 shouldn't use mst-save/load
+    # relevant for ppc(p7) TODO check power8/9 shouldn't use mst-save/load
+    if isWindows is False:
         logger.info('Save PCI Configuration space ...')
 
-        devList = PciOpsObj.getMFDeviceList(busId)  # Get all devices that you want to save/load pci configuration
+        # Get all devices that you want to save/load pci configuration
+        devList = PciOpsObj.getMFDeviceList(busId)
         logger.debug('devList is {0}'.format(devList))
         # for each PF/VF save its configuration space
         pci_device_dict = {}
@@ -1201,9 +1223,12 @@ def resetPciAddr(device, devicesSD, driverObj, cmdLineArgs):
 
         # Poll DLL Link Active (required to support AMD - RM #1599465)
         for root_pci_device in root_pci_devices:
-            if not isPPC and not is_in_internal_host() and root_pci_device.dll_link_active_reporting_capable:   # in BlueField's internal host (ARM) the root-port will
-                MAX_WAIT_TIME = 2  # sec                                                                        # return a valid response (blocking) or 0xffff0001 when
-                poll_start_time = time.time()                                                                   # it's not ready (depending on its configuration)
+            # in BlueField's internal host (ARM) the root-port will
+            if not isPPC and not is_in_internal_host() and root_pci_device.dll_link_active_reporting_capable:
+                # sec                                                                        # return a valid response (blocking) or 0xffff0001 when
+                MAX_WAIT_TIME = 2
+                # it's not ready (depending on its configuration)
+                poll_start_time = time.time()
                 for _ in range(1000 * MAX_WAIT_TIME):
                     if root_pci_device.dll_link_active == 1:
                         poll_end_time = (time.time() - poll_start_time) * 1000
@@ -1220,7 +1245,8 @@ def resetPciAddr(device, devicesSD, driverObj, cmdLineArgs):
         poll_start_time = time.time()
         for pci_device_to_poll_devid in pci_devices_to_poll_devid:
             for _ in range(1000 * MAX_WAIT_TIME):
-                if PciOpsObj.read(pci_device_to_poll_devid, 0) >> 16 != 0xffff:  # device-id (0x2.W)
+                # device-id (0x2.W)
+                if PciOpsObj.read(pci_device_to_poll_devid, 0) >> 16 != 0xffff:
                     iron_end_time = (time.time() - poll_start_time) * 1000
                     logger.debug(
                         'IRON is ready after {0} msec'.format(iron_end_time))
@@ -1240,7 +1266,8 @@ def resetPciAddr(device, devicesSD, driverObj, cmdLineArgs):
                 command_reg = PciOpsObj.read(pciDev, COMMAND_ADDR, "W")
                 logger.debug('command_reg for [{0}]is {1:x}.'.format(
                     pciDev, command_reg))
-                if (command_reg & 0x2) == 0:  # command_reg[MSE] - Indication for re-enumeration (OS rescan)
+                # command_reg[MSE] - Indication for re-enumeration (OS rescan)
+                if (command_reg & 0x2) == 0:
                     PciOpsObj.loadPCIConfigurationSpace(
                         pciDev, pci_device_object, full=True)
                 else:
@@ -1300,20 +1327,75 @@ def is_pci_bridge_is_mellanox_device(devAddr):
         return False
 
 
+def send_reset_cmd_to_cedar_devices(reset_level, reset_type, reset_sync):
+    #
+    # We are going to send MFRL request for all the Cedar devices on the host.
+    #
+
+    # Discover all Cedar devices.
+    peripherals = MlnxPeripheralComponents()
+    for pci_device in peripherals.pci_devices:
+        logger.debug("Creating regaccess obj for device %s" % pci_device.get_alias())
+        pci_device_mst = mtcr.MstDevice(pci_device.get_alias())
+        pci_device_reg_access = regaccess.RegAccess(pci_device_mst)
+        if is_cedar_device(pci_device.get_cfg_did(), pci_device_reg_access):
+            # Create MFRL for each Cedar device.
+            logger.debug("Creating MFRL for device %s" % pci_device.get_alias())
+            cedar_device_mfrl = CmdRegMfrl(pci_device_reg_access, logger)
+            # Send MFRL reset.
+            printAndFlush("-I- %-40s-" %
+                          ("Sending Reset Command To Fw"), endChar="")
+            logger.debug('[Timing Test] MFRL')
+            cedar_device_mfrl.send(reset_level, reset_type, reset_sync, True)
+            printAndFlush("Done")
+
+
 def send_reset_cmd_to_fw(mfrl, reset_level, reset_type, reset_sync=SyncOwner.TOOL):
     try:
+        if is_cedar:
+            send_reset_cmd_to_cedar_devices(reset_level, reset_type, reset_sync)
+            return
+
         printAndFlush("-I- %-40s-" %
                       ("Sending Reset Command To Fw"), endChar="")
         logger.debug('[Timing Test] MFRL')
         mfrl.send(reset_level, reset_type, reset_sync)
         printAndFlush("Done")
+
     except Exception as e:
         raise e
 
 
+def is_cedar_device(devid, reg_access_obj=None):
+    res = False
+    reg_access_obj = RegAccessObj if reg_access_obj is None else reg_access_obj
+    devDict = getDeviceDict(devid)
+    if devDict['name'] == 'ConnectX7':
+        psid = reg_access_obj.getPSID()
+        logger.debug("ConnectX7 device with PSID: %s" % psid)
+        if psid in ["MT_0000000891", "MT_0000000929", "MT_0000000937"]:
+            logger.debug("Found Cedar device")
+            res = True
+    return res
+
+
+def is_prometheus_device(devid, reg_access_obj=None):
+    res = False
+    reg_access_obj = RegAccessObj if reg_access_obj is None else reg_access_obj
+    devDict = getDeviceDict(devid)
+    if devDict['name'] == 'ConnectX7':
+        psid = reg_access_obj.getPSID()
+        logger.debug("ConnectX7 device with PSID: %s" % psid)
+        if psid in ["NVD0000000033"]:
+            logger.debug("Found Prometheus device")
+            res = True
+    return res
+
 ######################################################################
 # Description: Send MFRL to FW in Multihost setup
 ######################################################################
+
+
 def sendResetToFWSync(mfrl, reset_level, reset_type):
     status = CmdifObj.multiHostSyncStatus()
     if (status.state == SYNC_STATE_GET_READY and
@@ -1342,7 +1424,8 @@ def sendResetToFWSync(mfrl, reset_level, reset_type):
             CmdifObjSD.multiHostSync(SYNC_STATE_GET_READY, SYNC_TYPE_FW_RESET)
             logger.info('send SYNC_STATE_GET_READY command (SD)')
 
-    elif status.state == SYNC_STATE_GET_READY:  # TODO (update after GA) and status.fsm_sync_type == SYNC_TYPE_FW_RESET
+    # TODO (update after GA) and status.sync_type == SYNC_TYPE_FW_RESET
+    elif status.state == SYNC_STATE_GET_READY:
         logger.debug('[Timing Test] MH SYNC send GET_READY')
         CmdifObj.multiHostSync(SYNC_STATE_GET_READY, SYNC_TYPE_FW_RESET)
         logger.info('send SYNC_STATE_GET_READY command')
@@ -1391,8 +1474,8 @@ def stopDriverSync(driverObj):
     status = CmdifObj.multiHostSyncStatus()
     timestamp = time.time()
     print_waiting_msg = True
-    while(status.state == SYNC_STATE_GET_READY and
-          status.sync_type == SYNC_TYPE_FW_RESET):
+    while (status.state == SYNC_STATE_GET_READY and
+           status.sync_type == SYNC_TYPE_FW_RESET):
         status = CmdifObj.multiHostSyncStatus()
         diffTime = time.time() - timestamp
         if diffTime > 180:
@@ -1442,7 +1525,7 @@ def stopDriverSync(driverObj):
         errmsg = "Operation failed, the fsm register state or type is not as expected"
         msg = reloadDriver(driverObj)
         raise RuntimeError(errmsg + msg)
-        #raise RuntimeError("Operation failed, the fsm register state or type is not as expected")
+        # raise RuntimeError("Operation failed, the fsm register state or type is not as expected")
 
 ######################################################################
 # Description: Driver restart (link/managment up/down flow) w/wo PCI RESET
@@ -1456,7 +1539,8 @@ def sendPcnr(regAccess, port_num):
         regAccess.sendPcnr(1, port_num)
         logger.debug("Sending PCNR - Done")
     except Exception as e:
-        logger.debug('Failed to send pcnr. {0}'.format(e))  # port doesn't exist / old FW version, burn FW with allow_pcnr (ini file)
+        # port doesn't exist / old FW version, burn FW with allow_pcnr (ini file)
+        logger.debug('Failed to send pcnr. {0}'.format(e))
         raise PcnrError
 
 
@@ -1479,7 +1563,8 @@ def resetFlow(device, devicesSD, reset_level, reset_type, cmdLineArgs, mfrl):
 
     try:
         # Check if device with PCIe switch (BL) is supported
-        if platform.system() != "Windows" and is_pci_bridge_is_mellanox_device(DevDBDF):  # Skip check on Windows OS (is_pci_bridge_is_mellanox_device is not implemented on Windows)
+        # Skip check on Windows OS (is_pci_bridge_is_mellanox_device is not implemented on Windows)
+        if platform.system() != "Windows" and is_pci_bridge_is_mellanox_device(DevDBDF):
             if platform.system() != "Linux":
                 raise RuntimeError(
                     "Resetting a device that contains a PCIe switch is supported only in Linux")
@@ -1494,8 +1579,10 @@ def resetFlow(device, devicesSD, reset_level, reset_type, cmdLineArgs, mfrl):
 
         try:
             # PCNR - Reduce link up time (from ~4 sec to ~1.5 sec)
-            sendPcnr(RegAccessObj, 0)  # port #0 (will fail if pcnr isn't supported by FW)
-            sendPcnr(RegAccessObj, 1)  # port #1 (will fail if HW has only one port)
+            # port #0 (will fail if pcnr isn't supported by FW)
+            sendPcnr(RegAccessObj, 0)
+            # port #1 (will fail if HW has only one port)
+            sendPcnr(RegAccessObj, 1)
         except PcnrError:
             pass
 
@@ -1528,7 +1615,8 @@ def resetFlow(device, devicesSD, reset_level, reset_type, cmdLineArgs, mfrl):
         # Wait for FW to be ready to get ICMD
         try:
             wait_for_fw_ready(device)
-        except BaseException:  # bug 1980064 ('mst driver' is non-operational after PCI reset)
+        # bug 1980064 ('mst driver' is non-operational after PCI reset)
+        except BaseException:
             logger.warning(
                 "wait_for_fw_ready failed. Waiting 1 sec and continue")
             time.sleep(1)
@@ -1582,8 +1670,97 @@ def rebootMachine():
             "Failed to reboot machine please reboot machine manually")
 
 ######################################################################
+# BF3 reset
+######################################################################
+
+
+def bluefield_reset(mfrl, DevDBDF, dtor_result):
+    if is_bluefield is False:
+        return
+
+    logger.debug('bluefield reset workflow started')
+    pci_device_bridge = PciOpsObj.getPciBridgeAddr(DevDBDF)
+    root_pci_device = PCIDeviceFactory().get(pci_device_bridge, "debug")
+
+    check_if_pci_link_is_down(root_pci_device, mfrl, dtor_result)
+    check_if_pci_link_is_up(root_pci_device, dtor_result)
+
+
+def check_if_pci_link_is_down(root_pci_device, mfrl, dtor_result):
+    nic_driver_to_be_unloaded = 60000  # 1 minute in milliseconds.
+    timeout_in_milliseconds_until_the_pci_link_goes_down = nic_driver_to_be_unloaded + get_timeout_in_miliseconds(dtor_result, "DRIVER_UNLOAD_AND_RESET_TO")
+
+    logger.debug('timeout_in_milliseconds_until_the_pci_link_goes_down = {0}'.format(timeout_in_milliseconds_until_the_pci_link_goes_down))
+
+    # Send MFRL in order to check the reset state.
+    # Verify if we won't enter the loop.
+    is_in_shutdown_progress = check_if_shut_down_in_progress(mfrl)
+
+    start_time = time.time()
+    # Continuously monitoring the active register of the DLL link until the link goes down
+    while root_pci_device.dll_link_active == 1:
+        if is_in_shutdown_progress is False:
+            is_in_shutdown_progress = check_if_shut_down_in_progress(mfrl)
+
+        check_if_elapsed_time(start_time, "up", timeout_in_milliseconds_until_the_pci_link_goes_down / 1000)
+
+    logger.debug("Link is down")
+
+
+def get_timeout_in_miliseconds(dtor_result, timeout):
+    timeout_value = dtor_result[timeout].to_value
+    timeout_multiplier = dtor_result[timeout].to_multiplier
+
+    if timeout_multiplier == 0x0:  # Time in milliseconds.
+        return timeout_value
+    elif timeout_multiplier == 0x1:  # Time in seconds.
+        return (timeout_value * 1000)
+    elif timeout_multiplier == 0x2:  # Time in minutes.
+        return (timeout_value * 60 * 1000)
+    elif timeout_multiplier == 0x3:  # Time in hours.
+        return (timeout_value * 60 * 60 * 1000)
+    else:
+        raise RuntimeError("Unknown timeout multiplier, exit..")
+
+
+def check_if_pci_link_is_up(root_pci_device, dtor_result):
+    timeout_in_milliseconds_until_the_pci_link_goes_up = get_timeout_in_miliseconds(dtor_result, "PCIE_TOGGLE_TO")
+    start_time = time.time()
+
+    logger.debug('timeout_in_milliseconds_until_the_pci_link_goes_up = {0}'.format(timeout_in_milliseconds_until_the_pci_link_goes_up))
+
+    # Continuously monitoring the active register of the DLL link until the link goes up
+    while root_pci_device.dll_link_active == 0:
+        check_if_elapsed_time(start_time, "down", timeout_in_milliseconds_until_the_pci_link_goes_up / 1000)
+
+    logger.debug("Link is up")
+
+
+def check_if_elapsed_time(start_time, state, timeout):
+    current_time = time.time()
+    elapsed_time = current_time - start_time
+    if elapsed_time >= timeout:
+        raise RuntimeError("The PCI link is still {0} even after the expected time ({1}) seconds has passed. Exiting the process.".format(state, timeout))
+
+
+def check_if_shut_down_in_progress(mfrl):
+    res = False
+    try:
+        # Send MFRL in order to check the reset state.
+        mfrl.read()
+    except BaseException:
+        pass
+    else:
+        if mfrl.is_reset_state_in_progress() is True:
+            print("Arm OS shut down in progress, the completion of the process may take several minutes.")
+            res = True
+
+    return res
+
+######################################################################
 # Description:  execute sync 1 reset
 ######################################################################
+
 
 def execute_driver_sync_reset(mfrl, reset_level, reset_type):
     logger.debug('UpdateUptimeBeforeReset')
@@ -1594,18 +1771,56 @@ def execute_driver_sync_reset(mfrl, reset_level, reset_type):
         logger.debug('UpdateUptimeAfterReset')
         FWResetStatusChecker.UpdateUptimeAfterReset()
         if FWResetStatusChecker.GetStatus() == FirmwareResetStatusChecker.FirmwareResetStatusFailed:
-            raise e
+            exception_str = "MGIR.uptime check failed after MFRL failure: {}".format(str(e))
+            raise exception_str
         else:
             logger.debug("MFRL sync 1 worked although MFRL returned with error: {0}".format(e))
             printAndFlush("Done")
     else:
-        time.sleep(1)  # Adding a sleep for cases where reset didn't take place yet so MGIR.uptime wasn't reset yet
+        # Adding a sleep for cases where reset didn't take place yet so MGIR.uptime wasn't reset yet
+        time.sleep(1)
         logger.debug('UpdateUptimeAfterReset')
         FWResetStatusChecker.UpdateUptimeAfterReset()
 
 ######################################################################
+# Description:  execute sync 1 reset for BF
+######################################################################
+
+
+def execute_driver_sync_reset_bf(mfrl, reset_level, reset_type):
+    logger.debug('UpdateUptimeBeforeReset')
+    FWResetStatusChecker.UpdateUptimeBeforeReset()
+    try:
+        mfrl_error = None
+        dtor_result = RegAccessObj.getDTOR()
+        # The maximum reset time for HCA or BF2/3 in NIC mode is PCI_SYNC_UPDATE_TO + PCIE_TOGGLE_TO (probably 4 seconds)
+        sync_reset_TO = get_timeout_in_miliseconds(dtor_result, "PCI_SYNC_UPDATE_TO")
+        toggle_TO = get_timeout_in_miliseconds(dtor_result, "PCIE_TOGGLE_TO")
+        send_reset_cmd_to_fw(mfrl, reset_level, reset_type, SyncOwner.DRIVER)
+
+    except regaccess.RegAccException as e:
+        mfrl_error = str(e)
+    except Exception as e:
+        raise e
+    finally:
+        time.sleep((sync_reset_TO + toggle_TO) / 1000)
+        logger.debug('UpdateUptimeAfterReset')
+        FWResetStatusChecker.UpdateUptimeAfterReset()
+        if FWResetStatusChecker.GetStatus() == FirmwareResetStatusChecker.FirmwareResetStatusFailed:
+            if mfrl_error and "Method not supported" in mfrl_error:
+                raise Exception(mfrl_error)
+            # BF2/3 full chip reset flow.
+            bluefield_reset(mfrl, DevDBDF, dtor_result)
+            FWResetStatusChecker.UpdateUptimeAfterReset()
+            if FWResetStatusChecker.GetStatus() == FirmwareResetStatusChecker.FirmwareResetStatusFailed:
+                raise Exception("BF reset flow failed based on MGIR")
+        elif mfrl_error:
+            logger.debug("MFRL sync 1 worked although MFRL returned with error: {0}".format(mfrl_error))
+
+######################################################################
 # Description:  execute reset level for device
 ######################################################################
+
 
 def execResLvl(device, devicesSD, reset_level, reset_type, reset_sync, cmdLineArgs, mfrl):
 
@@ -1619,7 +1834,10 @@ def execResLvl(device, devicesSD, reset_level, reset_type, reset_sync, cmdLineAr
         send_reset_cmd_to_fw(mfrl, reset_level, reset_type)
     elif reset_level in [mfrl.PCI_RESET, mfrl.WARM_REBOOT]:
         if reset_sync == SyncOwner.DRIVER:
-            execute_driver_sync_reset(mfrl, reset_level, reset_type)
+            if is_bluefield is True:
+                execute_driver_sync_reset_bf(mfrl, reset_level, reset_type)
+            else:
+                execute_driver_sync_reset(mfrl, reset_level, reset_type)
         else:
             resetFlow(device, devicesSD, reset_level,
                       reset_type, cmdLineArgs, mfrl)
@@ -1734,17 +1952,14 @@ def reset_flow_host(device, args, command):
     # mpcir = CmdRegMpcir(RegAccessObj)
     mcam = CmdRegMcam(RegAccessObj)
 
+    if is_prometheus_device(devid):
+        raise RuntimeError("Prometheus device is not supported")
+
     logger.info('Check if device is livefish')
     DevMgtObj = dev_mgt.DevMgt(MstDevObj)  # check if device is in livefish
     if DevMgtObj.isLivefishMode() == 1:
         raise RuntimeError(
             "%s is not supported for device in Flash Recovery mode" % PROG)
-
-    if devid == 0x218:  # CX7
-        psid = RegAccessObj.getPSID()
-        logger.debug("ConnectX7 device with PSID: %s" % psid)
-        if psid in ["MT_0000000891", "MT_0000000929", "MT_0000000937"]:
-            raise RuntimeError("Cedar device is not supported")
 
     # Check if other process is accessing the device (burning the device)
     # Supported on Windows OS only
@@ -1799,18 +2014,26 @@ def reset_flow_host(device, args, command):
 
     print("")
 
+    devDict = getDeviceDict(devid)
+    if devDict['name'] in ['BlueField2', 'BlueField3']:
+        global is_bluefield
+        is_bluefield = True
     if command == "query":
-        print(mfrl.query_text())
+        print(mfrl.query_text(is_cedar_device(devid)))
         tool_owner_support = True
-        if platform.system() == "Linux":
-            devDict = getDeviceDict(devid)
-            if devDict['name'] in ['BlueField2', 'BlueField3']:
-                tool_owner_support = False
+        if platform.system() == "Linux" and is_bluefield:
+            tool_owner_support = False
         print(mcam.reset_sync_query_text(tool_owner_support))
 
     elif command == "reset":
-
-        # print("Reset device {0}:".format(device))
+        if is_cedar_device(devid):
+            if args.reset_level is None:
+                args.reset_level = CmdRegMfrl.WARM_REBOOT
+            if args.reset_level is not CmdRegMfrl.WARM_REBOOT:
+                raise RuntimeError("Only reboot is supported for Cedar device")
+            else:
+                global is_cedar
+                is_cedar = True
 
         reset_level = mfrl.default_reset_level(
         ) if args.reset_level is None else args.reset_level
@@ -1845,6 +2068,9 @@ def reset_flow_host(device, args, command):
         if CmdRegMfrl.is_reset_level_trigger_is_pci_link(reset_level) and mcam.is_pci_rescan_required_supported() and mfrl.is_pci_rescan_required():
             print("-W- PCI rescan is required after device reset.")
 
+        if is_bluefield:
+            print("Please be aware that resetting the Bluefield may take several minutes. Exiting the process in the middle of the waiting period will not halt the reset")
+
         AskUser("Continue with reset", args.yes)
         execResLvl(device, devicesSD, reset_level,
                    reset_type, reset_sync, args, mfrl)
@@ -1876,6 +2102,9 @@ def reset_flow_switch(device, args, command):
         raise RuntimeError("FW is not ready to handle ICMD")
 
     DevMgtObj = dev_mgt.DevMgt(MstDevObj)
+
+    if DevMgtObj.is_mlnx_os():
+        raise RuntimeError("fwreset is not allowed on switch sdk")
 
     # Check if device is connected via IB, as this method is not supported
     if DevMgtObj.is_ib_access():
@@ -1910,9 +2139,13 @@ def reset_flow_switch(device, args, command):
                 raise Exception(
                     "Timeout waiting for FW to respond after reset command sent")
             time.sleep(1)
-            if is_fw_ready(device):
-                logger.debug("FW is ready after = " + str(i) + " seconds")
-                break
+            try:
+                if is_fw_ready(device):
+                    logger.debug("FW is ready after = " + str(i) + " seconds")
+                    break
+            except BaseException:
+                logger.debug("FW is still not ready after = " +
+                             str(i) + " seconds")
 
         logger.debug('UpdateUptimeAfterReset')
         FWResetStatusChecker.UpdateUptimeAfterReset()
@@ -1928,6 +2161,7 @@ def reset_flow_switch(device, args, command):
 # Description: Returns default reset sync
 ######################################################################
 
+
 def get_default_reset_sync(devid, reset_level):
     reset_sync = SyncOwner.TOOL
     devDict = getDeviceDict(devid)
@@ -1938,6 +2172,7 @@ def get_default_reset_sync(devid, reset_level):
 ######################################################################
 # Description: Main
 ######################################################################
+
 
 def main():
     global logger


### PR DESCRIPTION
Bluefield:
The responsibility of resetting the Bluefield it will be handled by the Nic driver. The duration of the reset time is retrieved from the DTOR register.

Cedar:
The responsibility of resetting all Cedar devices when the user requests it will be handled by mlxfwreset tool. The user needs to provide one of the Cedar devices to the tool and the tool will then proceed to reset all the devices accordingly. As the final step in the reset process, a reboot command will be executed, resulting in the rebooting of the entire setup.