### PR TITLE
configure: don't use host's directories when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,8 +87,11 @@ fi
 AM_CONDITIONAL(KERNEL_BUILD,[test ${KERNEL_BUILD_CHK} = 1])
 AC_SUBST(KERNEL_BUILD)
 
-LDFLAGS="${LDFLAGS} -L/usr/local/lib -L/usr/local/lib64 -L/usr/lib64"
-CXXFLAGS="${CXXFLAGS} -isystem /usr/local/include"
+if test "x$cross_compiling" = "xno"; then
+    LDFLAGS="${LDFLAGS} -L/usr/local/lib -L/usr/local/lib64 -L/usr/lib64"
+    CXXFLAGS="${CXXFLAGS} -isystem /usr/local/include"
+fi
+
 if test "x$OS" = "xFreeBSD"; then
     AC_MSG_NOTICE(FreeBSD Build)
     MTCR_CONF_DIR="mtcr_freebsd"


### PR DESCRIPTION
I noticed that on some Linux distributions, like Arch Linux, cross-compiling fails while running the configure script despite the dependency being present within the cross-compilation toolchain.

<pre>
checking for uncompress in -lz... no
configure: error: cannot find zlib uncompress()
</pre>
<br>

The configure script always adds the host's include and library directories to `CXXFLAGS` and `LDFLAGS`, even when cross-compiling. This commit fixes the mentioned error by adding the host's directories only if we are not cross-compiling.
Tested on an Arch Linux installation cross-compiling `mstflint` using OpenWrt's x86_64 musl toolchain.