### PR TITLE
[flint] fixed boot2 size endianess

### DIFF
--- a/mlxfwops/lib/fs5_ops.cpp
+++ b/mlxfwops/lib/fs5_ops.cpp
@@ -170,7 +170,7 @@ bool Fs5Operations::CheckBoot2(bool fullRead, const char* pref, VerifyCallBack v
     {
         return false;
     }
-    _fwImgInfo.boot2Size = ncoreBCH.u8_stage1_component.u32_binary_len - hashes_table_size;
+    _fwImgInfo.boot2Size = __be32_to_cpu(ncoreBCH.u8_stage1_component.u32_binary_len) - hashes_table_size;
 
     DPRINTF(("FwOperations::CheckBoot2 size = 0x%x\n", _fwImgInfo.boot2Size));
     if (_fwImgInfo.boot2Size > 1048576 || _fwImgInfo.boot2Size < 4)


### PR DESCRIPTION
Description:

Tested OS: linux
Tested devices: N/A
Tested flows: flint image verify

Known gaps (with RM ticket): N/A

Issue: none