### PR TITLE
Adding support for recognizing the mlx5ctl device in mstfwreset

### DIFF
--- a/small_utils/mlxfwresetlib/mlxfwreset_utils.py
+++ b/small_utils/mlxfwresetlib/mlxfwreset_utils.py
@@ -104,6 +104,11 @@ def isDevDBDFFormat(dev):
         return True
     return False
 
+def isMlx5CtlFormat(dev):
+    pat = r"mlx5ctl-[0-9,A-F,a-f]{4}:[0-9,A-F,a-f]{2}:[0-9,A-F,a-f]{2}\.[0-9,A-F,a-f]{1,2}"
+    if re.match(pat, dev):
+        return True
+    return False
 
 def isDevBDFFormat(dev):
     pat = r"[0-9,A-F,a-f]{2}:[0-9,A-F,a-f]{2}\.[0-9,A-F,a-f]{1,2}"
@@ -122,6 +127,8 @@ def getDevDBDF(device, logger=None):
         return device
     if isDevBDFFormat(device):
         return addDomainToAddress(device)
+    if isMlx5CtlFormat(device):
+        return addDomainToAddress(device[8:])
 
     operatingSys = platform.system()
     if (operatingSys == "FreeBSD"):

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -1918,7 +1918,7 @@ def reset_flow_host(device, args, command):
 
     if platform.system() == "Linux":  # Convert ib-device , net-device to mst-device(mst started) or pci-device
         if IS_MSTFLINT:
-            if device.startswith('mlx'):
+            if device.startswith('mlx') and not device.startswith('mlx5ctl-'):
                 driver_path = '/sys/class/infiniband/{0}/device'.format(device)
                 try:
                     device = os.path.basename(os.readlink(driver_path))


### PR DESCRIPTION
Adding support for recognizing the mlx5ctl device in mstfwreset
mstfwreset -d mlx5ctl-<dbdf> q