### PR TITLE
Fix cross-compilation for the musl toolchain

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AM_CONDITIONAL(X86_64_BUILD, [ echo $build_cpu | grep -iq "x86_64" ])
 
 dnl Checks for headers
 AC_CHECK_HEADER(termios.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_TERMIOS_H"])
+AC_CHECK_HEADER(sys/pci.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_SYS_PCI_H"])
 TOOLS_CRYPTO=""
 MAD_IFC=""
 FW_MGR_TOOLS=""

--- a/configure.ac
+++ b/configure.ac
@@ -487,28 +487,30 @@ AM_CONDITIONAL(LINUX_BUILD, [test  "x$OS" = "xLinux"])
 AC_SUBST(LINUX_BUILD)
 AC_SUBST(LINUX_KERNEL_INCLUDE)
 
-# Certain older compilers may not fully support std::regex.
-# Signatuire is: the code compiles without issues, then it
-# crashes during runtime with:
-# terminate called after throwing an instance of 'std::regex_error'
-#  what():  regex_error
-# For those we resort to using GNU C regex as a fallback.
-AC_MSG_CHECKING([for std::regex compatibility])
-AC_LANG_PUSH([C++])
-AC_RUN_IFELSE([
-    AC_LANG_PROGRAM(
-        [[#include <regex>
-        ]],
-        [[std::regex e("[a-z]");]]
-    )
-],[
-    AC_MSG_RESULT([yes])
-],[
-    AC_MSG_RESULT([no])
-    AC_MSG_NOTICE([std::regex support appears to be incomplete, fallback to GNU C regex])
-    AC_DEFINE([USE_STDLIB_REGEX], [1], [Whether to use GNU C regex])
-])
-AC_LANG_POP([C++])
+if test "$cross_compiling" = "no"; then
+  # Certain older compilers may not fully support std::regex.
+  # Signatuire is: the code compiles without issues, then it
+  # crashes during runtime with:
+  # terminate called after throwing an instance of 'std::regex_error'
+  #  what():  regex_error
+  # For those we resort to using GNU C regex as a fallback.
+  AC_MSG_CHECKING([for std::regex compatibility])
+  AC_LANG_PUSH([C++])
+  AC_RUN_IFELSE([
+      AC_LANG_PROGRAM(
+          [[#include <regex>
+          ]],
+          [[std::regex e("[a-z]");]]
+      )
+  ],[
+      AC_MSG_RESULT([yes])
+  ],[
+      AC_MSG_RESULT([no])
+      AC_MSG_NOTICE([std::regex support appears to be incomplete, fallback to GNU C regex])
+      AC_DEFINE([USE_STDLIB_REGEX], [1], [Whether to use GNU C regex])
+  ])
+  AC_LANG_POP([C++])
+fi
 
 # we assume that project root may have a tools_git_sha
 TOOLS_GIT_SHA=$(cd $(dirname "$0"); ./eval_git_sha.sh)

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -85,7 +85,11 @@
 
 #if CONFIG_ENABLE_MMAP
 #include <sys/mman.h>
+#ifdef HAVE_SYS_PCI_H
 #include <sys/pci.h>
+#else
+#include <linux/pci.h>
+#endif
 #include <sys/ioctl.h>
 #endif
 


### PR DESCRIPTION
1. Commit a59f405:

The configure script compiles and runs a simple program to check for <code>std::regex</code> compatibility. But this is not possible while cross-compiling and returns an error message:
<code>configure: error: cannot run test program while cross compiling</code>

This patch only checks for std::regex compatibility if we are currently not cross-compiling.
<br>

2. Commit e10eea1:

The musl toolchain doesn't have <code><sys/pci.h></code>, only <code><linux/pci.h></code>, resulting in a compilation error. This patch checks if <code><sys/pci.h></code> is present and alternatively uses <code><linux/pci.h></code> if not.

I can also think of two alternatives for fixing this:
- <code>autoheader</code> could generate the macro when using <code>AC_CHECK_HEADERS</code> (e.g., like with <code>expat.h</code>, <code>infiniband/mlx5dv.h</code>, ...)
- Since <code><sys/pci.h></code> seems to be just a wrapper around <code><linux/pci.h></code>, <code><linux/pci.h></code> could just replace it

<br>
The cross-compilation was tested on Ubuntu 23.10 using OpenWrt's musl toolchain.<br>
The run was tested on a Mellanox Spectrum SN2100 running OpenWrt.