### PR TITLE
[flint][fs5] adding missing dtoc header treatment

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -1058,7 +1058,10 @@ bool Fs4Operations::FsVerifyAux(VerifyCallBack verifyCallBackFunc,
     if (dtocExists)
     {
         // We have a DTOC to verify
-        dtocPtr = _ioAccess->get_effective_size() - FS4_DEFAULT_SECTOR_SIZE;
+        if (!GetDtocAddress(dtocPtr))
+        {
+            return false;
+        }
         DPRINTF(("Fs4Operations::FsVerifyAux call verifyTocHeader() DTOC\n"));
         if (!verifyTocHeader(dtocPtr, true, verifyCallBackFunc))
         {
@@ -1255,6 +1258,10 @@ bool Fs4Operations::ParseDevData(bool quickQuery, bool verbose, VerifyCallBack v
         _ioAccess->set_address_convertor(0, 0);
         // Parse DTOC header:
         u_int32_t dtoc_addr = _ioAccess->get_size() - FS4_DEFAULT_SECTOR_SIZE;
+        if (!GetDtocAddress(dtoc_addr))
+        {
+            return false;
+        }
         DPRINTF(("Fs4Operations::ParseDevData call verifyTocHeader() DTOC, dtoc_addr = 0x%x\n", dtoc_addr));
         if (!verifyTocHeader(dtoc_addr, true, verifyCallBackFunc))
         {
@@ -2582,12 +2589,12 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
     {
         //* Burning DTOC
         // Get DTOC from the cache
+        u_int8_t* dtoc_data = new u_int8_t[FS4_DEFAULT_SECTOR_SIZE];
         u_int32_t dtoc_addr = imageOps->GetIoAccess()->get_size() - FS4_DEFAULT_SECTOR_SIZE;
-        if (!((Fs4Operations*)imageOps)->GetDtocAddress(dtoc_addr))
+        if (!GetDtocAddress(dtoc_addr))
         {
             return false;
         }
-        u_int8_t* dtoc_data = new u_int8_t[FS4_DEFAULT_SECTOR_SIZE];
         DPRINTF(("Fs4Operations::burnEncryptedImage - Burning DTOC at addr 0x%0x\n", dtoc_addr));
         ((Fs4Operations*)imageOps)->_imageCache.get(dtoc_data, dtoc_addr, FS4_DEFAULT_SECTOR_SIZE);
         if (!writeImageEx(burnParams.progressFuncEx,


### PR DESCRIPTION
Tested OS: linux
Tested devices: N/A
Tested flows: flint query on qtm3 image

Known gaps (with RM ticket): N/A

Issue: none