### PR TITLE
[flint] Print new INI version field

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -4590,6 +4590,12 @@ FlintStatus QuerySubCommand::printInfo(const fw_info_t& fwInfo, bool fullQuery)
         // blankGuids only exsists in FS2 image type in mlxfwops why?
         printf(FLINT_BLANK_GUIDS_WARNING);
     }
+
+    if (fwInfo.fs3_info.ini_file_version)
+    {
+        printf("INI revision:          0x%x\n", fwInfo.fs3_info.ini_file_version);
+    }
+
     return FLINT_SUCCESS;
 }
 

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -1804,6 +1804,7 @@ bool FwCompsMgr::queryFwInfo(fwInfoT* query, bool next_boot_fw_ver)
     query->sec_boot = mgir.fw_info.sec_boot;
     query->encryption = mgir.fw_info.encryption;
     query->signed_fw = _compsQueryMap[FwComponent::COMPID_BOOT_IMG].comp_cap.signed_updates_only;
+    query->ini_file_version = mgir.fw_info.ini_file_version;
 
     /* Since in switches MGIR 'dev' field is used to indicate dev-branch instead of the original purpose for dev-secure, */
     /* we now read from a new field called 'dev_sc' to determine if the switch is dev-secure */

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -136,6 +136,7 @@ typedef struct
     bool sec_boot;
     life_cycle_t life_cycle;
     bool encryption;
+    u_int32_t ini_file_version;
 
 } fwInfoT;
 

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -236,6 +236,7 @@ bool FsCtrlOperations::FsIntQuery()
     _fsCtrlImgInfo.sec_boot = fwQuery.sec_boot;
     _fsCtrlImgInfo.life_cycle = fwQuery.life_cycle;
     _fsCtrlImgInfo.encryption = fwQuery.encryption;
+    _fsCtrlImgInfo.ini_file_version = fwQuery.ini_file_version;
     std::vector<FwComponent> compsMap;
     if (!_fwCompsAccess->getFwComponents(compsMap, false))
     {

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -488,6 +488,7 @@ typedef struct fs3_info_ext
     struct reg_access_hca_mfsv_reg_ext device_security_version_mfsv;
 
     int global_image_status;
+    u_int32_t ini_file_version;
 
 } fs3_info_t;
 


### PR DESCRIPTION
Description: For alternate INI feature, expose
MGIR.FW_Info.ini_file_version in flint query

MSTFlint port needed: yes
Tested OS: TBD
Tested devices: TBD
Tested flows: TBD
Known gaps (with RM ticket): N/A