### PR TITLE
[mlxlink] - mlxlink failed with '-E- Showing PDDR raised'

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -1938,9 +1938,14 @@ void MlxlinkCommander::operatingInfoPage()
                     getAnDisableColor(_anDisable), true, !_prbsTestMode);
 
         // Checking cable DDM capability
-        sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_MODULE_INFO_PAGE);
+        if (_userInput._networkCmds != 0 || _userInput._ddm || _userInput._dump || _userInput._write ||
+            _userInput._read || _userInput.isModuleConfigParamsProvided || _userInput.isPrbsSelProvided ||
+            _userInput._csvBer != "")
+        {
+            sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_MODULE_INFO_PAGE);
 
-        _ddmSupported = getFieldValue("temperature") && _numOfLanes;
+            _ddmSupported = getFieldValue("temperature") && _numOfLanes;
+        }
     }
     catch (const std::exception& exc)
     {


### PR DESCRIPTION
Description:
mlxlink failed with '-E- Showing PDDR raised the following exception: Failed to send access register: Bad parameter'
There is a problem that if the device doesn't support PDDR reg with select_page=3 the tool won't work, even though it dosn't need that info for all flags of mlxlink. Changing that the function will be called only for flags that need that informantion.

MSTFlint port needed: None
Tested OS: None
Tested devices: None
Tested flows: mlxlink -d {device}

Known gaps (with RM ticket): None

Issue: 3649766