### PR TITLE
[flint][Sunbird] - fixed smg command failing to run on images when us…

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -5361,7 +5361,7 @@ SgSubCommand::SgSubCommand()
                     "Use -guid(s), -mac(s) and -uid(s) flags to set the desired values.\n"
                     "- On pre-ConnectX devices, the sg command  is used in production to apply GUIDs/MACs values to"
                     " cards that were pre-burnt with blank GUIDs. It is not meant for use in field.\n"
-                    "- On 4th generation devices, this command can operate on both image file and image on flash.\n"
+                    "- On 4th and 5th  generation devices, this command can operate on both image file and image on flash.\n"
                     "If the GUIDs/MACs/UIDs in the image on flash are non-blank, flint will re-burn the current"
                     " image using the given GUIDs/MACs/UIDs.";
     _flagLong = "sg";
@@ -5650,7 +5650,7 @@ SmgSubCommand::SmgSubCommand()
 {
     _name = "smg";
     _desc = "Set manufacture GUIDs (For FS3/FS4 image only).";
-    _extendedDesc = "Set manufacture GUID, Set manufacture GUIDs in the given FS3/FS4 image.\n"
+    _extendedDesc = "Set manufacture GUID, Set manufacture GUIDs in the given FS3/FS4/FS5 image.\n"
                     "Use -uid flag to set the desired GUIDs, intended for production use only.";
     _flagLong = "smg";
     _flagShort = "";

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2835,6 +2835,7 @@ bool FwOperations::IsExtendedGuidNumSupported()
     switch (_fwImgInfo.supportedHwId[0])
     {
         case SPECTRUM4_HW_ID:
+        case QUANTUM3_HW_ID:
             isSupported = true;
             break;
         default:


### PR DESCRIPTION
…er provides guids_num=1024

Description: added Sunbird (Quantum3) to extended guid number supported devices.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows:
1. flint -i <Sunbird image> -uid b8599f030023f954 smg guids_num=1024 step_size=1 then checked flint q full shows those 2 additional lines:
Orig Base GUID:        b8599f030023f954        1024
Orig Base MAC:         b8599f23f954            1024
checked that MFG_INFO section is updated. (flint verify to get the offset and length -> hexdump and "hexdump-parsing" according to image_layout_mfg_info struct).

2. (after running smg command): flint -i <Sunbird image> -uid b8599f030023f954 sg guids_num=1024 step_size=1 then checked flint q full has the Base GUID and Base MAC updated with the wanted values and that we no longer see "Orig Base GUID" and "Orig Base MAC".

Known gaps (with RM ticket): n/a

Issue: 3712465