### PR TITLE
Fix build of mstflint_access on recent kernels (>= 6.4)

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -1650,7 +1650,11 @@ static struct mst_dev_data* mst_device_create(enum dev_type type, struct pci_dev
 
     if (alloc_chrdev_region(&dev->my_dev, 0, 1, dev->name))
         mst_err("failed to allocate chrdev_region\n");
+#if KERNEL_VERSION(6, 4, 0) >= LINUX_VERSION_CODE
+    dev->cl = class_create(dev->name);
+#else
     dev->cl = class_create(THIS_MODULE, dev->name);
+#endif
     if (dev->cl == NULL)
     {
         pr_alert("Class creation failed\n");


### PR DESCRIPTION
fix build of mstflint_access on recent kernels (>= 6.4)