### PR TITLE
Adding support for recognizing the mlx5ctl device in mstfwreset query

### DIFF
--- a/small_utils/mlxfwresetlib/mlxfwreset_utils.py
+++ b/small_utils/mlxfwresetlib/mlxfwreset_utils.py
@@ -41,6 +41,7 @@ import platform
 import re
 import time
 
+MLX5CTL_PREFIX = 'mlx5ctl-'
 
 ######################################################################
 # Description:  Execute command and get (rc, stdout-output, stderr-output)
@@ -97,13 +98,20 @@ def removeDomainFromAddress(devAddr):
         return devAddr[5:]
     return devAddr
 
+def CheckIfMlx5CtlFormat(dev):
+    if dev.startswith(MLX5CTL_PREFIX):
+        prefix_length = len(MLX5CTL_PREFIX)
+        dev_new_name = full_string[prefix_length:]
+        return dev_new_name
+    else:
+        return dev
 
 def isDevDBDFFormat(dev):
+    dev = CheckIfMlx5CtlFormat(dev)
     pat = r"[0-9,A-F,a-f]{4}:[0-9,A-F,a-f]{2}:[0-9,A-F,a-f]{2}\.[0-9,A-F,a-f]{1,2}"
     if re.match(pat, dev):
         return True
     return False
-
 
 def isDevBDFFormat(dev):
     pat = r"[0-9,A-F,a-f]{2}:[0-9,A-F,a-f]{2}\.[0-9,A-F,a-f]{1,2}"

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -1918,7 +1918,7 @@ def reset_flow_host(device, args, command):
 
     if platform.system() == "Linux":  # Convert ib-device , net-device to mst-device(mst started) or pci-device
         if IS_MSTFLINT:
-            if device.startswith('mlx'):
+            if device.startswith('mlx') and not device.startswith(mlxfwreset_utils.MLX5CTL_PREFIX):
                 driver_path = '/sys/class/infiniband/{0}/device'.format(device)
                 try:
                     device = os.path.basename(os.readlink(driver_path))


### PR DESCRIPTION
mstfwreset -d mlx5ctl-<dbdf> q