### PR TITLE
mtcr_ul: Buffer overflow fixes

### DIFF
--- a/mtcr_ul/mtcr_ib_ofed.c
+++ b/mtcr_ul/mtcr_ib_ofed.c
@@ -411,7 +411,7 @@ static void set_mad_data_for_mode_2(u_int32_t memory_address,
 static uint64_t
   ibvsmad_craccess_rw_smp(ibvs_mad* h, u_int32_t memory_address, int method, u_int8_t num_of_dwords, u_int32_t* data)
 {
-    u_int8_t mad_data[IB_SMP_DATA_SIZE] = {0};
+    u_int8_t mad_data[2*IB_SMP_DATA_SIZE] = {0};
     int i;
     u_int8_t* p;
     u_int32_t attribute_mod = 0;
@@ -504,7 +504,7 @@ static uint64_t ibvsmad_craccess_rw_vs(ibvs_mad* h,
                                        u_int32_t* data,
                                        int class)
 {
-    u_int8_t vsmad_data[IB_VENDOR_RANGE1_DATA_SIZE] = {0};
+    u_int8_t vsmad_data[2*IB_VENDOR_RANGE1_DATA_SIZE] = {0};
     ib_vendor_call_t call;
     int i;
     u_int8_t* p;


### PR DESCRIPTION
This change addresses possible buffer overflow in mtcr_ul/mtcr_ib_ofed.c:

484  DWORD_TO_BYTES_BE(mad_data + IB_DATA_INDEX + CONFIG_ACCESS_MODE_2_BITMASK_OFFSET + (i * 4), &mask);

  i: 0..13
  IB_DATA_INDEX: 8
  CONFIG_ACCESS_MODE_2_BITMASK_OFFSET: 8
  mad_data capacity: 64

  i=11: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 60  - OK
  i=12: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 64  - out of mad_data !
  i=13: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 68  - out of mad_data !

569 DWORD_TO_BYTES_BE(vsmad_data + IB_DATA_INDEX + CONFIG_ACCESS_MODE_2_BITMASK_OFFSET + (i * 4), &mask);

  i: 0..55
  IB_DATA_INDEX: 8
  CONFIG_ACCESS_MODE_2_BITMASK_OFFSET: 8
  vsmad_data capacity: 232

  i=53: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 228 - OK
  i=54: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 232 - out of vsmad_data !
  i=55: IB_DATA_INDEX+CONFIG_ACCESS_MODE_2_BITMASK_OFFSET+(i*4) = 236 - out of vsmad_data !