### PR TITLE
[mlxlink] Fixing error message and help menu issues

### DIFF
--- a/mlxlink/modules/mlxlink_err_inj_commander.cpp
+++ b/mlxlink/modules/mlxlink_err_inj_commander.cpp
@@ -278,6 +278,10 @@ ReqParms MlxlinkErrInjCommander::validateErrType(const string& type,
             throw MlxRegException("Invalid parameters list for error type %s, %s", errTypeSt.errorTypeStr.c_str(),
                                   getNumOfValidParams(errTypeSt).c_str());
         }
+        if (params[idx].size() > MAX_PARAMS_ARG_LEN)
+        {
+            throw MlxRegException("Invalid error parameter value: %s", params[idx].c_str());
+        }
         strToUint32((char*)params[idx].c_str(), (u_int32_t&)paramsSet[idx]);
     }
 

--- a/mlxlink/modules/mlxlink_err_inj_commander.cpp
+++ b/mlxlink/modules/mlxlink_err_inj_commander.cpp
@@ -34,6 +34,8 @@
 
 #include "mlxlink_err_inj_commander.h"
 
+#define MAX_PARAMS_ARG_LEN 8
+
 MlxlinkErrInjCommander::MlxlinkErrInjCommander(Json::Value& jsonRoot) : _jsonRoot(jsonRoot)
 {
     _mixerOffset0 = -1;

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -316,7 +316,7 @@ void MlxlinkUi::printSynopsisCommands()
     MlxlinkRecord::printFlagLine(MPEINJ_ERR_TYPE_FLAG_SHORT, MPEINJ_ERR_TYPE_FLAG, "type",
                                  "PCIe error type [ABORT(0),BAD_DLLP_LCRC(1),BAD_TLP_LCRC(2),BAD_TLP_ECRC(3),"
                                  "ERR_MSG(4),MALFORMED_TLP(5),POISONED_TLP(6),UNEXPECTED_CPL(7),ACS_VIOLATION(8),"
-                                 "SURPRISE_LINK_DOWN(9),RECEIVER_ERROR(10)]");
+                                 "SURPRISE_LINK_DOWN(100),RECEIVER_ERROR(101)]");
     printf(IDENT);
     MlxlinkRecord::printFlagLine(MPEINJ_ERR_DURATION_FLAG_SHORT, MPEINJ_ERR_DURATION_FLAG, "duration",
                                  "Error duration, depend on the error type, refer to the UM for more info (Optional)");


### PR DESCRIPTION
Description:
Fixing error types in the help menu
Fixing erro message while providing invalid error parameter Adding missing info message while configuring FEC for main\tile ports

MSTFlint port needed: Yes
Tested OS: Linux64
Tested devices: CX7, SPC-3
Tested flows:
mlxink full commands

Known gaps (with RM ticket):  NA

Issue: 3577410
Issue: 3541189
Issue: 3567074