### PR TITLE
mflash: Fix build failure

### DIFF
--- a/mflash/mflash_dev_capability.c
+++ b/mflash/mflash_dev_capability.c
@@ -40,6 +40,7 @@
  */
 
 #include "mflash_dev_capability.h"
+#include <stdlib.h>
 
 // When (*status != MFE_OK) return value is undefined
 int is_four_byte_address_needed(mflash* mfl, MfError* status)


### PR DESCRIPTION
Fix the following failure:

mflash_dev_capability.c:43:1: note: 'getenv' is defined in header '<stdlib.h>';
	did you forget to '#include <stdlib.h>'?
   42 | #include "mflash_dev_capability.h"
  +++ |+#include <stdlib.h>
   43 |