### PR TITLE
fix cross-compilation check for boost::regex

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -505,8 +505,11 @@ AC_RUN_IFELSE([
     AC_MSG_RESULT([yes])
 ],[
     AC_MSG_RESULT([no])
-    AC_MSG_NOTICE([std::regex support appears to be incomplete, fallback to GNU C regex])
+    AC_MSG_NOTICE([std::regex support appears to be incomplete; falling back to GNU C regex.])
     AC_DEFINE([USE_STDLIB_REGEX], [1], [Whether to use GNU C regex])
+],[
+    AC_MSG_RESULT([yes])
+    AC_MSG_WARN([Assuming the cross-compiler has complete support for std::regex functionality. VERIFY BEFORE USING!!!])
 ])
 AC_LANG_POP([C++])
 


### PR DESCRIPTION
When cross-compiling (e.g. from x86-64 to ARM64), the test binary used here for std::regex functionality testing does not work. It gets either compiled for the host architecture which means nothing, does not compile at all or is not executable on the host architecture in most cases, when compiled for ARM64.