### PR TITLE
 fix for - "mstflint query shows MFE_REG_ACCESS_REG_NOT_SUPP error"

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -2845,7 +2845,7 @@ int maccess_reg_mad_ul(mfile* mf, u_int8_t* data)
     return ((ul_ctx_t*)mf->ul_ctx)->maccess_reg(mf, data);
 }
 
-static void mtcr_fix_endianness(u_int32_t* buf, int len)
+void mtcr_fix_endianness(u_int32_t* buf, int len)
 {
     int i;
 

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -166,6 +166,8 @@ extern "C"
 
     int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data);
 
+    void mtcr_fix_endianness(u_int32_t* buf, int len);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
fix for - [mstflint] query shows MFE_REG_ACCESS_REG_NOT_SUPP error when querying any device

Description: fixed icmd_send_command_com() function to change back the endianness of the data only when needed.

Tested OS: linux
Tested devices: ConnectX6
Tested flows: mstflint -d 42:00.0 q

Known gaps (with RM ticket): n/a

Issue: 3835403