### PR TITLE
[flint][XDR-switch/multi asic systems] - additional guids info for flint query.

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -430,6 +430,14 @@ public:
     void GenerateHandle();
     bool isMCDDSupported() { return _isDmaSupported; };
     bool IsSecondaryHost(bool& isSecondary);
+    bool runPGUID(reg_access_hca_pguid_reg_ext* guidsInfo,
+                  u_int32_t local_port = 0,
+                  u_int8_t pnat = 0,
+                  u_int32_t lp_msb = 0);
+    bool queryPGUID(fw_info_t* fwInfo,
+                    u_int32_t local_port = 0,
+                    u_int8_t pnat = 0,
+                    u_int32_t lp_msb = 0);
 
 private:
     typedef enum

--- a/mlxfwops/lib/fs3_ops.cpp
+++ b/mlxfwops/lib/fs3_ops.cpp
@@ -251,7 +251,7 @@ bool Fs3Operations::GetMfgInfo(u_int8_t* buff)
         memcpy(&_fs3ImgInfo.ext_info.orig_fs3_uids_info.image_layout_uids, &mfg_info.guids, sizeof(mfg_info.guids));
         strcpy(_fs3ImgInfo.ext_info.orig_psid, mfg_info.psid);
         _fs3ImgInfo.ext_info.guids_override_en = mfg_info.guids_override_en;
-        _fs3ImgInfo.ext_info.orig_fs3_uids_info.valid_field = 1;
+        _fs3ImgInfo.ext_info.orig_fs3_uids_info.guid_format = IMAGE_LAYOUT_UIDS;
     }
     else if (CHECK_MFG_OLD_FORMAT(cib_mfg_info))
     {
@@ -259,7 +259,7 @@ bool Fs3Operations::GetMfgInfo(u_int8_t* buff)
         memcpy(&_fs3ImgInfo.ext_info.orig_fs3_uids_info.cib_uids, &cib_mfg_info.guids, sizeof(cib_mfg_info.guids));
         strcpy(_fs3ImgInfo.ext_info.orig_psid, cib_mfg_info.psid);
         _fs3ImgInfo.ext_info.guids_override_en = cib_mfg_info.guids_override_en;
-        _fs3ImgInfo.ext_info.orig_fs3_uids_info.valid_field = 0;
+        _fs3ImgInfo.ext_info.orig_fs3_uids_info.guid_format = CIB_UIDS;
     }
     else
     {
@@ -416,7 +416,7 @@ bool Fs3Operations::GetDevInfo(u_int8_t* buff)
         CHECK_UID_STRUCTS_SIZE(_fs3ImgInfo.ext_info.fs3_uids_info.image_layout_uids, device_info.guids);
         memcpy(&_fs3ImgInfo.ext_info.fs3_uids_info.image_layout_uids, &device_info.guids, sizeof(device_info.guids));
         strcpy(_fwImgInfo.ext_info.vsd, device_info.vsd);
-        _fs3ImgInfo.ext_info.fs3_uids_info.valid_field = 1;
+        _fs3ImgInfo.ext_info.fs3_uids_info.guid_format = IMAGE_LAYOUT_UIDS;
         _fwImgInfo.ext_info.vsd_sect_found = true;
     }
     else if (CHECK_DEV_INFO_OLD_FORMAT(cib_dev_info))
@@ -424,7 +424,7 @@ bool Fs3Operations::GetDevInfo(u_int8_t* buff)
         CHECK_UID_STRUCTS_SIZE(_fs3ImgInfo.ext_info.fs3_uids_info.cib_uids, cib_dev_info.guids);
         memcpy(&_fs3ImgInfo.ext_info.fs3_uids_info.cib_uids, &cib_dev_info.guids, sizeof(cib_dev_info.guids));
         strcpy(_fwImgInfo.ext_info.vsd, cib_dev_info.vsd);
-        _fs3ImgInfo.ext_info.fs3_uids_info.valid_field = 0;
+        _fs3ImgInfo.ext_info.fs3_uids_info.guid_format = CIB_UIDS;
         _fwImgInfo.ext_info.vsd_sect_found = true;
     }
     else

--- a/mlxfwops/lib/fs5_ops.cpp
+++ b/mlxfwops/lib/fs5_ops.cpp
@@ -503,7 +503,7 @@ bool Fs5Operations::GetMfgInfo(u_int8_t* buff)
             memcpy(&_fs3ImgInfo.ext_info.fs3_uids_info.image_layout_uids,
                    &_fs3ImgInfo.ext_info.orig_fs3_uids_info.image_layout_uids,
                    sizeof(_fs3ImgInfo.ext_info.orig_fs3_uids_info.image_layout_uids));
-            _fs3ImgInfo.ext_info.fs3_uids_info.valid_field = 1;
+            _fs3ImgInfo.ext_info.fs3_uids_info.guid_format = IMAGE_LAYOUT_UIDS;
         }
     }
     return rc;

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -440,9 +440,18 @@ bool FsCtrlOperations::FwQuery(fw_info_t* fwInfo,
     (void)verbose;
     memcpy(&(fwInfo->fw_info), &(_fwImgInfo.ext_info), sizeof(fw_info_com_t));
     memcpy(&(fwInfo->fs3_info), &(_fsCtrlImgInfo), sizeof(fs3_info_t));
-    fwInfo->fs3_info.fs3_uids_info.valid_field = 1;
+    fwInfo->fs3_info.fs3_uids_info.guid_format = IMAGE_LAYOUT_UIDS;
     fwInfo->fw_type = FwType();
 
+    if (isMultiAsicSystemComponent())
+    {
+        fwInfo->fs3_info.fs3_uids_info.guid_format = MULTI_ASIC_GUIDS;
+        if (!_fwCompsAccess->queryPGUID(fwInfo, 0, 0, 0)) // this updates fwInfo, which contains the info flint
+                                                          // query displays.
+        {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -833,6 +842,15 @@ bool FsCtrlOperations::FwBurnAdvanced(FwOperations* imageOps, ExtBurnParams& bur
 bool FsCtrlOperations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& burnParams)
 {
     return FwBurnAdvanced(imageOps, burnParams);
+}
+
+bool FsCtrlOperations::isMultiAsicSystemComponent()
+{
+    if (_hwDevId == QUANTUM3_HW_ID || _hwDevId == CX8_HW_ID)
+    {
+        return true;
+    }
+    return false;
 }
 
 bool FsCtrlOperations::_Burn(std::vector<u_int8_t> imageOps4MData,

--- a/mlxfwops/lib/fsctrl_ops.h
+++ b/mlxfwops/lib/fsctrl_ops.h
@@ -115,6 +115,7 @@ public:
     Tlv_Status_t GetTsObj(TimeStampIFC** tsObj);
     bool isEncrypted(bool& is_encrypted);
     bool burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& burnParams);
+    bool isMultiAsicSystemComponent();
 
     virtual bool IsFsCtrlOperations() { return true; }
     virtual mfile* getMfileObj() { return _fwCompsAccess->getMfileObj(); }

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -421,14 +421,31 @@ typedef struct
     struct fs4_uid_entry base_mac;
 } image_layout_uids_t;
 
+typedef struct multi_asicfw_guids
+{
+    image_layout_uids_t image_layout_uids;
+    u_int64_t sys_guid;
+    u_int64_t node_guid;
+    u_int64_t port_guid;
+    u_int64_t allocated_guid;
+} multi_asic_guids_t;
+
+typedef enum guid_format
+{
+    CIB_UIDS,
+    IMAGE_LAYOUT_UIDS,
+    MULTI_ASIC_GUIDS
+} guid_format_t;
+
 typedef struct uids
 {
-    int valid_field; // 0: cib_uids , 1: image_layout_uids
+    guid_format_t guid_format;
     union
     {
         cib_uids_t cib_uids;
         cx4_uids_t cx4_uids; // keeping this member for neohost
         image_layout_uids_t image_layout_uids;
+        multi_asic_guids_t multi_asic_guids;
     };
 } uids_t;
 

--- a/mlxfwupdate/mlnx_dev.cpp
+++ b/mlxfwupdate/mlnx_dev.cpp
@@ -232,7 +232,7 @@ void MlnxDev::setGuidMac(fw_info_t& fw_query)
     }
     else
     {
-        if (fw_query.fs3_info.fs3_uids_info.valid_field)
+        if (fw_query.fs3_info.fs3_uids_info.guid_format == IMAGE_LAYOUT_UIDS)
         {
             snprintf(buff, sizeof(buff) - 1, "%016" U64H_FMT_GEN,
                      fw_query.fs3_info.fs3_uids_info.image_layout_uids.base_guid.uid);
@@ -247,7 +247,7 @@ void MlnxDev::setGuidMac(fw_info_t& fw_query)
         {
             guidPortOne = (string)buff;
         }
-        if (fw_query.fs3_info.fs3_uids_info.valid_field)
+        if (fw_query.fs3_info.fs3_uids_info.guid_format == IMAGE_LAYOUT_UIDS)
         {
             snprintf(buff, sizeof(buff) - 1, "%012" U64H_FMT_GEN,
                      fw_query.fs3_info.fs3_uids_info.image_layout_uids.base_mac.uid);

--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -109,6 +109,7 @@
 
 #define REG_ID_MDDT 0x9160
 #define REG_ID_MDDQ 0x9161
+#define REG_ID_PGUID 0x5066
 
 // For mstdump oob feature:
 #define REG_ID_ICAM 0x387F
@@ -810,4 +811,12 @@ reg_access_status_t reg_access_dtor(mfile* mf, reg_access_method_t method, struc
 reg_access_status_t reg_access_mrsi(mfile* mf, reg_access_method_t method, struct reg_access_hca_mrsi_ext* mrsi)
 {
     REG_ACCCESS(mf, method, REG_ID_MRSI, mrsi, mrsi_ext, reg_access_hca);
+}
+
+/************************************
+ * Function: reg_access_pguid
+ ************************************/
+reg_access_status_t reg_access_pguid(mfile* mf, reg_access_method_t method, struct reg_access_hca_pguid_reg_ext* pguid)
+{
+    REG_ACCCESS(mf, method, REG_ID_PGUID, pguid, pguid_reg_ext, reg_access_hca);
 }

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -37,6 +37,8 @@ extern "C"
 {
 #endif
 
+// #include <tools_layouts/reg_access_hca_layouts.h>
+// #include <tools_layouts/reg_access_switch_layouts.h>
 #include "reg_access_common.h"
 
 enum
@@ -256,6 +258,9 @@ reg_access_status_t
   reg_access_nic_dpa_eu_partition(mfile* mf,
                                   reg_access_method_t method,
                                   struct reg_access_hca_nic_dpa_eu_partition_reg_ext* nic_dpa_eu_partition);
+struct reg_access_hca_pguid_reg_ext;
+reg_access_status_t
+  reg_access_pguid(mfile* mf, reg_access_method_t method, struct reg_access_hca_pguid_reg_ext* pguid);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
[flint][XDR-switch/multi asic systems] - add sys_guid, node_guid, port_guid and allocated_guid to query command's output.

Description: when querying a device (asic) of type Quantum3(Sunbird) or ConnectX8, additional guids info will be displayed, letting the user learn more about the topography of the system. each GUID will be represented by 16 hexadecimal characters so it will be clear to the user that a GUID is 64 bits long.

Tested OS: linux
Tested devices: emulation for Sunbird
Tested flows:
1. to check the info in PGUID reg used:
mlxreg -d   /dev/mst/mt4123_pciconf0  --reg_name PGUID --get --indexes "local_port=0,pnat=0,lp_msb=0,plane_ind=0"
2. ran flint -d <> q
3. made sure each GUID is represented by 16 hexadecimal characters which are the same as those seen when using mlxreg.

Known gaps (with RM ticket): n/a

Issue: 3609033