### PR TITLE
Updates to the mlx5ctrl upstream driver include:

### DIFF
--- a/mlx5ctl/Makefile
+++ b/mlx5ctl/Makefile
@@ -1,0 +1,34 @@
+CC=gcc
+CFLAGS=-Wall -Wno-gnu-variable-sized-type-not-at-end
+PREFIX=/usr/local
+BINDIR=$(PREFIX)/bin
+
+# Source files
+SRCS = $(wildcard *.c)
+HDRS = $(wildcard *.h)
+RSRC = README.md LICENSE Makefile
+OBJS = $(SRCS:.c=.o)
+TARGET=mlx5ctl
+VERSION:=0.1
+
+.PHONY: all clean install
+
+all: mlx5ctl
+
+$(TARGET): $(OBJS)
+	$(CC) $(CFLAGS) $(OBJS) -o $(TARGET)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(TARGET) $(OBJS)
+
+install: $(TARGET)
+	install -Dm755 $(TARGET) $(DESTDIR)$(BINDIR)/$(TARGET)
+
+srctar:
+	mkdir -p SOURCE/$(TARGET)-$(VERSION)
+	cp -r $(SRCS) $(HDRS) $(RSRC) SOURCE/$(TARGET)-$(VERSION)
+	cd SOURCE && tar -czvf $(TARGET)-$(VERSION).tar.gz $(TARGET)-$(VERSION)
+	rm -rf SOURCE/$(TARGET)-$(VERSION)

--- a/mlx5ctl/ifcutil.h
+++ b/mlx5ctl/ifcutil.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __MLX5_IFCUTIL_H__
+#define __MLX5_IFCUTIL_H__
+
+#include <linux/types.h>
+#include <endian.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef uint8_t u8;
+typedef uint16_t u16;
+typedef uint32_t u32;
+typedef uint64_t u64;
+
+typedef u8    __u8;
+typedef u16   __u16;
+typedef u32   __u32;
+
+typedef __u16       __be16;
+typedef __u32       __be32;
+typedef __u64       __be64;
+
+#define BIT(nr)     (1UL << (nr))
+#define BIT_ULL(nr)     (1ULL << (nr))
+#define __packed
+#define gcm
+
+/* helper macros */
+#define __mlx5_nullp(typ) ((struct mlx5_ifc_##typ##_bits *)0)
+#define __mlx5_bit_sz(typ, fld) sizeof(__mlx5_nullp(typ)->fld)
+#define __mlx5_bit_off(typ, fld) (offsetof(struct mlx5_ifc_##typ##_bits, fld))
+#define __mlx5_16_off(typ, fld) (__mlx5_bit_off(typ, fld) / 16)
+#define __mlx5_dw_off(typ, fld) (__mlx5_bit_off(typ, fld) / 32)
+#define __mlx5_64_off(typ, fld) (__mlx5_bit_off(typ, fld) / 64)
+#define __mlx5_16_bit_off(typ, fld) (16 - __mlx5_bit_sz(typ, fld) - (__mlx5_bit_off(typ, fld) & 0xf))
+#define __mlx5_dw_bit_off(typ, fld) (32 - __mlx5_bit_sz(typ, fld) - (__mlx5_bit_off(typ, fld) & 0x1f))
+#define __mlx5_mask(typ, fld) ((u32)((1ull << __mlx5_bit_sz(typ, fld)) - 1))
+#define __mlx5_dw_mask(typ, fld) (__mlx5_mask(typ, fld) << __mlx5_dw_bit_off(typ, fld))
+#define __mlx5_mask16(typ, fld) ((u16)((1ull << __mlx5_bit_sz(typ, fld)) - 1))
+#define __mlx5_16_mask(typ, fld) (__mlx5_mask16(typ, fld) << __mlx5_16_bit_off(typ, fld))
+#define __mlx5_st_sz_bits(typ) sizeof(struct mlx5_ifc_##typ##_bits)
+
+#define MLX5_FLD_SZ_BYTES(typ, fld) (__mlx5_bit_sz(typ, fld) / 8)
+#define MLX5_ST_SZ_BYTES(typ) (sizeof(struct mlx5_ifc_##typ##_bits) / 8)
+#define MLX5_ST_SZ_DW(typ) (sizeof(struct mlx5_ifc_##typ##_bits) / 32)
+#define MLX5_ST_SZ_QW(typ) (sizeof(struct mlx5_ifc_##typ##_bits) / 64)
+#define MLX5_UN_SZ_BYTES(typ) (sizeof(union mlx5_ifc_##typ##_bits) / 8)
+#define MLX5_UN_SZ_DW(typ) (sizeof(union mlx5_ifc_##typ##_bits) / 32)
+#define MLX5_BYTE_OFF(typ, fld) (__mlx5_bit_off(typ, fld) / 8)
+#define MLX5_ADDR_OF(typ, p, fld) ((void *)((uint8_t *)(p) + MLX5_BYTE_OFF(typ, fld)))
+
+#define be32_to_cpu(x) be32toh(x)
+#define cpu_to_be32(x) htobe32(x)
+#define be16_to_cpu(x) be16toh(x)
+#define cpu_to_be16(x) htobe16(x)
+#define be64_to_cpu(x) be64toh(x)
+#define cpu_to_be64(x) htobe64(x)
+
+#define MLX5_GET(typ, p, fld) ((be32_to_cpu(*((__be32 *)(p) +\
+	__mlx5_dw_off(typ, fld))) >> __mlx5_dw_bit_off(typ, fld)) & \
+	__mlx5_mask(typ, fld))
+
+#define MLX5_GET64(typ, p, fld) be64_to_cpu(*((__be64 *)(p) + __mlx5_64_off(typ, fld)))
+
+/* insert a value to a struct */
+#define MLX5_SET(typ, p, fld, v) do { \
+	u32 _v = v; \
+	*((__be32 *)(p) + __mlx5_dw_off(typ, fld)) = \
+	cpu_to_be32((be32_to_cpu(*((__be32 *)(p) + __mlx5_dw_off(typ, fld))) & \
+		     (~__mlx5_dw_mask(typ, fld))) | (((_v) & __mlx5_mask(typ, fld)) \
+		     << __mlx5_dw_bit_off(typ, fld))); \
+} while (0)
+
+#define __MLX5_SET64(typ, p, fld, v) do { \
+	*((__be64 *)(p) + __mlx5_64_off(typ, fld)) = cpu_to_be64(v); \
+} while (0)
+
+#define MLX5_SET64(typ, p, fld, v) do { \
+	__MLX5_SET64(typ, p, fld, v); \
+} while (0)
+
+
+struct mlx5_ifc_mbox_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_mbox_in_bits {
+	u8         opcode[0x10];
+	u8         uid[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x40];
+};
+
+#define min(a, b) ((a) < (b) ? (a) : (b))
+
+static inline void hexdump(void *data, int size) {
+        unsigned char *byte = data;
+        for (int i = 0; i < size; i++) {
+                printf("%02x", byte[i]);
+                printf(" ");
+                if ((i + 1) % 16 == 0) {
+                     printf("\n");
+                }
+        }
+        printf("\n");
+}
+
+#endif /* __MLX5_IFCUTIL_H__ */

--- a/mlx5ctl/mlx5ctlu.c
+++ b/mlx5ctl/mlx5ctlu.c
@@ -1,0 +1,206 @@
+#include <stdlib.h>
+#include <errno.h>
+#include <string.h>
+#include <stddef.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <libgen.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <limits.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <glob.h>
+#include "mlx5ctl.h"
+
+int verbosity_level = 0;
+
+/* find parent device under symlink: /sys/bus/auxiliary/devices/<device_name> */
+static char *find_parent_device(char *device_name, char parent_dev[DEV_NAME_MAX])
+{
+	char resolved_path[PATH_MAX];
+	char dev_path[PATH_MAX];
+    char *parent, basename;
+
+	snprintf(dev_path, sizeof(dev_path),
+		 "/sys/bus/auxiliary/devices/%s", device_name);
+
+        if (realpath(dev_path, resolved_path) == NULL)
+                return NULL;
+
+        parent = dirname(resolved_path);
+        if (parent == NULL)
+                return NULL;
+
+	strncpy(parent_dev, strrchr(parent, '/') + 1, strlen(parent));
+	return parent_dev;
+}
+
+int mlx5u_devinfo(struct mlx5u_dev *dev)
+{
+	struct mlx5ctl_info info = {};
+	char parent_dev[DEV_PATH_MAX];
+	int fd = dev->fd;
+	int ret;
+
+	ret = ioctl(fd, MLX5CTL_IOCTL_INFO, &info);
+	if (ret) {
+		printf("ioctl failed: %d errno(%d): %s\n", ret, errno, strerror(errno));
+		return ret;
+	}
+
+	printf("ctldev: %s\n", dev->devname);
+	printf("Parent dev: %s\n", find_parent_device(strrchr(dev->devname, '-') + 1, parent_dev));
+	printf("UCTX UID: %d\n", info.uctx_uid);
+	printf("UCTX CAP: 0x%x\n", info.uctx_cap);
+	printf("DEV UCTX CAP: 0x%x\n", info.dev_uctx_cap);
+	printf("USER CAP: 0x%x\n", info.ucap);
+
+	printf("Current PID: %d FD %d\n", getpid(), fd);
+	return 0;
+}
+
+static struct mlx5ctl_dev *_scan_ctl_devs(int *count) {
+	glob_t glob_result;
+	struct mlx5ctl_dev *devs;
+	char* pattern = "/dev/mlx5ctl*";
+	char parent_device_name[DEV_NAME_MAX];
+	int ret = glob(pattern, GLOB_TILDE, NULL, &glob_result);
+
+	if(ret != 0) {
+		err_msg("Error while searching for files: %d\n", ret);
+		return NULL;
+	}
+
+	if (glob_result.gl_pathc == 0)
+		return NULL;
+
+	devs = malloc(sizeof(struct mlx5ctl_dev) * glob_result.gl_pathc);
+	memset(devs, 0, sizeof(struct mlx5ctl_dev) * glob_result.gl_pathc);
+	if(devs == NULL) {
+		err_msg("Error while allocating memory for devs: %d\n", ret);
+		return NULL;
+
+	}
+
+	*count = glob_result.gl_pathc;
+
+	for(unsigned int i = 0; i < glob_result.gl_pathc; ++i) {
+		char *pdev, *ctldev;
+
+		/* /dev/mlx5ctl-mlx5_core.ctl.X */
+		ctldev = strrchr(glob_result.gl_pathv[i], '-') + 1;
+		/* mlx5_core.ctl.X */
+		pdev = find_parent_device(ctldev, parent_device_name);
+
+		devs[i].ctl_id = atoi(strrchr(ctldev, '.') + 1);
+		strncpy(devs[i].ctldev, ctldev, DEV_NAME_MAX);
+		if (pdev)
+			strncpy(devs[i].mdev, pdev, DEV_NAME_MAX);
+	}
+
+	globfree(&glob_result);
+	return devs;
+}
+
+static int is_a_number(const char *str)
+{
+	for (int i = 0; i < strlen(str); i++)
+		if (!isdigit(str[i]))
+			return 0;
+
+	return 1;
+}
+
+static char *find_dev(const char *str, char dev_path[DEV_PATH_MAX])
+{
+	struct mlx5ctl_dev *devs;
+	int count, i;
+
+	snprintf(dev_path, DEV_PATH_MAX, "/dev/mlx5ctl-%s", str);
+	if (access(dev_path, F_OK) == 0)
+		return dev_path;
+
+	if (is_a_number(str)) {
+		int ctl_id = atoi(str);
+
+		snprintf(dev_path, DEV_PATH_MAX, "/dev/mlx5ctl-mlx5_core.ctl.%d", ctl_id);
+		if (access(dev_path, F_OK) == 0)
+			return dev_path;
+	}
+
+	devs = _scan_ctl_devs(&count);
+	if (devs == NULL)
+		return NULL;
+
+	for (i = 0; i < count; i++) {
+		if (strcmp(devs[i].mdev, str))
+			continue;
+
+		snprintf(dev_path, DEV_PATH_MAX, "/dev/mlx5ctl-%s", devs[i].ctldev);
+		free(devs);
+		return dev_path;
+	}
+
+	free(devs);
+	return NULL;
+}
+
+struct mlx5u_dev *mlx5u_open(const char *name)
+{
+	char dev_path[DEV_PATH_MAX];
+        struct mlx5u_dev *dev;
+        int fd;
+
+	dev = malloc(sizeof(*dev));
+	if (!dev)
+		return NULL;
+
+	dbg_msg(1, "looking for dev %s\n", name);
+	if (find_dev(name, dev_path) == NULL) {
+		err_msg("device %s not found\n", name);
+		free(dev);
+		return NULL;
+	}
+
+	strncpy(dev->devname, dev_path, sizeof(dev->devname));
+	dbg_msg(1, "opening %s\n", dev->devname);
+
+
+
+	fd = open(dev->devname, O_RDWR);
+	if (fd < 0) {
+		err_msg("open %s failed %d errno(%d): %s\n", dev->devname, fd, errno, strerror(errno));
+		err_msg("please insmod mlx5ctl.ko and make sure the device file exists\n");
+		free(dev);
+		return NULL;
+	}
+	dev->fd = fd;
+	dbg_msg(1, "opened %s descriptor fd(%d)\n", dev->devname, fd);
+	return dev;
+}
+
+
+void mlx5u_close(struct mlx5u_dev *dev)
+{
+	close(dev->fd);
+	free(dev);
+}
+
+int main(int argc, char *argv[])
+{
+	struct mlx5u_dev *dev;
+	int ret;
+
+	dev = mlx5u_open(argv[1]);
+	if (!dev) {
+		err_msg("Failed to open device %s\n", argv[1]);
+		return 1;
+	}
+    ret = mlx5u_devinfo(dev);
+
+	mlx5u_close(dev);
+
+	return ret;
+}

--- a/mtcr_ul/mlx5ctl.c
+++ b/mtcr_ul/mlx5ctl.c
@@ -47,9 +47,9 @@
 
 
 
-static int mlx5_cmd_ioctl(int fd, struct mlx5ctl_cmd_inout *cmd)
+static int mlx5_cmd_ioctl(int fd, struct mlx5ctl_cmdrpc *cmd)
 {
-	return ioctl(fd, MLX5CTL_IOCTL_CMD_INOUT, cmd);
+	return ioctl(fd, MLX5CTL_IOCTL_CMDRPC, cmd);
 }
 
 
@@ -80,10 +80,10 @@ int mlx5_control_access_register(int fd, void *data_in,
 {
 	int outlen = MLX5_ST_SZ_BYTES(access_register_out) + size_in;
 	int inlen = MLX5_ST_SZ_BYTES(access_register_in) + size_in;
-	struct mlx5ctl_cmd_inout cmd = {0};
+	struct mlx5ctl_cmdrpc cmd = {0};
 	int err = -ENOMEM;
-	u32 *out = NULL;
-	u32 *in = NULL;
+	__aligned_u64 *out = NULL;
+	__aligned_u64 *in = NULL;
 	void *data;
     void *status;
 
@@ -96,10 +96,10 @@ int mlx5_control_access_register(int fd, void *data_in,
     memset(in, 0, inlen);
     memset(out, 0, outlen);
 
-	cmd = (struct mlx5ctl_cmd_inout){
-		.in = in,
+	cmd = (struct mlx5ctl_cmdrpc){
+		.in = (__aligned_u64)in,
 		.inlen = inlen,
-		.out = out,
+		.out = (__aligned_u64)out,
 		.outlen = outlen,
 	};
 	data = MLX5_ADDR_OF(access_register_in, in, register_data);

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -957,12 +957,7 @@ static int mtcr_driver_mclose(mfile* mf)
 }
 
 
-static int mlx5ctl_driver_open(mfile     * mf,
-                               unsigned    domain_p,
-                               unsigned    bus_p,
-                               unsigned    dev_p,
-                               unsigned    func_p,
-                               const char* name)
+static int mlx5ctl_driver_open(mfile* mf, const char* name)
 {
     char full_path_name[60];
 
@@ -983,7 +978,6 @@ static int mlx5ctl_driver_open(mfile     * mf,
     ctx->mwrite4_block = mlx5ctl_driver_mwrite4_block;
     ctx->mclose = mtcr_driver_mclose;
     mf->bar_virtual_addr = NULL;
-    init_dev_info_ul(mf, name, domain_p, bus_p, dev_p, func_p);
     mlx5ctl_set_device_id(mf);
 
     mf->mlx5ctl_env_var_debug = getenv(MLX5CTL_ENV_VAR_DEBUG);
@@ -1704,14 +1698,7 @@ static MType mtcr_parse_name(const char* name,
         goto name_parsed;
     }
 
-    scnt = sscanf(name, "mlx5ctl-%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
-    if (scnt == 4) {
-        force_config = 1;
-        *domain_p = my_domain;
-        *bus_p = my_bus;
-        *dev_p = my_dev;
-        *func_p = my_func;
-        *force = 0;
+    if(strstr(name, "mlx5ctl-mlx5_core")) {
         return MST_MLX5_CONTROL_DRIVER;
     }
 
@@ -2471,7 +2458,7 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
         break;
 
     case MST_MLX5_CONTROL_DRIVER:
-        rc = mlx5ctl_driver_open(mf, domain, bus, dev, func, name);
+        rc = mlx5ctl_driver_open(mf, name);
         if (rc) {
             goto open_failed;
         }


### PR DESCRIPTION
1. Adjusting the IOCTLs according to community requests.
2. Introducing a small tool to interact with the driver, retrieving device information. This tool will not be included in the mstflint makefile and will need to be compiled separately. Here's an example of its output:
[root@mlx5ctrl_setup mstflint]# sudo ./mlx5ctl/mlx5ctl mlx5_core.ctl.0 ctldev: /dev/mlx5ctl-mlx5_core.ctl.0
Parent dev: 0000:00:07.0
UCTX UID: 2
UCTX CAP: 0x7
DEV UCTX CAP: 0x7
USER CAP: 0x1d
Current PID: 59168 FD 3