### PR TITLE
[mlxlink] - Product Technology - changed to be read from SLTP instead…

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -258,29 +258,21 @@ u_int32_t MlxlinkCommander::getTechnologyFromMGIR()
 
 void MlxlinkCommander::getProductTechnology()
 {
-    _productTechnology = getTechnologyFromMGIR();
-
-    if (_productTechnology)
+    // Use SLRG to get the product technology, for backward compatibility
+    try
     {
+        sendPrmReg(ACCESS_REG_SLTP, GET);
+        _productTechnology = getVersion(getFieldValue("version"));
         if (_productTechnology <= 2)
         {
             _productTechnology = PRODUCT_28NM;
         }
     }
-    else
+    catch (MlxRegException& exc)
     {
-        // Use SLRG to get the product technology, for backward compatibility
-        try
+        if (!_productTechnology)
         {
-            sendPrmReg(ACCESS_REG_SLRG, GET);
-            _productTechnology = getVersion(getFieldValue("version"));
-        }
-        catch (MlxRegException& exc)
-        {
-            if (!_productTechnology)
-            {
-                throw MlxRegException("Unable to get product technology: %s", exc.what_s().c_str());
-            }
+            throw MlxRegException("Unable to get product technology: %s", exc.what_s().c_str());
         }
     }
 }


### PR DESCRIPTION
… of MGIR

Description: requested by FR, since MGIR returned the wrong value for NDR SP4 We changed it first to SLRG - but this register has a FW bug when running in 25G per lane or less. So switched to SLTP.

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 3706030
Issue: 3747125