### PR TITLE
Add new architecture e2k

### DIFF
--- a/common/compatibility.h
+++ b/common/compatibility.h
@@ -41,7 +41,7 @@
 
 #include <stdio.h>
 
-#if defined(__ia64__) || defined(__x86_64__) || defined(__PPC64__) || defined(__arm__)
+#if defined(__ia64__) || defined(__x86_64__) || defined(__PPC64__) || defined(__arm__) || defined(__e2k__)
 #define U64L "l"
 #else
 #define U64L "ll"
@@ -71,6 +71,8 @@
 #define ARCH_riscv
 #elif defined(__loongarch_lp64)
 #define ARCH_loongarch64
+#elif defined(__e2k__)
+#define ARCH_e2k
 #else
 #error Unknown CPU architecture using the linux OS
 #endif
@@ -118,7 +120,7 @@
 #define U48H_FMT "0x%012llx"
 #define U64D_FMT_GEN "llu"
 #endif
-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
+#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64) || defined(ARCH_e2k)
 #define U64D_FMT "%lu"
 #define U64H_FMT "0x%016lx"
 #define U48H_FMT "0x%012lx"

--- a/mtcr_ul/packets_common.h
+++ b/mtcr_ul/packets_common.h
@@ -154,6 +154,8 @@
 #define ARCH_riscv
 #elif defined(__loongarch_lp64)
 #define ARCH_loongarch64
+#elif defined(__e2k__)
+#define ARCH_e2k
 #else
 #error Unknown CPU architecture using the linux OS
 #endif

--- a/tools_layouts/adb_to_c_utils.h
+++ b/tools_layouts/adb_to_c_utils.h
@@ -148,6 +148,8 @@ extern "C"
 #define ARCH_riscv
 #elif defined(__loongarch_lp64)
 #define ARCH_loongarch64
+#elif defined(__e2k__)
+#define ARCH_e2k
 #else
 #error Unknown CPU architecture using the linux OS
 #endif
@@ -190,7 +192,7 @@ extern "C"
 #define U64H_FMT "0x%016llx"
 #define U48H_FMT "0x%012llx"
 #endif
-#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64)
+#elif defined(ARCH_ia64) || defined(ARCH_x86_64) || defined(ARCH_ppc64) || defined(ARCH_arm64) || defined(ARCH_riscv) || defined(ARCH_loongarch64) || defined(ARCH_e2k)
 #define U64D_FMT "%lu"
 #define U64H_FMT "0x%016lx"
 #define U48H_FMT "0x%012lx"


### PR DESCRIPTION
Add new architecture e2k. Patch has been tested on linux e2k. For full support, please update two files:
config/config.guess
config/config.sub
from official resource: https://www.gnu.org/software/gettext/manual/html_node/config_002eguess.html