### PR TITLE
Feature/3444693

### DIFF
--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -98,6 +98,7 @@
 #define REG_ID_MTEIM 0x9118
 #define REG_ID_MRSR 0x9023
 #define REG_ID_DTOR 0xC00E
+#define REG_ID_MRSI 0x912A
 
 #define REG_ID_MDDT 0x9160
 #define REG_ID_MDDQ 0x9161
@@ -632,4 +633,12 @@ reg_access_status_t reg_access_mrsr(mfile* mf, reg_access_method_t method, struc
 reg_access_status_t reg_access_dtor(mfile* mf, reg_access_method_t method, struct reg_access_hca_dtor_reg_ext* dtor)
 {
     REG_ACCCESS(mf, method, REG_ID_DTOR, dtor, dtor_reg_ext, reg_access_hca);
+}
+
+/************************************
+ * Function: reg_access_mrsi
+ ************************************/
+reg_access_status_t reg_access_mrsi(mfile* mf, reg_access_method_t method, struct reg_access_hca_mrsi_ext* mrsi)
+{
+    REG_ACCCESS(mf, method, REG_ID_MRSI, mrsi, mrsi_ext, reg_access_hca);
 }

--- a/reg_access/regaccess.py
+++ b/reg_access/regaccess.py
@@ -126,6 +126,7 @@ if REG_ACCESS:
             self._reg_access_nic_dpa_eug = REG_ACCESS.reg_access_nic_dpa_eug
             self._reg_access_mrsr = REG_ACCESS.reg_access_mrsr
             self._reg_access_dtor = REG_ACCESS.reg_access_dtor
+            self._reg_access_mrsi = REG_ACCESS.reg_access_mrsi
 
         def _err2str(self, rc):
             err2str = REG_ACCESS.reg_access_err2str
@@ -309,6 +310,18 @@ if REG_ACCESS:
                 "PCIE_TOGGLE_TO": dtorRegisterP.contents.PCIE_TOGGLE_TO
             }
 
+        def getMRSI(self):
+            mrsiRegisterP = pointer(MRSI_EXT())
+            rc = self._reg_access_mrsi(self._mstDev.mf, REG_ACCESS_METHOD_GET, mrsiRegisterP)
+            if rc:
+                raise RegAccException("Failed to send Register MRSI")
+
+            return {
+                "reset_reason": mrsiRegisterP.contents.reset_reason,
+                "crts": mrsiRegisterP.contents.crts,
+                # "ecos": mrsiRegisterP.contents.ecos    # will be uncommented when regaccess_structs.py will be updated.
+            }
+
         ##########################
         def sendMFRL(self, method, resetLevel=None, reset_type=None, reset_sync=None):
 
@@ -330,9 +343,11 @@ if REG_ACCESS:
                 return mfrlRegisterP.contents.reset_trigger, mfrlRegisterP.contents.reset_type, mfrlRegisterP.contents.pci_rescan_required, mfrlRegisterP.contents.reset_state
 
         ##########################
-        def getMCAM(self):
+        def getMCAM(self, access_reg_group=0):
 
             mcamRegP = pointer(MCAM_REG_EXT())
+            mcamRegP.contents.access_reg_group = c_uint8(access_reg_group)
+
             rc = self._reg_access_mcam(self._mstDev.mf, c_uint(REG_ACCESS_METHOD_GET), mcamRegP)
             if rc:
                 raise RegAccException("Failed to send Register MCAM (rc: {0})".format(rc))

--- a/reg_access/regaccess_structs.py
+++ b/reg_access/regaccess_structs.py
@@ -67,6 +67,13 @@ class DTOR_REG_EXT(ctypes.Structure):
         ("DRIVER_UNLOAD_AND_RESET_TO", DEFAULT_TIMEOUT)
     ]
 
+class MRSI_EXT(ctypes.Structure):
+    _fields_ = [
+        ("device", ctypes.c_uint8),
+        ("reset_reason", ctypes.c_uint8),
+        ("crts", ctypes.c_uint64)
+    ]
+
 class PCNR_REG_EXT(ctypes.Structure):
     _fields_ = [
         ("tuning_override", ctypes.c_uint8),

--- a/small_utils/mlxfwresetlib/Makefile.am
+++ b/small_utils/mlxfwresetlib/Makefile.am
@@ -32,5 +32,5 @@
 
 
 docdir = $(libdir)/mstflint/python_tools/mstfwreset/mlxfwresetlib
-dist_doc_DATA = __init__.py mlxfwreset_mlnxdriver.py mlxfwreset_status_checker.py mlxfwreset_utils.py logger.py mcra.py mlnx_peripheral_components.py pci_device.py cmd_reg_mfrl.py cmd_reg_mpcir.py cmd_reg_mcam.py
+dist_doc_DATA = __init__.py mlxfwreset_mlnxdriver.py mlxfwreset_status_checker.py mlxfwreset_utils.py logger.py mcra.py mlnx_peripheral_components.py pci_device.py cmd_reg_mfrl.py cmd_reg_mpcir.py cmd_reg_mcam.py cmd_reg_mrsi.py
 

--- a/small_utils/mlxfwresetlib/cmd_reg_mrsi.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mrsi.py
@@ -1,0 +1,107 @@
+# Copyright (c) Sep 2019 Mellanox Technologies LTD. All rights reserved.
+# Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# OpenIB.org BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# --
+
+import sys
+try:
+    from regaccess import RegAccException, extractField
+except Exception as e:
+    print("-E- could not import : %s" % str(e))
+    sys.exit(1)
+
+
+class CmdRegMrsi():
+
+    ECOS_VALS = [
+        {0, 'Reset/Boot-ROM'},
+        {1, 'BL2'},
+        {2, 'BL31'},
+        {3, 'UEFI'},
+        {4, 'OS starting'},
+        {5, 'OS is running'},
+        {6, 'Low - Power standby'},
+        {7, 'Firmware update in progress'},
+        {8, 'OS Crash Dump in progress'},
+        {9, 'OS Crash Dump is complete'},
+        {10, 'FW Fault Crash Dump in progress'},
+        {11, 'FW Fault Crash Dump is complete'}
+    ]
+
+    def __init__(self, reg_access):
+        self._reg_access = reg_access
+        self._mrsi_get_result = None
+
+    def get_mrsi(self):
+        if self._mrsi_get_result is None:
+            self._mrsi_get_result = self._reg_access.getMRSI()
+        return self._mrsi_get_result  # returns {"reset_reason":value of reset_reason, "crts":value of crts, "ecos":value of ecos}
+
+    def is_warm_reset(self):
+        mrsi_get_result = self.get_mrsi()
+        if mrsi_get_result["reset_reason"] == 1:
+            return True
+        return False
+
+    def get_crts(self):
+        mrsi_get_result = self.get_mrsi()
+        return mrsi_get_result["crts"]
+
+    def get_ecos(self):
+        mrsi_get_result = self.get_mrsi()
+        return mrsi_get_result["ecos"]
+
+    def query_text(self, is_bluefield):
+        try:
+            warm_reset = self.is_warm_reset()
+            timestamp = self.get_crts()
+            reset_reason = "Warm reset" if warm_reset else "Cold reset"
+        except Exception as e:
+            reset_reason = "Unknown. Please check driver is up."
+            timestamp = "Unknown. Please check driver is up."
+
+        result = ""
+        result += "{0}: {1:<51}{2:<14}\n".format("Reset-reason", "", reset_reason)
+        result += "{0}: {1:<7}{2:<14}\n".format("Timestamp (number of clock cycles) since last cold reset", "", timestamp)
+
+        # if is_bluefield:  # will be uncommented when FW will implement their support.
+        #     ecos_result = self.ecos_query_text()
+        #     result += ecos_result
+
+        return result
+
+    def ecos_query_text(self):
+        state = self.get_ecos()
+        description = CmdRegMrsi.ecos_vals[state]
+
+        result = ""
+        result = "Embedded CPU OS state:\n"
+        result += "{0}: {1:<62}-{2:<14}{3}\n".format(state, description, "", "")
+        return result

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -68,6 +68,7 @@ try:
     from mlxfwresetlib.cmd_reg_mfrl import CmdRegMfrl, CmdNotSupported
     # from mlxfwresetlib.cmd_reg_mpcir import CmdRegMpcir
     from mlxfwresetlib.cmd_reg_mcam import CmdRegMcam
+    from mlxfwresetlib.cmd_reg_mrsi import CmdRegMrsi
     if os.name != 'nt':
         if not getattr(sys, 'frozen', False):
             sys.path.append(os.sep.join(
@@ -1951,6 +1952,7 @@ def reset_flow_host(device, args, command):
     mfrl = CmdRegMfrl(RegAccessObj, logger)
     # mpcir = CmdRegMpcir(RegAccessObj)
     mcam = CmdRegMcam(RegAccessObj)
+    mrsi = CmdRegMrsi(RegAccessObj)
 
     if is_prometheus_device(devid):
         raise RuntimeError("Prometheus device is not supported")
@@ -2024,6 +2026,8 @@ def reset_flow_host(device, args, command):
         if platform.system() == "Linux" and is_bluefield:
             tool_owner_support = False
         print(mcam.reset_sync_query_text(tool_owner_support))
+        if mcam.is_mrsi_supported():
+            print(mrsi.query_text(is_bluefield))
 
     elif command == "reset":
         if is_cedar_device(devid):

--- a/tools_layouts/reg_access_hca_layouts.c
+++ b/tools_layouts/reg_access_hca_layouts.c
@@ -3384,6 +3384,53 @@ void reg_access_hca_mqis_reg_ext_dump(const struct reg_access_hca_mqis_reg_ext *
 	reg_access_hca_mqis_reg_ext_print(ptr_struct, fd, 0);
 }
 
+void reg_access_hca_mrsi_ext_pack(const struct reg_access_hca_mrsi_ext *ptr_struct, u_int8_t *ptr_buff)
+{
+	u_int32_t offset;
+
+	offset = 28;
+	adb2c_push_bits_to_buff(ptr_buff, offset, 4, (u_int32_t)ptr_struct->device);
+	offset = 60;
+	adb2c_push_bits_to_buff(ptr_buff, offset, 4, (u_int32_t)ptr_struct->reset_reason);
+	offset = 64;
+	adb2c_push_integer_to_buff(ptr_buff, offset, 8, ptr_struct->crts);
+}
+
+void reg_access_hca_mrsi_ext_unpack(struct reg_access_hca_mrsi_ext *ptr_struct, const u_int8_t *ptr_buff)
+{
+	u_int32_t offset;
+
+	offset = 28;
+	ptr_struct->device = (u_int8_t)adb2c_pop_bits_from_buff(ptr_buff, offset, 4);
+	offset = 60;
+	ptr_struct->reset_reason = (u_int8_t)adb2c_pop_bits_from_buff(ptr_buff, offset, 4);
+	offset = 64;
+	ptr_struct->crts = adb2c_pop_integer_from_buff(ptr_buff, offset, 8);
+}
+
+void reg_access_hca_mrsi_ext_print(const struct reg_access_hca_mrsi_ext *ptr_struct, FILE *fd, int indent_level)
+{
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "======== reg_access_hca_mrsi_ext ========\n");
+
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "device               : " UH_FMT "\n", ptr_struct->device);
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "reset_reason         : " UH_FMT "\n", ptr_struct->reset_reason);
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "crts                 : " U64H_FMT "\n", ptr_struct->crts);
+}
+
+unsigned int reg_access_hca_mrsi_ext_size(void)
+{
+	return REG_ACCESS_HCA_MRSI_EXT_SIZE;
+}
+
+void reg_access_hca_mrsi_ext_dump(const struct reg_access_hca_mrsi_ext *ptr_struct, FILE *fd)
+{
+	reg_access_hca_mrsi_ext_print(ptr_struct, fd, 0);
+}
+
 void reg_access_hca_msgi_ext_pack(const struct reg_access_hca_msgi_ext *ptr_struct, u_int8_t *ptr_buff)
 {
 	u_int32_t offset;

--- a/tools_layouts/reg_access_hca_layouts.h
+++ b/tools_layouts/reg_access_hca_layouts.h
@@ -1922,6 +1922,27 @@ other values are reserved. */
 };
 
 /* Description -   */
+/* Size in bytes - 64 */
+struct reg_access_hca_mrsi_ext {
+/*---------------- DWORD[0] (Offset 0x0) ----------------*/
+	/* Description - [NIC_Only]
+0: Main 
+1: Embedded CPU 
+Reserved when Switches */
+	/* 0x0.0 - 0x0.3 */
+	u_int8_t device;
+/*---------------- DWORD[1] (Offset 0x4) ----------------*/
+	/* Description - Reset/shutdown reason
+0: cold reset - A reset triggered following application of power to the component. 1: warm reset - A reset triggered without removal and re-application of power to the device */
+	/* 0x4.0 - 0x4.3 */
+	u_int8_t reset_reason;
+/*---------------- DWORD[2] (Offset 0x8) ----------------*/
+	/* Description - Timestamp (number of clock cycles) since last cold reset */
+	/* 0x8.0 - 0xc.31 */
+	u_int64_t crts;
+};
+
+/* Description -   */
 /* Size in bytes - 128 */
 struct reg_access_hca_msgi_ext {
 /*---------------- DWORD[0] (Offset 0x0) ----------------*/
@@ -3267,6 +3288,13 @@ void reg_access_hca_mqis_reg_ext_print(const struct reg_access_hca_mqis_reg_ext 
 unsigned int reg_access_hca_mqis_reg_ext_size(void);
 #define REG_ACCESS_HCA_MQIS_REG_EXT_SIZE    (0x18)
 void reg_access_hca_mqis_reg_ext_dump(const struct reg_access_hca_mqis_reg_ext *ptr_struct, FILE *fd);
+/* mrsi_ext */
+void reg_access_hca_mrsi_ext_pack(const struct reg_access_hca_mrsi_ext *ptr_struct, u_int8_t *ptr_buff);
+void reg_access_hca_mrsi_ext_unpack(struct reg_access_hca_mrsi_ext *ptr_struct, const u_int8_t *ptr_buff);
+void reg_access_hca_mrsi_ext_print(const struct reg_access_hca_mrsi_ext *ptr_struct, FILE *fd, int indent_level);
+unsigned int reg_access_hca_mrsi_ext_size(void);
+#define REG_ACCESS_HCA_MRSI_EXT_SIZE    (0x40)
+void reg_access_hca_mrsi_ext_dump(const struct reg_access_hca_mrsi_ext *ptr_struct, FILE *fd);
 /* msgi_ext */
 void reg_access_hca_msgi_ext_pack(const struct reg_access_hca_msgi_ext *ptr_struct, u_int8_t *ptr_buff);
 void reg_access_hca_msgi_ext_unpack(struct reg_access_hca_msgi_ext *ptr_struct, const u_int8_t *ptr_buff);


### PR DESCRIPTION
[mlxfwreset] - Added query for last reboot type.
Description: added to mlxfwreset -d <> q output the type of the last reboot (warm/cold reboot).

Tested OS: linux
Tested devices: ConnectX7
Tested flows: mlxfwreset -d <> q

Known gaps (with RM ticket): n/a

Issue: 3444693
