### PR TITLE
fallback to <linux/pci.h> if <sys/pci.h> isn't available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,7 @@ AM_CONDITIONAL(X86_64_BUILD, [ echo $build_cpu | grep -iq "x86_64" ])
 
 dnl Checks for headers
 AC_CHECK_HEADER(termios.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_TERMIOS_H"])
+AC_CHECK_HEADER(sys/pci.h,[CXXFLAGS="${CXXFLAGS} -DHAVE_SYS_PCI_H"])
 TOOLS_CRYPTO=""
 MAD_IFC=""
 FW_MGR_TOOLS=""

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -85,7 +85,11 @@
 
 #if CONFIG_ENABLE_MMAP
 #include <sys/mman.h>
+#ifdef HAVE_SYS_PCI_H
 #include <sys/pci.h>
+#else
+#include <linux/pci.h>
+#endif
 #include <sys/ioctl.h>
 #endif
 


### PR DESCRIPTION
The musl toolchain doesn't have <code><sys/pci.h></code>, only <code><linux/pci.h></code>, resulting in a compilation error. This patch checks if <code><sys/pci.h></code> is present and alternatively uses <code><linux/pci.h></code> if not.

I can also think of two alternatives for fixing this:
- <code>autoheader</code> could generate the macro when using <code>AC_CHECK_HEADERS</code> (e.g., like with <code>expat.h</code>, <code>infiniband/mlx5dv.h</code>, ...)
- Since <code><sys/pci.h></code> seems to be just a wrapper around <code><linux/pci.h></code>, <code><linux/pci.h></code> could just replace it

<br>
The cross-compilation was tested on Ubuntu 23.10 using OpenWrt's musl toolchain.<br>
The run was tested on a Mellanox Spectrum SN2100 running OpenWrt.