### PR TITLE
add support to ZombieFish mode.

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -917,7 +917,7 @@ int dm_is_livefish_mode(mfile* mf)
         return 1;
     }
     dm_dev_id_t devid_t = DeviceUnknown;
-    u_int32_t   devid = 0;
+    u_int32_t   devid = 0; // hw dev ID
     u_int32_t   revid = 0;
     int         rc = dm_get_device_id(mf, &devid_t, &devid, &revid);
 
@@ -931,7 +931,8 @@ int dm_is_livefish_mode(mfile* mf)
     if (dm_is_4th_gen(devid_t)) {
         return (devid == swid - 1);
     } else {
-        return (devid == swid);
+        int zombiefish = is_zombiefish_device(mf);
+        return ((devid == swid) || zombiefish);
     }
 
     return 0;

--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -197,6 +197,8 @@ extern "C"
 
     int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data);
 
+    int is_zombiefish_device(mfile* mf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mtcr_freebsd/Makefile.am
+++ b/mtcr_freebsd/Makefile.am
@@ -35,7 +35,8 @@ AM_CPPFLAGS = \
     -I$(top_srcdir) \
     -I$(top_srcdir)/common -I$(top_builddir)/common \
     -I$(top_srcdir)/include/mtcr_ul \
-    -I$(top_srcdir)/mtcr_ul
+    -I$(top_srcdir)/mtcr_ul \
+    -I$(top_srcdir)/dev_mgt
 
 noinst_LTLIBRARIES = libmtcr_ul.la
 

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -169,6 +169,8 @@ extern "C"
 
     void mtcr_fix_endianness(u_int32_t* buf, int len);
 
+    int is_zombiefish_device(mfile* mf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -1310,7 +1310,7 @@ int icmd_open(mfile* mf)
 #ifndef __FreeBSD__
     // Currently livefish check is supported for PCI devices & devices that map to CR.
     // ICMD is not supported while in livefish (GW is locked).
-    if ((is_pci_device(mf) || (mf->flags & MDEVS_TAVOR_CR)) && is_livefish_device(mf))
+    if ((is_pci_device(mf) || (mf->flags & MDEVS_TAVOR_CR)) && (is_livefish_device(mf) || is_zombiefish_device(mf)))
     {
         return ME_ICMD_NOT_SUPPORTED;
     }


### PR DESCRIPTION
ZombieFish mode is supported from ConnectX8(Gilboa), Quantum3(Sunbird), and onwards.
a device in Zombiefish mode resembles a device in Livefish mode as they are both non-functional. i.e. in recovery mode.
while a device in livefish mode identifies on PCI with its recovery device ID (hw device ID), a device in ZombieFish mode identifies with its functional device ID (sw device ID).
to determine whether a device is in ZombieFish mode, we read the global image status to see if it differs from System Enabled (0x0 for adapters and 0x5E for switches).