### PR TITLE
mlxdpa: Fix missing include in elf_types.hpp

### DIFF
--- a/mlxdpa/elfio/elf_types.hpp
+++ b/mlxdpa/elfio/elf_types.hpp
@@ -23,6 +23,8 @@ THE SOFTWARE.
 #ifndef ELFTYPES_H
 #define ELFTYPES_H
 
+#include <cstdint>
+
 #ifdef __cplusplus
 namespace ELFIO {
 #endif


### PR DESCRIPTION
To fix compiler error with g++ (GCC) 13.2.0

    ./elfio/elf_types.hpp:30:20: error: 'uint16_t' does not name a type