### PR TITLE
Replace uses of auto_ptr with unique_ptr.

### DIFF
--- a/ext_libs/muparser/muParserBase.h
+++ b/ext_libs/muparser/muParserBase.h
@@ -264,7 +264,7 @@ private:
     mutable stringbuf_type m_vStringBuf; ///< String buffer, used for storing string function arguments
     stringbuf_type m_vStringVarBuf;
 
-    std::auto_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
+    std::unique_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
 
     funmap_type m_FunDef;       ///< Map of function names and pointers.
     funmap_type m_PostOprtDef;  ///< Postfix operator callbacks

--- a/ext_libs/muparser/muParserTest.cpp
+++ b/ext_libs/muparser/muParserTest.cpp
@@ -1251,7 +1251,7 @@ int ParserTester::EqnTest(const string_type& a_str, double a_fRes, bool a_fPass)
 
     try
     {
-        std::auto_ptr<Parser> p1;
+        std::unique_ptr<Parser> p1;
         Parser p2, p3; // three parser objects
                        // they will be used for testing copy and assignment operators
         // p1 is a pointer since i'm going to delete it in order to test if

--- a/ext_libs/muparser/muParserToken.h
+++ b/ext_libs/muparser/muParserToken.h
@@ -68,7 +68,7 @@ private:
     TString m_strTok;  ///< Token string
     TString m_strVal;  ///< Value for string variables
     value_type m_fVal; ///< the value
-    std::auto_ptr<ParserCallback> m_pCallback;
+    std::unique_ptr<ParserCallback> m_pCallback;
 
 public:
     //---------------------------------------------------------------------------

--- a/ext_libs/muparser/muParserTokenReader.cpp
+++ b/ext_libs/muparser/muParserTokenReader.cpp
@@ -145,7 +145,7 @@ ParserTokenReader::ParserTokenReader(ParserBase* a_pParent) :
 */
 ParserTokenReader* ParserTokenReader::Clone(ParserBase* a_pParent) const
 {
-    std::auto_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
+    std::unique_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
     ptr->SetParent(a_pParent);
     return ptr.release();
 }


### PR DESCRIPTION
The auto_ptr type was removed in C++17, and Clang/libc++ do stop providing it.

This cherry-picks muparser's commit from 6 years ago: https://github.com/beltoforion/muparser/commit/61c0969efb36e4c5e22565f41e05364c8f5a92e7