### PR TITLE
a few modifications to mlxfwreset

### DIFF
--- a/small_utils/mlxfwresetlib/cmd_reg_mcam.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mcam.py
@@ -70,6 +70,21 @@ class CmdRegMcam():
             pci_rescan_required_sup = extractField(mcam_get_result["mng_feature_cap_mask"][3 - 1], 13, 1)
         return True if pci_rescan_required_sup == 1 else False
 
+    def is_reset_by_fw_driver_sync_supported(self):
+        """
+        Read MCAM and check if the feature "reset by fw-driver sync" is supported
+        """
+        try:
+            mcam_get_result = self.get_mcam()
+        except RegAccException as e:
+            pci_sync_for_fw_update_sup = 0
+        else:
+            # bit 19 in 1st DWORD.
+            # due to FW bug, MCAM mng_feature_cap_mask dwords are set in reversed order
+            # so we actually access the 4th DWORD (index 3)
+            pci_sync_for_fw_update_sup = extractField(mcam_get_result["mng_feature_cap_mask"][3 - 0], 19, 1)
+        return True if pci_sync_for_fw_update_sup == 1 else False
+
     def is_mrsi_supported(self):
         """
         send MCAM access_reg_group=2
@@ -85,21 +100,6 @@ class CmdRegMcam():
             # so we actually access the 3rd DWORD (index 2)
             mrsi_sup = extractField(mcam_get_result["mng_access_reg_cap_mask"][3 - 1], 10, 1)
         return True if mrsi_sup == 1 else False
-
-    def is_reset_by_fw_driver_sync_supported(self):
-        """
-        Read MCAM and check if the feature "reset by fw-driver sync" is supported
-        """
-        try:
-            mcam_get_result = self.get_mcam()
-        except RegAccException as e:
-            pci_sync_for_fw_update_sup = 0
-        else:
-            # bit 19 in 1st DWORD.
-            # due to FW bug, MCAM mng_feature_cap_mask dwords are set in reversed order
-            # so we actually access the 4th DWORD (index 3)
-            pci_sync_for_fw_update_sup = extractField(mcam_get_result["mng_feature_cap_mask"][3 - 0], 19, 1)
-        return True if pci_sync_for_fw_update_sup == 1 else False
 
     def reset_sync_query_text(self, tool_owner_support):
         result = ""

--- a/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
@@ -53,7 +53,14 @@ class CmdRegMfrl():
         {'type': NIC_ONLY, 'description': 'NIC only reset (for SoC devices)', 'mask': 0x4}
     ]
 
+    RESET_STATE_ERROR_NEGOTIATION_TIMEOUT = 3
+    RESET_STATE_ERROR_NEGOTIATION_DIS_ACK = 4
     RESET_STATE_ARM_OS_SHUTDOWN_IN_PROGRESS = 7
+
+    RESET_STATE_ERRORS = {
+        RESET_STATE_ERROR_NEGOTIATION_TIMEOUT: "The BF reset flow encountered a failure due to a reset state error of negotiation timeout",
+        RESET_STATE_ERROR_NEGOTIATION_DIS_ACK: "The BF reset flow encountered a failure due to a reset state error of negotiation dis-acknowledgment"
+    }
 
     @classmethod
     def descriptions(cls):
@@ -250,8 +257,16 @@ class CmdRegMfrl():
     def is_default_reset_level(self, reset_level):
         return reset_level == self.default_reset_level()
 
+    def is_reset_state_in_error(self):
+        self.logger.debug("reset_state_error={}".format(self._reset_state))
+        if self._reset_state in CmdRegMfrl.RESET_STATE_ERRORS:
+            raise Exception(CmdRegMfrl.RESET_STATE_ERRORS[self._reset_state])
+
     def is_reset_state_in_progress(self):
         return True if self._reset_state == CmdRegMfrl.RESET_STATE_ARM_OS_SHUTDOWN_IN_PROGRESS else False
+
+    def is_arm_reset(self, reset_type):
+        return False if reset_type in [CmdRegMfrl.PHY_LESS, CmdRegMfrl.NIC_ONLY] else True
 
     def read(self):
         # Read register ('get' command) from device

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -123,8 +123,7 @@ MLNX_DEVICES = [
 # Supported devices.
 SUPP_DEVICES = ["ConnectIB", "ConnectX4", "ConnectX4LX", "ConnectX5", "BlueField",
                 "ConnectX6", "ConnectX6DX", "ConnectX6LX", "BlueField2", "ConnectX7", "BlueField3", "ConnectX8", "BlueField4"]
-SUPP_SWITCH_DEVICES = ["Spectrum", "Spectrum-2", "Spectrum-3", "Spectrum-4",
-                       "Switch-IB", "Switch-IB-2", "Quantum", "Quantum-2", "Quantum-3"]
+SUPP_SWITCH_DEVICES = ["Spectrum", "Spectrum-2", "Spectrum-3", "Switch-IB", "Switch-IB-2", "Quantum", "Quantum-2"]
 SUPP_OS = ["FreeBSD", "Linux", "Windows"]
 
 IS_MSTFLINT = os.path.basename(__file__) == "mstfwreset.py"
@@ -805,13 +804,27 @@ class MlnxPciOpFactory(object):
         else:
             raise RuntimeError("Unsupported OS: %s" % operatingSystem)
 
+
+def CloseAndMstRestart(lspci_valdation=True):
+    # We close MstDevObj to allow a clean operation of mst restart
+    MstDevObj.close()
+    for MstDevObjSD in MstDevObjsSD:
+        MstDevObjSD.close()
+
+    if SkipMstRestart == False and platform.system() == "Linux" and not IS_MSTFLINT:
+        printAndFlush("-I- %-40s-" % ("Restarting MST"), endChar="")
+        if mstRestart(lspci_valdation) == 0:
+            printAndFlush("Done")
+        else:
+            printAndFlush("Skipped")
+
 ######################################################################
 # Description:  Perform mst restart
 # OS Support :  Linux.
 ######################################################################
 
 
-def mstRestart(busId):
+def mstRestart(lspci_valdation):
     global MstFlags
     if platform.system() == "FreeBSD" or platform.system() == "Windows":
         return 1
@@ -833,22 +846,23 @@ def mstRestart(busId):
         else:
             time.sleep(2)
 
-    cmd = "lspci -s %s" % busId
-    logger.debug('Execute {0}'.format(cmd))
-    foundBus = False
-    rc = 0
-    for _ in range(0, 30):
-        (rc, stdout, _) = cmdExec(cmd)
-        if rc == 0 and stdout != "":
-            foundBus = True
-            break
-        else:
-            time.sleep(2)
-    if rc != 0:
-        raise WarningException(
-            "Failed to run lspci command, please restart MST manually")
-    if not foundBus:
-        raise RuntimeError("The device is not appearing in lspci output!")
+    if lspci_valdation is True:
+        cmd = "lspci -s %s" % DevDBDF
+        logger.debug('Execute {0}'.format(cmd))
+        foundBus = False
+        rc = 0
+        for _ in range(0, 30):
+            (rc, stdout, _) = cmdExec(cmd)
+            if rc == 0 and stdout != "":
+                foundBus = True
+                break
+            else:
+                time.sleep(2)
+        if rc != 0:
+            raise WarningException(
+                "Failed to run lspci command, please restart MST manually")
+        if not foundBus:
+            raise RuntimeError("The device is not appearing in lspci output!")
 
     ignore_signals()
     cmd = "/etc/init.d/mst restart %s" % MstFlags
@@ -1634,17 +1648,8 @@ def resetFlow(device, devicesSD, reset_level, reset_type, cmdLineArgs, mfrl):
         logger.debug('UpdateUptimeAfterReset')
         FWResetStatusChecker.UpdateUptimeAfterReset()
 
-        # we close MstDevObj to allow a clean operation of mst restart
-        MstDevObj.close()
-        for MstDevObjSD in MstDevObjsSD:  # Roei close mst devices for all "other" devices
-            MstDevObjSD.close()
+        CloseAndMstRestart()
 
-        if SkipMstRestart == False and platform.system() == "Linux" and not IS_MSTFLINT:
-            printAndFlush("-I- %-40s-" % ("Restarting MST"), endChar="")
-            if mstRestart(DevDBDF) == 0:
-                printAndFlush("Done")
-            else:
-                printAndFlush("Skipped")
     except Exception as e:
         reset_fsm_register()
         printAndFlush("Failed")
@@ -1753,6 +1758,8 @@ def check_if_shut_down_in_progress(mfrl):
     except BaseException:
         pass
     else:
+        mfrl.is_reset_state_in_error()
+
         if mfrl.is_reset_state_in_progress() is True:
             print("Arm OS shut down in progress, the completion of the process may take several minutes.")
             res = True
@@ -1783,6 +1790,11 @@ def execute_driver_sync_reset(mfrl, reset_level, reset_type):
         time.sleep(1)
         logger.debug('UpdateUptimeAfterReset')
         FWResetStatusChecker.UpdateUptimeAfterReset()
+
+        # When Hotplug is activated, resetting the device causes the bdf to change.
+        # As a result, running lspci on the previously known bdf will not be successful due to the altered bdf.
+        # Running mst restart is necessary to re-enumerate the mst devices.
+        CloseAndMstRestart(lspci_valdation=False)
 
 ######################################################################
 # Description:  execute sync 1 reset for BF
@@ -2074,7 +2086,9 @@ def reset_flow_host(device, args, command):
             print("-W- PCI rescan is required after device reset.")
 
         if is_bluefield:
-            print("Please be aware that resetting the Bluefield may take several minutes. Exiting the process in the middle of the waiting period will not halt the reset")
+            print("Please be aware that resetting the Bluefield may take several minutes. Exiting the process in the middle of the waiting period will not halt the reset.")
+            if mfrl.is_arm_reset(reset_type):
+                print("The ARM side will be restarted, and it will be unavailable for a while.")
 
         AskUser("Continue with reset", args.yes)
         execResLvl(device, devicesSD, reset_level,


### PR DESCRIPTION
mlxfwreset | issue 1: remove unsupported switches that doesn't support MRSR-1

Description:
The supported switches for MRSR-1 that are already supported in mlxfwreset: Spectrum, Spectrum-2, Spectrum-3, Switch-IB, Switch-IB-2, Quantum,  Quantum-2. The supported switches for MRSR-6 that have not been implemented yet and need to be addressed with a new feature request: Quantum-3, Spectrum-4 and above

mlxfwreset | new feature: Identify that we are in Controller mode and inform the user about it

Description:
The purpose of this feature is to give users an indication of what will happen when they execute the reset flow using mlxfwreset while the BF is in controller mode.

When a full chip reset is triggered, and there are no additional hosts except for the ARM itself (especially in controller mode), the ARM will reset the entire DPU. This includes an ARM reset, and it immediately initiates an ARM OS shutdown. During this process, the setup will be unavailable for some time, which the user may not expect.

The solution is to check the reset type:
The message will not printed to the user when the reset type is bit 1 ("Keep network port active during reset") or bit 2("NIC only reset for SoC devices").

mlxfwreset | issue 2: Adding mst restart after reset with sync 1.

Description:
When Hotplug is activated, resetting the device causes the bdf to change. As a result, running lspci on the previously known bdf will not be successful due to the altered bdf. Running mst restart is necessary to re-enumerate the mst devices.