### PR TITLE
[mlxlink] [Patch-2] Adding support for plane view

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -39,7 +39,6 @@ using namespace mlxreg;
 MlxlinkCommander::MlxlinkCommander() : _userInput()
 
 {
-    _device = "";
     _extAdbFile = "";
     _localPort = 0;
     _portType = 0;
@@ -47,7 +46,7 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _numOfLanesPcie = 0;
     _linkUP = false;
     _plugged = false;
-    _linkModeForce = false;
+    _userInput._linkModeForce = false;
     _prbsTestMode = false;
     _useExtAdb = true;
     _portPolling = false;
@@ -63,8 +62,6 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _cableMediaType = 0;
     _moduleNumber = 0;
     _slotIndex = 0;
-    _uniqueCmds = 0;
-    _networkCmds = 0;
     _activeSpeed = 0;
     _activeSpeedEx = 0;
     _protoCapability = 0;
@@ -93,8 +90,6 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _errInjector = NULL;
     _portInfo = NULL;
     _amberCollector = NULL;
-    _uniqueCableCmds = 0;
-    _uniquePcieCmds = 0;
     _groupOpcode = MONITOR_OPCODE;
 }
 
@@ -878,14 +873,6 @@ u_int32_t MlxlinkCommander::calculatePanelPort(bool ibSplitReady)
     return panelPort;
 }
 
-void MlxlinkCommander::checkStrLength(const string& str)
-{
-    if (str.size() > MAX_INPUT_LENGTH)
-    {
-        throw MlxRegException("Argument: %s... is invalid.", str.substr(0, MAX_INPUT_LENGTH).c_str());
-    }
-}
-
 void MlxlinkCommander::getActualNumOfLanes(u_int32_t linkSpeedActive, bool extended)
 {
     if (_protoActive == IB)
@@ -1014,42 +1001,6 @@ bool MlxlinkCommander::checkPpaosTestMode()
         return true;
     }
     return false;
-}
-
-void MlxlinkCommander::getSltpParamsFromVector(std::vector<string> sltpParams)
-{
-    for (u_int32_t i = 0; i < sltpParams.size(); i++)
-    {
-        strToInt32((char*)sltpParams[i].c_str(), _userInput._sltpParams[i]);
-    }
-}
-
-std::vector<string> MlxlinkCommander::parseParamsFromLine(const string& ParamsLine)
-{
-    std::vector<string> paramVector;
-    string param;
-    stringstream stream(ParamsLine);
-    while (getline(stream, param, ','))
-    {
-        if (param == "")
-        {
-            throw MlxRegException("Wrong input format");
-        }
-        paramVector.push_back(param.c_str());
-    }
-    return paramVector;
-}
-
-void MlxlinkCommander::getprbsLanesFromParams(std::vector<string> prbsLanesParams)
-{
-    u_int32_t lane = 0;
-    vector<string>::iterator it = prbsLanesParams.begin();
-    while (it != prbsLanesParams.end())
-    {
-        strToUint32((char*)(*it).c_str(), lane);
-        _userInput._prbsLanesToSet[lane] = true;
-        it++;
-    }
 }
 
 bool MlxlinkCommander::handleIBLocalPort(u_int32_t labelPort, bool ibSplitReady)
@@ -1700,7 +1651,7 @@ void MlxlinkCommander::preparePrtlSection()
 {
     if (_userInput._advancedMode)
     {
-        char rttFrmt[64];
+        char rttFrmt[64] = "";
         bool isRttSupported = false;
         u_int16_t asicLatency = 0;
         u_int16_t moduleLatency = 0;
@@ -1867,16 +1818,6 @@ string MlxlinkCommander::getValueAndThresholdsStr(T value, Q lowTH, Q highTH)
         out << "N/A";
     }
     return out.str();
-}
-
-void MlxlinkCommander::strToInt32(char* str, u_int32_t& value)
-{
-    char* endp;
-    value = strtol(str, &endp, 0);
-    if (*endp)
-    {
-        throw MlxRegException("Argument: %s is invalid.", str);
-    }
 }
 
 void MlxlinkCommander::runningVersion()
@@ -3617,7 +3558,8 @@ void MlxlinkCommander::sendPaosDown(bool toggleCommand)
                 string message = "port is not Down, for some reasons:\n";
                 message +=
                   "1- The link is configured to be up, run this command if KEEP_" + protocol + "_LINK_UP_Px is True:\n";
-                message += "   mlxconfig -d " + _device + " set KEEP_" + protocol + "_LINK_UP_P<port_number>=0\n";
+                message +=
+                  "   mlxconfig -d " + _userInput._device + " set KEEP_" + protocol + "_LINK_UP_P<port_number>=0\n";
                 message += "2- Port management is enabled (management protocol requiring the link to remain up, PAOS "
                            "won't manage to disable the port)\n";
                 message += "3- In case of multi-host please verify all hosts are not holding the port up";
@@ -3924,7 +3866,7 @@ void MlxlinkCommander::resetPprtPptt()
 void MlxlinkCommander::validateSpeedStr()
 {
     // Normalize IB speeds (Ignore IB- from infiniband speeds)
-    for (vector<string>::iterator it = _ptysSpeeds.begin(); it != _ptysSpeeds.end(); it++)
+    for (vector<string>::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++)
     {
         size_t found = (*it).find("IB-");
         if (found != std::string::npos)
@@ -3944,7 +3886,7 @@ void MlxlinkCommander::validateSpeedStr()
     string speedToCheck = "";
     size_t fromIndex = 0;
     size_t toIndex = 0;
-    for (vector<string>::iterator it = _ptysSpeeds.begin(); it != _ptysSpeeds.end(); it++)
+    for (vector<string>::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++)
     {
         fromIndex = validSpeedStr.find(*it);
         toIndex = validSpeedStr.find_first_of(',', fromIndex);
@@ -3958,7 +3900,7 @@ void MlxlinkCommander::validateSpeedStr()
         }
     }
 
-    if (isIn(string("56G"), _ptysSpeeds) && _linkModeForce == true)
+    if (isIn(string("56G"), _userInput._ptysSpeeds) && _userInput._linkModeForce == true)
     {
         throw MlxRegException("No support of 56G FORCE mode");
     }
@@ -3980,11 +3922,11 @@ void MlxlinkCommander::sendPtys()
         u_int32_t ptysMask = 0x0;
         string ptysExtraCmd = "";
         string protoAdminField = "";
-        for (u_int32_t i = 0; i < _ptysSpeeds.size(); i++)
+        for (u_int32_t i = 0; i < _userInput._ptysSpeeds.size(); i++)
         {
-            ptysMask |= ptysSpeedToMask(_ptysSpeeds[i]);
+            ptysMask |= ptysSpeedToMask(_userInput._ptysSpeeds[i]);
         }
-        if (_linkModeForce == true)
+        if (_userInput._linkModeForce == true)
         {
             gearboxBlock(PTYS_LINK_MODE_FORCE_FLAG);
 
@@ -3992,7 +3934,7 @@ void MlxlinkCommander::sendPtys()
         }
         if (_protoActive == IB)
         {
-            if (_linkModeForce == false)
+            if (_userInput._linkModeForce == false)
             {
                 ptysMask |= 0x1;
             }
@@ -5196,7 +5138,7 @@ void MlxlinkCommander::setAmBerCollectorFields()
     _amberCollector->_isHca = _isHCA;
     _amberCollector->_devID = _devID;
     _amberCollector->_productTechnology = _productTechnology;
-    _amberCollector->_mstDevName = _device;
+    _amberCollector->_mstDevName = _userInput._device;
 }
 
 void MlxlinkCommander::initAmBerCollector()

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -515,10 +515,10 @@ public:
     // Mlxlink config functions
     void clearCounters();
     void sendPaos();
-    void handlePrbs();
+    virtual void handlePrbs();
     void sendPtys();
     virtual void sendPplm();
-    void sendSltp();
+    virtual void sendSltp();
     void sendPplr();
     void sendPepc();
     void setTxGroupMapping();

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -378,9 +378,6 @@ public:
     bool checkGBPpaosDown();
     bool checkPaosDown();
     bool checkPpaosTestMode();
-    void getSltpParamsFromVector(std::vector<string> sltpParams);
-    void getprbsLanesFromParams(std::vector<string> prbsLanesParams);
-    std::vector<string> parseParamsFromLine(const string& ParamsLine);
     bool isSpect2WithGb();
     bool isIbLocalPortValid(u_int32_t localPort);
     void fillIbPortGroupMap(u_int32_t localPort, u_int32_t labelPort, u_int32_t group, bool splitReady);
@@ -430,7 +427,6 @@ public:
     void preparePowerAndCdrSection(bool valid);
     void prepareDDMSection(bool valid, bool isModuleExtSupported);
     virtual void preparePrtlSection();
-    void strToInt32(char* str, u_int32_t& value);
     template<typename T, typename Q>
     string getValueAndThresholdsStr(T value, Q lowTH, Q highTH);
     string getSltpFieldStr(const PRM_FIELD& field);
@@ -578,10 +574,6 @@ public:
     u_int32_t _cableMediaType;
     u_int32_t _fecActive;
     u_int32_t _protoActive;
-    u_int32_t _uniqueCmds;
-    u_int32_t _uniqueCableCmds;
-    u_int32_t _uniquePcieCmds;
-    u_int32_t _networkCmds;
     u_int32_t _anDisable;
     u_int32_t _speedBerCsv;
     u_int32_t _cableIdentifier;
@@ -600,7 +592,6 @@ public:
     u_int32_t _linkSpeed;
     u_int32_t _groupOpcode;
     string _extAdbFile;
-    string _device;
     string _fwVersion;
     string _speedStrG;
     string _speedForce;
@@ -623,7 +614,6 @@ public:
     bool _ignorePortStatus;
     bool _isGboxPort;
     bool _ignoreIbFECCheck;
-    std::vector<std::string> _ptysSpeeds;
     std::vector<PortGroup> _localPortsPerGroup;
     std::vector<DPN> _validDpns;
     string _allUnhandledErrors;

--- a/mlxlink/modules/mlxlink_reg_parser.cpp
+++ b/mlxlink/modules/mlxlink_reg_parser.cpp
@@ -43,6 +43,7 @@ MlxlinkRegParser::MlxlinkRegParser() : RegAccessParser("", "", "", NULL, 0)
     _localPort = 0;
     _portType = 0;
     _pnat = 0;
+    _planeInd = -1;
 
     _isHCA = false;
 }

--- a/mlxlink/modules/mlxlink_reg_parser.cpp
+++ b/mlxlink/modules/mlxlink_reg_parser.cpp
@@ -36,8 +36,8 @@
 
 MlxlinkRegParser::MlxlinkRegParser() : RegAccessParser("", "", "", NULL, 0)
 {
-    _mf = NULL;
-    _regLib = NULL;
+    _mf = nullptr;
+    _regLib = nullptr;
     _gvmiAddress = 0;
 
     _localPort = 0;

--- a/mlxlink/modules/mlxlink_reg_parser.h
+++ b/mlxlink/modules/mlxlink_reg_parser.h
@@ -72,6 +72,7 @@ public:
     u_int32_t _localPort;
     u_int32_t _pnat;
     u_int32_t _portType;
+    int _planeInd;
     bool _isHCA;
 };
 

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -78,16 +78,6 @@ void MlxlinkUi::initRegAccessLib()
     _mlxlinkCommander->_isHCA = dm_dev_is_hca(_mlxlinkCommander->_devID);
 }
 
-bool MlxlinkUi::isSwitch()
-{
-    return !_mlxlinkCommander->_isHCA;
-}
-
-bool MlxlinkUi::isPlaneSwitchDev()
-{
-    return (_mf->tp == MST_PLANARIZED);
-}
-
 void MlxlinkUi::initPortInfo()
 {
     _mlxlinkCommander->labelToLocalPort();

--- a/mlxlink/modules/mlxlink_ui.h
+++ b/mlxlink/modules/mlxlink_ui.h
@@ -47,7 +47,7 @@ public:
 
 protected:
     virtual void addCmd(OPTION_TYPE option);
-    virtual ParseStatus HandleOption(string name, string value);
+    ParseStatus HandleOption(string name, string value);
     virtual void printSynopsisHeader();
     virtual void printSynopsisQueries();
     virtual void printSynopsisCommands();
@@ -68,9 +68,22 @@ protected:
     virtual void validatePortInfoParams();
     virtual void paramValidate();
     virtual void createMlxlinkCommander();
+    virtual void initRegAccessLib();
+    virtual void initPortInfo();
+    virtual void initMlxlinkCommander();
+
+    void handlePortStr(UserInput& userInput, const string& portStr);
+    void strToInt32(char* str, u_int32_t& value);
+    std::vector<string> parseParamsFromLine(const string& paramsLine);
+    std::map<u_int32_t, u_int32_t> getSltpParamsFromVector(const string& paramsLine);
+    std::map<u_int32_t, bool> getprbsLanesFromParams(const string& paramsLine);
+    void checkStrLength(const string& str);
 
     CommandLineParser _cmdParser;
     std::vector<OPTION_TYPE> _sendRegFuncMap;
     MlxlinkCommander* _mlxlinkCommander;
+    UserInput _userInput;
+
+    mfile* _mf;
 };
 #endif /* MLXLINK_UI_H */

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -46,6 +46,11 @@ UserInput::UserInput()
     _pcieIndex = 0;
     _node = 0;
     _lane = 0;
+    _networkCmds = 0;
+    _uniqueCmds = 0;
+    _networkCmds = 0;
+    _uniqueCableCmds = 0;
+    _uniquePcieCmds = 0;
     _sendPrbs = false;
     _sendPprt = false;
     _sendPptt = false;
@@ -56,6 +61,7 @@ UserInput::UserInput()
     _sendPepcANMode = false;
     _pprtTuningTypeFlag = false;
     _toggle = true;
+    _linkModeForce = false;
     _pcie = false;
     _links = false;
     _showSltp = false;
@@ -78,6 +84,10 @@ UserInput::UserInput()
     _ddm = false;
     _write = false;
     _read = false;
+
+    _device = "";
+    _extAdbFile = "";
+    _logFile = "";
     _portType = "NETWORK";
     _paosCmd = "";
     _pplmFec = "";
@@ -103,7 +113,9 @@ UserInput::UserInput()
     _len = -1;
     _setGroup = -1;
     _showGroup = -1;
+    _slrgTestIterations = -1;
 
+    autoCsvName = false;
     eyeSelect = "";
     eyeSelectSpecified = false;
     measureTime = -1;

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -146,4 +146,6 @@ UserInput::UserInput()
     errorDuration = -1;
     injDelay = -1;
     dbdf = "";
+
+    planeIndex = -1;
 }

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -164,6 +164,8 @@ public:
     int injDelay;
     string dbdf;
     vector<string> parameters;
+
+    int planeIndex;
 };
 
 #endif /* MLXLINK_USER_INPUT_H */

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -55,6 +55,10 @@ public:
     u_int32_t _depth;
     u_int32_t _pcieIndex;
     u_int32_t _node;
+    u_int32_t _uniqueCmds;
+    u_int32_t _uniqueCableCmds;
+    u_int32_t _uniquePcieCmds;
+    u_int32_t _networkCmds;
     bool _sendPrbs;
     bool _sendPprt;
     bool _sendPptt;
@@ -65,6 +69,7 @@ public:
     bool _sendPepcANMode;
     bool _pprtTuningTypeFlag;
     bool _toggle;
+    bool _linkModeForce;
     bool _pcie;
     bool _links;
     bool _sendDepth;
@@ -88,7 +93,10 @@ public:
     bool _write;
     bool _read;
     bool gradeScanPerLane;
+    bool autoCsvName;
 
+    string _device;
+    string _extAdbFile;
     string _portType;
     string _paosCmd;
     string _pplmFec;
@@ -104,11 +112,14 @@ public:
     string _testMode;
     string _forceMode;
     string _anMode;
-    u_int32_t _iteration;
+    string _logFile;
     double _testTime;
     u_int32_t _feedbackIndex;
     u_int32_t _feedbackData;
+    u_int32_t _iteration;
     std::map<u_int32_t, u_int32_t> _sltpParams;
+    std::vector<std::string> _ptysSpeeds;
+    std::vector<string> _amberPagesStr;
     u_int32_t _lane;
     u_int32_t _gvmiAddress;
     vector<string> _bytesToWrite;
@@ -118,6 +129,7 @@ public:
     std::map<u_int32_t, bool> _prbsLanesToSet;
     int _setGroup;
     int _showGroup;
+    int _slrgTestIterations;
     vector<string> _labelPorts;
 
     string eyeSelect;


### PR DESCRIPTION
Description:
- Adding new flag (--plane) to the internal tool for plane view
- The default view will be aggregate view
- If the plane is provided then the tool will set plane_ind field
for all access reg requests

MSTFlint port needed: Yes
Tested OS: Linux64
Tested devices: NA
Tested flows: mlxlink --plane X

Known gaps (with RM ticket): NA

Issue: 3566234

















