### PR TITLE
resource_dump | fixed issue in shared object

### DIFF
--- a/resourcetools/resourcedump_lib/src/sdk/Makefile.am
+++ b/resourcetools/resourcedump_lib/src/sdk/Makefile.am
@@ -79,6 +79,7 @@ resource_dump_sdk_so_DEPS = \
     $(top_builddir)/resourcetools/resourcedump_lib/src/common/.libs/libresource_dump_common.a \
     $(top_builddir)/reg_access/.libs/libreg_access.a \
     $(top_builddir)/tools_layouts/.libs/libtools_layouts.a \
+    $(top_builddir)/dev_mgt/.libs/libdev_mgt.a \
     $(MTCR_LIB) \
     $(OFED_LIBS) \
     -lstdc++


### PR DESCRIPTION
Description: added missing dependency library in makefile

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: dynamically load libresource_dump_sdk.so

Known gaps (with RM ticket): n/a

Issue: 3760456