### PR TITLE
[CX8, QTM3 and above] - add support for Late LF mode

### DIFF
--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -528,6 +528,6 @@ typedef struct cables_info_t
      ((mf)->vsec_cap_mask & (1 << VCC_SEMAPHORE_SPACE_SUPPORTED)))
 
 // VSEC supported macro
-#define VSEC_SUPPORTED_UL(mf) ((mf)->vsec_supp && VSEC_MIN_SUPPORT_UL(mf))
+#define VSEC_SUPPORTED_UL(mf) ((mf)->functional_vsec_supp && VSEC_MIN_SUPPORT_UL(mf))
 
 #endif

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -115,7 +115,8 @@ struct mfile_t
     int old_mst;
     unsigned short mst_version_major;
     unsigned int mst_version_minor;
-    int vsec_supp;
+    int functional_vsec_supp;
+    u_int8_t vsec_type;
     mtcr_status_e icmd_support;
     unsigned int vsec_addr;
     u_int32_t vsec_cap_mask;

--- a/kernel/mst.h
+++ b/kernel/mst.h
@@ -63,7 +63,7 @@ struct mst_params
     unsigned int vendor;
     unsigned int subsystem_device;
     unsigned int subsystem_vendor;
-    unsigned int vendor_specific_cap;
+    unsigned int functional_vsc_offset;
 };
 
 typedef uint32_t u32;

--- a/kernel/mst_kernel.h
+++ b/kernel/mst_kernel.h
@@ -64,6 +64,10 @@
 #define MST_CONF_ADDR_REG 88
 #define MST_CONF_DATA_REG 92
 
+#define FUNCTIONAL_VSC 0
+#define RECOVERY_VSC 2
+#define RECOVERY_VSC_OFFSET_IN_CONFIG_SPACE 0x54 // Agreed with FW to keep the VSC offset always in 0x54 in recovery mode(LF/Late LF in CX8,QTM3 and above)
+
 #define MST_VPD_DEFAULT_TOUT 2000 /* milli seconds */
 
 #define mst_err(format, arg...) pr_err("%s: %s %d: " format, MST_PREFIX, __func__, __LINE__, ##arg)
@@ -110,8 +114,9 @@ struct mst_dev_data
 
     unsigned char connectx_wa_slots; /* wa for pci bug */
                                      /* Vendor specific capability address */
-    int vendor_specific_cap;
-    /* status on VSEC supported spaces*/
+    int functional_vsc_offset;
+    unsigned int recovery_vsc_offset; // For LF and Late LF in CX8, QTM3 and above
+    /* status on FUNCTIONAL VSC supported spaces*/
     int spaces_support_status;
 
     // Allocated pages for the user space.

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -261,7 +261,7 @@ int supports_reg_access_gmp(mfile* mf, maccess_reg_method_t reg_method)
 
 int mget_vsec_supp(mfile* mf)
 {
-    return mf->vsec_supp;
+    return mf->functional_vsec_supp;
 }
 
 MTCR_API int mget_addr_space(mfile* mf)

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -48,6 +48,12 @@ extern "C"
 {
 #endif
 
+/* Mellanox VSC */
+#define MLX_VSC_TYPE_OFFSET 24
+#define MLX_VSC_TYPE_LEN 8
+#define FUNCTIONAL_VSC 0
+#define RECOVERY_VSC 2
+
     /*
      * Read 4 bytes, return number of succ. read bytes or -1 on failure
      */

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -170,12 +170,12 @@
  * Macros for accessing Icmd Space
  */
 #define SET_SPACE_FOR_ICMD_ACCESS(mf) \
-    if (mf->vsec_supp)                \
+    if (mf->functional_vsec_supp)                \
     {                                 \
         mset_addr_space(mf, AS_ICMD); \
     }
 #define SET_SPACE_FOR_SEMAPHORE_ACCESS(mf) \
-    if (mf->vsec_supp)                     \
+    if (mf->functional_vsec_supp)                     \
     {                                      \
         mset_addr_space(mf, AS_SEMAPHORE); \
     }
@@ -663,7 +663,7 @@ static int icmd_take_semaphore_com(mfile* mf, u_int32_t expected_read_val)
         else
 #endif
         {
-            if (mf->vsec_supp)
+            if (mf->functional_vsec_supp)
             {
                 // write expected val before reading it
                 MWRITE4_SEMAPHORE(mf, mf->icmd.semaphore_addr, expected_read_val);
@@ -691,7 +691,7 @@ int icmd_take_semaphore(mfile* mf)
     ret = icmd_open(mf);
     CHECK_RC(ret);
 
-    if (mf->vsec_supp)
+    if (mf->functional_vsec_supp)
     {
         if (!pid)
         {
@@ -1321,7 +1321,7 @@ int icmd_open(mfile* mf)
     mf->icmd.ib_semaphore_lock_supported = 0;
     // attempt to open via CR-Space
 #if defined(MST_UL) && !defined(MST_UL_ICMD)
-    if (mf->vsec_supp)
+    if (mf->functional_vsec_supp)
     {
         return icmd_init_vcr(mf);
     }
@@ -1335,7 +1335,7 @@ int icmd_open(mfile* mf)
     /*if (mf->gb_info.is_gearbox){
         return icmd_init_cr(mf);
     }*/
-    if (mf->vsec_supp)
+    if (mf->functional_vsec_supp)
     {
         int rc = icmd_init_vcr(mf);
         if (rc == ME_OK)

--- a/small_utils/mtserver.c
+++ b/small_utils/mtserver.c
@@ -43,7 +43,7 @@
  *                   O   0x00000001 /dev/mst/mt25418_pci_cr0
  *       Send buff(W/O Dtype, deprecated):  O   DevName
  *                                          O   /dev/mst/mt25418_pci_cr0
- *       Rcv buff:   O   VSEC_SUPP
+ *       Rcv buff:   O   FUNCTIONAL_VSEC_SUPP
  *                   O   1
  *
  *  Mclose:


### PR DESCRIPTION
Description:
Late LF support: the driver will detect that the device is in Late LF mode to determine the right access method. LF in newer devices: in contrast to legacy LF, newer devices have VSC exposed. The driver will distinguish between a functional device and a LF device by the VSC type. When running MFT tools on a device in late LF mode, the user will get the same behavior received from a device in LF mode.

HLD - https://confluence.nvidia.com/pages/viewpage.action?pageId=3113761891

Tested OS: linux
Tested devices: ConnectX8
Tested flows: see detailed test and outputs in the bottom of the HLD

Known gaps (with RM ticket): n/a

Issue: 3909481 4043079