### PR TITLE
[ConnectX-8 Iris] - Detect ConnectX location using straps

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -4605,6 +4605,11 @@ FlintStatus QuerySubCommand::printInfo(const fw_info_t& fwInfo, bool fullQuery)
         printf("INI revision:          0x%x\n", fwInfo.fs3_info.ini_file_version);
     }
 
+    if (fwInfo.fs3_info.geo_address_valid)
+    {
+        printf("Geographical Address:  ASIC %x\n", fwInfo.fs3_info.geo_address);
+    }
+
     return FLINT_SUCCESS;
 }
 

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -1806,6 +1806,8 @@ bool FwCompsMgr::queryFwInfo(fwInfoT* query, bool next_boot_fw_ver)
     query->encryption = mgir.fw_info.encryption;
     query->signed_fw = _compsQueryMap[FwComponent::COMPID_BOOT_IMG].comp_cap.signed_updates_only;
     query->ini_file_version = mgir.fw_info.ini_file_version;
+    query->geo_address = mgir.hw_info.ga;
+    query->geo_address_valid = mgir.hw_info.ga_valid;
 
     /* Since in switches MGIR 'dev' field is used to indicate dev-branch instead of the original purpose for dev-secure, */
     /* we now read from a new field called 'dev_sc' to determine if the switch is dev-secure */

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -137,6 +137,8 @@ typedef struct
     life_cycle_t life_cycle;
     bool encryption;
     u_int32_t ini_file_version;
+    u_int8_t geo_address;
+    bool geo_address_valid;
 
 } fwInfoT;
 

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -237,6 +237,8 @@ bool FsCtrlOperations::FsIntQuery()
     _fsCtrlImgInfo.life_cycle = fwQuery.life_cycle;
     _fsCtrlImgInfo.encryption = fwQuery.encryption;
     _fsCtrlImgInfo.ini_file_version = fwQuery.ini_file_version;
+    _fsCtrlImgInfo.geo_address = fwQuery.geo_address;
+    _fsCtrlImgInfo.geo_address_valid = fwQuery.geo_address_valid;
     std::vector<FwComponent> compsMap;
     if (!_fwCompsAccess->getFwComponents(compsMap, false))
     {
@@ -463,6 +465,10 @@ bool FsCtrlOperations::FwQuery(fw_info_t* fwInfo,
             fwInfo->fs3_info.fs3_uids_info.guid_format = IMAGE_LAYOUT_UIDS;
             return true;
         }
+    }
+    else
+    {
+        fwInfo->fs3_info.geo_address_valid = false;
     }
     return true;
 }

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -489,6 +489,8 @@ typedef struct fs3_info_ext
 
     int global_image_status;
     u_int32_t ini_file_version;
+    u_int8_t geo_address;
+    bool geo_address_valid;
 
 } fs3_info_t;
 


### PR DESCRIPTION
Description:
For flint query: adding support in printing the geograpgical address of multi ASIC system component

MSTFlint port needed: yes
Tested OS: linux
Tested devices: Quantum3, ConnectX6LX
Tested flows: flint -d <dev> q

Known gaps (with RM ticket): no

Issue: 3830907