### PR TITLE
Support for new flashes for ConnectX-8 - commit fix

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -541,7 +541,9 @@ int get_log2size_by_vendor_type_density(u_int8_t vendor, u_int8_t type, u_int8_t
     {
         return cntx_sst_get_log2size(density, log2size);
     }
-    if (((type == FMT_WINBOND && vendor == FV_WINBOND) || (type == FMT_N25QXXX && vendor == FV_ST)) && density == 0x20)
+    if ((((type == FMT_WINBOND || type == FMT_WINBOND_3V) && vendor == FV_WINBOND) ||
+         (type == FMT_N25QXXX && vendor == FV_ST) || (type == FMT_IS25WPXXX && vendor == FV_IS25LPXXX)) &&
+        density == 0x20)
     {
         *log2size = 0x1a;
     }


### PR DESCRIPTION
Description: added support for both gigaDevice and issi flashes with 512MB for connectX-8

MSTFlint port needed: no
Tested OS: n/a
Tested devices: n/a
Tested flows: n/a

Known gaps (with RM ticket):

Issue:3847244