### PR TITLE
kernel module: fix wrong comparison order

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -1650,7 +1650,7 @@ static struct mst_dev_data* mst_device_create(enum dev_type type, struct pci_dev
 
     if (alloc_chrdev_region(&dev->my_dev, 0, 1, dev->name))
         mst_err("failed to allocate chrdev_region\n");
-#if KERNEL_VERSION(6, 4, 0) >= LINUX_VERSION_CODE
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
     dev->cl = class_create(dev->name);
 #else
     dev->cl = class_create(THIS_MODULE, dev->name);


### PR DESCRIPTION
I got the comparison order somehow messed up in my last PR.