### PR TITLE
[flint][4th gen] allow burning encrypted images on non encrypted devi…

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -3411,7 +3411,7 @@ FlintStatus BurnSubCommand::executeCommand()
         return FLINT_FAILED;
     }
 
-    if (device_encrypted != image_encrypted)
+    if (device_encrypted != image_encrypted && _fwType != FIT_FS5)
     {
         reportErr(true, "Burning %sencrypted image on %sencrypted device is not allowed.\n",
                   image_encrypted ? "" : "non-", device_encrypted ? "" : "non-");


### PR DESCRIPTION
…ce and vise versa

Description:

MSTFlint port needed:
Tested OS: linux
Tested devices: QTM3
Tested flows: flint burn

Known gaps (with RM ticket): N/A

Issue: 3879097