### PR TITLE
fix race condition during install

### DIFF
--- a/dev_mgt/Makefile.am
+++ b/dev_mgt/Makefile.am
@@ -46,7 +46,7 @@ libdev_mgt_a_SOURCES = \
 
 dev_mgt_pylibdir = $(libdir)/mstflint/python_tools/
 
-dev_mgt_pylib_DATA = c_dev_mgt.so dev_mgt.py
+dev_mgt_pylib_DATA = c_dev_mgt.so
 dist_dev_mgt_pylib_DATA = dev_mgt.py
 
 c_dev_mgt.so: libdev_mgt.a

--- a/mtcr_py/Makefile.am
+++ b/mtcr_py/Makefile.am
@@ -37,7 +37,7 @@ mtcr_pylibdir = $(libdir)/mstflint/python_tools/
 USER_DIR = ..
 MTCR_DIR = $(USER_DIR)/${MTCR_CONF_DIR}
 
-mtcr_pylib_DATA = cmtcr.so mtcr.py
+mtcr_pylib_DATA = cmtcr.so
 dist_mtcr_pylib_DATA = mtcr.py
 cmtcr.so:
 	$(CC) -g -Wall -pthread -shared ${CFLAGS} $(MTCR_DIR)/*.o -o cmtcr.so $(MFT_CORE_LIB_LINK)

--- a/reg_access/Makefile.am
+++ b/reg_access/Makefile.am
@@ -52,7 +52,7 @@ libmlxconfig_4th_gen_regsiters_a_LIBADD = $(libmlxconfig_4th_gen_regsiters_la_DE
 RREG_ACCESS_SO = rreg_access.so
 reg_access_pylibdir = $(libdir)/mstflint/python_tools/
 
-reg_access_pylib_DATA = ${RREG_ACCESS_SO} regaccess.py regaccess_structs.py
+reg_access_pylib_DATA = ${RREG_ACCESS_SO}
 dist_reg_access_pylib_DATA = regaccess.py regaccess_structs.py
 
 ${RREG_ACCESS_SO}: libreg_access.a


### PR DESCRIPTION
Files registered in both xxx_DATA and dist_xxx_DATA get installed twice which may cause error when building with make -j