### PR TITLE
[mlxlink][amber] - the XDR func is called also when productTechnology…

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -2238,7 +2238,10 @@ vector<AmberField> MlxlinkAmBerCollector::collectSheet(AMBER_SHEET sheet)
             break;
         case AMBER_SHEET_SERDES_5NM:
             groupValidIf(_productTechnology == PRODUCT_5NM);
-            fields = getSerdesXDR();
+            if (_productTechnology == PRODUCT_5NM)
+            {
+                fields = getSerdesXDR();
+            }
             break;
         case AMBER_SHEET_PORT_COUNTERS:
             if (!_inPRBSMode)


### PR DESCRIPTION
… is not XDR

Description:
Added condition that checks productTechnology

MSTFlint port needed: Yes
Tested OS: None
Tested devices: cx7
Tested flows: mlxlink -d <dev> --amber_collect

Known gaps (with RM ticket): None

Issue: 3726320