### PR TITLE
[mtcr] - fixed endiannes back in case icmd_send_command_com fails.

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -2845,7 +2845,7 @@ int maccess_reg_mad_ul(mfile* mf, u_int8_t* data)
     return ((ul_ctx_t*)mf->ul_ctx)->maccess_reg(mf, data);
 }
 
-static void mtcr_fix_endianness(u_int32_t* buf, int len)
+void mtcr_fix_endianness(u_int32_t* buf, int len)
 {
     int i;
 

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -166,6 +166,8 @@ extern "C"
 
     int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data);
 
+    void mtcr_fix_endianness(u_int32_t* buf, int len);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Description: in icmd_send_command_com: MWRITE_BUF_ICMD changes the endiannes, so in case of any failure after it, we do not get to the call to MREAD_BUF_ICMD which fixes back the endiannes. added a variable indicating whether the endiannes should be changed back. so even in case of any failure, in the cleanup stage we will know if the endiannes needs to be changed back.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: modified the return value from FW to be bad status, and single stepped with the debugger to see we get into fix_endianness in the cleanup stage.

Known gaps (with RM ticket): n/a

Issue: 3439259