### PR TITLE
mstflint | segfault while sending ICMDs on IB device

### DIFF
--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -1257,6 +1257,10 @@ static int is_pci_device(mfile* mf)
 
 static int is_livefish_device(mfile* mf)
 {
+    if (!mf || !mf->dinfo)
+    {
+        return 0;
+    }
     // Make sure to update this table both in mtcr.c & mtcr_ul_com.c !
     static u_int32_t live_fish_ids[][2] = {{DeviceConnectX4_HwId, DeviceConnectX4_HwId},
                                            {DeviceConnectX4LX_HwId, DeviceConnectX4LX_HwId},


### PR DESCRIPTION
Description: livefish check was missing NULL check for mf & mf->dinfo.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: Quantum IB
Tested flows: mstflint q

Known gaps (with RM ticket): n/a

Issue: 3972524