### PR TITLE
hardware support: linux on loongarch64

### DIFF
--- a/common/compatibility.h
+++ b/common/compatibility.h
@@ -69,6 +69,8 @@
 #define ARCH_arm6l
 #elif defined(__riscv)
 #define ARCH_riscv
+#elif defined(__loongarch_lp64)
+#define ARCH_loongarch64
 #else
 #error Unknown CPU architecture using the linux OS
 #endif
@@ -116,7 +118,7 @@
 #define U48H_FMT "0x%012llx"
 #define U64D_FMT_GEN "llu"
 #endif
-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv)
+#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
 #define U64D_FMT "%lu"
 #define U64H_FMT "0x%016lx"
 #define U48H_FMT "0x%012lx"

--- a/mtcr_ul/packets_common.h
+++ b/mtcr_ul/packets_common.h
@@ -152,6 +152,8 @@
 #define ARCH_arm6l
 #elif defined(__riscv)
 #define ARCH_riscv
+#elif defined(__loongarch_lp64)
+#define ARCH_loongarch64
 #else
 #error Unknown CPU architecture using the linux OS
 #endif

--- a/tools_layouts/adb_to_c_utils.h
+++ b/tools_layouts/adb_to_c_utils.h
@@ -146,6 +146,8 @@ extern "C"
 #define ARCH_arm6l
 #elif defined(__riscv)
 #define ARCH_riscv
+#elif defined(__loongarch_lp64)
+#define ARCH_loongarch64
 #else
 #error Unknown CPU architecture using the linux OS
 #endif
@@ -188,7 +190,7 @@ extern "C"
 #define U64H_FMT "0x%016llx"
 #define U48H_FMT "0x%012llx"
 #endif
-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv)
+#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
 #define U64D_FMT "%lu"
 #define U64H_FMT "0x%016lx"
 #define U48H_FMT "0x%012lx"


### PR DESCRIPTION
Adding support for little endian loongarch64 running linux.

The following features have been tested to work on a real loongson 3c5000 with a connectx-3:
- mstconfig querying settings values
- mstconfig setting sriov / port modes
- mstflint querying firmware version