### PR TITLE
[mtcr] NULL->false compilation fix for freebsd

### DIFF
--- a/mlxreg/mlxreg_lib/mlxreg_lib.cpp
+++ b/mlxreg/mlxreg_lib/mlxreg_lib.cpp
@@ -149,7 +149,7 @@ void MlxRegLib::initAdb(string extAdbFile)
     _adb = new Adb();
     if (extAdbFile != "")
     {
-        if (!_adb->load(extAdbFile, false, NULL, false))
+        if (!_adb->load(extAdbFile, false, false, false))
         {
             throw MlxRegException("Failure in loading Adabe file. %s", _adb->getLastError().c_str());
         }


### PR DESCRIPTION
Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 3557887