### PR TITLE
[mlxlink] [Patch-2] Adding support for plane

### DIFF
--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -515,10 +515,10 @@ public:
     // Mlxlink config functions
     void clearCounters();
     void sendPaos();
-    void handlePrbs();
+    virtual void handlePrbs();
     void sendPtys();
     virtual void sendPplm();
-    void sendSltp();
+    virtual void sendSltp();
     void sendPplr();
     void sendPepc();
     void setTxGroupMapping();

--- a/mlxlink/modules/mlxlink_reg_parser.cpp
+++ b/mlxlink/modules/mlxlink_reg_parser.cpp
@@ -43,6 +43,7 @@ MlxlinkRegParser::MlxlinkRegParser() : RegAccessParser("", "", "", NULL, 0)
     _localPort = 0;
     _portType = 0;
     _pnat = 0;
+    _planeInd = -1;
 
     _isHCA = false;
 }

--- a/mlxlink/modules/mlxlink_reg_parser.h
+++ b/mlxlink/modules/mlxlink_reg_parser.h
@@ -72,6 +72,7 @@ public:
     u_int32_t _localPort;
     u_int32_t _pnat;
     u_int32_t _portType;
+    int _planeInd;
     bool _isHCA;
 };
 

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -146,4 +146,6 @@ UserInput::UserInput()
     errorDuration = -1;
     injDelay = -1;
     dbdf = "";
+
+    planeIndex = -1;
 }

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -164,6 +164,8 @@ public:
     int injDelay;
     string dbdf;
     vector<string> parameters;
+
+    int planeIndex;
 };
 
 #endif /* MLXLINK_USER_INPUT_H */


### PR DESCRIPTION
Description:

Adding new flag (--plane) to the internal tool for plane view The default view will be aggregate view
If the plane is provided then the tool will set plane_ind field for all access reg requests
MSTFlint port needed: Yes
Tested OS: Linux64
Tested devices: NA
Tested flows: mlxlink --plane X

Known gaps (with RM ticket): NA

Issue: 3566234