### PR TITLE
[mlxlink] Fixing NDR modulation config in prbs testmode

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -3853,41 +3853,35 @@ void MlxlinkCommander::prbsConfiguration(const string& prbsReg,
                                          bool perLaneConfig,
                                          bool prbsPolInv)
 {
-    string rateToUpdate = prbsReg == "PPRT" ? "lane_rate_oper" : "lane_rate_admin";
-    string prbsExtraCmd = "";
+    const string rateToUpdate = (prbsReg == "PPRT") ? "lane_rate_oper" : "lane_rate_admin";
+
+    auto buildPrbsRegArgs = [&]() -> string
+    {
+        stringstream cmd;
+        if (prbsPolInv)
+        {
+            cmd << ",p=1";
+        }
+        if (laneRate >= PRBS_HDR && laneRate <= PRBS_XDR)
+        {
+            cmd << ",modulation=" << PRBS_PAM4_ENCODING;
+        }
+        cmd << ",e=" << enable << "," << rateToUpdate << "=" << laneRate << ",prbs_mode_admin=" << prbsMode;
+        return cmd.str();
+    };
+
     if (perLaneConfig)
     {
         for (const auto& lane : _userInput._prbsLanesToSet)
         {
-            prbsExtraCmd = "";
-            if (prbsPolInv)
-            {
-                prbsExtraCmd += ",p=1";
-            }
-
-            if (laneRate == PRBS_HDR)
-            {
-                prbsExtraCmd += ",modulation=" + to_string(PRBS_PAM4_ENCODING);
-            }
-
-            sendPrmReg(prbsReg, SET, "e=%d,%s=%d,prbs_mode_admin=%d,le=%d,lane=%d%s", enable, rateToUpdate.c_str(),
-                       laneRate, prbsMode, perLaneConfig, lane.first, prbsExtraCmd.c_str());
+            const string prbsRegArgs = buildPrbsRegArgs();
+            sendPrmReg(prbsReg, SET, "le=%d,lane=%d%s", perLaneConfig, lane.first, prbsRegArgs.c_str());
         }
     }
     else
     {
-        prbsExtraCmd = "";
-        if (prbsPolInv)
-        {
-            prbsExtraCmd += ",p=1";
-        }
-        if (laneRate == PRBS_HDR)
-        {
-            prbsExtraCmd += ",modulation=" + to_string(PRBS_PAM4_ENCODING);
-        }
-
-        sendPrmReg(prbsReg, SET, "e=%d,%s=%d,prbs_mode_admin=%d%s", enable, rateToUpdate.c_str(), laneRate, prbsMode,
-                   prbsExtraCmd.c_str());
+        const string prbsRegArgs = buildPrbsRegArgs();
+        sendPrmReg(prbsReg, SET, prbsRegArgs.c_str());
     }
 }
 


### PR DESCRIPTION
Description:
Fixing NDR modulation config in prbs testmode

MSTFlint port needed: Yes
Tested OS: Linux64
Tested devices: QTM-2
Tested flows: mlxlink prbs test_mode

Known gaps (with RM ticket): NA

Issue: 3612477