### PR TITLE
[mlxfwops] Remove redundant code from fsctrl_ops.cpp

### DIFF
--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -316,26 +316,6 @@ bool FsCtrlOperations::FsIntQuery()
         }
     }
 
-    //* Read global image status
-    if (_fsCtrlImgInfo.sec_boot == true)
-    {
-        try
-        {
-            CRSpaceRegisters cr_space_reg(mf, _fwImgInfo.ext_info.chip_type);
-            _fsCtrlImgInfo.global_image_status = cr_space_reg.getGlobalImageStatus();
-        }
-        catch (logic_error e)
-        {
-            printf("%s\n", e.what());
-            return false;
-        }
-        catch (exception e)
-        {
-            printf("%s\n", e.what());
-            return false;
-        }
-    }
-
     /*
      * Fill ROM info
      */


### PR DESCRIPTION
Description: In case of FW ctrl (MCC) flow, global image status is expected to be OK and we also don't print it as part of query (only in case of no FW ctrl flow). Removing the redundant code for reading global_image_status.

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: CX7
Tested flows: flint -d fwctrl2 q full; flint -d <DBDF> q full

Known gaps (with RM ticket): N/A

Issue: 4086069
Change-Id: If0fab8de215e3da1fb2b75b6c01c1c73a11824d3