### PR TITLE
porting blackwell support to mstflint

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -450,6 +450,8 @@ AS_IF([test "x$enable_adb_generic_tools" = "xyes"], [
         AC_CONFIG_FILES(tools_layouts/adb/prm/hca/ext/Makefile)
         AC_CONFIG_FILES(tools_layouts/adb/prm/switch/Makefile)
         AC_CONFIG_FILES(tools_layouts/adb/prm/switch/ext/Makefile)
+        AC_CONFIG_FILES(tools_layouts/adb/prm/gpu/Makefile)
+        AC_CONFIG_FILES(tools_layouts/adb/prm/gpu/ext/Makefile)
         AC_CONFIG_FILES(mlxreg/Makefile)
         AC_CONFIG_FILES(mlxreg/mlxreg_lib/Makefile)
         AC_CONFIG_FILES(mlxlink/Makefile)
@@ -457,7 +459,7 @@ AS_IF([test "x$enable_adb_generic_tools" = "xyes"], [
         AC_CONFIG_FILES(mlxlink/modules/printutil/Makefile)
         ADABE_TOOLS="adb_parser mlxreg mlxlink"
         ADABE_DBS="adb"
-        ADABE_DBS_EXTRA_DIST="adb/prm/hca/ext/*.adb adb/prm/switch/ext/*.adb"
+        ADABE_DBS_EXTRA_DIST="adb/prm/hca/ext/*.adb adb/prm/switch/ext/*.adb adb/prm/gpu/ext/*.adb"
     ])
 
 AM_CONDITIONAL([ADB_GENERIC_TOOLS_ENABLED], [test "x$enable_adb_generic_tools" = "xyes"])

--- a/dev_mgt/dev_mgt.py
+++ b/dev_mgt/dev_mgt.py
@@ -63,7 +63,7 @@ except Exception as exp:
 if DEV_MGT:
     class DevMgt:
         ##########################
-        def __init__(self, dev, i2c_secondary= -1):
+        def __init__(self, dev, i2c_secondary=-1):
             self.mf = 0
             self._isLivefishModeFunc = DEV_MGT.dm_is_livefish_mode  # dm_is_livefish_mode(mfile* mf)
             self._getDeviceIdFunc = DEV_MGT.dm_get_device_id
@@ -127,8 +127,8 @@ if DEV_MGT:
             return DEV_MGT.dm_is_connectib(dm_dev_id)
 
         @classmethod
-        def is_bw00(cls, dm_dev_id):
-            return DEV_MGT.dm_is_bw00(dm_dev_id)
+        def is_gb100(cls, dm_dev_id):
+            return DEV_MGT.dm_is_gb100(dm_dev_id)
 
         @classmethod
         def is_cx7(cls, dm_dev_id):

--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -421,13 +421,13 @@ static struct device_info g_devs_info[] = {
         DM_LINKX                                           /* dev_type */
     },
     {
-        DeviceArcusE, // dm_id
-        0xb200,       // hw_dev_id (other versions 0x6f,0x73)
-        -1,           // hw_rev_id
-        -1,           // sw_dev_id
-        "ArcusE",     // name
-        -1,           // port_num
-        DM_RETIMER    // dev_type
+        DeviceArcusE, /* dm_id */
+        0xb200,       /* hw_dev_id (other versions 0x6f,0x73) */
+        -1,           /* hw_rev_id */
+        -1,           /* sw_dev_id */
+        "ArcusE",     /* name */
+        -1,           /* port_num */
+        DM_RETIMER    /* dev_type */
     },
     {
         DeviceSecureHost,                                      /* dm_id */
@@ -475,11 +475,11 @@ static struct device_info g_devs_info[] = {
         DM_SWITCH                                            /* dev_type */
     },
     {
-        DeviceBW00,                                      /* dm_id */
+        DeviceGB100,                                      /* dm_id */
         0x2900,                                           /* hw_dev_id */
         -1,                                               /* hw_rev_id */
         10496,                                            /* sw_dev_id */
-        "BW00",                                          /* name */
+        "GB100",                                          /* name */
         128,                                              /* port_num NEED_CHECK */
         DM_SWITCH                                         /* dev_type */
     },
@@ -688,7 +688,7 @@ static int dm_get_device_id_inner(mfile      * mf,
             }
         }
     } else {
-        if (mread4(mf, DEVID_ADDR, &dword) != 4) {
+        if (read_device_id(mf, &dword) != 4) {
             return CRSPACE_READ_ERROR;
         }
 
@@ -933,7 +933,7 @@ int dm_is_livefish_mode(mfile* mf)
         return 1;
     }
     dm_dev_id_t devid_t = DeviceUnknown;
-    u_int32_t   devid = 0; // hw dev ID
+    u_int32_t   devid = 0; /* hw dev ID */
     u_int32_t   revid = 0;
     int         rc = dm_get_device_id(mf, &devid_t, &devid, &revid);
 
@@ -944,6 +944,11 @@ int dm_is_livefish_mode(mfile* mf)
     u_int32_t swid = mf->dinfo->pci.dev_id;
 
     /* printf("-D- swid: %#x, devid: %#x\n", swid, devid); */
+
+    if (dm_is_gpu(devid_t)) {
+        return 0;
+    }
+
     if (dm_is_4th_gen(devid_t)) {
         return (devid == swid - 1);
     } else {
@@ -981,12 +986,7 @@ int dm_is_gr100(dm_dev_id_t type)
 
 int dm_is_gpu(dm_dev_id_t type)
 {
-    return (dm_is_gb100(type) || dm_is_gb100(type));
-}
-
-int dm_is_bw00(dm_dev_id_t type)
-{
-    return (type == DeviceBW00);
+    return (dm_is_gb100(type) || dm_is_gr100(type));
 }
 
 int dm_is_cx7(dm_dev_id_t type)
@@ -1002,14 +1002,14 @@ int dm_is_new_gen_switch(dm_dev_id_t type)
 int dm_dev_is_raven_family_switch(dm_dev_id_t type)
 {
     return (dm_dev_is_switch(type) &&
-            (type == DeviceQuantum || type == DeviceQuantum2 || type == DeviceQuantum3 || type == DeviceBW00 ||
+            (type == DeviceQuantum || type == DeviceQuantum2 || type == DeviceQuantum3 || type == DeviceGB100 ||
              type == DeviceSpectrum2 || type == DeviceSpectrum3 || type == DeviceSpectrum4));
 }
 
 int dm_dev_is_ib_switch(dm_dev_id_t type)
 {
     return (dm_dev_is_switch(type) && (type == DeviceQuantum || type == DeviceQuantum2 || type == DeviceQuantum3 ||
-                                       type == DeviceBW00 || type == DeviceSwitchIB || type == DeviceSwitchIB2));
+                                       type == DeviceGB100 || type == DeviceSwitchIB || type == DeviceSwitchIB2));
 }
 
 int dm_dev_is_eth_switch(dm_dev_id_t type)

--- a/dev_mgt/tools_dev_types.h
+++ b/dev_mgt/tools_dev_types.h
@@ -52,253 +52,251 @@ extern "C"
 #include <common/compatibility.h>
 #include <mtcr.h>
 
-    enum dm_dev_id
-    {
-        DeviceUnknown = -1,    // Dummy Device - Marker for indicating error.
-        DeviceStartMarker = 0, // Dummy Device - Marker for first device
-                               // to let user iterate from DeviceStartMarker to DeviceEndMarker
-                               // Note: Call dm_is_device_supported() to see if a device is supported by the lib.
+enum dm_dev_id {
+    DeviceUnknown     = -1,    /* Dummy Device - Marker for indicating error. */
+    DeviceStartMarker = 0,     /* Dummy Device - Marker for first device */
+                               /* to let user iterate from DeviceStartMarker to DeviceEndMarker */
+                               /* Note: Call dm_is_device_supported() to see if a device is supported by the lib. */
 
-        DeviceConnectX3,
-        DeviceConnectIB,
-        DeviceConnectX3Pro,
-        DeviceSwitchIB,
-        DeviceSpectrum,
-        DeviceQuantum,
-        DeviceConnectX4,
-        DeviceConnectX4LX,
-        DeviceConnectX5,
-        DeviceConnectX6,
-        DeviceBlueField,
-        DeviceBlueField2,
-        DeviceBlueField3,
-        DeviceBlueField4,
-        DeviceSwitchIB2,
-        DeviceCable,
-        DeviceCableQSFP,
-        DeviceCableQSFPaging,
-        DeviceCableSFP,
-        DeviceCableSFP51,
-        DeviceCableSFP51Paging,
-        DeviceArdbeg,
-        DeviceBaritone,
-        DeviceMenhit,
-        DeviceSpectrum2,
-        DeviceDummy,
-        DeviceSecureHost,
-        DeviceConnectX6DX,
-        DeviceConnectX6LX,
-        DeviceConnectX7,
-        DeviceConnectX8,
-        DeviceSpectrum3, // Firebird
-        DeviceSpectrum4, // Albatross
-        DeviceQuantum2,  // Blackbird
-        DeviceQuantum3,  // Sunbird
-        DeviceGearBox,
-        DeviceGearBoxManager,
-        DeviceAbirGearBox,
-        DeviceCableCMIS,
-        DeviceCableCMISPaging,
-        DeviceBW00,    // Blackwell
-        DeviceGB100,
-        DeviceGR100,
-        DeviceArcusPTC, // ArcusP Test Chip
-        DeviceArcusP,
-        DeviceArcusE,
-        DeviceEndMarker // Dummy Device - Marker for indicating end of devices when iterating
-    };
+    DeviceConnectX3,
+    DeviceConnectIB,
+    DeviceConnectX3Pro,
+    DeviceSwitchIB,
+    DeviceSpectrum,
+    DeviceQuantum,
+    DeviceConnectX4,
+    DeviceConnectX4LX,
+    DeviceConnectX5,
+    DeviceConnectX6,
+    DeviceBlueField,
+    DeviceBlueField2,
+    DeviceBlueField3,
+    DeviceBlueField4,
+    DeviceSwitchIB2,
+    DeviceCable,
+    DeviceCableQSFP,
+    DeviceCableQSFPaging,
+    DeviceCableSFP,
+    DeviceCableSFP51,
+    DeviceCableSFP51Paging,
+    DeviceArdbeg,
+    DeviceBaritone,
+    DeviceMenhit,
+    DeviceSpectrum2,
+    DeviceDummy,
+    DeviceSecureHost,
+    DeviceConnectX6DX,
+    DeviceConnectX6LX,
+    DeviceConnectX7,
+    DeviceConnectX8,
+    DeviceSpectrum3,     /* Firebird */
+    DeviceSpectrum4,     /* Albatross */
+    DeviceQuantum2,      /* Blackbird */
+    DeviceQuantum3,      /* Sunbird */
+    DeviceGearBox,
+    DeviceGearBoxManager,
+    DeviceAbirGearBox,
+    DeviceCableCMIS,
+    DeviceCableCMISPaging,
+    DeviceGB100,     /* Blackwell */
+    DeviceGR100,
+    DeviceArcusPTC,     /* ArcusP Test Chip */
+    DeviceArcusP,
+    DeviceArcusE,
+    DeviceEndMarker     /* Dummy Device - Marker for indicating end of devices when iterating */
+};
 
-    enum hw_dev_id
-    {
-        DeviceConnectX3_HwId = 0x1f5,
-        DeviceConnectIB_HwId = 0x1ff,
-        DeviceConnectX3Pro_HwId = 0x1f7,
-        DeviceSwitchIB_HwId = 0x247,
-        DeviceSpectrum_HwId = 0x249,
-        DeviceConnectX4_HwId = 0x209,
-        DeviceConnectX4LX_HwId = 0x20b,
-        DeviceConnectX5_HwId = 0x20d,
-        DeviceConnectX6_HwId = 0x20f,
-        DeviceConnectX6DX_HwId = 0x212,
-        DeviceConnectX6LX_HwId = 0x216,
-        DeviceConnectX7_HwId = 0x218,
-        DeviceConnectX8_HwId = 0x21e,
-        DeviceBlueField_HwId = 0x211,
-        DeviceBlueField2_HwId = 0x214,
-        DeviceBlueField3_HwId = 0x21c,
-        DeviceBlueField4_HwId = 0x220,
-        DeviceSwitchIB2_HwId = 0x24b,
-        DeviceCableQSFP_HwId = 0x0d,
-        DeviceCableQSFPaging_HwId = 0x11,
-        DeviceCableCMIS_HwId = 0x19,
-        DeviceCableCMISPaging_HwId = 0x19,
-        DeviceCableSFP_HwId = 0x03,
-        DeviceCableSFP51_HwId = 0x03,
-        DeviceCableSFP51Paging_HwId = 0x03,
-        DeviceSpectrum2_HwId = 0x24e,
-        DeviceQuantum_HwId = 0x24d,
-        DeviceQuantum2_HwId = 0x257,
-        DeviceQuantum3_HwId = 0x25b,
-        DeviceBW00_HwId = 0x2900,
-        DeviceArdbeg_HwId = 0x6e,
-        DeviceBaritone_HwId = 0x6b,
-        DeviceMenhit_HwId = 0x72,
-        DeviceSecureHost_HwId = 0xcafe,
-        DeviceSpectrum3_HwId = 0x250,
-        DeviceSpectrum4_HwId = 0x254,
-        DeviceGearBox_HwId = 0x252,
-        DeviceGearBoxManager_HwId = 0x253,
-        DeviceAbirGearBox_HwId = 0x256,
-        DeviceArcusPTC_HwId = 0x7f, // ArcusP Test Chip
-        DeviceArcusP_HwId = 0x80,
-        DeviceArcusE_HwId = 0x81,
-    };
-    typedef enum dm_dev_id dm_dev_id_t;
+enum hw_dev_id {
+    DeviceConnectX3_HwId        = 0x1f5,
+    DeviceConnectIB_HwId        = 0x1ff,
+    DeviceConnectX3Pro_HwId     = 0x1f7,
+    DeviceSwitchIB_HwId         = 0x247,
+    DeviceSpectrum_HwId         = 0x249,
+    DeviceConnectX4_HwId        = 0x209,
+    DeviceConnectX4LX_HwId      = 0x20b,
+    DeviceConnectX5_HwId        = 0x20d,
+    DeviceConnectX6_HwId        = 0x20f,
+    DeviceConnectX6DX_HwId      = 0x212,
+    DeviceConnectX6LX_HwId      = 0x216,
+    DeviceConnectX7_HwId        = 0x218,
+    DeviceConnectX8_HwId        = 0x21e,
+    DeviceBlueField_HwId        = 0x211,
+    DeviceBlueField2_HwId       = 0x214,
+    DeviceBlueField3_HwId       = 0x21c,
+    DeviceBlueField4_HwId       = 0x220,
+    DeviceSwitchIB2_HwId        = 0x24b,
+    DeviceCableQSFP_HwId        = 0x0d,
+    DeviceCableQSFPaging_HwId   = 0x11,
+    DeviceCableCMIS_HwId        = 0x19,
+    DeviceCableCMISPaging_HwId  = 0x19,
+    DeviceCableSFP_HwId         = 0x03,
+    DeviceCableSFP51_HwId       = 0x03,
+    DeviceCableSFP51Paging_HwId = 0x03,
+    DeviceSpectrum2_HwId        = 0x24e,
+    DeviceQuantum_HwId          = 0x24d,
+    DeviceQuantum2_HwId         = 0x257,
+    DeviceQuantum3_HwId         = 0x25b,
+    DeviceGB100_HwId            = 0x2900,
+    DeviceGR100_HwId            = 0x3000,
+    DeviceArdbeg_HwId           = 0x6e,
+    DeviceBaritone_HwId         = 0x6b,
+    DeviceMenhit_HwId           = 0x72,
+    DeviceSecureHost_HwId       = 0xcafe,
+    DeviceSpectrum3_HwId        = 0x250,
+    DeviceSpectrum4_HwId        = 0x254,
+    DeviceGearBox_HwId          = 0x252,
+    DeviceGearBoxManager_HwId   = 0x253,
+    DeviceAbirGearBox_HwId      = 0x256,
+    DeviceArcusPTC_HwId         = 0x7f, /* ArcusP Test Chip */
+    DeviceArcusP_HwId           = 0x80,
+    DeviceArcusE_HwId           = 0x81,
+};
+typedef enum dm_dev_id dm_dev_id_t;
 
-    /**
-     * Returns 0 on success and 1 on failure.
-     */
-    int dm_get_device_id(mfile* mf, dm_dev_id_t* ptr_dev_type, u_int32_t* ptr_dev_id, u_int32_t* ptr_chip_rev);
+/**
+ * Returns 0 on success and 1 on failure.
+ */
+int dm_get_device_id(mfile* mf, dm_dev_id_t* ptr_dev_type, u_int32_t* ptr_dev_id, u_int32_t* ptr_chip_rev);
 
-    int dm_get_device_id_without_prints(mfile* mf,
-                                        dm_dev_id_t* ptr_dm_dev_id,
-                                        u_int32_t* ptr_hw_dev_id,
-                                        u_int32_t* ptr_hw_rev);
+int dm_get_device_id_without_prints(mfile      * mf,
+                                    dm_dev_id_t* ptr_dm_dev_id,
+                                    u_int32_t  * ptr_hw_dev_id,
+                                    u_int32_t  * ptr_hw_rev);
 
-    /**
-     * Returns 0 on success and 1 on failure.
-     */
-    int dm_get_device_id_offline(u_int32_t devid, u_int32_t chip_rev, dm_dev_id_t* ptr_dev_type);
+/**
+ * Returns 0 on success and 1 on failure.
+ */
+int dm_get_device_id_offline(u_int32_t devid, u_int32_t chip_rev, dm_dev_id_t* ptr_dev_type);
 
-    /**
-     * Returns 1 if device is supported and 0 otherwise (library dependant)
-     */
-    int dm_is_device_supported(dm_dev_id_t type);
+/**
+ * Returns 1 if device is supported and 0 otherwise (library dependant)
+ */
+int dm_is_device_supported(dm_dev_id_t type);
 
-    /**
-     * Returns the device name as a "const char*"
-     */
-    const char* dm_dev_type2str(dm_dev_id_t type);
-    
-    /**
-     * Returns the device name as a "const char*"
-     */
-    const char* dm_dev_hw_id2str(unsigned int hw_dev_id);
+/**
+ * Returns the device name as a "const char*"
+ */
+const char* dm_dev_type2str(dm_dev_id_t type);
 
-    /**
-     * Returns the device id
-     */
-    dm_dev_id_t dm_dev_str2type(const char* str);
+/**
+ * Returns the device name as a "const char*"
+ */
+const char* dm_dev_hw_id2str(unsigned int hw_dev_id);
 
-    /**
-     * A predicate returning if the device is an hca
-     */
-    int dm_dev_is_hca(dm_dev_id_t type);
+/**
+ * Returns the device id
+ */
+dm_dev_id_t dm_dev_str2type(const char* str);
 
-    /**
-     * A predicate returning if the device is gearbox
-     */
-    int dm_dev_is_gearbox(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is an hca
+ */
+int dm_dev_is_hca(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is menhit
-     */
-    int dm_is_menhit(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is gearbox
+ */
+int dm_dev_is_gearbox(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is dummy
-     */
-    int dm_dev_is_dummy(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is menhit
+ */
+int dm_is_menhit(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the hca supports 200G speed and above
-     */
-    int dm_dev_is_200g_speed_supported_hca(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is dummy
+ */
+int dm_dev_is_dummy(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a switch
-     */
-    int dm_dev_is_switch(dm_dev_id_t type);
+/**
+ * A predicate returning if the hca supports 200G speed and above
+ */
+int dm_dev_is_200g_speed_supported_hca(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the switch supports 200G speed and above
-     */
-    int dm_dev_is_200g_speed_supported_switch(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a switch
+ */
+int dm_dev_is_switch(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a bridge
-     */
-    int dm_dev_is_bridge(dm_dev_id_t type);
+/**
+ * A predicate returning if the switch supports 200G speed and above
+ */
+int dm_dev_is_200g_speed_supported_switch(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a Cable
-     */
-    int dm_dev_is_cable(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a bridge
+ */
+int dm_dev_is_bridge(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is an ArcusE chipset
-     */
-    int dm_dev_is_retimer(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a Cable
+ */
+int dm_dev_is_cable(dm_dev_id_t type);
 
-    /**
-     * Returns the max num of ports or -1 on error
-     */
-    int dm_get_hw_ports_num(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is an ArcusE chipset
+ */
+int dm_dev_is_retimer(dm_dev_id_t type);
 
-    /**
-     * Returns the HW device id of the givn device type or zero on failure.
-     */
-    u_int32_t dm_get_hw_dev_id(dm_dev_id_t type);
+/**
+ * Returns the max num of ports or -1 on error
+ */
+int dm_get_hw_ports_num(dm_dev_id_t type);
 
-    /**
-     * Returns the HW chip revision of the given device type or zero on failures,
-     * This is useful to distinguish between ConnectX2 and ConnectX.
-     */
-    u_int32_t dm_get_hw_rev_id(dm_dev_id_t type);
+/**
+ * Returns the HW device id of the givn device type or zero on failure.
+ */
+u_int32_t dm_get_hw_dev_id(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device supports Function Per Port
-     */
-    int dm_is_fpp_supported(dm_dev_id_t type);
+/**
+ * Returns the HW chip revision of the given device type or zero on failures,
+ * This is useful to distinguish between ConnectX2 and ConnectX.
+ */
+u_int32_t dm_get_hw_rev_id(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a gb100
-     */
-    int dm_is_gb100(dm_dev_id_t type);
+/**
+ * A predicate returning if the device supports Function Per Port
+ */
+int dm_is_fpp_supported(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a gpu device
-     */
-    int dm_is_gpu(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a gb100
+ */
+int dm_is_gb100(dm_dev_id_t type);
 
-    /**
-     * A predicate returning if the device is a gr100
-     */
-    int dm_is_gr100(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a gpu device
+ */
+int dm_is_gpu(dm_dev_id_t type);
 
-    int dm_is_4th_gen(dm_dev_id_t type);
+/**
+ * A predicate returning if the device is a gr100
+ */
+int dm_is_gr100(dm_dev_id_t type);
 
-    int dm_dev_is_fs5(dm_dev_id_t type);
+int dm_is_4th_gen(dm_dev_id_t type);
 
-    int dm_is_5th_gen_hca(dm_dev_id_t type);
+int dm_dev_is_fs5(dm_dev_id_t type);
 
-    int dm_is_connectib(dm_dev_id_t type);
+int dm_is_5th_gen_hca(dm_dev_id_t type);
 
-    int dm_is_new_gen_switch(dm_dev_id_t type);
+int dm_is_connectib(dm_dev_id_t type);
 
-    int dm_dev_is_raven_family_switch(dm_dev_id_t type);
+int dm_is_new_gen_switch(dm_dev_id_t type);
 
-    int dm_dev_is_ib_switch(dm_dev_id_t type);
+int dm_dev_is_raven_family_switch(dm_dev_id_t type);
 
-    int dm_dev_is_eth_switch(dm_dev_id_t type);
-    /*
-     * A predicate returning if the device is in LiveFish mode
-     */
-    int dm_is_livefish_mode(mfile* mf);
+int dm_dev_is_ib_switch(dm_dev_id_t type);
 
-    int dm_is_ib_access(mfile* mf);
+int dm_dev_is_eth_switch(dm_dev_id_t type);
+/*
+ * A predicate returning if the device is in LiveFish mode
+ */
+int dm_is_livefish_mode(mfile* mf);
+
+int dm_is_ib_access(mfile* mf);
 #ifdef __cplusplus
 } /* end of 'extern "C"' */
 #endif
 
-#endif // TOOLS_DEV_TYPE_H
+#endif /* TOOLS_DEV_TYPE_H */

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -57,7 +57,7 @@ typedef __int8 int8_t;
 typedef __int16 int16_t;
 typedef __int32 int32_t;
 typedef __int64 int64_t;
-#endif // !_MSC_VER
+#endif /* !_MSC_VER */
 typedef unsigned __int8 u_int8_t;
 typedef unsigned __int16 u_int16_t;
 typedef unsigned __int32 u_int32_t;
@@ -89,48 +89,45 @@ typedef long long int64_t;
 
 #include <sys/types.h>
 #define MTCR_API
-#define LOCK_FILE_DIR "/tmp/mstflint_lockfiles"
-#define LOCK_FILE_FORMAT "/tmp/mstflint_lockfiles/%04x:%02x:%02x.%x_%s"
+#define LOCK_FILE_DIR                "/tmp/mstflint_lockfiles"
+#define LOCK_FILE_FORMAT             "/tmp/mstflint_lockfiles/%04x:%02x:%02x.%x_%s"
 #define LOCK_VIRTUAL_PCI_FILE_FORMAT "/tmp/mstflint_lockfiles/%s_%s"
-#define MAX_RETRY_CNT 4096
-#endif
+#define MAX_RETRY_CNT                4096
+#endif /* ifdef __WIN__ */
 
-#define DEV_NAME_SZ 512
-#define MAX_PAGES_SIZE 8
+#define DEV_NAME_SZ           512
+#define MAX_PAGES_SIZE        8
 #define SMP_SEMAPHOE_LOCK_CMD 0xff53
 
 /*
  * MST <--> MTCR API defines
  */
-#define MST_HEADER_VERSION 1
-#define MST_META_DATA_MAJOR 1
-#define MST_META_DATA_MINOR 0
+#define MST_HEADER_VERSION              1
+#define MST_META_DATA_MAJOR             1
+#define MST_META_DATA_MINOR             0
 #define MTCR_SUPP_MST_API_MAJOR_VERSION 1
 
-// Service name.
+/* Service name. */
 #define MST_PREFIX_64_BIT "mst64_"
 #define MST_PREFIX_32_BIT "mst32_"
 #define MST_SUFFIX_MAXLEN 11
 #define MST_SERVICE_NAME_SIZE \
-    (sizeof(MST_PREFIX_64_BIT) + sizeof(MFT_VERSION_STR) + MST_SUFFIX_MAXLEN + 9) // 9 is just in case reserve
+    (sizeof(MST_PREFIX_64_BIT) + sizeof(MFT_VERSION_STR) + MST_SUFFIX_MAXLEN + 9) /* 9 is just in case reserve */
 
-//#ifndef USE_IB_MGT
-typedef struct mib_private_t
-{
+/*#ifndef USE_IB_MGT */
+typedef struct mib_private_t {
     int dummy;
 } MIB_Private;
-//#else
-//#include "mtcr_ib_private.h"
-//#endif
+/*#else */
+/*#include "mtcr_ib_private.h" */
+/*#endif */
 
-typedef enum
-{
+typedef enum {
     SEM_LOCK_GET = 0x0,
     SEM_LOCK_SET = 0x1
 } sem_lock_method_t;
 
-typedef enum MError
-{
+typedef enum MError {
     ME_OK = 0,
     ME_ERROR,
     ME_BAD_PARAMS,
@@ -154,8 +151,8 @@ typedef enum MError
     ME_UNSUPPORTED_ACCESS_TYPE,
     ME_GMP_MAD_UNSUPPORTED_OPERATION,
 
-    // errors regarding REG_ACCESS
-    ME_REG_ACCESS_OK = 0,
+    /* errors regarding REG_ACCESS */
+    ME_REG_ACCESS_OK             = 0,
     ME_REG_ACCESS_BAD_STATUS_ERR = 0x100,
     ME_REG_ACCESS_BAD_METHOD,
     ME_REG_ACCESS_NOT_SUPPORTED,
@@ -176,8 +173,8 @@ typedef enum MError
     ME_REG_ACCESS_ERASE_EXEEDED,
     ME_REG_ACCESS_INTERNAL_ERROR,
 
-    // errors regarding ICMD
-    ME_ICMD_STATUS_CR_FAIL = 0x200, // cr-space access failure
+    /* errors regarding ICMD */
+    ME_ICMD_STATUS_CR_FAIL = 0x200, /* cr-space access failure */
     ME_ICMD_INVALID_OPCODE,
     ME_ICMD_INVALID_CMD,
     ME_ICMD_OPERATIONAL_ERROR,
@@ -185,8 +182,8 @@ typedef enum MError
     ME_ICMD_BUSY,
     ME_ICMD_INIT_FAILED,
     ME_ICMD_NOT_SUPPORTED,
-    ME_ICMD_STATUS_SEMAPHORE_TO, // timed out while trying to take semaphore
-    ME_ICMD_STATUS_EXECUTE_TO,   // timed out while waiting for command to execute
+    ME_ICMD_STATUS_SEMAPHORE_TO, /* timed out while trying to take semaphore */
+    ME_ICMD_STATUS_EXECUTE_TO,   /* timed out while waiting for command to execute */
     ME_ICMD_STATUS_IFC_BUSY,
     ME_ICMD_STATUS_ICMD_NOT_READY,
     ME_ICMD_UNSUPPORTED_ICMD_VERSION,
@@ -195,7 +192,7 @@ typedef enum MError
     ME_ICMD_WRITE_PROTECT,
     ME_ICMD_SIZE_EXCEEDS_LIMIT,
 
-    // errors regarding Tools CMDIF
+    /* errors regarding Tools CMDIF */
     ME_CMDIF_BUSY = 0x300,
     ME_CMDIF_TOUT,
     ME_CMDIF_BAD_STATUS,
@@ -206,7 +203,7 @@ typedef enum MError
     ME_CMDIF_RES_STATE,
     ME_CMDIF_UNKN_STATUS,
 
-    // errors regarding MAD IF
+    /* errors regarding MAD IF */
     ME_MAD_BUSY = 0x400,
     ME_MAD_REDIRECT,
     ME_MAD_BAD_VER,
@@ -215,7 +212,7 @@ typedef enum MError
     ME_MAD_BAD_DATA,
     ME_MAD_GENERAL_ERR,
 
-    // errors regarding gearbox icmd new interface gateway
+    /* errors regarding gearbox icmd new interface gateway */
     ME_GB_ICMD_OK = 0x500,
     ME_GB_ICMD_FAILED,
     ME_GB_ICMD_FAILED_ACCESS,
@@ -227,44 +224,42 @@ typedef enum MError
     ME_LAST
 } MError;
 
-// typedefs for UEFI
+/* typedefs for UEFI */
 #ifdef UEFI_BUILD
 #include <mft_uefi_common.h>
 #endif
-typedef enum MType_t
-{
-    MST_ERROR = 0x0,
-    MST_FPGA = 0x1, // Unsupported
-    MST_MLNXOS = 0x2,
-    MST_LPC = 0x4,
-    MST_PCI = 0x8,
+typedef enum MType_t {
+    MST_ERROR   = 0x0,
+    MST_FPGA    = 0x1, /* Unsupported */
+    MST_MLNXOS  = 0x2,
+    MST_LPC     = 0x4,
+    MST_PCI     = 0x8,
     MST_PCICONF = 0x10,
     /*MST_CALBR,*/
-    MST_USB = 0x20,
-    MST_IB = 0x40,
+    MST_USB                  = 0x20,
+    MST_IB                   = 0x40,
     MST_FWCTL_CONTROL_DRIVER = 0x80,
-    MST_PPC = 0x100,
-    MST_USB_DIMAX = 0x200,
-    MST_FWCTX = 0x400,
-    MST_REMOTE = 0x800,
+    MST_PPC                  = 0x100,
+    MST_USB_DIMAX            = 0x200,
+    MST_FWCTX                = 0x400,
+    MST_REMOTE               = 0x800,
 #ifdef ENABLE_MST_DEV_I2C
     MST_DEV_I2C = 0x1000,
 #endif
-    MST_CALBR = 0x2000,
-    MST_FPGA_ICMD = 0x4000, // Unsupported
-    MST_CABLE = 0x8000,
-    MST_FPGA_DRIVER = 0x10000, // Unsupported
-    MST_SOFTWARE = 0x20000,
+    MST_CALBR       = 0x2000,
+    MST_FPGA_ICMD   = 0x4000, /* Unsupported */
+    MST_CABLE       = 0x8000,
+    MST_FPGA_DRIVER = 0x10000, /* Unsupported */
+    MST_SOFTWARE    = 0x20000,
     MST_DRIVER_CONF = 0x40000,
-    MST_DRIVER_CR = 0x80000,
-    MST_LINKX_CHIP = 0x100000,
+    MST_DRIVER_CR   = 0x80000,
+    MST_LINKX_CHIP  = 0x100000,
     MST_BAR0_GW_PCI = 0x200000,
-    MST_GEARBOX = 0x400000,
-    MST_DEFAULT = 0xffffffff & ~MST_CABLE & ~MST_FPGA & ~MST_FPGA_ICMD & ~MST_FPGA_DRIVER & ~MST_LINKX_CHIP
+    MST_GEARBOX     = 0x400000,
+    MST_DEFAULT     = 0xffffffff & ~MST_CABLE & ~MST_FPGA & ~MST_FPGA_ICMD & ~MST_FPGA_DRIVER & ~MST_LINKX_CHIP
 } MType;
 
-typedef enum DType_t
-{
+typedef enum DType_t {
     MST_GAMLA,
     MST_TAVOR,
     MST_DIMM,
@@ -272,215 +267,194 @@ typedef enum DType_t
 } DType;
 #define MST_ANAFA2 MST_TAVOR
 #define MST_EEPROM MST_GAMLA
-typedef enum Mdevs_t
-{
-    MDEVS_GAMLA = 0x01,         /*  Each device that actually is a Gamla */
-    MDEVS_I2CM = 0x02,          /*  Each device that can work as I2C master */
-    MDEVS_MEM = 0x04,           /*  Each device that is a memory driver (vtop) */
-    MDEVS_TAVOR_DDR = 0x08,     /*  Each device that maps to DDR */
-    MDEVS_TAVOR_UAR = 0x10,     /*  Each device that maps to UAR */
-    MDEVS_TAVOR_CR = 0x20,      /*  Each device that maps to CR */
-    MDEVS_REM = 0x80,           /*  Remote devices */
-    MDEVS_PPC = 0x100,          /*  PPC devices */
-    MDEVS_DEV_I2C = 0x200,      /* Generic linux kernel i2c device */
-    MDEVS_IB = 0x400,           /* Cr access over IB Mads */
-    MDEVS_MLNX_OS = 0x800,      /* access by CmdIf in MlnxOS */
-    MDEVS_FWCTX = 0x900,        /* access by func/context (like UEFI) */
-    MDEVS_LPC = 0x1000,         /* Access LPC region */
-    MDEVS_FPGA = 0x2000,        /* Access LPC region - DEPRECATED */
+typedef enum Mdevs_t {
+    MDEVS_GAMLA       = 0x01,   /*  Each device that actually is a Gamla */
+    MDEVS_I2CM        = 0x02,   /*  Each device that can work as I2C master */
+    MDEVS_MEM         = 0x04,   /*  Each device that is a memory driver (vtop) */
+    MDEVS_TAVOR_DDR   = 0x08,   /*  Each device that maps to DDR */
+    MDEVS_TAVOR_UAR   = 0x10,   /*  Each device that maps to UAR */
+    MDEVS_TAVOR_CR    = 0x20,   /*  Each device that maps to CR */
+    MDEVS_REM         = 0x80,   /*  Remote devices */
+    MDEVS_PPC         = 0x100,  /*  PPC devices */
+    MDEVS_DEV_I2C     = 0x200,  /* Generic linux kernel i2c device */
+    MDEVS_IB          = 0x400,  /* Cr access over IB Mads */
+    MDEVS_MLNX_OS     = 0x800,  /* access by CmdIf in MlnxOS */
+    MDEVS_FWCTX       = 0x900,  /* access by func/context (like UEFI) */
+    MDEVS_LPC         = 0x1000, /* Access LPC region */
+    MDEVS_FPGA        = 0x2000, /* Access LPC region - DEPRECATED */
     MDEVS_FPGA_NEWTON = 0x4000, /* Access LPC region - DEPRECATED */
-    MDEVS_CABLE = 0x8000,
-    MDEVS_SOFTWARE = 0x10000, /* Software system char dev */
-    MDEVS_LINKX_CHIP = 0x200000,
-    MDEVS_GBOX = 0x400000,
-    MDEVS_TAVOR = (MDEVS_TAVOR_DDR | MDEVS_TAVOR_UAR | MDEVS_TAVOR_CR),
-    MDEVS_ALL = 0xffffffff
+    MDEVS_CABLE       = 0x8000,
+    MDEVS_SOFTWARE    = 0x10000, /* Software system char dev */
+    MDEVS_LINKX_CHIP  = 0x200000,
+    MDEVS_GBOX        = 0x400000,
+    MDEVS_TAVOR       = (MDEVS_TAVOR_DDR | MDEVS_TAVOR_UAR | MDEVS_TAVOR_CR),
+    MDEVS_ALL         = 0xffffffff
 } Mdevs;
 
-typedef enum
-{
-    MACCESS_REG_METHOD_GET = 1,
-    MACCESS_REG_METHOD_SET = 2,
+typedef enum {
+    MACCESS_REG_METHOD_GET  = 1,
+    MACCESS_REG_METHOD_SET  = 2,
     MACCESS_LAST_REG_METHOD = 3
 } maccess_reg_method_t;
 
-typedef enum
-{
-    VCC_INITIALIZED = 0x0,
-    VCC_ICMD_EXT_SPACE_SUPPORTED = 0x1,
-    VCC_CRSPACE_SPACE_SUPPORTED = 0x2,
-    VCC_ICMD_SPACE_SUPPORTED = 0x3,
+typedef enum {
+    VCC_INITIALIZED                     = 0x0,
+    VCC_ICMD_EXT_SPACE_SUPPORTED        = 0x1,
+    VCC_CRSPACE_SPACE_SUPPORTED         = 0x2,
+    VCC_ICMD_SPACE_SUPPORTED            = 0x3,
     VCC_NODNIC_INIT_SEG_SPACE_SUPPORTED = 0x4,
-    VCC_EXPANSION_ROM_SPACE_SUPPORTED = 0x5,
-    VCC_ND_CRSPACE_SPACE_SUPPORTED = 0x6,
-    VCC_SCAN_CRSPACE_SPACE_SUPPORTED = 0x7,
-    VCC_SEMAPHORE_SPACE_SUPPORTED = 0x8,
-    VCC_MAC_SPACE_SUPPORTED = 0x9,
+    VCC_EXPANSION_ROM_SPACE_SUPPORTED   = 0x5,
+    VCC_ND_CRSPACE_SPACE_SUPPORTED      = 0x6,
+    VCC_SCAN_CRSPACE_SPACE_SUPPORTED    = 0x7,
+    VCC_SEMAPHORE_SPACE_SUPPORTED       = 0x8,
+    VCC_MAC_SPACE_SUPPORTED             = 0x9,
 } VSCCapCom;
 
-typedef enum
-{
-    AS_ICMD_EXT = 0x1,
-    AS_CR_SPACE = 0x2,
-    AS_ICMD = 0x3,
+typedef enum {
+    AS_ICMD_EXT        = 0x1,
+    AS_CR_SPACE        = 0x2,
+    AS_ICMD            = 0x3,
     AS_NODNIC_INIT_SEG = 0x4,
-    AS_EXPANSION_ROM = 0x5,
-    AS_ND_CRSPACE = 0x6,
-    AS_SCAN_CRSPACE = 0x7,
-    AS_SEMAPHORE = 0xa,
-    AS_MAC = 0xf,
+    AS_EXPANSION_ROM   = 0x5,
+    AS_ND_CRSPACE      = 0x6,
+    AS_SCAN_CRSPACE    = 0x7,
+    AS_SEMAPHORE       = 0xa,
+    AS_MAC             = 0xf,
     AS_END
 } address_space_t;
 
-typedef struct vf_info_t
-{
-    char dev_name[512];
+typedef struct vf_info_t {
+    char      dev_name[512];
     u_int16_t domain;
-    u_int8_t bus;
-    u_int8_t dev;
-    u_int8_t func;
-    char** net_devs; // Null terminated array
-    char** ib_devs;  // Null terminated array
+    u_int8_t  bus;
+    u_int8_t  dev;
+    u_int8_t  func;
+    char   ** net_devs; /* Null terminated array */
+    char   ** ib_devs; /* Null terminated array */
 } vf_info;
 
-typedef struct dev_info_t
-{
+typedef struct dev_info_t {
     Mdevs type;
-    char dev_name[512];
-    int ul_mode;
+    char  dev_name[512];
+    int   ul_mode;
 
-    union
-    {
-        struct
-        {
+    union {
+        struct {
             u_int16_t domain;
-            u_int8_t bus;
-            u_int8_t dev;
-            u_int8_t func;
-
+            u_int8_t  bus;
+            u_int8_t  dev;
+            u_int8_t  func;
             u_int16_t dev_id;
             u_int16_t vend_id;
             u_int32_t class_id;
             u_int16_t subsys_id;
             u_int16_t subsys_vend_id;
-
-            char cr_dev[512];
-            char conf_dev[512];
-            char** net_devs;      // Null terminated array
-            char** ib_devs;       // Null terminated array
-            char numa_node[4096]; //
-            vf_info* virtfn_arr;
+            char      cr_dev[512];
+            char      conf_dev[512];
+            char   ** net_devs;   /* Null terminated array */
+            char   ** ib_devs;    /* Null terminated array */
+            char      numa_node[4096]; /* */
+            vf_info * virtfn_arr;
             u_int16_t virtfn_count;
         } pci;
 
-        struct
-        {
+        struct {
             u_int32_t mtusb_serial;
             u_int32_t TBD;
         } usb;
 
-        struct
-        {
+        struct {
             u_int32_t TBD;
         } ib;
 
-        struct
-        {
+        struct {
             char remote_device_name[512];
         } remote;
     };
 } dev_info;
 
-typedef enum
-{
+typedef enum {
     RA_MFPA = 0x9010,
     RA_MFBA = 0x9011,
     RA_MFBE = 0x9012,
 } reg_access_t;
 typedef struct dma_lib_hdl_t dma_lib_hdl;
 
-typedef enum
-{
-    GEARBPX_OVER_MTUSB = 1,
-    GEARBPX_OVER_I2C = 2,
-    GEARBPX_OVER_SWITCH = 3,
+typedef enum {
+    GEARBPX_OVER_MTUSB          = 1,
+    GEARBPX_OVER_I2C            = 2,
+    GEARBPX_OVER_SWITCH         = 3,
     GEARBPXO_UNKNOWN_CONNECTION = 0
 } gearbox_connection_t;
-typedef enum
-{
+typedef enum {
     MTCR_STATUS_UNKNOWN,
     MTCR_STATUS_TRUE,
     MTCR_STATUS_FALSE,
 } mtcr_status_e;
 
-typedef struct icmd_params_t
-{
-    int icmd_opened;
-    int took_semaphore;
-    int ctrl_addr;
-    int cmd_addr;
-    u_int32_t max_cmd_size;
-    int semaphore_addr;
-    int static_cfg_not_done_addr;
-    int static_cfg_not_done_offs;
-    u_int32_t lock_key;
-    int ib_semaphore_lock_supported;
-    u_int64_t dma_pa;
-    u_int32_t dma_size;
-    int dma_icmd;
+typedef struct icmd_params_t {
+    int           icmd_opened;
+    int           took_semaphore;
+    int           ctrl_addr;
+    int           cmd_addr;
+    int           cmd_ptr_bitlen;
+    int           version_addr;
+    int           version_bit_offset;
+    int           version_bitlen;
+    u_int32_t     max_cmd_size;
+    int           semaphore_addr;
+    int           static_cfg_not_done_addr;
+    int           static_cfg_not_done_offs;
+    u_int32_t     lock_key;
+    int           ib_semaphore_lock_supported;
+    u_int64_t     dma_pa;
+    u_int32_t     dma_size;
+    int           dma_icmd;
     mtcr_status_e icmd_ready;
 } icmd_params;
 
-typedef struct ctx_params_t
-{
+typedef struct ctx_params_t {
     void* fw_cmd_context;
     void* fw_cmd_func;
     void* fw_cmd_dma;
 } ctx_params;
 
-typedef struct io_region_t
-{
+typedef struct io_region_t {
     unsigned int start;
     unsigned int end;
 } io_region;
 
-typedef struct tools_hcr_params_t
-{
-    int supp_cr_mbox; // 1: mbox supported , -1: mbox not supported
+typedef struct tools_hcr_params_t {
+    int supp_cr_mbox; /* 1: mbox supported , -1: mbox not supported */
 } tools_hcr_params;
 
-// max_reg_size depends on the desired method operated on the register.
-// max_reg_size[<method_enum_value>] will give the relevant max_reg_size.
-// For example max_reg_size[MACCESS_REG_METHOD_GET] will give max_reg_size for Get() method.
-typedef struct access_reg_params_t
-{
+/* max_reg_size depends on the desired method operated on the register. */
+/* max_reg_size[<method_enum_value>] will give the relevant max_reg_size. */
+/* For example max_reg_size[MACCESS_REG_METHOD_GET] will give max_reg_size for Get() method. */
+typedef struct access_reg_params_t {
     int max_reg_size[MACCESS_LAST_REG_METHOD];
 } access_reg_params;
 
 typedef struct mfile_t mfile;
 
-struct mtcr_page_addresses
-{
+struct mtcr_page_addresses {
     u_int64_t dma_address;
     u_int64_t virtual_address;
 };
 
-struct page_list
-{
-    // User space buffer page aligned.
+struct page_list {
+    /* User space buffer page aligned. */
     char* page_list;
-    int page_amount;
+    int   page_amount;
 };
 
-struct mtcr_page_info
-{
-    unsigned int page_amount;
-    unsigned long page_pointer_start;
+struct mtcr_page_info {
+    unsigned int               page_amount;
+    unsigned long              page_pointer_start;
     struct mtcr_page_addresses page_addresses_array[MAX_PAGES_SIZE];
 };
 
-struct mtcr_read_dword_from_config_space
-{
+struct mtcr_read_dword_from_config_space {
     unsigned int offset;
     unsigned int data;
 };
@@ -491,33 +465,30 @@ typedef void (*f_mpci_change)(mfile* mf);
 #define GEARBOX_SLAVE_ADDR 0x48
 #define GB_MNGR_SLAVE_ADDR 0x33
 
-typedef enum
-{
+typedef enum {
     GB_UNKNOWN = 0,
     GB_AMOS,
     GB_ABIR
 } gearbox_type;
 
-typedef struct gearbox_info_t
-{
-    gearbox_type gb_type;
-    u_int8_t is_gearbox;
-    u_int8_t is_gb_mngr;
-    int gearbox_index;
-    int ilne_card_id;
+typedef struct gearbox_info_t {
+    gearbox_type         gb_type;
+    u_int8_t             is_gearbox;
+    u_int8_t             is_gb_mngr;
+    int                  gearbox_index;
+    int                  ilne_card_id;
     gearbox_connection_t gb_conn_type;
-    char gb_mngr_full_name[DEV_NAME_SZ];
-    char gearbox_full_name[DEV_NAME_SZ];
-    unsigned char i2c_slave;
-    u_int8_t addr_width;
-    char device_orig_name[DEV_NAME_SZ];
-    char device_real_name[DEV_NAME_SZ];
-    u_int32_t data_req_addr;
-    u_int32_t data_res_addr;
+    char                 gb_mngr_full_name[DEV_NAME_SZ];
+    char                 gearbox_full_name[DEV_NAME_SZ];
+    unsigned char        i2c_slave;
+    u_int8_t             addr_width;
+    char                 device_orig_name[DEV_NAME_SZ];
+    char                 device_real_name[DEV_NAME_SZ];
+    u_int32_t            data_req_addr;
+    u_int32_t            data_res_addr;
 } gearbox_info;
 
-typedef struct cables_info_t
-{
+typedef struct cables_info_t {
     int slave_addr_additional_offset;
 } cables_info;
 
@@ -526,7 +497,7 @@ typedef struct cables_info_t
      ((mf)->vsec_cap_mask & (1 << VCC_ICMD_EXT_SPACE_SUPPORTED)) &&                                                  \
      ((mf)->vsec_cap_mask & (1 << VCC_SEMAPHORE_SPACE_SUPPORTED)))
 
-// VSEC supported macro
+/* VSEC supported macro */
 #define VSEC_SUPPORTED_UL(mf) ((mf)->vsec_supp && VSEC_MIN_SUPPORT_UL(mf))
 
-#endif
+#endif /* ifndef _MTCR_COM_DEFS_H */

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -39,123 +39,124 @@
 #include <sys/pciio.h>
 #endif
 
-struct mft_core_wrapper
-{
+struct mft_core_wrapper {
     void* config_space_access;
     void* reg_access;
     void* reset_access;
 };
 
 #ifdef __FreeBSD__
-struct page_list_fbsd
-{
-    // User space buffer page aligned.
+struct page_list_fbsd {
+    /* User space buffer page aligned. */
     char* page_list[MAX_PAGES_SIZE];
-    int page_amount;
+    int   page_amount;
 };
 #endif
 
 /*  All fields in follow structure are not supposed to be used */
 /*  or modified by user programs. Except i2c_slave that may be */
 /*  modified before each access to target I2C slave address */
-struct mfile_t
-{
-    MType tp; /*  type of driver */
-    MType orig_tp;
-    MType res_tp;         /*  Will be used with HCR if need */
-    DType dtype;          /*  target device to access to */
-    DType itype;          /*  interface device to access via */
-    u_int32_t device_hw_id;
-    int is_i2cm;          /*  use device as I2C master */
-    int is_vm;            /*  if the machine is VM    */
-    int cr_access;        /* If cr access is allowed in MLNXOS devices */
-    cables_info ext_info; /*keeps info for calculate the correct slave address (0x50 + offset) */
+struct mfile_t {
+    u_int16_t     hw_dev_id;
+    u_int16_t     rev_id;
+    MType         tp; /*  type of driver */
+    MType         orig_tp;
+    MType         res_tp; /*  Will be used with HCR if need */
+    DType         dtype;  /*  target device to access to */
+    DType         itype;  /*  interface device to access via */
+    u_int32_t     device_hw_id;
+    int           is_i2cm; /*  use device as I2C master */
+    int           is_vm;  /*  if the machine is VM    */
+    int           cr_access; /* If cr access is allowed in MLNXOS devices */
+    cables_info   ext_info; /*keeps info for calculate the correct slave address (0x50 + offset) */
     unsigned char i2c_slave;
-    int gpio_en;
-    io_region* iorw_regions; /* For LPC devices */
-    int regions_num;
-    char* dev_name;
-    int fd;
-    int res_fd;          /*  Will be used with HCR if need*/
-    int sock;            /*  in not -1 - remote interface */
-    int is_mtserver_req; // request came from mtServer - means came from remote client
-    void* bar_virtual_addr;
-    unsigned int map_size;
-    unsigned int bar0_gw_offset; // for MST_BAR0_GW_PCI devices, offset from BAR0 - gateway - for R/W operations
-    int file_lock_descriptor; // file descriptor to the lock file aka semaphore in order to protect parallel read/write
-                              // GW operations
+    int           gpio_en;
+    io_region   * iorw_regions; /* For LPC devices */
+    int           regions_num;
+    char        * dev_name;
+    int           fd;
+    int           res_fd; /*  Will be used with HCR if need*/
+    int           sock;  /*  in not -1 - remote interface */
+    int           is_mtserver_req; /* request came from mtServer - means came from remote client */
+    void        * bar_virtual_addr;
+    unsigned int  big_endian;
+    unsigned int  cr_space_offset;
+    unsigned int  map_size;
+    unsigned int  bar0_gw_offset; /* for MST_BAR0_GW_PCI devices, offset from BAR0 - gateway - for R/W operations */
+    int           file_lock_descriptor; /* file descriptor to the lock file aka semaphore in order to protect parallel read/write */
+                                        /* GW operations */
     unsigned long long start_idx;
     /************************ FPGA DDR3 *********************************/
-    void* ddr3_ptr;
+    void             * ddr3_ptr;
     unsigned long long ddr3_start_idx;
-    unsigned int ddr3_map_size;
+    unsigned int       ddr3_map_size;
     /********************************************************************/
-    MIB_Private mib; /*  Data for IB interface (if relevant) */
-    void* ctx;
-    void* fallback_mf;
+    MIB_Private  mib; /*  Data for IB interface (if relevant) */
+    void       * ctx;
+    void       * fallback_mf;
     unsigned int i2c_RESERVED; /*  Reserved for internal usage (i2c internal) */
-    int i2c_smbus;
+    int          i2c_smbus;
     enum Mdevs_t flags;
-    u_int32_t connectx_wa_slot; /* apply connectx cr write workaround */
-    int connectx_wa_last_op_write;
-    u_int32_t connectx_wa_stat;
-    u_int64_t connectx_wa_max_retries;
-    u_int64_t connectx_wa_num_of_writes;
-    u_int64_t connectx_wa_num_of_retry_writes;
-    int server_ver_major;
-    int server_ver_minor;
+    u_int32_t    connectx_wa_slot; /* apply connectx cr write workaround */
+    int          connectx_wa_last_op_write;
+    u_int32_t    connectx_wa_stat;
+    u_int64_t    connectx_wa_max_retries;
+    u_int64_t    connectx_wa_num_of_writes;
+    u_int64_t    connectx_wa_num_of_retry_writes;
+    int          server_ver_major;
+    int          server_ver_minor;
     unsigned int proto_type;
-    dev_info* dinfo;
+    dev_info   * dinfo;
 
-    // for ICMD access
+    /* for ICMD access */
     icmd_params icmd;
-    // for UEFI
+    /* for UEFI */
     ctx_params context;
-    // for mst driver compatibility
-    int old_mst;
+    /* for mst driver compatibility */
+    int            old_mst;
     unsigned short mst_version_major;
-    unsigned int mst_version_minor;
-    int vsec_supp;
-    mtcr_status_e icmd_support;
-    unsigned int vsec_addr;
-    u_int32_t vsec_cap_mask;
-    int address_space;
-    int multifunction;
-    // for tools HCR access
+    unsigned int   mst_version_minor;
+    int            vsec_supp;
+    mtcr_status_e  icmd_support;
+    unsigned int   vsec_addr;
+    u_int32_t      vsec_cap_mask;
+    int            address_space;
+    int            multifunction;
+    /* for tools HCR access */
     tools_hcr_params hcr_params;
-    // for sending access registers
+    /* for sending access registers */
     access_reg_params acc_reg_params;
-    // UL
+    /* UL */
     void* ul_ctx;
-    // Dynamic libs Ctx
+    /* Dynamic libs Ctx */
     void* dl_context;
-    // Cables CTX
-    int is_cable;
-    void* cable_ctx;
-    unsigned int linkx_chip_devid;
-    void* cable_chip_ctx; // TODO change the name
+    /* Cables CTX */
+    int           is_cable;
+    void        * cable_ctx;
+    unsigned int  linkx_chip_devid;
+    void        * cable_chip_ctx; /* TODO change the name */
     f_mpci_change mpci_change;
-    // Amos gear-box
+    /* Amos gear-box */
     gearbox_info gb_info;
 #ifdef __FreeBSD__
-    struct pcisel sel;
-    unsigned int vpd_cap_addr;
-    int wo_addr;
-    int connectx_flush;
-    int fdlock;
+    struct pcisel         sel;
+    unsigned int          vpd_cap_addr;
+    int                   wo_addr;
+    int                   connectx_flush;
+    int                   fdlock;
     struct page_list_fbsd user_page_list;
-    void* ptr;
+    void                * ptr;
 #else
     struct page_list user_page_list;
 #endif
 
-    // For dma purpose
+    /* For dma purpose */
     void* dma_props;
 
-    // MFT core wrapper objects.
+    /* MFT core wrapper objects. */
     struct mft_core_wrapper mft_core_object;
-    char* fwctl_env_var_debug;
-    int is_remote;
+    char                  * fwctl_env_var_debug;
+    int                     is_remote;
 };
 
-#endif
+#endif /* ifndef __MTCR_MF__ */

--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -75,31 +75,33 @@ MlxlinkAmBerCollector::MlxlinkAmBerCollector(Json::Value& jsonRoot) : _jsonRoot(
 
     _mlxlinkMaps = NULL;
 
-    _baseSheetsList[AMBER_SHEET_GENERAL] = FIELDS_COUNT{4, 4, 4};
-    _baseSheetsList[AMBER_SHEET_INDEXES] = FIELDS_COUNT{8, 3, 4};
-    _baseSheetsList[AMBER_SHEET_LINK_STATUS] = FIELDS_COUNT{88, 97, 6};
-    _baseSheetsList[AMBER_SHEET_MODULE_STATUS] = FIELDS_COUNT{94, 110, 0};
-    _baseSheetsList[AMBER_SHEET_SYSTEM] = FIELDS_COUNT{19, 19, 10};
-    _baseSheetsList[AMBER_SHEET_SERDES_16NM] = FIELDS_COUNT{376, 736, 0};
-    _baseSheetsList[AMBER_SHEET_SERDES_7NM] = FIELDS_COUNT{182, 362, 406};
-    _baseSheetsList[AMBER_SHEET_SERDES_5NM] = FIELDS_COUNT{138, 0, 0};
-    _baseSheetsList[AMBER_SHEET_PORT_COUNTERS] = FIELDS_COUNT{45, 0, 50};
-    _baseSheetsList[AMBER_SHEET_TROUBLESHOOTING] = FIELDS_COUNT{2, 2, 0};
-    _baseSheetsList[AMBER_SHEET_PHY_OPERATION_INFO] = FIELDS_COUNT{18, 17, 15};
-    _baseSheetsList[AMBER_SHEET_LINK_UP_INFO] = FIELDS_COUNT{9, 9, 0};
-    _baseSheetsList[AMBER_SHEET_LINK_DOWN_INFO] = FIELDS_COUNT{11, 14, 0};
-    _baseSheetsList[AMBER_SHEET_TEST_MODE_INFO] = FIELDS_COUNT{68, 136, 0};
-    _baseSheetsList[AMBER_SHEET_TEST_MODE_MODULE_INFO] = FIELDS_COUNT{70, 110, 0};
-    _baseSheetsList[AMBER_SHEET_PHY_DEBUG_INFO] = FIELDS_COUNT{4, 4, 0};
-    _baseSheetsList[AMBER_SHEET_EXT_MODULE_STATUS] = FIELDS_COUNT{76, 116, 0};
+    _baseSheetsList[AMBER_SHEET_GENERAL] = FIELDS_COUNT {4, 4, 4};
+    _baseSheetsList[AMBER_SHEET_INDEXES] = FIELDS_COUNT {8, 3, 4};
+    _baseSheetsList[AMBER_SHEET_LINK_STATUS] = FIELDS_COUNT {88, 97, 6};
+    _baseSheetsList[AMBER_SHEET_MODULE_STATUS] = FIELDS_COUNT {94, 110, 0};
+    _baseSheetsList[AMBER_SHEET_SYSTEM] = FIELDS_COUNT {19, 19, 10};
+    _baseSheetsList[AMBER_SHEET_SERDES_16NM] = FIELDS_COUNT {376, 736, 0};
+    _baseSheetsList[AMBER_SHEET_SERDES_7NM] = FIELDS_COUNT {182, 362, 406};
+    _baseSheetsList[AMBER_SHEET_SERDES_5NM] = FIELDS_COUNT {138, 0, 0};
+    _baseSheetsList[AMBER_SHEET_PORT_COUNTERS] = FIELDS_COUNT {45, 0, 50};
+    _baseSheetsList[AMBER_SHEET_TROUBLESHOOTING] = FIELDS_COUNT {2, 2, 0};
+    _baseSheetsList[AMBER_SHEET_PHY_OPERATION_INFO] = FIELDS_COUNT {18, 17, 15};
+    _baseSheetsList[AMBER_SHEET_LINK_UP_INFO] = FIELDS_COUNT {9, 9, 0};
+    _baseSheetsList[AMBER_SHEET_LINK_DOWN_INFO] = FIELDS_COUNT {11, 14, 0};
+    _baseSheetsList[AMBER_SHEET_TEST_MODE_INFO] = FIELDS_COUNT {68, 136, 0};
+    _baseSheetsList[AMBER_SHEET_TEST_MODE_MODULE_INFO] = FIELDS_COUNT {70, 110, 0};
+    _baseSheetsList[AMBER_SHEET_PHY_DEBUG_INFO] = FIELDS_COUNT {4, 4, 0};
+    _baseSheetsList[AMBER_SHEET_EXT_MODULE_STATUS] = FIELDS_COUNT {76, 116, 0};
 
     for_each(_baseSheetsList.begin(), _baseSheetsList.end(),
-             [&](pair<AMBER_SHEET, FIELDS_COUNT> sheet) {
-                 _sheetsList.push_back({sheet.first, sheet.second});
-             });
+             [&](pair < AMBER_SHEET, FIELDS_COUNT > sheet) {
+        _sheetsList.push_back({sheet.first, sheet.second});
+    });
 }
 
-MlxlinkAmBerCollector::~MlxlinkAmBerCollector() {}
+MlxlinkAmBerCollector::~MlxlinkAmBerCollector()
+{
+}
 
 void MlxlinkAmBerCollector::resetLocalParser(const string& regName)
 {
@@ -113,12 +115,11 @@ void MlxlinkAmBerCollector::sendRegister(const string& regName, maccess_reg_meth
 {
     try
     {
-        if (AmberField::_dataValid)
-        {
+        if (AmberField::_dataValid) {
             genBuffSendRegister(regName, method);
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
 #ifdef VALIDATE_REG_REQUEST
         throw MlxRegException(regName + ": " + exc.what());
@@ -128,13 +129,14 @@ void MlxlinkAmBerCollector::sendRegister(const string& regName, maccess_reg_meth
     }
 }
 
-void MlxlinkAmBerCollector::sendLocalPrmReg(const string& regName, maccess_reg_method_t method, const char* fields, ...)
+void MlxlinkAmBerCollector::sendLocalPrmReg(const string& regName, maccess_reg_method_t method, const char* fields,
+                                            ...)
 {
     char fieldsCstr[MAX_FIELDS_BUFFER];
+
     try
     {
-        if (AmberField::_dataValid)
-        {
+        if (AmberField::_dataValid) {
             va_list args;
             va_start(args, fields);
             vsnprintf(fieldsCstr, MAX_FIELDS_BUFFER, fields, args);
@@ -143,7 +145,7 @@ void MlxlinkAmBerCollector::sendLocalPrmReg(const string& regName, maccess_reg_m
             sendPrmReg(regName, method, fieldsCstr);
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
 #ifdef VALIDATE_REG_REQUEST
         throw MlxRegException(regName + ": " + exc.what());
@@ -156,11 +158,12 @@ void MlxlinkAmBerCollector::sendLocalPrmReg(const string& regName, maccess_reg_m
 string MlxlinkAmBerCollector::getLocalFieldStr(const string& fieldName)
 {
     string fieldVal = "N/A";
+
     try
     {
         fieldVal = getFieldStr(fieldName);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
 #ifdef VALIDATE_REG_REQUEST
         throw MlxRegException(exc.what());
@@ -172,11 +175,12 @@ string MlxlinkAmBerCollector::getLocalFieldStr(const string& fieldName)
 u_int32_t MlxlinkAmBerCollector::getLocalFieldValue(const string& fieldName)
 {
     u_int32_t fieldVal = 0;
+
     try
     {
         fieldVal = getFieldValue(fieldName);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
 #ifdef VALIDATE_REG_REQUEST
         throw MlxRegException(exc.what());
@@ -187,13 +191,11 @@ u_int32_t MlxlinkAmBerCollector::getLocalFieldValue(const string& fieldName)
 
 void MlxlinkAmBerCollector::startCollector()
 {
-    if (_localPorts.empty())
-    {
+    if (_localPorts.empty()) {
         _localPorts.push_back(PortGroup(_localPort, _localPort, 0, 0));
     }
 
-    for (auto it = _localPorts.begin(); it != _localPorts.end(); it++)
-    {
+    for (auto it = _localPorts.begin(); it != _localPorts.end(); it++) {
         _localPort = it->localPort;
         _labelPort = it->labelPort;
         _splitPort = it->split;
@@ -214,8 +216,7 @@ void MlxlinkAmBerCollector::init()
     {
         _isPortPCIE = (_pnat == PNAT_PCIE);
 
-        if (!_isPortPCIE)
-        {
+        if (!_isPortPCIE) {
             resetLocalParser(ACCESS_REG_PDDR);
             updateField("local_port", _localPort);
             updateField("page_select", PDDR_OPERATIONAL_INFO_PAGE);
@@ -224,8 +225,7 @@ void MlxlinkAmBerCollector::init()
             bool linkUp = getFieldValue("phy_mngr_fsm_state") == PHY_MNGR_ACTIVE_LINKUP;
 
             _protoActive = getFieldValue("proto_active");
-            if (_protoActive == NVLINK)
-            {
+            if (_protoActive == NVLINK) {
                 _isPortNVLINK = true;
                 _protoActive = IB;
             }
@@ -234,28 +234,22 @@ void MlxlinkAmBerCollector::init()
             _isPortETH = (_protoActive == ETH) && (_pnat != PNAT_PCIE);
             _maxLanes = MAX_NETWORK_LANES;
 
-            if (_protoActive == IB)
-            {
+            if (_protoActive == IB) {
                 _activeSpeed = getFieldValue("link_speed_active");
                 _numOfLanes = getFieldValue("link_width_active");
                 _maxLanes = MAX_IB_LANES;
-            }
-            else
-            {
-                if (linkUp)
-                {
+            } else {
+                if (linkUp) {
                     resetParser(ACCESS_REG_PTYS);
                     updateField("local_port", _localPort);
                     updateField("proto_mask", _protoActive);
                     genBuffSendRegister(ACCESS_REG_PTYS, MACCESS_REG_METHOD_GET);
 
                     _activeSpeed = _productTechnology >= PRODUCT_16NM ? getFieldValue("ext_eth_proto_oper") :
-                                                                        getFieldValue("eth_proto_oper");
+                                   getFieldValue("eth_proto_oper");
                     _numOfLanes = _productTechnology >= PRODUCT_16NM ? _mlxlinkMaps->_ExtETHSpeed2Lanes[_activeSpeed] :
-                                                                       _mlxlinkMaps->_ETHSpeed2Lanes[_activeSpeed];
-                }
-                else
-                {
+                                  _mlxlinkMaps->_ETHSpeed2Lanes[_activeSpeed];
+                } else {
                     resetParser(ACCESS_REG_PMLP);
                     updateField("local_port", _localPort);
                     genBuffSendRegister(ACCESS_REG_PMLP, MACCESS_REG_METHOD_GET);
@@ -306,9 +300,7 @@ void MlxlinkAmBerCollector::init()
             _moduleMediaSt = getFieldValue("status");
 
             _inPRBSMode |= (_moduleHostSt >= PMPT_STATUS_GEN_ONLY || _moduleMediaSt >= PMPT_STATUS_GEN_ONLY);
-        }
-        else
-        {
+        } else {
             resetParser(ACCESS_REG_MPEIN);
             updateField("pcie_index", _pcieIndex);
             updateField("depth", _depth);
@@ -321,21 +313,20 @@ void MlxlinkAmBerCollector::init()
 
         initAmberSheetsToDump();
     }
-    catch (...)
+    catch(...)
     {
     }
 }
 
 void MlxlinkAmBerCollector::initAmberSheetsToDump()
 {
-    // Custom sheet\s dump
-    if (!_sheetsToDump.empty())
-    {
+    /* Custom sheet\s dump */
+    if (!_sheetsToDump.empty()) {
         _sheetsList.clear();
         for_each(_sheetsToDump.begin(), _sheetsToDump.end(),
-                 [&](AMBER_SHEET& sheet) {
-                     _sheetsList.push_back({sheet, _baseSheetsList[sheet]});
-                 });
+                 [&](AMBER_SHEET & sheet) {
+            _sheetsList.push_back({sheet, _baseSheetsList[sheet]});
+        });
     }
 }
 
@@ -352,14 +343,16 @@ bool MlxlinkAmBerCollector::isMCMValid()
 string MlxlinkAmBerCollector::getCurrentTimeStamp()
 {
     timeval curTime;
-    gettimeofday(&curTime, NULL);
-    int millis = curTime.tv_usec / 1000;
 
-    char buffer[80];
+    gettimeofday(&curTime, NULL);
+    int         millis = curTime.tv_usec / 1000;
+    char        buffer[80];
     std::time_t curTime_secs = curTime.tv_sec;
+
     strftime(buffer, 80, "%x-%X", localtime(&curTime_secs));
 
     char currentTime[84] = "";
+
     sprintf(currentTime, "%s.%03d", buffer, millis);
     return string(currentTime);
 }
@@ -368,16 +361,13 @@ string MlxlinkAmBerCollector::getNodeGUID()
 {
     string strGuid;
 
-    if (_isHca)
-    {
+    if (_isHca) {
         resetLocalParser(ACCESS_REG_PGUID);
         updateField("local_port", _localPort);
         sendRegister(ACCESS_REG_PGUID, MACCESS_REG_METHOD_GET);
 
         strGuid = getRawFieldValueStr("node_guid");
-    }
-    else
-    {
+    } else {
         char charGuid[64];
         resetLocalParser(ACCESS_REG_SPZR);
         sendRegister(ACCESS_REG_SPZR, MACCESS_REG_METHOD_GET);
@@ -392,18 +382,15 @@ string MlxlinkAmBerCollector::getNodeGUID()
 
 string MlxlinkAmBerCollector::getMACAddress()
 {
-    char charMac[64];
+    char   charMac[64];
     string strMac;
     string fieldName;
 
-    if (_isHca)
-    {
+    if (_isHca) {
         resetLocalParser(ACCESS_REG_MGIR);
         sendRegister(ACCESS_REG_MGIR, MACCESS_REG_METHOD_GET);
         fieldName = "manufacturing_base_mac";
-    }
-    else
-    {
+    } else {
         resetLocalParser(ACCESS_REG_SPAD);
         sendRegister(ACCESS_REG_SPAD, MACCESS_REG_METHOD_GET);
         fieldName = "base_mac";
@@ -417,34 +404,32 @@ string MlxlinkAmBerCollector::getMACAddress()
     return strMac.empty() ? "N/A" : strMac;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
+vector < AmberField > MlxlinkAmBerCollector::getIndexesInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
-    if (_isPortIB || _isPortPCIE)
-    {
+    if (_isPortIB || _isPortPCIE) {
         fields.push_back(AmberField("Node_GUID", getNodeGUID()));
     }
 
-    if (_isPortETH)
-    {
+    if (_isPortETH) {
         fields.push_back(AmberField("MAC_Address", getMACAddress()));
     }
     string aggregatedPort = "N/A";
     string planePort = "N/A";
+
     AmberField::_dataValid = true;
     string labelPortStr = to_string(_labelPort);
-    if ((_splitPort && _splitPort != 1) || (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) ||
-        (_devID == DeviceBW00))
-    {
+
+    if ((_splitPort && (_splitPort != 1)) || (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) ||
+        (_devID == DeviceGB100)) {
         /* For Quantum-2, the split notation will stand for the port in the cage
          * For other, only add the split notation if it's not 1
          */
         labelPortStr += "/" + to_string(_splitPort);
     }
-    if ((_secondSplit && _secondSplit != 1) &&
-        ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceBW00)))
-    {
+    if ((_secondSplit && (_secondSplit != 1)) &&
+        ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100))) {
         labelPortStr += "/" + to_string(_secondSplit);
     }
     fields.push_back(AmberField("Port_Number", labelPortStr + "(" + to_string(_localPort) + ")", !_isPortPCIE));
@@ -452,8 +437,7 @@ vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
     fields.push_back(AmberField("pcie_index", to_string(_pcieIndex), _isPortPCIE));
     fields.push_back(AmberField("node", to_string(_node), _isPortPCIE));
 
-    if (_productTechnology == PRODUCT_5NM)
-    {
+    if (_productTechnology == PRODUCT_5NM) {
         resetLocalParser(ACCESS_REG_PPCR);
         updateField("local_port", _localPort);
         sendRegister(ACCESS_REG_PPCR, MACCESS_REG_METHOD_GET);
@@ -465,24 +449,20 @@ vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
 
     string labelCage = "N/A";
 
-    if (!_isPortPCIE)
-    {
+    if (!_isPortPCIE) {
         resetLocalParser(ACCESS_REG_MGIR);
         sendRegister(ACCESS_REG_MGIR, MACCESS_REG_METHOD_GET);
         fields.push_back(AmberField("IC_GA", getRawFieldValueStr("hw_info__ga"), _isPortIB));
 
-        if (dm_dev_is_switch((dm_dev_id_t)_devID))
-        {
+        if (dm_dev_is_switch((dm_dev_id_t)_devID)) {
             resetLocalParser(ACCESS_REG_PLLP);
             updateField("local_port", _localPort);
             sendRegister(ACCESS_REG_PLLP, MACCESS_REG_METHOD_GET);
             labelCage = getRawFieldValueStr("label_port");
-            if (getFieldValue("ipil_stat") == 0)
-            {
+            if (getFieldValue("ipil_stat") == 0) {
                 fields.push_back(AmberField("IPIL", getRawFieldValueStr("ipil_num"), _isPortIB));
             }
-            if (getFieldValue("split_stat") == 0)
-            {
+            if (getFieldValue("split_stat") == 0) {
                 fields.push_back(AmberField("split", getRawFieldValueStr("split_num"), _isPortIB));
             }
         }
@@ -492,9 +472,9 @@ vector<AmberField> MlxlinkAmBerCollector::getIndexesInfo()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getGeneralInfo()
+vector < AmberField > MlxlinkAmBerCollector::getGeneralInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     AmberField::_dataValid = true;
 
@@ -506,9 +486,9 @@ vector<AmberField> MlxlinkAmBerCollector::getGeneralInfo()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
+vector < AmberField > MlxlinkAmBerCollector::getSystemInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
@@ -528,7 +508,8 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
         resetLocalParser(ACCESS_REG_MGIR);
         sendRegister(ACCESS_REG_MGIR, MACCESS_REG_METHOD_GET);
         string fwVersion =
-          getFieldStr("extended_major") + "." + getFieldStr("extended_minor") + "." + getFieldStr("extended_sub_minor");
+            getFieldStr("extended_major") + "." + getFieldStr("extended_minor") + "." + getFieldStr(
+                "extended_sub_minor");
         string tech = _mlxlinkMaps->_tech[getFieldValue("technology")];
         fields.push_back(AmberField("Device_FW_Version", fwVersion));
 
@@ -540,14 +521,13 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
         resetLocalParser(ACCESS_REG_MVCAP);
         sendRegister(ACCESS_REG_MVCAP, MACCESS_REG_METHOD_GET);
         _isValidSensorMvcap = getFieldValue("sensor_map_lo") & 0x1;
-        if (_isValidSensorMvcap)
-        {
+        if (_isValidSensorMvcap) {
             resetLocalParser(ACCESS_REG_MVCR);
             sendRegister(ACCESS_REG_MVCR, MACCESS_REG_METHOD_GET);
             sysVol = to_string(getFieldValue("voltage_sensor_value") * 0.01) + "V";
             sysCur = getFieldStr("current_sensor_value");
             sensNameVoltage =
-              getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
+                getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
         }
         fields.push_back(AmberField("System_Voltage", sysVol));
         fields.push_back(AmberField("System_Current", sysCur));
@@ -556,13 +536,12 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
         resetLocalParser(ACCESS_REG_MTCAP);
         sendRegister(ACCESS_REG_MTCAP, MACCESS_REG_METHOD_GET);
         _isValidSensorMtcap = getFieldValue("sensor_map_lo") & 0x1;
-        if (_isValidSensorMtcap)
-        {
+        if (_isValidSensorMtcap) {
             resetLocalParser(ACCESS_REG_MTMP);
             sendRegister(ACCESS_REG_MTMP, MACCESS_REG_METHOD_GET);
             temp = getTemp(getFieldValue("temperature"), 8);
             sensNameTemp =
-              getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
+                getFullString(add32BitTo64(getFieldValue("sensor_name_hi"), getFieldValue("sensor_name_lo")));
         }
         fields.push_back(AmberField("Chip_Temp", temp));
 
@@ -572,8 +551,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
 
         fields.push_back(AmberField("Temp_sensor_name", sensNameTemp));
 
-        if (_productTechnology == PRODUCT_5NM)
-        {
+        if (_productTechnology == PRODUCT_5NM) {
             resetLocalParser(ACCESS_REG_PPCR);
             updateField("local_port", _localPort);
             sendRegister(ACCESS_REG_PPCR, MACCESS_REG_METHOD_GET);
@@ -581,7 +559,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSystemInfo()
         }
         fields.push_back(AmberField("num_of_planes", numPlanes, _isPortIB));
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Device information: %s", exc.what());
     }
@@ -595,17 +573,16 @@ string MlxlinkAmBerCollector::getClRawBer()
     double rawBerMag = getFieldValue("raw_ber_magnitude");
     double rawBer = rawBerCoef * std::pow(10, -rawBerMag);
     double timeSinceLinkUp =
-      ((double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low"))) /
-      1000.0;
+        ((double)add32BitTo64(getFieldValue("time_since_last_clear_high"),
+                              getFieldValue("time_since_last_clear_low"))) /
+        1000.0;
     double activeRate =
-      _protoActive == IB ? _mlxlinkMaps->_IBSpeed2gNum[_activeSpeed] : _mlxlinkMaps->_EthExtSpeed2gNum[_activeSpeed];
-
+        _protoActive == IB ? _mlxlinkMaps->_IBSpeed2gNum[_activeSpeed] : _mlxlinkMaps->_EthExtSpeed2gNum[_activeSpeed];
     double rateBerLane = (activeRate / _numOfLanes) * pow(10.0, 9);
-
     double clBer = 0;
-    char clBerStr[128];
-    if (activeRate)
-    {
+    char   clBerStr[128];
+
+    if (activeRate) {
         clBer = 1 - exp(-1 * rateBerLane * timeSinceLinkUp * rawBer);
     }
     sprintf(clBerStr, "%.1E", clBer);
@@ -613,9 +590,9 @@ string MlxlinkAmBerCollector::getClRawBer()
     return string(clBerStr);
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
+vector < AmberField > MlxlinkAmBerCollector::getPhyOperationInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
@@ -636,35 +613,31 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
                                     _mlxlinkMaps->_ibPhyFsmState[getFieldValue("ib_phy_fsm_"
                                                                                "state")],
                                     !_isPortPCIE));
-        if (_isPortIB)
-        {
+        if (_isPortIB) {
             phyManagerLinkEnabledStr =
-              getStrByMask(getFieldValue("phy_manager_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
+                getStrByMask(getFieldValue("phy_manager_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
             coreToPhyLinkEnabledStr =
-              getStrByMask(getFieldValue("core_to_phy_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
+                getStrByMask(getFieldValue("core_to_phy_link_proto_enabled"), _mlxlinkMaps->_IBSpeed2Str);
             cableProtoCapStr = getStrByMask(getFieldValue("cable_link_speed_cap"), _mlxlinkMaps->_IBSpeed2Str);
-        }
-        else if (_isPortETH)
-        {
+        } else if (_isPortETH) {
             phyManagerLinkEnabledStr =
-              getStrByMask(getFieldValue("phy_manager_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
+                getStrByMask(getFieldValue("phy_manager_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
             coreToPhyLinkEnabledStr =
-              getStrByMask(getFieldValue("core_to_phy_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
+                getStrByMask(getFieldValue("core_to_phy_link_eth_enabled"), _mlxlinkMaps->_EthExtSpeed2Str);
             cableProtoCapStr = getStrByMask(getFieldValue("cable_ext_eth_proto_cap"), _mlxlinkMaps->_EthExtSpeed2Str);
         }
         fields.push_back(AmberField("phy_manager_link_enabled", phyManagerLinkEnabledStr, !_isPortPCIE));
         fields.push_back(AmberField("core_to_phy_link_enabled", coreToPhyLinkEnabledStr, !_isPortPCIE));
         fields.push_back(AmberField("cable_proto_cap", cableProtoCapStr, !_isPortPCIE));
         u_int32_t phyMngrFsmState = getFieldValue("phy_mngr_fsm_state");
-        string loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ?
-                                _mlxlinkMaps->_loopbackModeList[getFieldValue("loopback_mode")].second :
-                                "-1";
+        string    loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ?
+                                 _mlxlinkMaps->_loopbackModeList[getFieldValue("loopback_mode")].second :
+                                 "-1";
         u_int32_t fecModeRequest = (u_int32_t)log2((float)getFieldValue("fec_mode_request"));
         fields.push_back(AmberField("loopback_mode", loopbackMode, !_isPortPCIE));
         fields.push_back(AmberField("fec_mode_request", _mlxlinkMaps->_fecModeActive[fecModeRequest], !_isPortPCIE));
 
-        if (_isPortPCIE)
-        {
+        if (_isPortPCIE) {
             resetLocalParser(ACCESS_REG_MPEIN);
             updateField("depth", _depth);
             updateField("pcie_index", _pcieIndex);
@@ -684,13 +657,15 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
             fields.push_back(AmberField("pwr_status", _mlxlinkMaps->_pwrStatus[getFieldValue("pwr_status")]));
             fields.push_back(AmberField("port_type", _mlxlinkMaps->_portType[getFieldValue("port_type")]));
             fields.push_back(
-              AmberField("link_peer_max_speed", _mlxlinkMaps->_linkPeerMaxSpeed[getFieldValue("link_peer_max_speed")]));
+                AmberField("link_peer_max_speed", _mlxlinkMaps->_linkPeerMaxSpeed[getFieldValue(
+                                                                                      "link_peer_max_speed")]));
             fields.push_back(AmberField("pci_power", getFieldStr("pci_power") + 'W'));
             fields.push_back(
-              AmberField("device_status", getStrByMask(getFieldValue("device_status"), _mlxlinkMaps->_pcieDevStatus)));
+                AmberField("device_status",
+                           getStrByMask(getFieldValue("device_status"), _mlxlinkMaps->_pcieDevStatus)));
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Phy Operation status: %s", exc.what());
     }
@@ -701,20 +676,19 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyOperationInfo()
 string MlxlinkAmBerCollector::getBerAndErrorTitle(u_int32_t portType)
 {
     string title = "";
-    if (portType)
-    {
+
+    if (portType) {
         title = "N/A";
     }
     return title;
 }
 
-void MlxlinkAmBerCollector::getPpcntBer(u_int32_t portType, vector<AmberField>& fields)
+void MlxlinkAmBerCollector::getPpcntBer(u_int32_t portType, vector < AmberField >& fields)
 {
     resetLocalParser(ACCESS_REG_PPCNT);
     updateField("local_port", _localPort);
     updateField("lp_gl", (u_int32_t)(_localPort == 255));
-    if (portType != NETWORK_PORT_TYPE && !_isHca)
-    {
+    if ((portType != NETWORK_PORT_TYPE) && !_isHca) {
         updateField("port_type", portType);
     }
     updateField("grp", PPCNT_STATISTICAL_GROUP);
@@ -723,8 +697,8 @@ void MlxlinkAmBerCollector::getPpcntBer(u_int32_t portType, vector<AmberField>& 
     string preTitle = getBerAndErrorTitle(portType);
     string berStr = to_string(getFieldValue("raw_ber_coef")) + "E-" + to_string(getFieldValue("raw_ber_magnitude"));
     string confLevelStr = preTitle + "Conf_Level_Raw_BER";
-    if (portType == NETWORK_PORT_TYPE_MAIN_USR || portType == NETWORK_PORT_TYPE_TILE_USR)
-    {
+
+    if ((portType == NETWORK_PORT_TYPE_MAIN_USR) || (portType == NETWORK_PORT_TYPE_TILE_USR)) {
         confLevelStr = "Conf_Level_" + preTitle + "Raw_BER";
     }
 
@@ -732,39 +706,35 @@ void MlxlinkAmBerCollector::getPpcntBer(u_int32_t portType, vector<AmberField>& 
     fields.push_back(AmberField(preTitle + "Raw_BER", berStr));
 
     berStr =
-      to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
+        to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
     fields.push_back(AmberField(preTitle + "Effective_BER", berStr));
 
-    if (_isPortETH && (portType == NETWORK_PORT_TYPE_NEAR || portType == NETWORK_PORT_TYPE_FAR))
-    {
+    if (_isPortETH && ((portType == NETWORK_PORT_TYPE_NEAR) || (portType == NETWORK_PORT_TYPE_FAR))) {
         string effErrorsStr = to_string(
-          add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
+            add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
 
         fields.push_back(AmberField(preTitle + "Effective_Errors", effErrorsStr));
     }
 
-    if (portType != NETWORK_PORT_TYPE || (portType == NETWORK_PORT_TYPE && _isPortIB))
-    {
+    if ((portType != NETWORK_PORT_TYPE) || ((portType == NETWORK_PORT_TYPE) && _isPortIB)) {
         berStr = getLocalFieldStr("symbol_ber_coef") + "E-" + getLocalFieldStr("symbol_ber_magnitude");
         fields.push_back(AmberField(preTitle + "Symbol_BER", berStr));
 
-        if (portType != NETWORK_PORT_TYPE)
-        {
+        if (portType != NETWORK_PORT_TYPE) {
             u_int64_t symErrors =
-              add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
+                add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
             fields.push_back(AmberField(preTitle + "Symbol_Errors", to_string(symErrors)));
         }
     }
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
+vector < AmberField > MlxlinkAmBerCollector::getLinkStatus()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
     try
     {
-        if (!_isPortPCIE)
-        {
-            // Getting link status fields for IB and ETH ports
+        if (!_isPortPCIE) {
+            /* Getting link status fields for IB and ETH ports */
             resetLocalParser(ACCESS_REG_PDDR);
             updateField("local_port", _localPort);
             updateField("page_select", PDDR_OPERATIONAL_INFO_PAGE);
@@ -773,7 +743,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             fields.push_back(AmberField("Phy_Manager_State", _mlxlinkMaps->_pmFsmState[getFieldValue("phy_mngr_fsm_"
                                                                                                      "state")]));
             fields.push_back(AmberField("Protocol", (_isPortNVLINK) ? _mlxlinkMaps->_networkProtocols[NVLINK] :
-                                                                      _mlxlinkMaps->_networkProtocols[_protoActive]));
+                                        _mlxlinkMaps->_networkProtocols[_protoActive]));
 
             resetLocalParser(ACCESS_REG_PTYS);
             updateField("local_port", _localPort);
@@ -781,7 +751,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             sendRegister(ACCESS_REG_PTYS, MACCESS_REG_METHOD_GET);
 
             float dataRate = ((float)getFieldValue("data_rate_oper")) * 0.1;
-            char dataRateStr[64];
+            char  dataRateStr[64];
             sprintf(dataRateStr, "%.2f", dataRate);
             u_int32_t ethLinkActive = getFieldValue("ext_eth_proto_oper");
             fields.push_back(AmberField("Speed_[Gb/s]", string(dataRateStr)));
@@ -794,8 +764,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             updateField("grp", PPCNT_PHY_GROUP);
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
 
-            if (_isPortETH)
-            {
+            if (_isPortETH) {
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("port_type", NETWORK_PORT_TYPE_NEAR);
@@ -815,7 +784,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
 
             fields.push_back(AmberField("Link_Down", to_string(getFieldValue("link_down_events"))));
             fields.push_back(
-              AmberField("successful_recovery_events", to_string(getFieldValue("successful_recovery_events"))));
+                AmberField("successful_recovery_events", to_string(getFieldValue("successful_recovery_events"))));
 
             resetLocalParser(ACCESS_REG_PDDR);
             updateField("local_port", _localPort);
@@ -824,9 +793,9 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
 
             string linkSpeedActive = SupportedSpeeds2Str(IB, getFieldValue("link_speed_active"), true);
             fields.push_back(
-              AmberField("Link_Speed_Active", linkSpeedActive.empty() ? "N/A" : linkSpeedActive, _isPortIB));
+                AmberField("Link_Speed_Active", linkSpeedActive.empty() ? "N/A" : linkSpeedActive, _isPortIB));
             fields.push_back(
-              AmberField("Link_Width_Active", linkWidthMaskToStr(getFieldValue("link_width_active")), _isPortIB));
+                AmberField("Link_Width_Active", linkWidthMaskToStr(getFieldValue("link_width_active")), _isPortIB));
             fields.push_back(AmberField("Active_FEC", _mlxlinkMaps->_fecModeActive[getFieldValue("fec_mode_active")]));
 
             string roundTripLatency = "N/A";
@@ -837,14 +806,12 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
                 sendRegister(ACCESS_REG_PRTL, MACCESS_REG_METHOD_GET);
                 roundTripLatency = getFieldStr("round_trip_latency");
             }
-            catch (MlxRegException& exc)
+            catch(MlxRegException & exc)
             {
             }
             fields.push_back(AmberField("round_trip_latency", roundTripLatency, _isPortIB));
-        }
-        else
-        {
-            // Getting link info for PCIE
+        } else {
+            /* Getting link info for PCIE */
             resetLocalParser(ACCESS_REG_MPEIN);
             updateField("depth", _depth);
             updateField("pcie_index", _pcieIndex);
@@ -854,39 +821,33 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             fields.push_back(AmberField("pci_link_width_active", to_string(getFieldValue("link_width_active")) + "x"));
         }
 
-        if (_isPortETH)
-        {
+        if (_isPortETH) {
             resetLocalParser(ACCESS_REG_PPCNT);
             updateField("local_port", _localPort);
-            if (!_isHca)
-            {
+            if (!_isHca) {
                 updateField("port_type", NETWORK_PORT_TYPE_TILE_USR);
             }
             updateField("grp", PPCNT_PHY_GROUP);
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-            if (!_isMCMSysValid)
-            {
+            if (!_isMCMSysValid) {
                 AmberField::_dataValid = false;
             }
             fields.push_back(AmberField("USR-T_Link_Down", to_string(getFieldValue("link_down_events"))));
 
             resetLocalParser(ACCESS_REG_PPCNT);
             updateField("local_port", _localPort);
-            if (!_isHca)
-            {
+            if (!_isHca) {
                 updateField("port_type", NETWORK_PORT_TYPE_MAIN_USR);
             }
             updateField("grp", PPCNT_PHY_GROUP);
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-            if (!_isMCMSysValid)
-            {
+            if (!_isMCMSysValid) {
                 AmberField::_dataValid = false;
             }
             fields.push_back(AmberField("USR-M_Link_Down", to_string(getFieldValue("link_down_events"))));
         }
 
-        if (!_isPortPCIE)
-        {
+        if (!_isPortPCIE) {
             resetLocalParser(ACCESS_REG_PPCNT);
             updateField("local_port", _localPort);
             updateField("grp", PPCNT_STATISTICAL_GROUP);
@@ -902,44 +863,40 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             getPpcntBer(NETWORK_PORT_TYPE, fields);
 
             u_int32_t numOfBins = 0;
-            bool skipBinLimit = false;
-            map<string, string> histRange;
+            bool      skipBinLimit = false;
+            map < string, string > histRange;
             try
             {
                 resetLocalParser(ACCESS_REG_PPHCR);
                 updateField("local_port", _localPort);
                 genBuffSendRegister(ACCESS_REG_PPHCR, MACCESS_REG_METHOD_GET);
                 numOfBins = getFieldValue("num_of_bins");
-                for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++)
-                {
+                for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++) {
                     histRange["high_val_" + to_string(idx)] = getFieldStr("high_val_" + to_string(idx));
                     histRange["low_val_" + to_string(idx)] = getFieldStr("low_val_" + to_string(idx));
                 }
             }
-            catch (...)
+            catch(...)
             {
                 skipBinLimit = true;
-                for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++)
-                {
+                for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++) {
                     histRange["high_val_" + to_string(idx)] = "N/A";
                     histRange["low_val_" + to_string(idx)] = "N/A";
                 }
             }
 
-            // Getting histogram info for ETH and IB only
+            /* Getting histogram info for ETH and IB only */
             resetLocalParser(ACCESS_REG_PPCNT);
             updateField("local_port", _localPort);
             updateField("grp", PPCNT_HISTOGRAM_GROUP);
             updateField("lp_gl", (u_int32_t)(_localPort == 255));
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
-            vector<string> histPerLane;
+            vector < string > histPerLane;
             u_int64_t histBin = 0;
-            string val = "";
-            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++)
-            {
+            string    val = "";
+            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++) {
                 val = "N/A";
-                if (idx < numOfBins || (skipBinLimit || !numOfBins))
-                {
+                if ((idx < numOfBins) || (skipBinLimit || !numOfBins)) {
                     histBin = add32BitTo64(getFieldValue("hist[" + to_string(idx) + "]_hi"),
                                            getFieldValue("hist[" + to_string(idx) + "]_lo"));
                     val = to_string(histBin);
@@ -947,12 +904,9 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
                 histPerLane.push_back(val);
             }
             int firstZeroHist = -1;
-            for (u_int32_t idx = NUM_OF_BINS - 1; idx > 0; idx--)
-            {
-                if (histPerLane[idx] != "N/A")
-                {
-                    if (histPerLane[idx] != "0")
-                    {
+            for (u_int32_t idx = NUM_OF_BINS - 1; idx > 0; idx--) {
+                if (histPerLane[idx] != "N/A") {
+                    if (histPerLane[idx] != "0") {
                         firstZeroHist = idx + 1;
                         break;
                     }
@@ -960,29 +914,26 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             }
             fields.push_back(AmberField("FC_Zero_Hist", firstZeroHist >= 0 ? to_string(firstZeroHist) : "N/A"));
             fields.push_back(AmberField("Number_of_histogram_bins", to_string(numOfBins)));
-            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++)
-            {
+            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++) {
                 fields.push_back(
-                  AmberField("bin" + to_string(idx) + string("_high_value"), histRange["high_val_" + to_string(idx)]));
+                    AmberField("bin" + to_string(idx) + string("_high_value"),
+                               histRange["high_val_" + to_string(idx)]));
                 fields.push_back(
-                  AmberField("bin" + to_string(idx) + string("_low_value"), histRange["low_val_" + to_string(idx)]));
+                    AmberField("bin" + to_string(idx) + string("_low_value"), histRange["low_val_" + to_string(idx)]));
             }
-            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++)
-            {
+            for (u_int32_t idx = 0; idx < NUM_OF_BINS; idx++) {
                 fields.push_back(AmberField("hist" + to_string(idx), histPerLane[idx]));
             }
-            // Getting raw errors per lane for ETH and IB only
+            /* Getting raw errors per lane for ETH and IB only */
             resetLocalParser(ACCESS_REG_PPCNT);
             updateField("local_port", _localPort);
             updateField("grp", PPCNT_STATISTICAL_GROUP);
             updateField("lp_gl", (u_int32_t)(_localPort == 255));
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
             u_int64_t rawError = 0;
-            for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++)
-            {
+            for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++) {
                 val = "N/A";
-                if (lane < _numOfLanes)
-                {
+                if (lane < _numOfLanes) {
                     rawError = add32BitTo64(getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_high"),
                                             getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_low"));
                     val = to_string(rawError);
@@ -996,18 +947,15 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
 
             string effErrorsStr = to_string(
-              add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
+                add32BitTo64(getFieldValue("phy_effective_errors_high"), getFieldValue("phy_effective_errors_low")));
             fields.push_back(AmberField("Effective_Errors", effErrorsStr));
             u_int64_t symErrors =
-              add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
-            if (_isPortIB)
-            {
+                add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low"));
+            if (_isPortIB) {
                 fields.push_back(AmberField("Symbol_Errors", to_string(symErrors)));
             }
-        }
-        else
-        {
-            // Getting link errors info for PCIE
+        } else {
+            /* Getting link errors info for PCIE */
             resetLocalParser(ACCESS_REG_MPCNT);
             updateField("depth", _depth);
             updateField("pcie_index", _pcieIndex);
@@ -1021,8 +969,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             fields.push_back(AmberField("Tx_error_pci", to_string(getFieldValue("tx_errors"))));
         }
 
-        if (_productTechnology == PRODUCT_5NM && _isPortIB && !_isHca)
-        {
+        if ((_productTechnology == PRODUCT_5NM) && _isPortIB && !_isHca) {
             resetLocalParser(ACCESS_REG_PAOS);
             updateField("local_port", _localPort);
             updateField("swid", SWID);
@@ -1038,7 +985,7 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
             fields.push_back(AmberField("fw_mode_act", to_string(getFieldValue("fw_mode_act"))));
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Link Status information: %s", exc.what());
     }
@@ -1046,17 +993,16 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkStatus()
     return fields;
 }
 
-void MlxlinkAmBerCollector::fillParamsToFields(const string& title,
-                                               const vector<string>& values,
-                                               vector<AmberField>& fields)
+void MlxlinkAmBerCollector::fillParamsToFields(const string&            title,
+                                               const vector < string >& values,
+                                               vector < AmberField >&   fields)
 {
     string val = "";
     string fieldName = "";
-    for (u_int32_t idx = 0; idx < values.size(); idx++)
-    {
+
+    for (u_int32_t idx = 0; idx < values.size(); idx++) {
         val = "N/A";
-        if (((_numOfLanes - 1) < values.size()) && (idx < _numOfLanes))
-        {
+        if (((_numOfLanes - 1) < values.size()) && (idx < _numOfLanes)) {
             val = values[idx];
         }
         fieldName = "Lane" + to_string(idx) + "_" + title;
@@ -1064,21 +1010,19 @@ void MlxlinkAmBerCollector::fillParamsToFields(const string& title,
     }
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getSerdesHDR()
+vector < AmberField > MlxlinkAmBerCollector::getSerdesHDR()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
-            vector<vector<string>> slrgParams(SLRG_PARAMS_LAST, vector<string>(_maxLanes, ""));
-            vector<vector<string>> sltpParams(SLTP_HDR_LAST, vector<string>(_maxLanes, ""));
-            vector<string> sltpStatus;
+        if (!_isPortPCIE) {
+            vector < vector < string >> slrgParams(SLRG_PARAMS_LAST, vector < string > (_maxLanes, ""));
+            vector < vector < string >> sltpParams(SLTP_HDR_LAST, vector < string > (_maxLanes, ""));
+            vector < string > sltpStatus;
             u_int32_t lane = 0;
-            // Getting 16nm SLRG information for all lanes
-            for (; lane < _maxLanes; lane++)
-            {
+            /* Getting 16nm SLRG information for all lanes */
+            for (; lane < _maxLanes; lane++) {
                 resetLocalParser(ACCESS_REG_SLRG);
                 updateField("local_port", _localPort);
                 updateField("lane", lane);
@@ -1095,9 +1039,8 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesHDR()
             fillParamsToFields("mid_eye_grade", slrgParams[SLRG_PARAMS_MID_EYE], fields);
             fillParamsToFields("low_eye_grade", slrgParams[SLRG_PARAMS_LOWER_EYE], fields);
 
-            // Getting 16nm SLTP information for all lanes
-            for (u_int32_t lane = 0; lane < _maxLanes; lane++)
-            {
+            /* Getting 16nm SLTP information for all lanes */
+            for (u_int32_t lane = 0; lane < _maxLanes; lane++) {
                 resetLocalParser(ACCESS_REG_SLTP);
                 updateField("local_port", _localPort);
                 updateField("lane", lane);
@@ -1123,7 +1066,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesHDR()
             fillParamsToFields("ob_alev_out", sltpParams[SLTP_HDR_OB_ALEV_OUT], fields);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get SerDes[16nm] information: %s", exc.what());
     }
@@ -1131,22 +1074,20 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesHDR()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getSerdesNDR()
+vector < AmberField > MlxlinkAmBerCollector::getSerdesNDR()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
         fields.push_back(AmberField("UPHY_version", "N/A"));
         fields.push_back(AmberField("BKV_version", "N/A"));
 
-        vector<vector<string>> sltpParams(SLTP_NDR_LAST + 1, vector<string>(_maxLanes, ""));
+        vector < vector < string >> sltpParams(SLTP_NDR_LAST + 1, vector < string > (_maxLanes, ""));
 
-        if (!_isPortPCIE)
-        {
-            // Getting 7nm SLTP information for all lanes
-            for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-            {
+        if (!_isPortPCIE) {
+            /* Getting 7nm SLTP information for all lanes */
+            for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
                 resetLocalParser(ACCESS_REG_SLTP);
                 updateField("local_port", _localPort);
                 updateField("lane", lane);
@@ -1166,7 +1107,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesNDR()
             fillParamsToFields("post_1_tap", sltpParams[SLTP_NDR_FIR_POST1], fields);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get SerDes[7nm] information: %s", exc.what());
     }
@@ -1174,17 +1115,15 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesNDR()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getSerdesXDR()
+vector < AmberField > MlxlinkAmBerCollector::getSerdesXDR()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
-            vector<vector<string>> sltpParams(SLTP_XDR_LAST, vector<string>(_maxLanes, ""));
-            for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-            {
+        if (!_isPortPCIE) {
+            vector < vector < string >> sltpParams(SLTP_XDR_LAST, vector < string > (_maxLanes, ""));
+            for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
                 resetLocalParser(ACCESS_REG_SLTP);
                 updateField("local_port", _localPort);
                 updateField("lane", lane);
@@ -1221,7 +1160,7 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesXDR()
             fillParamsToFields("tap11", sltpParams[SLTP_XDR_TAP11], fields);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get SerDes[5nm] information: %s", exc.what());
     }
@@ -1231,92 +1170,86 @@ vector<AmberField> MlxlinkAmBerCollector::getSerdesXDR()
 
 void MlxlinkAmBerCollector::initCableIdentifier(u_int32_t cableIdentifier)
 {
-    switch (cableIdentifier)
-    {
-        case IDENTIFIER_QSFP28:
-        case IDENTIFIER_QSFP_PLUS:
-            _isQsfpCable = true;
-            break;
-        case IDENTIFIER_SFP:
-        case IDENTIFIER_QSA:
-            _isSfpCable = true;
-            break;
-        case IDENTIFIER_SFP_DD:
-        case IDENTIFIER_QSFP_DD:
-        case IDENTIFIER_OSFP:
-        case IDENTIFIER_DSFP:
-        case IDENTIFIER_QSFP_CMIS:
-            _isCmisCable = true;
-            break;
+    switch (cableIdentifier) {
+    case IDENTIFIER_QSFP28:
+    case IDENTIFIER_QSFP_PLUS:
+        _isQsfpCable = true;
+        break;
+
+    case IDENTIFIER_SFP:
+    case IDENTIFIER_QSA:
+        _isSfpCable = true;
+        break;
+
+    case IDENTIFIER_SFP_DD:
+    case IDENTIFIER_QSFP_DD:
+    case IDENTIFIER_OSFP:
+    case IDENTIFIER_DSFP:
+    case IDENTIFIER_QSFP_CMIS:
+        _isCmisCable = true;
+        break;
     }
 }
 
 void MlxlinkAmBerCollector::getCmisComplianceCode(u_int32_t ethComplianceCode,
                                                   u_int32_t extEthComplianceCode,
-                                                  string& ethComplianceStr,
-                                                  string& extComplianceStr,
+                                                  string&   ethComplianceStr,
+                                                  string&   extComplianceStr,
                                                   u_int32_t cableMediaType,
                                                   u_int32_t cableTechnology)
 {
-    switch (cableMediaType)
-    {
-        case UNIDENTIFIED:
-        case UNPLUGGED:
-        default:
-            ethComplianceStr = "N/A";
-            extComplianceStr = "N/A";
-            break;
+    switch (cableMediaType) {
+    case UNIDENTIFIED:
+    case UNPLUGGED:
+    default:
+        ethComplianceStr = "N/A";
+        extComplianceStr = "N/A";
+        break;
 
-        case ACTIVE:
-            ethComplianceStr = _mlxlinkMaps->_activeCableCompliance[ethComplianceCode];
-            ethComplianceStr = ethComplianceStr.empty() ? "N/A" : ethComplianceStr;
-            extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
-            break;
+    case ACTIVE:
+        ethComplianceStr = _mlxlinkMaps->_activeCableCompliance[ethComplianceCode];
+        ethComplianceStr = ethComplianceStr.empty() ? "N/A" : ethComplianceStr;
+        extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
+        break;
 
-        case OPTICAL_MODULE:
-            if (cableTechnology == TECHNOLOGY_850NM_VCSEL)
-            {
-                ethComplianceStr = _mlxlinkMaps->_mmfCompliance[ethComplianceCode];
-            }
-            else if (cableTechnology >= TECHNOLOGY_1310NM_VCSEL && cableTechnology <= TECHNOLOGY_1550NM_EML)
-            {
-                ethComplianceStr = _mlxlinkMaps->_smfCompliance[ethComplianceCode];
-            }
+    case OPTICAL_MODULE:
+        if (cableTechnology == TECHNOLOGY_850NM_VCSEL) {
+            ethComplianceStr = _mlxlinkMaps->_mmfCompliance[ethComplianceCode];
+        } else if ((cableTechnology >= TECHNOLOGY_1310NM_VCSEL) && (cableTechnology <= TECHNOLOGY_1550NM_EML)) {
+            ethComplianceStr = _mlxlinkMaps->_smfCompliance[ethComplianceCode];
+        }
 
-            extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
-            break;
+        extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
+        break;
 
-        case PASSIVE:
-            ethComplianceStr = "N/A";
-            extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
-            break;
+    case PASSIVE:
+        ethComplianceStr = "N/A";
+        extComplianceStr = _mlxlinkMaps->_cmisHostCompliance[extEthComplianceCode];
+        break;
     }
 }
 
 void MlxlinkAmBerCollector::getEthComplianceCodes(u_int32_t cableTechnology,
-                                                  string& ethComplianceStr,
-                                                  string& extComplianceStr,
+                                                  string&   ethComplianceStr,
+                                                  string&   extComplianceStr,
                                                   u_int32_t cableMediaType)
 {
     u_int32_t ethComplianceCode = getFieldValue("ethernet_compliance_code");
     u_int32_t extEthComplianceCode = getFieldValue("ext_ethernet_compliance_code");
 
-    if (_isQsfpCable)
-    {
+    if (_isQsfpCable) {
         ethComplianceStr =
-          ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceQsfp, true) : "N/A";
+            ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceQsfp, true) : "N/A";
         extComplianceStr = (extEthComplianceCode & QSFP_ETHERNET_COMPLIANCE_CODE_EXT) ?
-                             _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] :
-                             "N/A";
+                           _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] :
+                           "N/A";
     }
-    if (_isSfpCable)
-    {
+    if (_isSfpCable) {
         ethComplianceStr =
-          ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceSfp, true) : "N/A";
+            ethComplianceCode ? getCompliance(ethComplianceCode, _mlxlinkMaps->_cableComplianceSfp, true) : "N/A";
         extComplianceStr = extEthComplianceCode ? _mlxlinkMaps->_cableComplianceExt[extEthComplianceCode] : "N/A";
     }
-    if (_isCmisCable)
-    {
+    if (_isCmisCable) {
         getCmisComplianceCode(ethComplianceCode, extEthComplianceCode, ethComplianceStr, extComplianceStr,
                               cableMediaType, cableTechnology);
     }
@@ -1325,23 +1258,20 @@ void MlxlinkAmBerCollector::getEthComplianceCodes(u_int32_t cableTechnology,
 void MlxlinkAmBerCollector::getIbComplianceCodes(string& ibComplianceCodeStr)
 {
     u_int32_t ibComplianceCode = getFieldValue("ib_compliance_code");
+
     ibComplianceCodeStr =
-      ibComplianceCode ? getCompliance(ibComplianceCode, _mlxlinkMaps->_cableComplianceCmisIb, true) : "N/A";
+        ibComplianceCode ? getCompliance(ibComplianceCode, _mlxlinkMaps->_cableComplianceCmisIb, true) : "N/A";
 }
 
 string MlxlinkAmBerCollector::getCableTechnologyStr(u_int32_t cableTechnology)
 {
     string technologyStr = "N/A";
-    if (_isCmisCable)
-    {
+
+    if (_isCmisCable) {
         technologyStr = _mlxlinkMaps->_cableTechnologyQsfp[cableTechnology];
-    }
-    else if (_isQsfpCable)
-    {
+    } else if (_isQsfpCable) {
         technologyStr = _mlxlinkMaps->_cableTechnologyQsfp[(cableTechnology & 240) >> 4];
-    }
-    else
-    {
+    } else {
         technologyStr = _mlxlinkMaps->_cableTechnologySfp[(cableTechnology & 15)];
     }
     return technologyStr;
@@ -1353,82 +1283,67 @@ string MlxlinkAmBerCollector::getCableBreakoutStr(u_int32_t cableBreakout, u_int
     string impCh = "";
     string notImpCh = "";
 
-    if (_isCmisCable)
-    {
+    if (_isCmisCable) {
         cableBreakoutStr = _mlxlinkMaps->_cimsCableBreakout[cableBreakout];
         findAndReplace(cableBreakoutStr, "X", getCableIdentifier(cableIdentifier));
-    }
-    else if (_isQsfpCable)
-    {
+    } else if (_isQsfpCable) {
         u_int32_t near_end_bits = cableBreakout & 0xF;
         u_int32_t far_end_bits = (cableBreakout >> 4) & 0xF;
 
-        for (u_int32_t channel = 1; channel < QSFP_CHANNELS + 1; channel++)
-        {
-            if (getBitvalue(near_end_bits, channel))
-            {
+        for (u_int32_t channel = 1; channel < QSFP_CHANNELS + 1; channel++) {
+            if (getBitvalue(near_end_bits, channel)) {
                 notImpCh += to_string(channel) + "_";
-            }
-            else
-            {
+            } else {
                 impCh += to_string(channel) + "_";
             }
         }
         impCh = deleteLastChar(impCh);
         notImpCh = deleteLastChar(notImpCh);
 
-        if (!impCh.empty())
-        {
+        if (!impCh.empty()) {
             cableBreakoutStr = "Channels implemented [" + impCh + "]";
         }
-        if (!notImpCh.empty())
-        {
+        if (!notImpCh.empty()) {
             cableBreakoutStr += ",Channels not implemented [" + notImpCh + "]";
         }
 
         cableBreakoutStr += '/' + _mlxlinkMaps->_qsfpFarEndCableBreakout[far_end_bits];
-    }
-    else
-    {
+    } else {
         cableBreakoutStr = "N/A";
     }
 
     return cableBreakoutStr;
 }
 
-void MlxlinkAmBerCollector::pushModulePerLaneField(vector<AmberField>& fields,
-                                                   string fieldName,
-                                                   float valueCorrection,
-                                                   string laneSep)
+void MlxlinkAmBerCollector::pushModulePerLaneField(vector < AmberField >& fields,
+                                                   string                 fieldName,
+                                                   float                  valueCorrection,
+                                                   string                 laneSep)
 {
-    float value = 0;
+    float     value = 0;
     u_int32_t lanes = MAX_NETWORK_LANES;
 
-    if (_isPortIB)
-    {
+    if (_isPortIB) {
         lanes = MAX_IB_LANES;
     }
 
-    for (u_int32_t lane = 0; lane < lanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < lanes; lane++) {
         value = getLocalFieldValue(fieldName + to_string(lane));
-        if (fieldName.find("power") != string::npos)
-        {
+        if (fieldName.find("power") != string::npos) {
             value = getPower(value);
         }
         fields.push_back(AmberField(fieldName + laneSep + to_string(lane), floatToStr(value / valueCorrection, 2)));
     }
 }
 
-void MlxlinkAmBerCollector::pushModuleDpPerLane(vector<AmberField>& fields, const string str)
+void MlxlinkAmBerCollector::pushModuleDpPerLane(vector < AmberField >& fields, const string str)
 {
     string dpStateStr = "N/A";
     string fieldName = str;
 
     fieldName = toLowerCase(fieldName);
 
-    for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++)
-    {
+    for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++) {
         string laneStr = to_string(lane);
         dpStateStr = getStrByMask(getLocalFieldValue(fieldName + laneStr), _mlxlinkMaps->_dataPathSt);
         fields.push_back(AmberField(str + laneStr, dpStateStr));
@@ -1436,24 +1351,20 @@ void MlxlinkAmBerCollector::pushModuleDpPerLane(vector<AmberField>& fields, cons
     }
 }
 
-string
-  MlxlinkAmBerCollector::getSmfLength(const u_int32_t smfLength, const u_int32_t cableTechnology, const bool optical)
+string MlxlinkAmBerCollector::getSmfLength(const u_int32_t smfLength,
+                                           const u_int32_t cableTechnology,
+                                           const bool      optical)
 {
     string lengthStr = "N/A";
 
-    if (cableTechnology >= TECHNOLOGY_1310NM_VCSEL && cableTechnology <= TECHNOLOGY_1550NM_EML && optical)
-    {
-        bool lengthBasedOn100m = getBitvalue(smfLength, 9);
-
+    if ((cableTechnology >= TECHNOLOGY_1310NM_VCSEL) && (cableTechnology <= TECHNOLOGY_1550NM_EML) && optical) {
+        bool      lengthBasedOn100m = getBitvalue(smfLength, 9);
         u_int32_t length = smfLength & 0XFF;
 
-        if (lengthBasedOn100m)
-        {
+        if (lengthBasedOn100m) {
             length *= 100;
             lengthStr = to_string(length) + "m";
-        }
-        else
-        {
+        } else {
             lengthStr = to_string(length) + "km";
         }
     }
@@ -1463,26 +1374,21 @@ string
 
 string MlxlinkAmBerCollector::getDateCode(u_int64_t dateCode)
 {
-    string dateCodeStr;
+    string    dateCodeStr;
     u_int64_t dateCodeRev = 0;
     u_int64_t tmpDateCode = dateCode;
 
-    while (tmpDateCode)
-    {
+    while (tmpDateCode) {
         dateCodeRev = (dateCodeRev << 16) | (tmpDateCode & 0xffff);
         tmpDateCode = tmpDateCode >> 16;
     }
 
-    if (dateCodeRev)
-    {
-        for (int i = 56; i > -1; i -= 8)
-        {
+    if (dateCodeRev) {
+        for (int i = 56; i > -1; i -= 8) {
             char ch = (char)(dateCodeRev >> i);
-            if (ch)
-            {
+            if (ch) {
                 dateCodeStr.push_back(ch);
-                if (i % 16 == 0)
-                {
+                if (i % 16 == 0) {
                     dateCodeStr.push_back('_');
                 }
             }
@@ -1491,16 +1397,14 @@ string MlxlinkAmBerCollector::getDateCode(u_int64_t dateCode)
         dateCodeStr = deleteLastChar(dateCodeStr);
         MlxlinkRecord::trim(dateCodeStr);
         MlxlinkRecord::trim(dateCodeStr, "_");
-    }
-    else
-    {
+    } else {
         dateCodeStr = "N/A";
     }
 
     return dateCodeStr;
 }
 
-void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
+void MlxlinkAmBerCollector::getModuleInfoPage(vector < AmberField >& fields)
 {
     u_int32_t cableIdentifier = getFieldValue("cable_identifier");
     u_int32_t ibWidth = getFieldValue("ib_width");
@@ -1508,28 +1412,26 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     u_int32_t cableBreakout = getFieldValue("cable_breakout");
     u_int32_t cableMediaType = getFieldValue("cable_type");
     u_int32_t vendorOUI = getFieldValue("vendor_oui");
+    bool      passive = cableMediaType == PASSIVE;
+    bool      optical = cableMediaType == OPTICAL_MODULE;
+    string    ethComplianceStr = "N/A";
+    string    extComplianceStr = "N/A";
+    string    ibComplianceCodeStr = "N/A";
+    string    ibWidthStr = linkWidthMaskToStr(ibWidth);
+    string    moduleSt = "N/A";
+    string    activeSetHostComplianceCode = "N/A";
+    string    activeSetMediaComplianceCode = "N/A";
+    string    nbrString = "N/A";
+    string    error_code_res = "N/A";
+    char      vendorOUIStr[32];
 
-    bool passive = cableMediaType == PASSIVE;
-    bool optical = cableMediaType == OPTICAL_MODULE;
-    string ethComplianceStr = "N/A";
-    string extComplianceStr = "N/A";
-    string ibComplianceCodeStr = "N/A";
-    string ibWidthStr = linkWidthMaskToStr(ibWidth);
-    string moduleSt = "N/A";
-    string activeSetHostComplianceCode = "N/A";
-    string activeSetMediaComplianceCode = "N/A";
-    string nbrString = "N/A";
-    string error_code_res = "N/A";
-    char vendorOUIStr[32];
     sprintf(vendorOUIStr, "0x%X", vendorOUI);
 
     initCableIdentifier(cableIdentifier);
-    if (_isPortETH || _isCmisCable)
-    {
+    if (_isPortETH || _isCmisCable) {
         getEthComplianceCodes(cableTechnology, ethComplianceStr, extComplianceStr, cableMediaType);
     }
-    if (_isPortIB)
-    {
+    if (_isPortIB) {
         getIbComplianceCodes(ibComplianceCodeStr);
     }
 
@@ -1550,8 +1452,9 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("smf_length", getSmfLength(getFieldValue("smf_length"), cableTechnology, optical)));
     fields.push_back(AmberField("cable_identifier", getCableIdentifier(getFieldValue("cable_identifier"))));
     fields.push_back(AmberField(
-      "cable_power_class",
-      getPowerClass(_mlxlinkMaps, cableIdentifier, getFieldValue("cable_power_class"), getFieldValue("max_power"))));
+                         "cable_power_class",
+                         getPowerClass(_mlxlinkMaps, cableIdentifier, getFieldValue("cable_power_class"),
+                                       getFieldValue("max_power"))));
     fields.push_back(AmberField("max_power", getFieldStr("max_power")));
     fields.push_back(AmberField("cable_rx_amp", passive ? "N/A" : getFieldStr("cable_rx_amp")));
     fields.push_back(AmberField("cable_rx_pre_emphasis", passive ? "N/A" : getFieldStr("cable_rx_emphasis")));
@@ -1562,7 +1465,8 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("cable_attenuation_7g", getFieldStr("cable_attenuation_7g")));
     fields.push_back(AmberField("cable_attenuation_5g", getFieldStr("cable_attenuation_5g")));
     fields.push_back(
-      AmberField("tx_input_freq_sync", getStrByValue(getFieldValue("tx_input_freq_sync"), _mlxlinkMaps->_txInputFreq)));
+        AmberField("tx_input_freq_sync", getStrByValue(getFieldValue(
+                                                           "tx_input_freq_sync"), _mlxlinkMaps->_txInputFreq)));
     fields.push_back(AmberField("rx_cdr_cap", _mlxlinkMaps->_rxTxCdrCap[getFieldValue("rx_cdr_cap")]));
     fields.push_back(AmberField("tx_cdr_cap", _mlxlinkMaps->_rxTxCdrCap[getFieldValue("tx_cdr_cap")]));
     fields.push_back(AmberField("rx_cdr_state", getRxTxCDRState(getFieldValue("rx_cdr_state"), _maxLanes)));
@@ -1588,14 +1492,14 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
     fields.push_back(AmberField("wavelength", getFieldStr("wavelength")));
 
     float waveLenTol = float(getFieldValue("wavelength_tolerance")) / 200.0;
-    char waveLenTolCh[64];
+    char  waveLenTolCh[64];
+
     sprintf(waveLenTolCh, "%.1f", waveLenTol);
     string waveLenTolStr = waveLenTolCh;
 
     fields.push_back(AmberField("wavelength_tolerance", passive ? "N/A" : waveLenTolStr + "nm"));
 
-    if (_isCmisCable)
-    {
+    if (_isCmisCable) {
         moduleSt = _mlxlinkMaps->_cimsModuleSt[getFieldValue("module_st")];
     }
 
@@ -1605,10 +1509,9 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
 
     fields.push_back(AmberField("rx_output_valid", getBitmaskPerLaneStr(getFieldValue("rx_output_valid"))));
 
-    if (cableIdentifier < IDENTIFIER_SFP_DD)
-    {
+    if (cableIdentifier < IDENTIFIER_SFP_DD) {
         float nbr = float(getFieldValue("nbr250") * 250) / float(1000);
-        char nbrCh[64];
+        char  nbrCh[64];
         sprintf(nbrCh, "%.3f", nbr);
         nbrString = nbrCh + string("Gb/s");
     }
@@ -1616,20 +1519,19 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
 
     fields.push_back(AmberField("Rx_Power_Type", _mlxlinkMaps->_rxPowerType[getFieldValue("rx_power_type")]));
     fields.push_back(
-      AmberField("Date_Code", getDateCode(add32BitTo64(getFieldValue("date_code_hi"), getFieldValue("date_code_lo")))));
+        AmberField("Date_Code", getDateCode(add32BitTo64(getFieldValue("date_code_hi"), getFieldValue(
+                                                             "date_code_lo")))));
     fields.push_back(AmberField("Module_Temperature", getTemp(getFieldValue("temperature"))));
     fields.push_back(AmberField("Module_Voltage", to_string(getFieldValue("voltage") / 10.0)));
 
-    if (_isCmisCable)
-    {
+    if (_isCmisCable) {
         activeSetHostComplianceCode = extComplianceStr;
         activeSetMediaComplianceCode = ethComplianceStr;
     }
     fields.push_back(AmberField("Active_set_host_compliance_code", activeSetHostComplianceCode));
     fields.push_back(AmberField("Active_set_media_compliance_code", activeSetMediaComplianceCode));
 
-    if (_isCmisCable)
-    {
+    if (_isCmisCable) {
         error_code_res = getStrByValue(getFieldValue("error_code"), _mlxlinkMaps->_errorCodeRes);
     }
     fields.push_back(AmberField("error_code_response", error_code_res));
@@ -1638,11 +1540,10 @@ void MlxlinkAmBerCollector::getModuleInfoPage(vector<AmberField>& fields)
 string MlxlinkAmBerCollector::getBitmaskPerLaneStr(u_int32_t bitmask)
 {
     string bitMaskStr = "";
-    for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++)
-    {
+
+    for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++) {
         bitMaskStr += getBitvalue(bitmask, lane + 1) ? "1" : "0";
-        if (lane != 7)
-        {
+        if (lane != 7) {
             bitMaskStr += ",";
         }
     }
@@ -1650,14 +1551,14 @@ string MlxlinkAmBerCollector::getBitmaskPerLaneStr(u_int32_t bitmask)
     return bitMaskStr;
 }
 
-void MlxlinkAmBerCollector::getModuleLatchedFlagInfoPage(vector<AmberField>& fields)
+void MlxlinkAmBerCollector::getModuleLatchedFlagInfoPage(vector < AmberField >& fields)
 {
     string modFwFault = "N/A";
     string dpFwFault = "N/A";
     string txLoss = "N/A";
     string txAdEqFault = "N/A";
-    if (_isCmisCable)
-    {
+
+    if (_isCmisCable) {
         modFwFault = getFieldStr("mod_fw_fault");
         dpFwFault = getFieldStr("dp_fw_fault");
     }
@@ -1667,14 +1568,12 @@ void MlxlinkAmBerCollector::getModuleLatchedFlagInfoPage(vector<AmberField>& fie
     fields.push_back(AmberField("Mod_fw_fault", modFwFault));
     fields.push_back(AmberField("Dp_fw_fault", dpFwFault));
     fields.push_back(AmberField("tx_fault", getBitmaskPerLaneStr(getFieldValue("tx_fault"))));
-    if (!_isSfpCable)
-    {
+    if (!_isSfpCable) {
         txLoss = getBitmaskPerLaneStr(getFieldValue("tx_los"));
     }
     fields.push_back(AmberField("tx_los", txLoss));
     fields.push_back(AmberField("tx_cdr_lol", getBitmaskPerLaneStr(getFieldValue("tx_cdr_lol"))));
-    if (!_isSfpCable)
-    {
+    if (!_isSfpCable) {
         txAdEqFault = getBitmaskPerLaneStr(getFieldValue("tx_ad_eq_fault"));
     }
     fields.push_back(AmberField("tx_ad_eq_fault", txAdEqFault));
@@ -1694,24 +1593,22 @@ void MlxlinkAmBerCollector::getModuleLatchedFlagInfoPage(vector<AmberField>& fie
     fields.push_back(AmberField("rx_power_lo_war", getBitmaskPerLaneStr(getFieldValue("rx_power_lo_war"))));
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getModuleStatus()
+vector < AmberField > MlxlinkAmBerCollector::getModuleStatus()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
+        if (!_isPortPCIE) {
             resetLocalParser(ACCESS_REG_PMAOS);
             updateField("module", _moduleIndex);
             updateField("slot_index", _slotIndex);
             sendRegister(ACCESS_REG_PMAOS, MACCESS_REG_METHOD_GET);
 
             u_int32_t operSt = getFieldValue("oper_status");
-            string operStStr = getStrByValue(operSt, _mlxlinkMaps->_moduleOperSt);
-            string errTypeStr = "N/A";
-            if (operSt == MODULE_OPER_STATUS_PLUGGED_WITH_ERROR)
-            {
+            string    operStStr = getStrByValue(operSt, _mlxlinkMaps->_moduleOperSt);
+            string    errTypeStr = "N/A";
+            if (operSt == MODULE_OPER_STATUS_PLUGGED_WITH_ERROR) {
                 errTypeStr = getStrByValue(getFieldValue("error_type"), _mlxlinkMaps->_moduleErrType);
             }
 
@@ -1723,8 +1620,7 @@ vector<AmberField> MlxlinkAmBerCollector::getModuleStatus()
             updateField("page_select", PDDR_MODULE_INFO_PAGE);
             sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
 
-            if (!_cablePlugged)
-            {
+            if (!_cablePlugged) {
                 AmberField::_dataValid = false;
             }
             getModuleInfoPage(fields);
@@ -1734,14 +1630,13 @@ vector<AmberField> MlxlinkAmBerCollector::getModuleStatus()
             updateField("page_select", PDDR_MODULE_LATCHED_FLAG_INFO_PAGE);
             sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
 
-            if (!_cablePlugged)
-            {
+            if (!_cablePlugged) {
                 AmberField::_dataValid = false;
             }
             getModuleLatchedFlagInfoPage(fields);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Module status: %s", exc.what());
     }
@@ -1749,17 +1644,15 @@ vector<AmberField> MlxlinkAmBerCollector::getModuleStatus()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
+vector < AmberField > MlxlinkAmBerCollector::getPortCounters()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
     try
     {
-        // Getting counters for ETH and IB ports
-        if (!_isPortPCIE)
-        {
-            // Getting IB link errors
-            if (_isPortIB)
-            {
+        /* Getting counters for ETH and IB ports */
+        if (!_isPortPCIE) {
+            /* Getting IB link errors */
+            if (_isPortIB) {
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_IB_PORT_COUNTERS_GROUP);
@@ -1782,7 +1675,7 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                 fields.push_back(AmberField("PortXmitPkts", getFieldStr("port_xmit_pkts")));
                 fields.push_back(AmberField("PortRcvPkts", getFieldStr("port_rcv_pkts")));
                 fields.push_back(AmberField("PortXmitWait", getFieldStr("port_xmit_wait")));
-                // Getting port extended counters info
+                /* Getting port extended counters info */
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_EXT_IB_PORT_COUNTERS_GROUP);
@@ -1790,17 +1683,21 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
 
                 fields.push_back(AmberField(
-                  "PortXmitDataExtended",
-                  to_string(add32BitTo64(getFieldValue("port_xmit_data_high"), getFieldValue("port_xmit_data_low")))));
+                                     "PortXmitDataExtended",
+                                     to_string(add32BitTo64(getFieldValue("port_xmit_data_high"),
+                                                            getFieldValue("port_xmit_data_low")))));
                 fields.push_back(AmberField(
-                  "PortRcvDataExtended",
-                  to_string(add32BitTo64(getFieldValue("port_rcv_data_high"), getFieldValue("port_rcv_data_low")))));
+                                     "PortRcvDataExtended",
+                                     to_string(add32BitTo64(getFieldValue("port_rcv_data_high"),
+                                                            getFieldValue("port_rcv_data_low")))));
                 fields.push_back(AmberField(
-                  "PortXmitPktsExtended",
-                  to_string(add32BitTo64(getFieldValue("port_xmit_pkts_high"), getFieldValue("port_xmit_pkts_low")))));
+                                     "PortXmitPktsExtended",
+                                     to_string(add32BitTo64(getFieldValue("port_xmit_pkts_high"),
+                                                            getFieldValue("port_xmit_pkts_low")))));
                 fields.push_back(AmberField(
-                  "PortRcvPktsExtended",
-                  to_string(add32BitTo64(getFieldValue("port_rcv_pkts_high"), getFieldValue("port_rcv_pkts_low")))));
+                                     "PortRcvPktsExtended",
+                                     to_string(add32BitTo64(getFieldValue("port_rcv_pkts_high"),
+                                                            getFieldValue("port_rcv_pkts_low")))));
                 fields.push_back(AmberField("PortUniCastXmitPkts",
                                             to_string(add32BitTo64(getFieldValue("port_unicast_xmit_pkts_high"),
                                                                    getFieldValue("port_unicast_xmit_pkts_low")))));
@@ -1842,27 +1739,29 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                             to_string(add32BitTo64(getFieldValue("port_neighbor_mtu_discards_high"),
                                                                    getFieldValue("port_neighbor_mtu_discards_low")))));
 
-                // Getting engress counters
+                /* Getting engress counters */
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_DISC_COUNTERS_GROUP);
                 updateField("lp_gl", (u_int32_t)(_localPort == 255));
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
                 fields.push_back(AmberField(
-                  "PortSwLifetimeLimitDiscards",
-                  to_string(add32BitTo64(getFieldValue("egress_sll_high"), getFieldValue("egress_sll_low")))));
+                                     "PortSwLifetimeLimitDiscards",
+                                     to_string(add32BitTo64(getFieldValue("egress_sll_high"),
+                                                            getFieldValue("egress_sll_low")))));
                 fields.push_back(AmberField("PortSwHOQLifetimeLimitDiscards",
                                             to_string(add32BitTo64(getFieldValue("egress_hoq_stall_high"),
                                                                    getFieldValue("egress_hoq_stall_low")))));
-                // Getting PLR counters data
+                /* Getting PLR counters data */
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);
                 updateField("grp", PPCNT_PLR_GROUP);
                 updateField("lp_gl", (u_int32_t)(_localPort == 255));
                 sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
                 fields.push_back(AmberField(
-                  "PlrRcvCodes",
-                  to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"), getFieldValue("plr_rcv_codes_low")))));
+                                     "PlrRcvCodes",
+                                     to_string(add32BitTo64(getFieldValue("plr_rcv_codes_high"),
+                                                            getFieldValue("plr_rcv_codes_low")))));
                 fields.push_back(AmberField("PlrRcvCodeErr",
                                             to_string(add32BitTo64(getFieldValue("plr_rcv_code_err_high"),
                                                                    getFieldValue("plr_rcv_code_err_low")))));
@@ -1870,8 +1769,9 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                             to_string(add32BitTo64(getFieldValue("plr_rcv_uncorrectable_code_high"),
                                                                    getFieldValue("plr_rcv_uncorrectable_code_low")))));
                 fields.push_back(AmberField(
-                  "PlrXmitCodes",
-                  to_string(add32BitTo64(getFieldValue("plr_xmit_codes_high"), getFieldValue("plr_xmit_codes_low")))));
+                                     "PlrXmitCodes",
+                                     to_string(add32BitTo64(getFieldValue("plr_xmit_codes_high"),
+                                                            getFieldValue("plr_xmit_codes_low")))));
                 fields.push_back(AmberField("PlrXmitRetryCodes",
                                             to_string(add32BitTo64(getFieldValue("plr_xmit_retry_codes_high"),
                                                                    getFieldValue("plr_xmit_retry_codes_low")))));
@@ -1885,9 +1785,11 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                             to_string(add32BitTo64(getLocalFieldValue("plr_codes_loss_high"),
                                                                    getLocalFieldValue("plr_codes_loss_low")))));
                 fields.push_back(AmberField(
-                  "PlrXmitRetryEventsWithinTSecMax",
-                  to_string(add32BitTo64(getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_high"),
-                                         getLocalFieldValue("plr_xmit_retry_events_within_t_sec_max_low")))));
+                                     "PlrXmitRetryEventsWithinTSecMax",
+                                     to_string(add32BitTo64(getLocalFieldValue(
+                                                                "plr_xmit_retry_events_within_t_sec_max_high"),
+                                                            getLocalFieldValue(
+                                                                "plr_xmit_retry_events_within_t_sec_max_low")))));
 
                 fields.push_back(AmberField("PlrBWLoss_Percent",
                                             to_string(add32BitTo64(getLocalFieldValue("plr_codes_loss_high"),
@@ -1904,10 +1806,8 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                             to_string(add32BitTo64(getLocalFieldValue("rq_general_error_high"),
                                                                    getLocalFieldValue("rq_general_error_low")))));
             }
-        }
-        else
-        {
-            // Getting the PCIE errors fields (PCIE only)
+        } else {
+            /* Getting the PCIE errors fields (PCIE only) */
             resetLocalParser(ACCESS_REG_MPCNT);
             updateField("depth", _depth);
             updateField("pcie_index", _pcieIndex);
@@ -1922,7 +1822,8 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                                                getFieldValue("tx_overflow_buffer_pkt_lo")))));
             fields.push_back(AmberField("outbound_stalled_reads", getFieldStr("outbound_stalled_reads")));
             fields.push_back(AmberField("outbound_stalled_writes", getFieldStr("outbound_stalled_writes")));
-            fields.push_back(AmberField("outbound_stalled_reads_events", getFieldStr("outbound_stalled_reads_events")));
+            fields.push_back(AmberField("outbound_stalled_reads_events",
+                                        getFieldStr("outbound_stalled_reads_events")));
             fields.push_back(AmberField("outbound_stalled_writes_events", getFieldStr("outbound_stalled_writes_"
                                                                                       "events")));
             fields.push_back(AmberField("tx_overflow_buffer_marked_pkt",
@@ -1930,7 +1831,7 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
                                                                getFieldValue("tx_overflow_buffer_marked_pkt_lo")))));
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Port Counters information: %s", exc.what());
     }
@@ -1938,14 +1839,13 @@ vector<AmberField> MlxlinkAmBerCollector::getPortCounters()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getTroubleshootingInfo()
+vector < AmberField > MlxlinkAmBerCollector::getTroubleshootingInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
+        if (!_isPortPCIE) {
             resetLocalParser(ACCESS_REG_PDDR);
             updateField("local_port", _localPort);
             updateField("pnat", PNAT_LOCAL);
@@ -1953,29 +1853,25 @@ vector<AmberField> MlxlinkAmBerCollector::getTroubleshootingInfo()
             updateField("group_opcode", MONITOR_OPCODE);
             sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
 
-            string message = "";
-            char txt[16], c;
+            string    message = "";
+            char      txt[16], c;
             u_int32_t message_buf;
-            bool finalize = false;
-            for (int i = 0; i < PDDR_STATUS_MESSAGE_LENGTH_SWITCH; i++)
-            {
+            bool      finalize = false;
+            for (int i = 0; i < PDDR_STATUS_MESSAGE_LENGTH_SWITCH; i++) {
                 string path = "status_message[";
                 sprintf(txt, "%d", i);
                 path.append(txt);
                 path.append("]");
                 message_buf = getFieldValue(path);
-                for (int k = 24; k > -1; k -= 8)
-                {
+                for (int k = 24; k > -1; k -= 8) {
                     c = (char)(message_buf >> k);
-                    if (c == '\0')
-                    {
+                    if (c == '\0') {
                         finalize = true;
                         break;
                     }
                     message.push_back(c);
                 }
-                if (finalize == true)
-                {
+                if (finalize == true) {
                     break;
                 }
             }
@@ -1984,7 +1880,7 @@ vector<AmberField> MlxlinkAmBerCollector::getTroubleshootingInfo()
             fields.push_back(AmberField("Status_Message", message));
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Troubleshooting information: %s", exc.what());
     }
@@ -1992,15 +1888,15 @@ vector<AmberField> MlxlinkAmBerCollector::getTroubleshootingInfo()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getLinkUpInfo()
+vector < AmberField > MlxlinkAmBerCollector::getLinkUpInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        // Access regs: [PDDR.linkup_info_page]
+        /* Access regs: [PDDR.linkup_info_page] */
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get LinkUp information: %s", exc.what());
     }
@@ -2008,28 +1904,27 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkUpInfo()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getLinkDownInfo()
+vector < AmberField > MlxlinkAmBerCollector::getLinkDownInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
+        if (!_isPortPCIE) {
             sendLocalPrmReg(ACCESS_REG_PDDR, GET, "local_port=%d,page_select=%d", _localPort,
                             PDDR_MODULE_LINK_DOWN_INFO_PAGE);
 
             fields.push_back(AmberField("down_blame", _mlxlinkMaps->_downBlame[getFieldValue("down_blame")]));
             fields.push_back(
-              AmberField("local_reason_opcode", _mlxlinkMaps->_localReasonOpcode[getFieldValue("local_reason_"
-                                                                                               "opcode")]));
+                AmberField("local_reason_opcode", _mlxlinkMaps->_localReasonOpcode[getFieldValue("local_reason_"
+                                                                                                 "opcode")]));
             fields.push_back(
-              AmberField("remote_reason_opcode", _mlxlinkMaps->_localReasonOpcode[getFieldValue("remote_reason_"
-                                                                                                "opcode")]));
+                AmberField("remote_reason_opcode", _mlxlinkMaps->_localReasonOpcode[getFieldValue("remote_reason_"
+                                                                                                  "opcode")]));
             fields.push_back(AmberField("e2e_reason_opcode", getFieldStr("e2e_reason_opcode")));
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get LinkDown information: %s", exc.what());
     }
@@ -2039,19 +1934,17 @@ vector<AmberField> MlxlinkAmBerCollector::getLinkDownInfo()
 
 string MlxlinkAmBerCollector::getPrbsModeCap(u_int32_t modeSelector, u_int32_t capsMask)
 {
-    string modeCapStr = "";
+    string    modeCapStr = "";
     u_int32_t mask = 0;
-    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin();
+
+    for (map < u_int32_t, string > ::iterator it = _mlxlinkMaps->_prbsModesList.begin();
          it != _mlxlinkMaps->_prbsModesList.end();
-         it++)
-    {
+         it++) {
         mask = PRBS31_CAP << it->first;
-        if (capsMask & mask)
-        {
+        if (capsMask & mask) {
             modeCapStr += it->second;
-            if (modeSelector == PRBS_RX && mask == SQUARE_WAVEA_CAP)
-            {
-                // return SQUARE_WAVE without A for RX pattern
+            if ((modeSelector == PRBS_RX) && (mask == SQUARE_WAVEA_CAP)) {
+                /* return SQUARE_WAVE without A for RX pattern */
                 modeCapStr = deleteLastChar(modeCapStr);
             }
             modeCapStr += ",";
@@ -2060,50 +1953,48 @@ string MlxlinkAmBerCollector::getPrbsModeCap(u_int32_t modeSelector, u_int32_t c
     return deleteLastChar(modeCapStr);
 }
 
-void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params)
+void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg, vector < vector < string >>& params)
 {
     string laneRateStr = "lane_rate_admin";
-    if (prbsReg == ACCESS_REG_PPRT)
-    {
+
+    if (prbsReg == ACCESS_REG_PPRT) {
         laneRateStr = "lane_rate_oper";
     }
 
-    for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
         resetLocalParser(prbsReg);
         updateField("local_port", _localPort);
         updateField("lane", lane);
         updateField("pnat", _pnat);
         sendRegister(prbsReg, MACCESS_REG_METHOD_GET);
 
-        if (prbsReg == ACCESS_REG_PPRT)
-        {
+        if (prbsReg == ACCESS_REG_PPRT) {
             params[PRBS_PARAMS_RX_TUNING_STATUS][lane] =
-              getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
+                getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
             params[PRBS_PARAMS_LOCK_STATUS][lane] =
-              getStrByValue(getFieldValue("prbs_lock_status"), _mlxlinkMaps->_prbsLockStatus);
+                getStrByValue(getFieldValue("prbs_lock_status"), _mlxlinkMaps->_prbsLockStatus);
         }
         params[PRBS_PARAMS_E][lane] = getStrByValue(getFieldValue("e"), _mlxlinkMaps->_prbsEStatus);
         params[PRBS_PARAMS_P][lane] = getStrByValue(getFieldValue("p"), _mlxlinkMaps->_prbsPStatus);
         params[PRBS_PARAMS_MODES_CAP][lane] = getPrbsModeCap(PRBS_TX, getFieldValue("prbs_modes_cap"));
         params[PRBS_PARAMS_MODE_ADMIN][lane] =
-          getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList);
+            getStrByValue(getFieldValue("prbs_mode_admin"), _mlxlinkMaps->_prbsModesList);
         params[PRBS_PARAMS_MODULATION][lane] =
-          getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_prbsModulation);
+            getStrByValue(getFieldValue("modulation"), _mlxlinkMaps->_prbsModulation);
         params[PRBS_PARAMS_LANE_RATE_CAP][lane] =
-          getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_prbsLaneRateCap);
+            getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_prbsLaneRateCap);
         params[PRBS_PARAMS_LANE_RATE_ADMIN][lane] =
-          getStrByValue(getFieldValue(laneRateStr), _mlxlinkMaps->_prbsLaneRateList);
+            getStrByValue(getFieldValue(laneRateStr), _mlxlinkMaps->_prbsLaneRateList);
     }
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getTestModeInfo()
+vector < AmberField > MlxlinkAmBerCollector::getTestModeInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
     try
     {
-        vector<vector<string>> pprtParams(PRBS_PARAMS_LAST, vector<string>(_maxLanes, ""));
-        vector<vector<string>> ppttParams(PRBS_PARAMS_LAST, vector<string>(_maxLanes, ""));
+        vector < vector < string >> pprtParams(PRBS_PARAMS_LAST, vector < string > (_maxLanes, ""));
+        vector < vector < string >> ppttParams(PRBS_PARAMS_LAST, vector < string > (_maxLanes, ""));
         getTestModePrpsInfo(ACCESS_REG_PPRT, pprtParams);
         getTestModePrpsInfo(ACCESS_REG_PPTT, ppttParams);
 
@@ -2125,7 +2016,7 @@ vector<AmberField> MlxlinkAmBerCollector::getTestModeInfo()
         fillParamsToFields("prbs_tx_lane_rate_cap", ppttParams[PRBS_PARAMS_LANE_RATE_CAP], fields);
         fillParamsToFields("prbs_tx_lane_rate_admin", ppttParams[PRBS_PARAMS_LANE_RATE_ADMIN], fields);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Test Mode information: %s", exc.what());
     }
@@ -2133,7 +2024,8 @@ vector<AmberField> MlxlinkAmBerCollector::getTestModeInfo()
     return fields;
 }
 
-void MlxlinkAmBerCollector::getTestModeModulePMPT(vector<AmberField>& fields, string moduleSide, ModuleAccess_t mode)
+void MlxlinkAmBerCollector::getTestModeModulePMPT(vector < AmberField >& fields, string moduleSide,
+                                                  ModuleAccess_t mode)
 {
     resetLocalParser(ACCESS_REG_PMPT);
     updateField("module", _moduleIndex);
@@ -2157,15 +2049,15 @@ void MlxlinkAmBerCollector::getTestModeModulePMPT(vector<AmberField>& fields, st
     fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_cap_" + moduleSide,
                                 getStrByMask(getFieldValue("lane_rate_cap"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
     fields.push_back(AmberField("prbs_" + modeStr + "_lane_rate_admin_" + moduleSide,
-                                getStrByValue(getFieldValue("lane_rate_admin"), _mlxlinkMaps->_modulePrbsRateCapToStr)));
+                                getStrByValue(getFieldValue("lane_rate_admin"),
+                                              _mlxlinkMaps->_modulePrbsRateCapToStr)));
 }
 
-void MlxlinkAmBerCollector::getTestModeModulePMPD(vector<AmberField>& fields, string moduleSide)
+void MlxlinkAmBerCollector::getTestModeModulePMPD(vector < AmberField >& fields, string moduleSide)
 {
-    vector<vector<string>> pmpdParams(PMPD_PARAM_LAST, vector<string>(_maxLanes, ""));
+    vector < vector < string >> pmpdParams(PMPD_PARAM_LAST, vector < string > (_maxLanes, ""));
 
-    for (u_int32_t lane = 0; lane < _maxLanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < _maxLanes; lane++) {
         resetLocalParser(ACCESS_REG_PMPD);
         updateField("module", _moduleIndex);
         updateField("slot_index", _slotIndex);
@@ -2175,9 +2067,9 @@ void MlxlinkAmBerCollector::getTestModeModulePMPD(vector<AmberField>& fields, st
 
         pmpdParams[PMPD_PARAM_STATUS][lane] = getStrByValue(getFieldValue("status"), _mlxlinkMaps->_modulePMPDStatus);
         pmpdParams[PMPD_PARAM_PRBS_BITS][lane] =
-          to_string(add32BitTo64(getFieldValue("prbs_bits_high"), getFieldValue("prbs_bits_low")));
+            to_string(add32BitTo64(getFieldValue("prbs_bits_high"), getFieldValue("prbs_bits_low")));
         pmpdParams[PMPD_PARAM_PRBS_ERRORS][lane] =
-          to_string(add32BitTo64(getFieldValue("prbs_errors_high"), getFieldValue("prbs_errors_low")));
+            to_string(add32BitTo64(getFieldValue("prbs_errors_high"), getFieldValue("prbs_errors_low")));
         pmpdParams[PMPD_PARAM_SNR][lane] = getFieldStr("measured_snr") + "dB";
         pmpdParams[PMPD_PARAM_BER][lane] = getFieldStr("ber_coef") + "E-" + getFieldStr("ber_magnitude");
     }
@@ -2189,9 +2081,9 @@ void MlxlinkAmBerCollector::getTestModeModulePMPD(vector<AmberField>& fields, st
     fillParamsToFields("prbs_checker_ber_" + moduleSide, pmpdParams[PMPD_PARAM_BER], fields);
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getTestModeModuleInfo()
+vector < AmberField > MlxlinkAmBerCollector::getTestModeModuleInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
@@ -2205,7 +2097,7 @@ vector<AmberField> MlxlinkAmBerCollector::getTestModeModuleInfo()
         getTestModeModulePMPT(fields, "media", MODULE_PRBS_ACCESS_GEN);
         getTestModeModulePMPD(fields, "media");
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Test Mode Module information: %s", exc.what());
     }
@@ -2213,14 +2105,14 @@ vector<AmberField> MlxlinkAmBerCollector::getTestModeModuleInfo()
     return fields;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getPhyDebugInfo()
+vector < AmberField > MlxlinkAmBerCollector::getPhyDebugInfo()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Phy Debug information: %s", exc.what());
     }
@@ -2228,10 +2120,9 @@ vector<AmberField> MlxlinkAmBerCollector::getPhyDebugInfo()
     return fields;
 }
 
-void MlxlinkAmBerCollector::getPemiSnr(vector<AmberField>& fields, bool isGroupSupported)
+void MlxlinkAmBerCollector::getPemiSnr(vector < AmberField >& fields, bool isGroupSupported)
 {
-    if (!isGroupSupported)
-    {
+    if (!isGroupSupported) {
         AmberField::_dataValid = false;
     }
 
@@ -2243,22 +2134,21 @@ void MlxlinkAmBerCollector::getPemiSnr(vector<AmberField>& fields, bool isGroupS
     AmberField::_dataValid = true;
 }
 
-vector<AmberField> MlxlinkAmBerCollector::getExtModuleStatus()
+vector < AmberField > MlxlinkAmBerCollector::getExtModuleStatus()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
 
     try
     {
-        if (!_isPortPCIE)
-        {
-            // sendLocalPrmReg(ACCESS_REG_PEMI, GET, "local_port=%d", _localPort);
+        if (!_isPortPCIE) {
+            /* sendLocalPrmReg(ACCESS_REG_PEMI, GET, "local_port=%d", _localPort); */
 
-            // u_int32_t groupCapMask = getLocalFieldValue("group_cap_mask");
+            /* u_int32_t groupCapMask = getLocalFieldValue("group_cap_mask"); */
 
-            getPemiSnr(fields, true); // Change to groupCapMask & PEMI_GROUP_CAP_SNR when become supported
+            getPemiSnr(fields, true); /* Change to groupCapMask & PEMI_GROUP_CAP_SNR when become supported */
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException("Failed to get Extended Module information: %s", exc.what());
     }
@@ -2268,155 +2158,139 @@ vector<AmberField> MlxlinkAmBerCollector::getExtModuleStatus()
 
 void MlxlinkAmBerCollector::groupValidIf(bool condition)
 {
-    if (condition)
-    {
+    if (condition) {
         _invalidate = false;
-    }
-    else
-    {
+    } else {
         _invalidate = true;
     }
 }
 
-vector<AmberField> MlxlinkAmBerCollector::collectSheet(AMBER_SHEET sheet)
+vector < AmberField > MlxlinkAmBerCollector::collectSheet(AMBER_SHEET sheet)
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
     bool invalidSheet = false;
+
     _invalidate = false;
     fields.push_back(AmberField("N/A", "N/A"));
 
     AmberField::reset();
 
-    switch (sheet)
-    {
-        case AMBER_SHEET_GENERAL:
-            fields = getGeneralInfo();
-            break;
-        case AMBER_SHEET_INDEXES:
-            fields = getIndexesInfo();
-            break;
-        case AMBER_SHEET_LINK_STATUS:
-            fields = getLinkStatus();
-            break;
-        case AMBER_SHEET_MODULE_STATUS:
-            fields = getModuleStatus();
-            break;
-        case AMBER_SHEET_SYSTEM:
-            fields = getSystemInfo();
-            break;
-        case AMBER_SHEET_SERDES_16NM:
-            groupValidIf(_productTechnology == PRODUCT_16NM);
-            fields = getSerdesHDR();
-            break;
-        case AMBER_SHEET_SERDES_7NM:
-            groupValidIf(_productTechnology == PRODUCT_7NM);
-            fields = getSerdesNDR();
-            break;
-        case AMBER_SHEET_SERDES_5NM:
-            groupValidIf(_productTechnology == PRODUCT_5NM);
-            if (_productTechnology == PRODUCT_5NM)
-            {
-                fields = getSerdesXDR();
-            }
-            break;
-        case AMBER_SHEET_PORT_COUNTERS:
-            if (!_inPRBSMode)
-            {
-                fields = getPortCounters();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_TROUBLESHOOTING:
-            if (!_inPRBSMode)
-            {
-                fields = getTroubleshootingInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_PHY_OPERATION_INFO:
-            if (!_inPRBSMode)
-            {
-                fields = getPhyOperationInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_LINK_UP_INFO:
-            if (!_inPRBSMode)
-            {
-                fields = getLinkUpInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_LINK_DOWN_INFO:
-            if (!_inPRBSMode)
-            {
-                fields = getLinkDownInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_TEST_MODE_INFO:
-            if (_inPRBSMode)
-            {
-                fields = getTestModeInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_TEST_MODE_MODULE_INFO:
-            if (_inPRBSMode)
-            {
-                fields = getTestModeModuleInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_PHY_DEBUG_INFO:
-            if (!_inPRBSMode)
-            {
-                fields = getPhyDebugInfo();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        case AMBER_SHEET_EXT_MODULE_STATUS:
-            if (!_inPRBSMode)
-            {
-                fields = getExtModuleStatus();
-            }
-            else if (isIn(sheet, _sheetsToDump))
-            {
-                invalidSheet = true;
-            }
-            break;
-        default:
-            throw MlxRegException("Invalid amBER page index: %d", sheet);
+    switch (sheet) {
+    case AMBER_SHEET_GENERAL:
+        fields = getGeneralInfo();
+        break;
+
+    case AMBER_SHEET_INDEXES:
+        fields = getIndexesInfo();
+        break;
+
+    case AMBER_SHEET_LINK_STATUS:
+        fields = getLinkStatus();
+        break;
+
+    case AMBER_SHEET_MODULE_STATUS:
+        fields = getModuleStatus();
+        break;
+
+    case AMBER_SHEET_SYSTEM:
+        fields = getSystemInfo();
+        break;
+
+    case AMBER_SHEET_SERDES_16NM:
+        groupValidIf(_productTechnology == PRODUCT_16NM);
+        fields = getSerdesHDR();
+        break;
+
+    case AMBER_SHEET_SERDES_7NM:
+        groupValidIf(_productTechnology == PRODUCT_7NM);
+        fields = getSerdesNDR();
+        break;
+
+    case AMBER_SHEET_SERDES_5NM:
+        groupValidIf(_productTechnology == PRODUCT_5NM);
+        if (_productTechnology == PRODUCT_5NM) {
+            fields = getSerdesXDR();
+        }
+        break;
+
+    case AMBER_SHEET_PORT_COUNTERS:
+        if (!_inPRBSMode) {
+            fields = getPortCounters();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_TROUBLESHOOTING:
+        if (!_inPRBSMode) {
+            fields = getTroubleshootingInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_PHY_OPERATION_INFO:
+        if (!_inPRBSMode) {
+            fields = getPhyOperationInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_LINK_UP_INFO:
+        if (!_inPRBSMode) {
+            fields = getLinkUpInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_LINK_DOWN_INFO:
+        if (!_inPRBSMode) {
+            fields = getLinkDownInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_TEST_MODE_INFO:
+        if (_inPRBSMode) {
+            fields = getTestModeInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_TEST_MODE_MODULE_INFO:
+        if (_inPRBSMode) {
+            fields = getTestModeModuleInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_PHY_DEBUG_INFO:
+        if (!_inPRBSMode) {
+            fields = getPhyDebugInfo();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    case AMBER_SHEET_EXT_MODULE_STATUS:
+        if (!_inPRBSMode) {
+            fields = getExtModuleStatus();
+        } else if (isIn(sheet, _sheetsToDump)) {
+            invalidSheet = true;
+        }
+        break;
+
+    default:
+        throw MlxRegException("Invalid amBER page index: %d", sheet);
     }
 
-    if (!_sheetsToDump.empty())
-    {
-        if (invalidSheet)
-        {
+    if (!_sheetsToDump.empty()) {
+        if (invalidSheet) {
             string mode = _inPRBSMode ? "Operational mode" : "PRBS test mode";
             throw MlxRegException("Page %d is valid in %s only!", sheet, mode.c_str());
         }
@@ -2426,11 +2300,9 @@ vector<AmberField> MlxlinkAmBerCollector::collectSheet(AMBER_SHEET sheet)
 
 void MlxlinkAmBerCollector::collect()
 {
-    for (const auto& sheet : _sheetsList)
-    {
+    for (const auto& sheet : _sheetsList) {
         auto sheetFields = collectSheet(sheet.first);
-        if (sheetFields.empty() || sheetFields.back().getUiField() != "N/A")
-        {
+        if (sheetFields.empty() || (sheetFields.back().getUiField() != "N/A")) {
             _amberCollection[sheet.first] = sheetFields;
         }
     }
@@ -2441,36 +2313,24 @@ u_int32_t MlxlinkAmBerCollector::fixFieldsData()
     u_int32_t lastFieldIndexPerGroup = 0;
     u_int32_t totalFields = 0;
 
-    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++)
-    {
-        for (auto fieldIt = (*it).second.begin(); fieldIt != (*it).second.end();)
-        {
-            if ((*fieldIt).getFieldIndex() == 0)
-            {
+    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++) {
+        for (auto fieldIt = (*it).second.begin(); fieldIt != (*it).second.end();) {
+            if ((*fieldIt).getFieldIndex() == 0) {
                 (*it).second.erase(fieldIt);
-            }
-            else
-            {
+            } else {
                 ++fieldIt;
             }
         }
     }
-    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++)
-    {
-        if (_isPortPCIE)
-        {
+    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++) {
+        if (_isPortPCIE) {
             lastFieldIndexPerGroup = _sheetsList[getSheetIndex((*it).first)].second.numOfPcieFields;
-        }
-        else if (_isPortETH)
-        {
+        } else if (_isPortETH) {
             lastFieldIndexPerGroup = _sheetsList[getSheetIndex((*it).first)].second.numOfEthFields;
-        }
-        else if (_isPortIB)
-        {
+        } else if (_isPortIB) {
             lastFieldIndexPerGroup = _sheetsList[getSheetIndex((*it).first)].second.numOfIbFields;
         }
-        for (u_int32_t fieldIdx = (*it).second.size() + 1; fieldIdx <= lastFieldIndexPerGroup; fieldIdx++)
-        {
+        for (u_int32_t fieldIdx = (*it).second.size() + 1; fieldIdx <= lastFieldIndexPerGroup; fieldIdx++) {
             (*it).second.push_back(AmberField("F" + to_string(totalFields + fieldIdx), "N/A", fieldIdx));
         }
         totalFields += lastFieldIndexPerGroup;
@@ -2481,10 +2341,9 @@ u_int32_t MlxlinkAmBerCollector::fixFieldsData()
 u_int32_t MlxlinkAmBerCollector::getSheetIndex(AMBER_SHEET sheet)
 {
     u_int32_t index = 0;
-    for (; index < _sheetsList.size(); index++)
-    {
-        if (_sheetsList[index].first == sheet)
-        {
+
+    for (; index < _sheetsList.size(); index++) {
+        if (_sheetsList[index].first == sheet) {
             break;
         }
     }
@@ -2494,27 +2353,23 @@ u_int32_t MlxlinkAmBerCollector::getSheetIndex(AMBER_SHEET sheet)
 void MlxlinkAmBerCollector::exportToCSV()
 {
     const char* fileName = _csvFileName.c_str();
+
     ifstream ifile(fileName);
     ofstream berFile(fileName, std::ofstream::app);
 
     u_int32_t totalNumOfFields = fixFieldsData();
-    // Preparing CSV header line
-    if (!ifile.good())
-    {
-        if (!berFile.good())
-        {
+
+    /* Preparing CSV header line */
+    if (!ifile.good()) {
+        if (!berFile.good()) {
             throw MlxRegException("The provided file path does not exist!");
         }
-        // Going over all groups inside _amberCollection and getting the field name for each one
-        for (const auto& sheet : _sheetsList)
-        {
-            for (const auto& field : _amberCollection[sheet.first])
-            {
-                if (field.isVisible())
-                {
+        /* Going over all groups inside _amberCollection and getting the field name for each one */
+        for (const auto& sheet : _sheetsList) {
+            for (const auto& field : _amberCollection[sheet.first]) {
+                if (field.isVisible()) {
                     berFile << field.getUiField();
-                    if (field.getFieldIndex() < totalNumOfFields)
-                    {
+                    if (field.getFieldIndex() < totalNumOfFields) {
                         berFile << ",";
                     }
                 }
@@ -2522,17 +2377,13 @@ void MlxlinkAmBerCollector::exportToCSV()
         }
         berFile << endl;
     }
-    // Preparing CSV values
-    // Going over all groups inside _amberCollection and getting the field value for each one
-    for (const auto& sheet : _sheetsList)
-    {
-        for (const auto& field : _amberCollection[sheet.first])
-        {
-            if (field.isVisible())
-            {
+    /* Preparing CSV values */
+    /* Going over all groups inside _amberCollection and getting the field value for each one */
+    for (const auto& sheet : _sheetsList) {
+        for (const auto& field : _amberCollection[sheet.first]) {
+            if (field.isVisible()) {
                 berFile << field.getUiValue();
-                if (field.getFieldIndex() < totalNumOfFields)
-                {
+                if (field.getFieldIndex() < totalNumOfFields) {
                     berFile << ",";
                 }
             }
@@ -2545,13 +2396,10 @@ void MlxlinkAmBerCollector::exportToCSV()
 
 void MlxlinkAmBerCollector::exportToConsole()
 {
-    // Printing all fields to the console (for debugging, will be removed later)
-    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++)
-    {
-        for (auto fieldIt = (*it).second.begin(); fieldIt != (*it).second.end(); fieldIt++)
-        {
-            if ((*fieldIt).isVisible())
-            {
+    /* Printing all fields to the console (for debugging, will be removed later) */
+    for (auto it = _amberCollection.begin(); it != _amberCollection.end(); it++) {
+        for (auto fieldIt = (*it).second.begin(); fieldIt != (*it).second.end(); fieldIt++) {
+            if ((*fieldIt).isVisible()) {
                 cout << *fieldIt << endl;
             }
         }

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -28,7 +28,7 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
-
+ *
  *
  */
 
@@ -38,14 +38,13 @@
 using namespace mlxreg;
 
 MlxlinkCommander::MlxlinkCommander() : _userInput()
-
 {
     _extAdbFile = "";
     _localPort = 0;
     _portType = 0;
     _numOfLanes = MAX_LANES_NUMBER;
     _numOfLanesPcie = 0;
-    _moduleLanesMapping = vector<u_int32_t>(MAX_LANES_NUMBER);
+    _moduleLanesMapping = vector < u_int32_t > (MAX_LANES_NUMBER);
     _linkUP = false;
     _plugged = false;
     _userInput._linkModeForce = false;
@@ -99,40 +98,31 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
 
 MlxlinkCommander::~MlxlinkCommander()
 {
-    if (_cablesCommander)
-    {
+    if (_cablesCommander) {
         delete _cablesCommander;
     }
-    if (_eyeOpener)
-    {
+    if (_eyeOpener) {
         delete _eyeOpener;
     }
-    if (_errInjector)
-    {
+    if (_errInjector) {
         delete _errInjector;
     }
-    if (_portInfo)
-    {
+    if (_portInfo) {
         delete _portInfo;
     }
-    if (_amberCollector)
-    {
+    if (_amberCollector) {
         delete _amberCollector;
     }
-    if (_gvmiAddress)
-    {
+    if (_gvmiAddress) {
         writeGvmi(0);
     }
-    if (_mf)
-    {
+    if (_mf) {
         mclose(_mf);
     }
-    if (_regLib)
-    {
+    if (_regLib) {
         delete _regLib;
     }
-    if (_mlxlinkMaps)
-    {
+    if (_mlxlinkMaps) {
         delete _mlxlinkMaps;
     }
 }
@@ -140,35 +130,28 @@ MlxlinkCommander::~MlxlinkCommander()
 void MlxlinkCommander::validatePortType(const string& portTypeStr)
 {
     _portType = NETWORK_PORT_TYPE;
-    map<string, u_int32_t>::iterator it = _mlxlinkMaps->_networkPorts.find(portTypeStr);
-    if (it == _mlxlinkMaps->_networkPorts.end())
-    {
+    map < string, u_int32_t > ::iterator it = _mlxlinkMaps->_networkPorts.find(portTypeStr);
+    if (it == _mlxlinkMaps->_networkPorts.end()) {
         string errMsg = "";
-        for (it = _mlxlinkMaps->_networkPorts.begin(); it != _mlxlinkMaps->_networkPorts.end(); it++)
-        {
+        for (it = _mlxlinkMaps->_networkPorts.begin(); it != _mlxlinkMaps->_networkPorts.end(); it++) {
             errMsg += it->first;
-            if (it->second == NETWORK_PORT_TYPE)
-            {
+            if (it->second == NETWORK_PORT_TYPE) {
                 errMsg += "(Default)";
             }
             errMsg += ", ";
         }
         errMsg = deleteLastChar(errMsg, 2);
         throw MlxRegException("Invalid port type, valid port types are [" + errMsg + "]");
-    }
-    else if (it->second != NETWORK_PORT_TYPE_LAST)
-    {
+    } else if (it->second != NETWORK_PORT_TYPE_LAST) {
         _portType = it->second;
     }
 
     if ((_portType == NETWORK_PORT_TYPE_NEAR) || (_portType == NETWORK_PORT_TYPE_IC_LR) ||
-        (_portType == NETWORK_PORT_TYPE_FAR))
-    {
+        (_portType == NETWORK_PORT_TYPE_FAR)) {
         _isGboxPort = true;
     }
 
-    if (_isGboxPort && !isDSdevice())
-    {
+    if (_isGboxPort && !isDSdevice()) {
         throw MlxRegException("Port types of GEARBOX_HOST, INTERNAL_IC_LR and "
                               "GEARBOX_LINE can be used with Switches supporting downstream devices only");
     }
@@ -176,8 +159,7 @@ void MlxlinkCommander::validatePortType(const string& portTypeStr)
 
 void MlxlinkCommander::gearboxBlock(const string& option)
 {
-    if (_isGboxPort)
-    {
+    if (_isGboxPort) {
         throw MlxRegException("--" + option + " flag is not applicable for " + _userInput._portType + " port type");
     }
 }
@@ -188,7 +170,7 @@ void MlxlinkCommander::checkRegCmd()
     {
         sendPrmReg(ACCESS_REG_PAOS, GET, "local_port=%d,swid=%d", _localPort, SWID);
     }
-    catch (MlxRegException& exp)
+    catch(MlxRegException & exp)
     {
         throw MlxRegException("Problem accessing the device. Please verify that driver is up");
     }
@@ -199,7 +181,7 @@ void MlxlinkCommander::checkValidFW()
 {
     try
     {
-        char fwVersion[32];
+        char      fwVersion[32];
         u_int32_t tmpLocalPort = _localPort;
 
         sendPrmReg(ACCESS_REG_MGIR, GET);
@@ -207,8 +189,7 @@ void MlxlinkCommander::checkValidFW()
                 getFieldValue("extended_sub_minor"));
         _fwVersion = string(fwVersion);
 
-        if (_userInput._pcie)
-        { // Fw validity should be checked, so set the local port to 1.
+        if (_userInput._pcie) { /* Fw validity should be checked, so set the local port to 1. */
             _localPort = 1;
         }
 
@@ -216,14 +197,11 @@ void MlxlinkCommander::checkValidFW()
         {
             sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_OPERATIONAL_INFO_PAGE);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
-            if (exp.what_s() != "Please Provide Valid gvmi Address (--gvmi_address <address>)")
-            {
+            if (exp.what_s() != "Please Provide Valid gvmi Address (--gvmi_address <address>)") {
                 checkRegCmd();
-            }
-            else
-            {
+            } else {
                 throw MlxRegException(exp);
             }
         }
@@ -235,13 +213,12 @@ void MlxlinkCommander::checkValidFW()
 
         u_int32_t statusOpcode = getFieldValue("monitor_opcode");
 
-        if (phyMngrFsmState == 0 && statusOpcode == 0)
-        {
+        if ((phyMngrFsmState == 0) && (statusOpcode == 0)) {
             checkAllPortsStatus();
         }
         _localPort = tmpLocalPort;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException(string("Checking valid firmware raised the following exception: ") + string(exc.what()) +
                               string("\n"));
@@ -257,20 +234,18 @@ u_int32_t MlxlinkCommander::getTechnologyFromMGIR()
 
 void MlxlinkCommander::getProductTechnology()
 {
-    // Use SLRG to get the product technology, for backward compatibility
+    /* Use SLRG to get the product technology, for backward compatibility */
     try
     {
         sendPrmReg(ACCESS_REG_SLTP, GET);
         _productTechnology = getVersion(getFieldValue("version"));
-        if (_productTechnology <= 2)
-        {
+        if (_productTechnology <= 2) {
             _productTechnology = PRODUCT_28NM;
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
-        if (!_productTechnology)
-        {
+        if (!_productTechnology) {
             throw MlxRegException("Unable to get product technology: %s", exc.what_s().c_str());
         }
     }
@@ -278,34 +253,33 @@ void MlxlinkCommander::getProductTechnology()
 
 u_int32_t MlxlinkCommander::maxLocalPort()
 {
-    switch (_devID)
-    {
-        case DeviceSpectrum:
-            return MAX_LOCAL_PORT_ETH;
+    switch (_devID) {
+    case DeviceSpectrum:
+        return MAX_LOCAL_PORT_ETH;
 
-        case DeviceSwitchIB:
-        case DeviceSwitchIB2:
-            return MAX_LOCAL_PORT_IB;
+    case DeviceSwitchIB:
+    case DeviceSwitchIB2:
+        return MAX_LOCAL_PORT_IB;
 
-        case DeviceQuantum:
-            return MAX_LOCAL_PORT_QUANTUM;
+    case DeviceQuantum:
+        return MAX_LOCAL_PORT_QUANTUM;
 
-        case DeviceQuantum2:
-        case DeviceBW00:
-            return MAX_LOCAL_PORT_QUANTUM2;
+    case DeviceQuantum2:
+    case DeviceGB100:
+        return MAX_LOCAL_PORT_QUANTUM2;
 
-        case DeviceQuantum3:
-            return MAX_LOCAL_PORT_QUANTUM3;
+    case DeviceQuantum3:
+        return MAX_LOCAL_PORT_QUANTUM3;
 
-        case DeviceSpectrum2:
-        case DeviceSpectrum3:
-            return MAX_LOCAL_PORT_SPECTRUM2;
+    case DeviceSpectrum2:
+    case DeviceSpectrum3:
+        return MAX_LOCAL_PORT_SPECTRUM2;
 
-        case DeviceSpectrum4:
-            return MAX_LOCAL_PORT_SPECTRUM4;
+    case DeviceSpectrum4:
+        return MAX_LOCAL_PORT_SPECTRUM4;
 
-        default:
-            return 0;
+    default:
+        return 0;
     }
     return 0;
 }
@@ -321,8 +295,7 @@ bool MlxlinkCommander::checkPortStatus(u_int32_t localPort)
 
     u_int32_t statusOpcode = getFieldValue("monitor_opcode");
 
-    if (!(phyMngrFsmState == 0 && statusOpcode == 0))
-    {
+    if (!((phyMngrFsmState == 0) && (statusOpcode == 0))) {
         return true;
     }
     return false;
@@ -330,41 +303,31 @@ bool MlxlinkCommander::checkPortStatus(u_int32_t localPort)
 
 void MlxlinkCommander::checkAllPortsStatus()
 {
-    if (_isHCA)
-    {
+    if (_isHCA) {
         checkRegCmd();
     }
-    if (_devID == DeviceSpectrum)
-    {
-        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-        {
+    if (_devID == DeviceSpectrum) {
+        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
             sendPrmReg(ACCESS_REG_PMLP, GET, "local_port=%d", localPort);
 
-            if (getFieldValue("width") == 0)
-            {
+            if (getFieldValue("width") == 0) {
                 continue;
             }
 
-            if (checkPortStatus(localPort))
-            {
+            if (checkPortStatus(localPort)) {
                 return;
             }
         }
         throw MlxRegException("FW Version " + _fwVersion + " is not supported. Please update FW.");
-    }
-    else if (dm_dev_is_ib_switch(_devID))
-    {
-        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-        {
+    } else if (dm_dev_is_ib_switch(_devID)) {
+        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
             sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
 
-            if (getFieldValue("ib_port") == 0)
-            {
+            if (getFieldValue("ib_port") == 0) {
                 continue;
             }
 
-            if (checkPortStatus(localPort))
-            {
+            if (checkPortStatus(localPort)) {
                 return;
             }
         }
@@ -384,22 +347,17 @@ void MlxlinkCommander::validatePortToLC()
     {
         sendPrmReg(ACCESS_REG_MDDQ, GET, "query_type=%d,slot_index=%d", 1, slotIndex);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         isDownStreamDevValid = false;
     }
 
-    if (!isDownStreamDevValid)
-    {
-        if (slotIndex == 0 && _isGboxPort)
-        {
+    if (!isDownStreamDevValid) {
+        if ((slotIndex == 0) && _isGboxPort) {
             throw MlxRegException("No cards detected on the device.");
         }
-    }
-    else if (_isGboxPort)
-    {
-        if (getFieldValue("lc_ready") != 1)
-        {
+    } else if (_isGboxPort) {
+        if (getFieldValue("lc_ready") != 1) {
             throw MlxRegException("Invalid port number, Line card %d is not ready", slotIndex);
         }
     }
@@ -408,11 +366,10 @@ void MlxlinkCommander::validatePortToLC()
 void MlxlinkCommander::handlePortStr(const string& portStr)
 {
     auto portParts = MlxlinkRecord::split(portStr, "/");
-    // validate arguments
-    for (auto it = portParts.begin(); it != portParts.end(); it++)
-    {
-        if ((*it).empty())
-        {
+
+    /* validate arguments */
+    for (auto it = portParts.begin(); it != portParts.end(); it++) {
+        if ((*it).empty()) {
             throw MlxRegException("Argument: %s is invalid.", portStr.c_str());
         }
     }
@@ -424,18 +381,14 @@ void MlxlinkCommander::handlePortStr(const string& portStr)
      * portStr should represent: (port/split) if split sign provided
      *                           (port) if no split sign provided
      */
-    if (portParts.size() > 1)
-    {
+    if (portParts.size() > 1) {
         strToUint32((char*)portParts[1].c_str(), _userInput._splitPort);
         _userInput._splitProvided = true;
-        if (portParts.size() > SECOND_LEVEL_PORT_ACCESS)
-        {
-            // it's the split part of Quantum-2 (xx/xx/split)
+        if (portParts.size() > SECOND_LEVEL_PORT_ACCESS) {
+            /* it's the split part of Quantum-2 (xx/xx/split) */
             strToUint32((char*)portParts[2].c_str(), _userInput._secondSplitPort);
             _userInput._secondSplitProvided = true;
-        }
-        else if (portParts.size() > THIRD_LEVEL_PORT_ACCESS)
-        {
+        } else if (portParts.size() > THIRD_LEVEL_PORT_ACCESS) {
             throw MlxRegException("Failed to handle option port");
         }
     }
@@ -450,17 +403,17 @@ void MlxlinkCommander::updateSwControlStatus()
     {
         sendPrmReg(ACCESS_REG_MMCR, GET);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _isSwControled = false;
         return;
     }
     u_int32_t currentModuleControl =
-      getFieldValue("curr_module_control[" + to_string((_userInput._labelPort - 1) / 32) + "]");
+        getFieldValue("curr_module_control[" + to_string((_userInput._labelPort - 1) / 32) + "]");
     u_int32_t portMask = 0;
+
     portMask = portMask | 1 << ((_userInput._labelPort - 1) % 32);
-    if (portMask & currentModuleControl)
-    {
+    if (portMask & currentModuleControl) {
         _isSwControled = true;
     }
 }
@@ -469,75 +422,53 @@ void MlxlinkCommander::labelToLocalPort()
 {
     _pnat = _userInput._pcie ? PNAT_PCIE : PNAT_LOCAL;
 
-    if (_isHCA && _userInput._pcie)
-    {
+    if (_isHCA && _userInput._pcie) {
         _dpn.depth = _userInput._depth;
         _dpn.pcieIndex = _userInput._pcieIndex;
         _dpn.node = _userInput._node;
 
         initValidDPNList();
 
-        if (_userInput._sendDpn)
-        {
+        if (_userInput._sendDpn) {
             int localPort = getLocalPortFromMPIR(_dpn);
-            if (localPort >= 0)
-            {
+            if (localPort >= 0) {
                 _localPort = localPort;
-            }
-            else
-            {
+            } else {
                 throw MlxRegException("Invalid PCIe link: depth, pcie_index and node [%d, %d, %d]", _dpn.depth,
                                       _dpn.pcieIndex, _dpn.node);
             }
-        }
-        else if (_userInput._portSpecified)
-        {
+        } else if (_userInput._portSpecified) {
             checkLocalPortDPNMapping(_userInput._labelPort);
             _localPort = _userInput._labelPort;
-        }
-        else
-        {
-            if (!_validDpns.empty())
-            {
-                _dpn = _validDpns[0]; // default DPN link
+        } else {
+            if (!_validDpns.empty()) {
+                _dpn = _validDpns[0]; /* default DPN link */
             }
             _localPort = _dpn.pcieIndex;
-            if (_dpn.depth > 0)
-            {
+            if (_dpn.depth > 0) {
                 _localPort = _dpn.node + DBN_TO_LOCAL_PORT_BASE;
             }
         }
         return;
     }
-    if (_isHCA)
-    {
+    if (_isHCA) {
         labelToHCALocalPort();
         return;
-    }
-    else if (_userInput._pcie)
-    {
+    } else if (_userInput._pcie) {
         throw MlxRegException("No PCIE in Switch!");
     }
 
-    if (_devID == DeviceSpectrum || _devID == DeviceSpectrum2 || _devID == DeviceSpectrum3 || _devID == DeviceSpectrum4)
-    {
-        if (isDSdevice())
-        {
+    if ((_devID == DeviceSpectrum) || (_devID == DeviceSpectrum2) || (_devID == DeviceSpectrum3) ||
+        (_devID == DeviceSpectrum4)) {
+        if (isDSdevice()) {
             labeltoDSlocalPort();
-        }
-        else
-        {
+        } else {
             labelToSpectLocalPort();
         }
-    }
-    else if (dm_dev_is_ib_switch(_devID))
-    {
-        if (_devID == DeviceQuantum3 || _devID == DeviceBW00)
-        {
+    } else if (dm_dev_is_ib_switch(_devID)) {
+        if ((_devID == DeviceQuantum3) || (_devID == DeviceGB100)) {
             labelToQtm3LocalPort();
-        }
-        else
-        {
+        } else {
             labelToIBLocalPort();
         }
     }
@@ -551,7 +482,7 @@ bool MlxlinkCommander::isDSdevice()
     {
         sendPrmReg(ACCESS_REG_MDDQ, GET, "query_type=1,slot_index=1");
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         isDownStreamDevValid = false;
     }
@@ -563,33 +494,29 @@ void MlxlinkCommander::labeltoDSlocalPort()
 {
     u_int32_t lineCard = _userInput._labelPort;
     u_int32_t port = _userInput._splitPort;
-    bool isLocalPortValid = false;
+    bool      isLocalPortValid = false;
 
-    if (_userInput._secondSplitProvided)
-    {
+    if (_userInput._secondSplitProvided) {
         throw MlxRegException("No split supported for downstream devices");
     }
 
     sendPrmReg(ACCESS_REG_MDDQ, GET, "query_type=%d,slot_index=%d", 1, lineCard);
 
-    if (getFieldValue("lc_ready") != 1)
-    {
+    if (getFieldValue("lc_ready") != 1) {
         throw MlxRegException("Invalid port number, Line card %d is not ready", lineCard);
     }
 
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
             continue;
         }
 
-        if ((getFieldValue("label_port") == port) && (getFieldValue("slot_num") == lineCard))
-        {
+        if ((getFieldValue("label_port") == port) && (getFieldValue("slot_num") == lineCard)) {
             _localPort = localPort;
             _slotIndex = lineCard;
             isLocalPortValid = true;
@@ -597,27 +524,24 @@ void MlxlinkCommander::labeltoDSlocalPort()
         }
     }
 
-    if (!isLocalPortValid)
-    {
+    if (!isLocalPortValid) {
         throw MlxRegException("Invalid port number");
     }
 }
 
 void MlxlinkCommander::checkLocalPortDPNMapping(u_int32_t localPort)
 {
-    for (u_int32_t i = 0; i < _validDpns.size(); i++)
-    {
+    for (u_int32_t i = 0; i < _validDpns.size(); i++) {
         try
         {
             sendPrmReg(ACCESS_REG_MPIR, GET, "depth=%d,pcie_index=%d,node=%d", _validDpns[i].depth,
                        _validDpns[i].pcieIndex, _validDpns[i].node);
         }
-        catch (MlxRegException& exc)
+        catch(MlxRegException & exc)
         {
             continue;
         }
-        if (getFieldValue("local_port") == localPort)
-        {
+        if (getFieldValue("local_port") == localPort) {
             _dpn = _validDpns[i];
             return;
         }
@@ -627,31 +551,26 @@ void MlxlinkCommander::checkLocalPortDPNMapping(u_int32_t localPort)
 
 int MlxlinkCommander::getLocalPortFromMPIR(DPN& dpn)
 {
-    if (!isIn(dpn, _validDpns))
-    {
+    if (!isIn(dpn, _validDpns)) {
         throw MlxRegException("Invalid PCIe link: depth, pcie_index and node [%d, %d, %d]", dpn.depth, dpn.pcieIndex,
                               dpn.node);
     }
 
     int localPort = -1;
-    if (!_userInput._portSpecified && !(dpn.depth == 0 && dpn.node == 0 && dpn.pcieIndex == 0))
-    {
+
+    if (!_userInput._portSpecified && !((dpn.depth == 0) && (dpn.node == 0) && (dpn.pcieIndex == 0))) {
         try
         {
             sendPrmReg(ACCESS_REG_MPIR, GET, "depth=%d,pcie_index=%d,node=%d", dpn.depth, dpn.pcieIndex, dpn.node);
             localPort = getFieldValue("local_port");
             dpn.bdf = getBDFStr(getFieldValue("bdf0"));
         }
-        catch (MlxRegException& exc)
+        catch(MlxRegException & exc)
         {
         }
-    }
-    else if (_userInput._portSpecified)
-    {
+    } else if (_userInput._portSpecified) {
         localPort = _userInput._labelPort;
-    }
-    else
-    {
+    } else {
         localPort = 0;
     }
 
@@ -661,26 +580,18 @@ int MlxlinkCommander::getLocalPortFromMPIR(DPN& dpn)
 void MlxlinkCommander::labelToHCALocalPort()
 {
     u_int32_t mtype = 0;
+
     mget_mdevs_type(_mf, &mtype);
-    if (_userInput._splitProvided)
-    {
+    if (_userInput._splitProvided) {
         throw MlxRegException("No Splits in HCA!");
-    }
-    else if (_userInput._labelPort > 1 && !(mtype & (MST_USB_DIMAX)))
-    {
+    } else if ((_userInput._labelPort > 1) && !(mtype & (MST_USB_DIMAX))) {
         throw MlxRegException("Please Provide the Physical Device of Port " + to_string(_userInput._labelPort));
-    }
-    else if (_userInput._labelPort > 1 && (mtype & (MST_USB_DIMAX)))
-    {
-        if (_userInput._labelPort == 2)
-        {
-            if (_userInput._gvmiAddress == 0)
-            {
+    } else if ((_userInput._labelPort > 1) && (mtype & (MST_USB_DIMAX))) {
+        if (_userInput._labelPort == 2) {
+            if (_userInput._gvmiAddress == 0) {
                 throw MlxRegException("Please Provide Valid gvmi Address (--gvmi_address <address>)");
             }
-        }
-        else
-        {
+        } else {
             throw MlxRegException("Please Provide Valid Port Number (1/2)");
         }
     }
@@ -689,41 +600,34 @@ void MlxlinkCommander::labelToHCALocalPort()
 
 void MlxlinkCommander::labelToSpectLocalPort()
 {
-    if (_userInput._secondSplitProvided)
-    {
+    if (_userInput._secondSplitProvided) {
         throw MlxRegException("Invalid port number!");
     }
-    if (_userInput._splitProvided)
-    {
-        if (_userInput._splitPort == 1)
-        {
+    if (_userInput._splitProvided) {
+        if (_userInput._splitPort == 1) {
             throw MlxRegException("Invalid split number!");
         }
-        if (_userInput._splitPort > MAX_ETH_SW_SPLIT)
-        {
+        if (_userInput._splitPort > MAX_ETH_SW_SPLIT) {
             throw MlxRegException("Port %d/%d does not exist!", _userInput._labelPort, _userInput._splitPort);
         }
     }
 
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
         }
-        catch (...)
+        catch(...)
         {
-        } // access register will fail if local port does not exist
+        } /* access register will fail if local port does not exist */
         if ((getFieldValue("label_port") == _userInput._labelPort) &&
-            (getFieldValue("split_num") == (_userInput._splitPort - 1)))
-        {
+            (getFieldValue("split_num") == (_userInput._splitPort - 1))) {
             _localPort = localPort;
             break;
         }
     }
 
-    if (!_localPort)
-    {
+    if (!_localPort) {
         throw MlxRegException("Failed to find Local Port, please provide valid Port Number");
     }
 }
@@ -732,71 +636,60 @@ void MlxlinkCommander::labelToQtm3LocalPort()
 {
     u_int32_t foundedLocalPort = 0;
 
-    if (_devID == DeviceBW00)
-    {
-        if (_userInput._splitProvided || _userInput._secondSplitProvided)
-        {
+    if (_devID == DeviceGB100) {
+        if (_userInput._splitProvided || _userInput._secondSplitProvided) {
             throw MlxRegException("Invalid port number!");
         }
-        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-        {
+        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
             try
             {
                 sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
             }
-            catch (MlxRegException& exp)
+            catch(MlxRegException & exp)
             {
                 continue;
             }
-            if (getFieldValue("ib_port") == _userInput._labelPort)
-            {
+            if (getFieldValue("ib_port") == _userInput._labelPort) {
                 foundedLocalPort = localPort;
                 break;
             }
         }
-    }
-    else
-    {
+    } else {
         u_int32_t cageIn = _userInput._labelPort;
         u_int32_t ipilIn = _userInput._splitProvided ? _userInput._splitPort : 1;
         u_int32_t splitIn = _userInput._secondSplitProvided ? _userInput._secondSplitPort : 1;
-
         u_int32_t splitStat = 0;
         u_int32_t ipilStat = 0;
-        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-        {
+        for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
             try
             {
                 sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
             }
-            catch (MlxRegException& exp)
+            catch(MlxRegException & exp)
             {
                 continue;
             }
 
             ipilStat = getFieldValue("ipil_stat");
             splitStat = getFieldValue("split_stat");
-            if (ipilIn > (u_int32_t)(1 << ipilStat))
-            {
+            if (ipilIn > (u_int32_t)(1 << ipilStat)) {
                 throw MlxRegException("Invalid inter-port number!");
             }
 
-            if (splitIn > (u_int32_t)(1 << splitStat))
-            {
+            if (splitIn > (u_int32_t)(1 << splitStat)) {
                 throw MlxRegException("Invalid split number!");
             }
 
-            if (cageIn == getFieldValue("label_port") && (ipilStat == 0 || ipilIn == getFieldValue("ipil_num")) &&
-                (splitStat == 0 || splitIn == getFieldValue("split_num") - 1))
-            {
+            if ((cageIn == getFieldValue("label_port")) &&
+                ((ipilStat == 0) || (ipilIn == getFieldValue("ipil_num"))) &&
+                ((splitStat == 0) || (splitIn == getFieldValue("split_num") - 1))) {
                 foundedLocalPort = localPort;
                 break;
             }
         }
     }
 
-    if (!foundedLocalPort)
-    {
+    if (!foundedLocalPort) {
         throw MlxRegException("Invalid port number!");
     }
     _localPort = foundedLocalPort;
@@ -805,71 +698,65 @@ void MlxlinkCommander::labelToQtm3LocalPort()
 void MlxlinkCommander::labelToIBLocalPort()
 {
     u_int32_t labelPort = _userInput._labelPort;
-    bool ibSplitReady = isIBSplitReady() && (_devID == DeviceQuantum || _devID == DeviceQuantum2);
-    if (_userInput._splitProvided && _devID != DeviceQuantum && _devID != DeviceQuantum2)
-    {
+    bool      ibSplitReady = isIBSplitReady() && (_devID == DeviceQuantum || _devID == DeviceQuantum2);
+
+    if (_userInput._splitProvided && (_devID != DeviceQuantum) && (_devID != DeviceQuantum2)) {
         throw MlxRegException("No split in IB!");
     }
     u_int32_t maxLabelPort = _devID == DeviceQuantum2 ? maxLocalPort() / 4 :
-                             _devID == DeviceQuantum  ? maxLocalPort() / 2 - 1 :
-                                                        maxLocalPort();
+                             _devID == DeviceQuantum ? maxLocalPort() / 2 - 1 :
+                             maxLocalPort();
+
     if ((labelPort > maxLabelPort) ||
-        (_userInput._secondSplitProvided && _devID != DeviceQuantum2 && _devID != DeviceBW00) ||
-        (_userInput._splitPort > 2))
-    {
+        (_userInput._secondSplitProvided && (_devID != DeviceQuantum2) && (_devID != DeviceGB100)) ||
+        (_userInput._splitPort > 2)) {
         throw MlxRegException("Invalid port number!");
     }
-    if (_devID == DeviceQuantum || _devID == DeviceQuantum2)
-    {
+    if ((_devID == DeviceQuantum) || (_devID == DeviceQuantum2)) {
         labelPort = calculatePanelPort(ibSplitReady);
     }
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
-            continue; // no reason to fail when one of the ports is not supported, such as in split mode.
+            continue; /* no reason to fail when one of the ports is not supported, such as in split mode. */
         }
-        if (getFieldValue("ib_port") == labelPort)
-        {
+        if (getFieldValue("ib_port") == labelPort) {
             _localPort = localPort;
             return;
         }
     }
-    if ((_devID == DeviceQuantum || _devID == DeviceQuantum2) && ibSplitReady)
-    {
+    if (((_devID == DeviceQuantum) || (_devID == DeviceQuantum2)) && ibSplitReady) {
         string portStr = "Port " + to_string(_userInput._labelPort);
         string swSplitCmd = "module-type qsfp-split-2";
-        if (_devID == DeviceQuantum2)
-        {
+        if (_devID == DeviceQuantum2) {
             portStr = portStr + "/" + to_string(_userInput._splitPort);
             swSplitCmd = "port-type split-2";
         }
-        throw MlxRegException(
-          "%s is not splitted physically from switch side, Use this command to split it physically:\n"
-          "interface ib <port/ports range> %s",
-          portStr.c_str(), swSplitCmd.c_str());
+        throw MlxRegException("%s is not splitted physically from switch side, Use this command to split it physically:\n"
+                              "interface ib <port/ports range> %s",
+                              portStr.   c_str(),
+                              swSplitCmd.c_str());
     }
 }
 
 bool MlxlinkCommander::isIBSplitReady()
 {
     u_int32_t max_port = maxLocalPort();
-    for (u_int32_t localPort = 1; localPort <= max_port; localPort++)
-    {
+
+    for (u_int32_t localPort = 1; localPort <= max_port; localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
-            continue; // no reason to fail when one of the ports is not supported, such as in split mode.
+            continue; /* no reason to fail when one of the ports is not supported, such as in split mode. */
         }
-        if (getFieldValue("ib_port") == max_port / 2)
-        {
+        if (getFieldValue("ib_port") == max_port / 2) {
             return true;
         }
     }
@@ -878,37 +765,30 @@ bool MlxlinkCommander::isIBSplitReady()
 
 u_int32_t MlxlinkCommander::calculatePanelPort(bool ibSplitReady)
 {
-    u_int32_t panelPort = _userInput._labelPort; // by default, the label port is equal to panel port if no split
-    bool splitProvided = _devID == DeviceQuantum ? _userInput._splitProvided : _userInput._secondSplitProvided;
+    u_int32_t panelPort = _userInput._labelPort; /* by default, the label port is equal to panel port if no split */
+    bool      splitProvided = _devID == DeviceQuantum ? _userInput._splitProvided : _userInput._secondSplitProvided;
     u_int32_t split = _devID == DeviceQuantum ? _userInput._splitPort : _userInput._secondSplitPort;
-    if (_devID == DeviceQuantum2)
-    {
-        // For Quantum-2, user should provide cage/port to access the ports in the cage
-        // cage"panelPort"/port"_userInput._splitPort" is converted to label port according to the following equation:
+
+    if (_devID == DeviceQuantum2) {
+        /* For Quantum-2, user should provide cage/port to access the ports in the cage */
+        /* cage"panelPort"/port"_userInput._splitPort" is converted to label port according to the following equation: */
         panelPort = 2 * panelPort + _userInput._splitPort - 2;
     }
-    if (ibSplitReady)
-    {
-        // If split ready, then the panelPort mapping will be chaned
-        if (!splitProvided)
-        {
-            panelPort = (panelPort * 2) - 1; // Access the main port (without providing the split)
-                                             // For Quantum will be e.g (port/split): 2/1
-                                             // For Quantum-2 will be e.g (cage/port/split): 1/2/1
-        }
-        else
-        {
-            if (split != 2)
-            {
+    if (ibSplitReady) {
+        /* If split ready, then the panelPort mapping will be chaned */
+        if (!splitProvided) {
+            panelPort = (panelPort * 2) - 1; /* Access the main port (without providing the split) */
+                                             /* For Quantum will be e.g (port/split): 2/1 */
+                                             /* For Quantum-2 will be e.g (cage/port/split): 1/2/1 */
+        } else {
+            if (split != 2) {
                 throw MlxRegException("Invalid split number!");
             }
-            panelPort = 2 * panelPort; // Access the second port (with providing the split)
-                                       // For Quantum will be e.g (port/split): 2/2
-                                       // For Quantum-2 will be e.g (cage/port/split): 1/2/2
+            panelPort = 2 * panelPort; /* Access the second port (with providing the split) */
+                                       /* For Quantum will be e.g (port/split): 2/2 */
+                                       /* For Quantum-2 will be e.g (cage/port/split): 1/2/2 */
         }
-    }
-    else if (splitProvided)
-    {
+    } else if (splitProvided) {
         throw MlxRegException("Split mode is not ready!"
                               "\nThis command is used to set the split mode ready from switch side:"
                               "\nsystem profile ib split-ready");
@@ -919,45 +799,34 @@ u_int32_t MlxlinkCommander::calculatePanelPort(bool ibSplitReady)
 
 void MlxlinkCommander::getActualNumOfLanes(u_int32_t linkSpeedActive, bool extended)
 {
-    if (_protoActive == IB)
-    {
+    if (_protoActive == IB) {
         sendPrmReg(ACCESS_REG_PTYS, GET, "proto_mask=%d", _protoActive);
 
         _numOfLanes = getFieldValue("ib_link_width_oper");
-    }
-    else if (_protoActive == ETH)
-    {
-        if (_linkUP)
-        {
-            if (extended)
-            {
+    } else if (_protoActive == ETH) {
+        if (_linkUP) {
+            if (extended) {
                 _numOfLanes = _mlxlinkMaps->_ExtETHSpeed2Lanes[linkSpeedActive];
-            }
-            else
-            {
+            } else {
                 _numOfLanes = _mlxlinkMaps->_ETHSpeed2Lanes[linkSpeedActive];
             }
-        }
-        else
-        {
+        } else {
             sendPrmReg(ACCESS_REG_PMLP, GET);
 
             _numOfLanes = getFieldValue("width");
         }
     }
-    
+
     sendPrmReg(ACCESS_REG_PMLP, GET);
 
-    for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
         _moduleLanesMapping[lane] = getFieldValue("rx_lane_" + to_string(lane));
     }
 }
 
 u_int32_t MlxlinkCommander::activeSpeed2gNum(u_int32_t mask, bool extended)
 {
-    if (extended)
-    {
+    if (extended) {
         return _mlxlinkMaps->_EthExtSpeed2gNum[mask];
     }
     return (_protoActive == IB) ? _mlxlinkMaps->_IBSpeed2gNum[mask] : _mlxlinkMaps->_ETHSpeed2gNum[mask];
@@ -965,13 +834,12 @@ u_int32_t MlxlinkCommander::activeSpeed2gNum(u_int32_t mask, bool extended)
 
 string MlxlinkCommander::activeSpeed2Str(u_int32_t mask, bool extended)
 {
-    if (extended)
-    {
+    if (extended) {
         return _mlxlinkMaps->_EthExtSpeed2Str[mask];
     }
-    return (_isNVLINK)          ? _mlxlinkMaps->_NVLINKSpeed2Str[mask] :
+    return (_isNVLINK) ? _mlxlinkMaps->_NVLINKSpeed2Str[mask] :
            (_protoActive == IB) ? _mlxlinkMaps->_IBSpeed2Str[mask] :
-                                  _mlxlinkMaps->_ETHSpeed2Str[mask];
+           _mlxlinkMaps->_ETHSpeed2Str[mask];
 }
 
 void MlxlinkCommander::getCableParams()
@@ -996,7 +864,7 @@ void MlxlinkCommander::getCableParams()
 
         _moduleNumber = getFieldValue("module_0");
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Getting cable parameters via PDDR raised the following exception: ") +
                                string(exc.what()) + string("\n");
@@ -1010,10 +878,10 @@ bool MlxlinkCommander::inPrbsTestMode()
         bool res = checkPaosDown() && checkPpaosTestMode();
         return res;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Checking in PRBS test mode raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Checking in PRBS test mode raised the following exception: ") + string(exc.what()) + string("\n");
     }
     return false;
 }
@@ -1027,17 +895,13 @@ bool MlxlinkCommander::checkGBPpaosDown()
 
 bool MlxlinkCommander::checkPaosDown()
 {
-    if (_isGboxPort)
-    {
+    if (_isGboxPort) {
         return checkGBPpaosDown();
-    }
-    else
-    {
+    } else {
         sendPrmReg(ACCESS_REG_PAOS, GET);
 
         u_int32_t paosOperStatus = getFieldValue("oper_status");
-        if (paosOperStatus == PAOS_DOWN)
-        {
+        if (paosOperStatus == PAOS_DOWN) {
             return true;
         }
         return false;
@@ -1049,8 +913,8 @@ bool MlxlinkCommander::checkPpaosTestMode()
     sendPrmReg(ACCESS_REG_PPAOS, GET);
 
     u_int32_t ppaosPhyTestModeStatus = getFieldValue("phy_test_mode_status");
-    if (ppaosPhyTestModeStatus == PHY_TEST_MODE_STATUS)
-    {
+
+    if (ppaosPhyTestModeStatus == PHY_TEST_MODE_STATUS) {
         return true;
     }
     return false;
@@ -1059,26 +923,23 @@ bool MlxlinkCommander::checkPpaosTestMode()
 bool MlxlinkCommander::handleIBLocalPort(u_int32_t labelPort, bool ibSplitReady)
 {
     bool isLabelPortValid = false;
-    if ((_devID == DeviceQuantum2 || (_devID == DeviceQuantum && ibSplitReady)))
-    {
+
+    if (((_devID == DeviceQuantum2) || ((_devID == DeviceQuantum) && ibSplitReady))) {
         labelPort = 2 * labelPort - 1;
     }
-    if ((_devID == DeviceQuantum2) && ibSplitReady)
-    {
+    if ((_devID == DeviceQuantum2) && ibSplitReady) {
         labelPort = 2 * labelPort - 1;
     }
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
             continue;
         }
-        if (getFieldValue("ib_port") == labelPort)
-        {
+        if (getFieldValue("ib_port") == labelPort) {
             fillIbPortGroupMap(localPort, labelPort, _userInput._setGroup, ibSplitReady);
             isLabelPortValid = true;
             break;
@@ -1090,19 +951,18 @@ bool MlxlinkCommander::handleIBLocalPort(u_int32_t labelPort, bool ibSplitReady)
 bool MlxlinkCommander::handleQTM3LocalPort(u_int32_t labelPort)
 {
     bool isLabelPortValid = false;
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         try
         {
             sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
         }
-        catch (MlxRegException& exp)
+        catch(MlxRegException & exp)
         {
             continue;
         }
 
-        if (getFieldValue("label_port") == labelPort)
-        {
+        if (getFieldValue("label_port") == labelPort) {
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, _userInput._setGroup,
                                                     getFieldValue("ipil_num"), getFieldValue("split_num")));
             isLabelPortValid = true;
@@ -1114,17 +974,15 @@ bool MlxlinkCommander::handleQTM3LocalPort(u_int32_t labelPort)
 bool MlxlinkCommander::handleEthLocalPort(u_int32_t labelPort, bool spect2WithGb)
 {
     bool isLabelPortValid = false;
-    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
-    {
+
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++) {
         sendPrmReg(ACCESS_REG_PMLP, GET, "local_port=%d", localPort);
 
-        if (getFieldValue("width") == 0)
-        {
+        if (getFieldValue("width") == 0) {
             continue;
         }
 
-        if (getFieldValue("module_0") + 1 == labelPort)
-        {
+        if (getFieldValue("module_0") + 1 == labelPort) {
             isLabelPortValid = true;
             fillEthPortGroupMap(localPort, labelPort, _userInput._setGroup, getFieldValue("width"), spect2WithGb);
             break;
@@ -1137,51 +995,42 @@ void MlxlinkCommander::fillEthPortGroupMap(u_int32_t localPort,
                                            u_int32_t labelPort,
                                            u_int32_t group,
                                            u_int32_t width,
-                                           bool spect2WithGb)
+                                           bool      spect2WithGb)
 {
-    if (_ignorePortStatus)
-    {
-        if (!width)
-        {
+    if (_ignorePortStatus) {
+        if (!width) {
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
         }
     }
-    if (spect2WithGb)
-    {
-        switch (width)
-        {
-            case 2:
-                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
-                _localPortsPerGroup.push_back(PortGroup(localPort + 1, labelPort, group, 2));
-                break;
-            case 4:
-                _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
-                break;
+    if (spect2WithGb) {
+        switch (width) {
+        case 2:
+            _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
+            _localPortsPerGroup.push_back(PortGroup(localPort + 1, labelPort, group, 2));
+            break;
+
+        case 4:
+            _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
+            break;
         }
-    }
-    else
-    {
+    } else {
         sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
         u_int32_t splitStat = getFieldValue("split_stat");
-        if (splitStat == 0)
-        {
+        if (splitStat == 0) {
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
-        }
-        else
-        {
+        } else {
             int found = 0;
-            for (int i = 0; i < (int)(pow(2.0, (double)splitStat)) || found < (int)(pow(2.0, (double)splitStat)); i++)
-            {
+            for (int i = 0; i < (int)(pow(2.0, (double)splitStat)) || found < (int)(pow(2.0, (double)splitStat));
+                 i++) {
                 try
                 {
                     sendPrmReg(ACCESS_REG_PMLP, GET, "local_port=%d", localPort + i);
 
-                    if (getFieldValue("width") == 0)
-                    {
+                    if (getFieldValue("width") == 0) {
                         continue;
                     }
                 }
-                catch (...)
+                catch(...)
                 {
                     continue;
                 }
@@ -1195,11 +1044,12 @@ void MlxlinkCommander::fillEthPortGroupMap(u_int32_t localPort,
 bool MlxlinkCommander::isIbLocalPortValid(u_int32_t localPort)
 {
     bool valid = true;
+
     try
     {
         sendPrmReg(ACCESS_REG_PLIB, GET, "local_port=%d", localPort);
     }
-    catch (MlxRegException& exp)
+    catch(MlxRegException & exp)
     {
         valid = false;
     }
@@ -1208,52 +1058,34 @@ bool MlxlinkCommander::isIbLocalPortValid(u_int32_t localPort)
 
 void MlxlinkCommander::fillIbPortGroupMap(u_int32_t localPort, u_int32_t labelPort, u_int32_t group, bool splitReady)
 {
-    if (splitReady)
-    {
+    if (splitReady) {
         labelPort = (labelPort + 1) / 2;
-        if (_devID == DeviceQuantum)
-        {
-            if (isIbLocalPortValid(localPort + 1))
-            {
+        if (_devID == DeviceQuantum) {
+            if (isIbLocalPortValid(localPort + 1)) {
                 _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
                 _localPortsPerGroup.push_back(PortGroup(localPort + 1, labelPort, group, 2));
-            }
-            else
-            {
+            } else {
                 _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
             }
-        }
-        else if (_devID == DeviceQuantum2)
-        {
+        } else if (_devID == DeviceQuantum2) {
             labelPort = (labelPort / 2) + 1;
-            if (isIbLocalPortValid(localPort + 1))
-            {
+            if (isIbLocalPortValid(localPort + 1)) {
                 _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1, 1));
                 _localPortsPerGroup.push_back(PortGroup(localPort + 1, labelPort, group, 1, 2));
-            }
-            else
-            {
+            } else {
                 _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1, 1));
             }
-            if (isIbLocalPortValid(localPort + 3))
-            {
+            if (isIbLocalPortValid(localPort + 3)) {
                 _localPortsPerGroup.push_back(PortGroup(localPort + 2, labelPort, group, 2, 1));
                 _localPortsPerGroup.push_back(PortGroup(localPort + 3, labelPort, group, 2, 2));
-            }
-            else
-            {
+            } else {
                 _localPortsPerGroup.push_back(PortGroup(localPort + 2, labelPort, group, 2, 1));
             }
         }
-    }
-    else
-    {
-        if (_devID == DeviceQuantum)
-        {
+    } else {
+        if (_devID == DeviceQuantum) {
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 0));
-        }
-        else if (_devID == DeviceQuantum2)
-        {
+        } else if (_devID == DeviceQuantum2) {
             labelPort = (labelPort / 2) + 1;
             _localPortsPerGroup.push_back(PortGroup(localPort, labelPort, group, 1));
             _localPortsPerGroup.push_back(PortGroup(localPort + 2, labelPort, group, 2));
@@ -1268,50 +1100,51 @@ bool MlxlinkCommander::isSpect2WithGb()
     return getFieldValue("num_of_devices") > 0;
 }
 
-vector<string> MlxlinkCommander::localToPortsPerGroup(vector<u_int32_t> localPorts)
+vector < string > MlxlinkCommander::localToPortsPerGroup(vector < u_int32_t > localPorts)
 {
     u_int32_t labelPort = 0;
-    vector<u_int32_t> labelPorts;
-    vector<string> labelPortsStr;
+
+    vector < u_int32_t > labelPorts;
+    vector < string > labelPortsStr;
     string regName = "";
     string labelPortField = "";
 
-    switch (_devID)
-    {
-        case DeviceSpectrum2:
-            regName = ACCESS_REG_PMLP;
-            labelPortField = "module_0";
-            break;
-        case DeviceQuantum:
-        case DeviceQuantum2:
-        case DeviceBW00:
-            regName = ACCESS_REG_PLIB;
-            labelPortField = "ib_port";
-            break;
-        case DeviceQuantum3:
-            regName = ACCESS_REG_PLLP;
-            labelPortField = "label_port";
-            break;
-        default:
-            regName = ACCESS_REG_PMLP;
-            labelPortField = "module_0";
+    switch (_devID) {
+    case DeviceSpectrum2:
+        regName = ACCESS_REG_PMLP;
+        labelPortField = "module_0";
+        break;
+
+    case DeviceQuantum:
+    case DeviceQuantum2:
+    case DeviceGB100:
+        regName = ACCESS_REG_PLIB;
+        labelPortField = "ib_port";
+        break;
+
+    case DeviceQuantum3:
+        regName = ACCESS_REG_PLLP;
+        labelPortField = "label_port";
+        break;
+
+    default:
+        regName = ACCESS_REG_PMLP;
+        labelPortField = "module_0";
     }
 
-    for (vector<u_int32_t>::iterator it = localPorts.begin(); it != localPorts.end(); ++it)
-    {
+    for (vector < u_int32_t > ::iterator it = localPorts.begin(); it != localPorts.end(); ++it) {
         try
         {
             sendPrmReg(regName, GET, "local_port=%d", *it);
 
-            if (regName == ACCESS_REG_PMLP && getFieldValue("width") == 0)
-            {
+            if ((regName == ACCESS_REG_PMLP) && (getFieldValue("width") == 0)) {
                 continue;
             }
 
             labelPort = getFieldValue(labelPortField);
             labelPort = regName == ACCESS_REG_PMLP ? labelPort + 1 : labelPort;
         }
-        catch (MlxRegException& exc)
+        catch(MlxRegException & exc)
         {
             continue;
         }
@@ -1320,10 +1153,8 @@ vector<string> MlxlinkCommander::localToPortsPerGroup(vector<u_int32_t> localPor
 
     sort(labelPorts.begin(), labelPorts.end());
 
-    for (vector<u_int32_t>::iterator it = labelPorts.begin(); it != labelPorts.end(); it++)
-    {
-        if (!isIn(to_string(*it), labelPortsStr))
-        {
+    for (vector < u_int32_t > ::iterator it = labelPorts.begin(); it != labelPorts.end(); it++) {
+        if (!isIn(to_string(*it), labelPortsStr)) {
             labelPortsStr.push_back(to_string(*it));
         }
     }
@@ -1331,33 +1162,27 @@ vector<string> MlxlinkCommander::localToPortsPerGroup(vector<u_int32_t> localPor
     return labelPortsStr;
 }
 
-void MlxlinkCommander::handleLabelPorts(std::vector<string> labelPortsStr, bool skipException)
+void MlxlinkCommander::handleLabelPorts(std::vector < string > labelPortsStr, bool skipException)
 {
     u_int32_t labelPort = 0;
-    bool isLabelPortValid = false;
-    if (labelPortsStr.size() > maxLocalPort() && !skipException)
-    {
+    bool      isLabelPortValid = false;
+
+    if ((labelPortsStr.size() > maxLocalPort()) && !skipException) {
         throw MlxRegException("The number of ports is invalid");
     }
     bool ibSplitReady = (_devID == DeviceQuantum || _devID == DeviceQuantum2) ? isIBSplitReady() : false;
     bool spect2WithGb = (_devID == DeviceSpectrum2) ? isSpect2WithGb() : false;
-    for (vector<string>::iterator it = labelPortsStr.begin(); it != labelPortsStr.end(); ++it)
-    {
+
+    for (vector < string > ::iterator it = labelPortsStr.begin(); it != labelPortsStr.end(); ++it) {
         strToUint32((char*)(*it).c_str(), labelPort);
-        if (_devID == DeviceSpectrum2 || _devID == DeviceSpectrum3 || _devID == DeviceSpectrum4)
-        {
+        if ((_devID == DeviceSpectrum2) || (_devID == DeviceSpectrum3) || (_devID == DeviceSpectrum4)) {
             isLabelPortValid = handleEthLocalPort(labelPort, spect2WithGb);
-        }
-        else if (_devID == DeviceQuantum || _devID == DeviceQuantum2)
-        {
+        } else if ((_devID == DeviceQuantum) || (_devID == DeviceQuantum2)) {
             isLabelPortValid = handleIBLocalPort(labelPort, ibSplitReady);
-        }
-        else if (_devID == DeviceQuantum3 || _devID == DeviceBW00)
-        {
+        } else if ((_devID == DeviceQuantum3) || (_devID == DeviceGB100)) {
             isLabelPortValid = handleQTM3LocalPort(labelPort);
         }
-        if (!isLabelPortValid && !skipException)
-        {
+        if (!isLabelPortValid && !skipException) {
             throw MlxRegException("Invalid port number %d!\n", labelPort);
         }
     }
@@ -1366,16 +1191,12 @@ void MlxlinkCommander::handleLabelPorts(std::vector<string> labelPortsStr, bool 
 string MlxlinkCommander::getCableTechnologyStr(u_int32_t cableTechnology)
 {
     string technologyStr = "N/A";
-    if (_cmisCable)
-    {
+
+    if (_cmisCable) {
         technologyStr = _mlxlinkMaps->_cableTechnologyQsfp[cableTechnology];
-    }
-    else if (_qsfpCable)
-    {
+    } else if (_qsfpCable) {
         technologyStr = _mlxlinkMaps->_cableTechnologyQsfp[(cableTechnology & 240) >> 4];
-    }
-    else
-    {
+    } else {
         technologyStr = _mlxlinkMaps->_cableTechnologySfp[(cableTechnology & 15)];
     }
     return technologyStr;
@@ -1384,20 +1205,20 @@ string MlxlinkCommander::getCableTechnologyStr(u_int32_t cableTechnology)
 string MlxlinkCommander::getCableTypeStr(u_int32_t cableType)
 {
     string cableTypeStr = "N/A";
+
     cableTypeStr = getCableType(cableType);
     return cableTypeStr;
 }
 
-// Query functions
+/* Query functions */
 
 void MlxlinkCommander::prepareStaticInfoSection(bool valid)
 {
-    if (!_isSwControled)
-    {
+    if (!_isSwControled) {
         u_int32_t cableVendor = getFieldValue("cable_vendor");
-        string complianceStr = getComplianceLabel(getFieldValue("ethernet_compliance_code"),
-                                                  getFieldValue("ext_ethernet_compliance_code"),
-                                                  (cableVendor != NVIDIA && cableVendor != MELLANOX));
+        string    complianceStr = getComplianceLabel(getFieldValue("ethernet_compliance_code"),
+                                                     getFieldValue("ext_ethernet_compliance_code"),
+                                                     (cableVendor != NVIDIA && cableVendor != MELLANOX));
         u_int32_t cableLength = getFieldValue("cable_length");
 
         setPrintVal(_moduleInfoCmd, "Identifier", _plugged ? getCableIdentifier(_cableIdentifier) : "N/A",
@@ -1424,26 +1245,22 @@ void MlxlinkCommander::prepareAttenuationAndFwSection(bool valid)
 {
     string cableAttenuation = "N/A";
     string attenuationTitle = "Attenuation (5g,7g,12g";
-    bool passive = _cableMediaType == PASSIVE;
-    if (_cmisCable)
-    {
+    bool   passive = _cableMediaType == PASSIVE;
+
+    if (_cmisCable) {
         attenuationTitle += ",25g";
     }
 
-    if (_cableIdentifier != IDENTIFIER_SFP && _cableIdentifier != IDENTIFIER_QSA)
-    {
-        if (passive)
-        {
+    if ((_cableIdentifier != IDENTIFIER_SFP) && (_cableIdentifier != IDENTIFIER_QSA)) {
+        if (passive) {
             cableAttenuation = getFieldStr("cable_attenuation_5g") + "," + getFieldStr("cable_attenuation_7g") + "," +
                                getFieldStr("cable_attenuation_12g");
-            if (_cmisCable)
-            {
+            if (_cmisCable) {
                 cableAttenuation += "," + getFieldStr("cable_attenuation_25g");
             }
 
             string attenuation53g = getFieldStr("cable_attenuation_53g");
-            if (attenuation53g != "0")
-            {
+            if (attenuation53g != "0") {
                 attenuationTitle += ",53g";
                 cableAttenuation += "," + attenuation53g;
             }
@@ -1452,8 +1269,7 @@ void MlxlinkCommander::prepareAttenuationAndFwSection(bool valid)
     attenuationTitle += ")[dB]";
 
     setPrintVal(_moduleInfoCmd, attenuationTitle, cableAttenuation, ANSI_COLOR_RESET, true, valid);
-    if (!_isSwControled)
-    {
+    if (!_isSwControled) {
         setPrintVal(_moduleInfoCmd, "FW Version", getModuleFwVersion(passive, getFieldValue("fw_version")),
                     ANSI_COLOR_RESET, true, valid);
     }
@@ -1464,18 +1280,19 @@ void MlxlinkCommander::preparePowerAndCdrSection(bool valid)
     string rxCdrState = "N/A";
     string txCdrState = "N/A";
     string powerClassStr = "N/A";
-    if (!_isSwControled)
-    {
-        if (getFieldValue("rx_cdr_cap") > 0)
-        {
+
+    if (!_isSwControled) {
+        if (getFieldValue("rx_cdr_cap") > 0) {
             rxCdrState = getRxTxCDRState(getFieldValue("rx_cdr_state"), _numOfLanes);
         }
-        if (getFieldValue("tx_cdr_cap") > 0)
-        {
+        if (getFieldValue("tx_cdr_cap") > 0) {
             txCdrState = getRxTxCDRState(getFieldValue("tx_cdr_state"), _numOfLanes);
         }
         powerClassStr =
-          getPowerClass(_mlxlinkMaps, _cableIdentifier, getFieldValue("cable_power_class"), getFieldValue("max_power"));
+            getPowerClass(_mlxlinkMaps,
+                          _cableIdentifier,
+                          getFieldValue("cable_power_class"),
+                          getFieldValue("max_power"));
     }
 
     setPrintVal(_moduleInfoCmd, "Digital Diagnostic Monitoring", _ddmSupported ? "Yes" : "No", ANSI_COLOR_RESET, true,
@@ -1489,26 +1306,24 @@ void MlxlinkCommander::preparePowerAndCdrSection(bool valid)
 
 void MlxlinkCommander::prepareDDMSection(bool valid, bool isModuleExtSupported)
 {
-    std::vector<float> rxPowerLane, txPowerLane, biasCurrentLane;
-    float rxPowerHighTH;
-    float rxPowerLowTH;
-    float txPowerHighTH;
-    float txPowerLowTH;
+    std::vector < float > rxPowerLane, txPowerLane, biasCurrentLane;
+    float     rxPowerHighTH;
+    float     rxPowerLowTH;
+    float     txPowerHighTH;
+    float     txPowerLowTH;
     u_int32_t tempNum = getFieldValue("temperature");
-    string temp = getTemp(tempNum);
-    string tempHighTH = getTemp(getFieldValue("temperature_high_th"));
-    string tempLowTH = getTemp(getFieldValue("temperature_low_th"));
-
-    float voltage = getFieldValue("voltage") / 10.0;
-    float voltageHighTH = getFieldValue("voltage_high_th") / 10.0;
-    float voltageLowTH = getFieldValue("voltage_low_th") / 10.0;
+    string    temp = getTemp(tempNum);
+    string    tempHighTH = getTemp(getFieldValue("temperature_high_th"));
+    string    tempLowTH = getTemp(getFieldValue("temperature_low_th"));
+    float     voltage = getFieldValue("voltage") / 10.0;
+    float     voltageHighTH = getFieldValue("voltage_high_th") / 10.0;
+    float     voltageLowTH = getFieldValue("voltage_low_th") / 10.0;
 
     rxPowerHighTH = getPower(getFieldValue("rx_power_high_th"), isModuleExtSupported);
     rxPowerLowTH = getPower(getFieldValue("rx_power_low_th"), isModuleExtSupported);
     txPowerHighTH = getPower(getFieldValue("tx_power_high_th"), isModuleExtSupported);
     txPowerLowTH = getPower(getFieldValue("tx_power_low_th"), isModuleExtSupported);
-    if (isModuleExtSupported)
-    {
+    if (isModuleExtSupported) {
         rxPowerHighTH = convertFloatPrec(rxPowerHighTH);
         rxPowerLowTH = convertFloatPrec(rxPowerLowTH);
         txPowerHighTH = convertFloatPrec(txPowerHighTH);
@@ -1518,38 +1333,50 @@ void MlxlinkCommander::prepareDDMSection(bool valid, bool isModuleExtSupported)
     float biasLowTH = getFieldValue("tx_bias_low_th") / 500.0;
     float biasHighTH = getFieldValue("tx_bias_high_th") / 500.0;
 
-    for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
         string laneStr = to_string(_moduleLanesMapping[lane]);
         rxPowerLane.push_back(getPower(getFieldValue("rx_power_lane" + laneStr), isModuleExtSupported));
         txPowerLane.push_back(getPower(getFieldValue("tx_power_lane" + laneStr), isModuleExtSupported));
         biasCurrentLane.push_back(getFieldValue("tx_bias_lane" + laneStr) / 500.0);
     }
 
-    setPrintVal(_moduleInfoCmd, "Temperature [C]",
-                getValueAndThresholdsStr<string, string>(temp, tempLowTH, tempHighTH), ANSI_COLOR_RESET, true, valid);
-    setPrintVal(_moduleInfoCmd, "Voltage [mV]",
-                getValueAndThresholdsStr<float, float>(voltage, voltageLowTH, voltageHighTH), ANSI_COLOR_RESET, true,
+    setPrintVal(_moduleInfoCmd,
+                "Temperature [C]",
+                getValueAndThresholdsStr < string,
+                string > (temp, tempLowTH, tempHighTH),
+                ANSI_COLOR_RESET,
+                true,
                 valid);
-    setPrintVal(_moduleInfoCmd, "Bias Current [mA]",
-                getValueAndThresholdsStr<string, float>(getStringFromVector(biasCurrentLane), biasLowTH, biasHighTH),
-                ANSI_COLOR_RESET, true, valid);
+    setPrintVal(_moduleInfoCmd,
+                "Voltage [mV]",
+                getValueAndThresholdsStr < float,
+                float > (voltage, voltageLowTH, voltageHighTH),
+                ANSI_COLOR_RESET,
+                true,
+                valid);
+    setPrintVal(_moduleInfoCmd,
+                "Bias Current [mA]",
+                getValueAndThresholdsStr < string,
+                float > (getStringFromVector(biasCurrentLane), biasLowTH, biasHighTH),
+                ANSI_COLOR_RESET,
+                true,
+                valid);
     setPrintVal(_moduleInfoCmd, "Rx Power Current [dBm]",
-                getValueAndThresholdsStr<string, float>(getStringFromVector(rxPowerLane), rxPowerLowTH, rxPowerHighTH),
+                getValueAndThresholdsStr < string,
+                float > (getStringFromVector(rxPowerLane), rxPowerLowTH, rxPowerHighTH),
                 ANSI_COLOR_RESET, true, valid);
     setPrintVal(_moduleInfoCmd, "Tx Power Current [dBm]",
-                getValueAndThresholdsStr<string, float>(getStringFromVector(txPowerLane), txPowerLowTH, txPowerHighTH),
+                getValueAndThresholdsStr < string,
+                float > (getStringFromVector(txPowerLane), txPowerLowTH, txPowerHighTH),
                 ANSI_COLOR_RESET, true, valid);
 }
 
 string MlxlinkCommander::getValuesOfActiveLanes(const string& row)
 {
     string newValue = row;
+    auto   valuesPerLane = MlxlinkRecord::split(newValue, ",");
 
-    auto valuesPerLane = MlxlinkRecord::split(newValue, ",");
-
-    if (valuesPerLane.size() > 1)
-    {
+    if (valuesPerLane.size() > 1) {
         valuesPerLane.erase(valuesPerLane.begin() + _numOfLanes, valuesPerLane.end());
         newValue = getStringFromVector(valuesPerLane);
     }
@@ -1559,37 +1386,31 @@ string MlxlinkCommander::getValuesOfActiveLanes(const string& row)
 
 void MlxlinkCommander::pushSnrModuleInfoFields(bool valid)
 {
-    vector<MODULE_FIELD> fieldsToQuery;
+    vector < MODULE_FIELD > fieldsToQuery;
     string snrMediaLanes = "N/A";
     string snrHostLanes = "N/A";
 
     try
     {
-        vector<AmberField> moduleInfoFields = _amberCollector->getExtModuleStatus();
+        vector < AmberField > moduleInfoFields = _amberCollector->getExtModuleStatus();
         snrMediaLanes = AmberField::getValueFromFields(moduleInfoFields, "snr_media_lane", false);
         snrHostLanes = AmberField::getValueFromFields(moduleInfoFields, "snr_host_lane", false);
 
-        if (snrMediaLanes.find("N/A") != string::npos)
-        {
+        if (snrMediaLanes.find("N/A") != string::npos) {
             snrMediaLanes = "N/A";
-        }
-        else
-        {
+        } else {
             findAndReplace(snrMediaLanes, "_", ",");
             snrMediaLanes = getValuesOfActiveLanes(snrMediaLanes);
         }
 
-        if (snrHostLanes.find("N/A") != string::npos)
-        {
+        if (snrHostLanes.find("N/A") != string::npos) {
             snrHostLanes = "N/A";
-        }
-        else
-        {
+        } else {
             findAndReplace(snrHostLanes, "_", ",");
             snrHostLanes = getValuesOfActiveLanes(snrHostLanes);
         }
     }
-    catch (MlxRegException& excep)
+    catch(MlxRegException & excep)
     {
     }
 
@@ -1599,58 +1420,55 @@ void MlxlinkCommander::pushSnrModuleInfoFields(bool valid)
                 true);
 }
 
-void MlxlinkCommander::prepareBerModuleInfo(bool valid, const vector<AmberField>& moduleInfoFields)
+void MlxlinkCommander::prepareBerModuleInfo(bool valid, const vector < AmberField >& moduleInfoFields)
 {
-    vector<MODULE_FIELD> fieldsToQuery;
+    vector < MODULE_FIELD > fieldsToQuery;
 
-    fieldsToQuery.push_back(MODULE_FIELD{"IB Cable Width", "ib_width", true, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Memory Map Revision", "Memory_map_rev", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Linear Direct Drive", "linear_direct_drive", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Cable Breakout", "cable_breakout", true, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"SMF Length", "smf_length", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"MAX Power", "max_power", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Cable Rx AMP", "cable_rx_amp", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Cable Rx Emphasis", "cable_rx_pre_emphasis", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Cable Rx Post Emphasis", "cable_rx_post_emphasis", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Cable Tx Equalization", "cable_tx_equalization", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Wavelength Tolerance", "wavelength_tolerance", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Module State", "Module_st", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"DataPath state [per lane]", "Dp_st_lane", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Rx Output Valid [per lane]", "rx_output_valid", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Nominal bit rate", "Nominal_Bit_Rate", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Rx Power Type", "Rx_Power_Type", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Manufacturing Date", "Date_Code", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"IB Cable Width", "ib_width", true, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Memory Map Revision", "Memory_map_rev", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Linear Direct Drive", "linear_direct_drive", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Cable Breakout", "cable_breakout", true, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"SMF Length", "smf_length", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"MAX Power", "max_power", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Cable Rx AMP", "cable_rx_amp", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Cable Rx Emphasis", "cable_rx_pre_emphasis", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Cable Rx Post Emphasis", "cable_rx_post_emphasis", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Cable Tx Equalization", "cable_tx_equalization", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Wavelength Tolerance", "wavelength_tolerance", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Module State", "Module_st", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"DataPath state [per lane]", "Dp_st_lane", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Rx Output Valid [per lane]", "rx_output_valid", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Nominal bit rate", "Nominal_Bit_Rate", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Rx Power Type", "Rx_Power_Type", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Manufacturing Date", "Date_Code", false, false, false});
     fieldsToQuery.push_back(
-      MODULE_FIELD{"Active Set Host Compliance Code", "Active_set_host_compliance_code", false, false, false});
+        MODULE_FIELD {"Active Set Host Compliance Code", "Active_set_host_compliance_code", false, false, false});
     fieldsToQuery.push_back(
-      MODULE_FIELD{"Active Set Media Compliance Code", "Active_set_media_compliance_code", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Error Code Response", "error_code_response", false, false, false});
-    fieldsToQuery.push_back(MODULE_FIELD{"Module FW Fault", "Mod_fw_fault", false, false, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"DataPath FW Fault", "Dp_fw_fault", false, false, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Tx Fault [per lane]", "tx_fault", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Tx LOS [per lane]", "tx_los", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Tx CDR LOL [per lane]", "tx_cdr_lol", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Rx LOS [per lane]", "rx_los", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Rx CDR LOL [per lane]", "rx_cdr_lol", true, true, true});
-    fieldsToQuery.push_back(MODULE_FIELD{"Tx Adaptive EQ Fault [per lane]", "tx_ad_eq_fault", true, true, true});
+        MODULE_FIELD {"Active Set Media Compliance Code", "Active_set_media_compliance_code", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Error Code Response", "error_code_response", false, false, false});
+    fieldsToQuery.push_back(MODULE_FIELD {"Module FW Fault", "Mod_fw_fault", false, false, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"DataPath FW Fault", "Dp_fw_fault", false, false, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Tx Fault [per lane]", "tx_fault", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Tx LOS [per lane]", "tx_los", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Tx CDR LOL [per lane]", "tx_cdr_lol", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Rx LOS [per lane]", "rx_los", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Rx CDR LOL [per lane]", "rx_cdr_lol", true, true, true});
+    fieldsToQuery.push_back(MODULE_FIELD {"Tx Adaptive EQ Fault [per lane]", "tx_ad_eq_fault", true, true, true});
 
     pushSnrModuleInfoFields(valid);
 
     string fieldValue = "";
-    for (auto it = fieldsToQuery.begin(); it != fieldsToQuery.end(); it++)
-    {
+
+    for (auto it = fieldsToQuery.begin(); it != fieldsToQuery.end(); it++) {
         fieldValue = AmberField::getValueFromFields(moduleInfoFields, it->amberName, !it->perLane);
-        if (it->multiVal)
-        {
+        if (it->multiVal) {
             findAndReplace(fieldValue, "_", ",");
         }
-        if (it->perLane)
-        {
+        if (it->perLane) {
             fieldValue = getValuesOfActiveLanes(fieldValue);
         }
 
-        if (it->uiName == "Cable Rx Emphasis" && _cmisCable)
-        {
+        if ((it->uiName == "Cable Rx Emphasis") && _cmisCable) {
             it->uiName += " (Pre)";
         }
         setPrintVal(_moduleInfoCmd, it->uiName, fieldValue, ANSI_COLOR_RESET, true,
@@ -1661,12 +1479,14 @@ void MlxlinkCommander::prepareBerModuleInfo(bool valid, const vector<AmberField>
 bool MlxlinkCommander::checkIfModuleExtSupported()
 {
     bool isModuleExtSupported = false;
+
     sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d , module_info_ext=0", PDDR_MODULE_INFO_PAGE);
     float rxPowerHighTH_fst = getFieldValue("rx_power_high_th");
+
     sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d , module_info_ext=1", PDDR_MODULE_INFO_PAGE);
     float rxPowerHighTH_sec = getFieldValue("rx_power_high_th");
-    if (rxPowerHighTH_sec != rxPowerHighTH_fst)
-    {
+
+    if (rxPowerHighTH_sec != rxPowerHighTH_fst) {
         isModuleExtSupported = true;
     }
 
@@ -1682,12 +1502,11 @@ void MlxlinkCommander::showModuleInfo()
         sendPrmReg(ACCESS_REG_PMAOS, GET, "module=%d,slot_index=%d", _moduleNumber, _slotIndex);
 
         u_int32_t oper_status = getFieldValue("oper_status");
-        bool isModuleExtSupported = false;
-        bool valid = (_cableMediaType != UNIDENTIFIED) && _plugged;
+        bool      isModuleExtSupported = false;
+        bool      valid = (_cableMediaType != UNIDENTIFIED) && _plugged;
         setPrintTitle(_moduleInfoCmd, "Module Info",
                       _productTechnology >= PRODUCT_16NM ? MODULE_INFO_AMBER : MODULE_INFO_LAST);
-        if (!_isSwControled)
-        {
+        if (!_isSwControled) {
             isModuleExtSupported = checkIfModuleExtSupported();
             prepareDDMSection(valid, isModuleExtSupported);
         }
@@ -1695,53 +1514,50 @@ void MlxlinkCommander::showModuleInfo()
         prepareStaticInfoSection(valid);
         prepareAttenuationAndFwSection(valid);
         preparePowerAndCdrSection(valid);
-        if (_productTechnology >= PRODUCT_16NM)
-        {
+        if (_productTechnology >= PRODUCT_16NM) {
             preparePrtlSection();
         }
         initAmBerCollector();
         _amberCollector->init();
-        vector<AmberField> moduleInfoFields = _amberCollector->getModuleStatus();
+        vector < AmberField > moduleInfoFields = _amberCollector->getModuleStatus();
 
         prepareBerModuleInfo(valid, moduleInfoFields);
 
         cout << _moduleInfoCmd;
 
-        if (oper_status != 1)
-        {
+        if (oper_status != 1) {
             MlxlinkRecord::printWar(
-              "Warning: Cannot get module EEPROM information, module operation status is not 'plugged and enabled'",
-              _jsonRoot);
+                "Warning: Cannot get module EEPROM information, module operation status is not 'plugged and enabled'",
+                _jsonRoot);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing Module Info via PDDR raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing Module Info via PDDR raised the following exception: ") + string(exc.what()) +
+            string("\n");
     }
 }
 
 void MlxlinkCommander::preparePrtlSection()
 {
-    if (_userInput._advancedMode)
-    {
-        char rttFrmt[64] = "";
-        bool isRttSupported = false;
+    if (_userInput._advancedMode) {
+        char      rttFrmt[64] = "";
+        bool      isRttSupported = false;
         u_int16_t asicLatency = 0;
         u_int16_t moduleLatency = 0;
-        bool valid = true;
+        bool      valid = true;
 
         try
         {
             sendPrmReg(ACCESS_REG_PRTL, GET);
         }
-        catch (const std::exception& exc)
+        catch(const std::exception& exc)
         {
             valid = false;
         }
 
-        if (valid)
-        {
+        if (valid) {
             u_int32_t rttLatencyInt = getFieldValue("round_trip_latency");
             isRttSupported = rttLatencyInt && rttLatencyInt != 0xffffff;
             asicLatency = (u_int16_t)getFieldValue("local_phy_latency");
@@ -1765,30 +1581,28 @@ string MlxlinkCommander::getCompliaceLabelForCIMIS(u_int32_t hostCompliance, u_i
     string complianceStr = "N/A";
     string hostComplianceStr = "";
     string mediaComplianceStr = "";
-    switch (_cableMediaType)
-    {
-        case PASSIVE:
-            hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
-            break;
-        case ACTIVE:
-            mediaComplianceStr = _mlxlinkMaps->_activeCableCompliance[mediaCompliance];
-            hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
-            break;
-        case OPTICAL_MODULE:
-            if (_cableTechnology == TECHNOLOGY_850NM_VCSEL)
-            {
-                mediaComplianceStr = _mlxlinkMaps->_mmfCompliance[mediaCompliance];
-            }
-            else if (_cableTechnology >= TECHNOLOGY_1310NM_VCSEL && _cableTechnology <= TECHNOLOGY_1550NM_EML)
-            {
-                mediaComplianceStr = _mlxlinkMaps->_smfCompliance[mediaCompliance];
-            }
-            hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
-            break;
+
+    switch (_cableMediaType) {
+    case PASSIVE:
+        hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
+        break;
+
+    case ACTIVE:
+        mediaComplianceStr = _mlxlinkMaps->_activeCableCompliance[mediaCompliance];
+        hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
+        break;
+
+    case OPTICAL_MODULE:
+        if (_cableTechnology == TECHNOLOGY_850NM_VCSEL) {
+            mediaComplianceStr = _mlxlinkMaps->_mmfCompliance[mediaCompliance];
+        } else if ((_cableTechnology >= TECHNOLOGY_1310NM_VCSEL) && (_cableTechnology <= TECHNOLOGY_1550NM_EML)) {
+            mediaComplianceStr = _mlxlinkMaps->_smfCompliance[mediaCompliance];
+        }
+        hostComplianceStr = _mlxlinkMaps->_cmisHostCompliance[hostCompliance];
+        break;
     }
     complianceStr = hostComplianceStr;
-    if (!mediaComplianceStr.empty())
-    {
+    if (!mediaComplianceStr.empty()) {
         complianceStr += "," + mediaComplianceStr;
     }
     return complianceStr;
@@ -1797,36 +1611,25 @@ string MlxlinkCommander::getCompliaceLabelForCIMIS(u_int32_t hostCompliance, u_i
 string MlxlinkCommander::getComplianceLabel(u_int32_t compliance, u_int32_t extCompliance, bool ignoreExtBitChk)
 {
     string complianceLabel = "N/A";
-    if (_cmisCable)
-    {
+
+    if (_cmisCable) {
         complianceLabel = getCompliaceLabelForCIMIS(extCompliance, compliance);
-    }
-    else if (_protoActive == ETH)
-    {
-        if (_qsfpCable)
-        {
-            if (compliance)
-            {
+    } else if (_protoActive == ETH) {
+        if (_qsfpCable) {
+            if (compliance) {
                 complianceLabel = getCompliance(compliance, _mlxlinkMaps->_cableComplianceQsfp, true);
-                if (ignoreExtBitChk || (compliance & QSFP_ETHERNET_COMPLIANCE_CODE_EXT))
-                {
+                if (ignoreExtBitChk || (compliance & QSFP_ETHERNET_COMPLIANCE_CODE_EXT)) {
                     complianceLabel += !complianceLabel.empty() ? "," : "";
                     complianceLabel += getCompliance(extCompliance, _mlxlinkMaps->_cableComplianceExt);
                 }
-            }
-            else if (ignoreExtBitChk)
-            {
+            } else if (ignoreExtBitChk) {
                 complianceLabel = getCompliance(extCompliance, _mlxlinkMaps->_cableComplianceExt);
             }
-        }
-        else if (_cableIdentifier == IDENTIFIER_SFP || _cableIdentifier == IDENTIFIER_QSA)
-        {
-            if (compliance)
-            {
+        } else if ((_cableIdentifier == IDENTIFIER_SFP) || (_cableIdentifier == IDENTIFIER_QSA)) {
+            if (compliance) {
                 complianceLabel = getCompliance(compliance, _mlxlinkMaps->_cableComplianceSfp, true);
             }
-            if (extCompliance)
-            {
+            if (extCompliance) {
                 complianceLabel = (compliance ? complianceLabel + ", " : "") +
                                   getCompliance(extCompliance, _mlxlinkMaps->_cableComplianceExt);
             }
@@ -1838,59 +1641,53 @@ string MlxlinkCommander::getComplianceLabel(u_int32_t compliance, u_int32_t extC
 string MlxlinkCommander::getSltpFieldStr(const PRM_FIELD& field)
 {
     string fieldStr = getFieldStr(field.prmField);
-    if (field.isSigned)
-    {
+
+    if (field.isSigned) {
         fieldStr = to_string(readSigned(getFieldValue(field.prmField), getFieldSize(field.prmField)));
     }
     return MlxlinkRecord::addSpace(fieldStr, field.uiField.size() + 1, false);
 }
 
-void MlxlinkCommander::prepareSltpEdrHdrGen(vector<vector<string>>& sltpLanes, u_int32_t laneNumber)
+void MlxlinkCommander::prepareSltpEdrHdrGen(vector < vector < string >>& sltpLanes, u_int32_t laneNumber)
 {
-    map<u_int32_t, PRM_FIELD> sltpParam = _mlxlinkMaps->_SltpEdrParams;
-    if (_productTechnology == PRODUCT_16NM)
-    {
+    map < u_int32_t, PRM_FIELD > sltpParam = _mlxlinkMaps->_SltpEdrParams;
+    if (_productTechnology == PRODUCT_16NM) {
         sltpParam = _mlxlinkMaps->_SltpHdrParams;
     }
 
-    for (auto const& param : sltpParam)
-    {
+    for (auto const& param : sltpParam) {
         if ((param.second.fieldAccess & FIELD_ACCESS_R) ||
-            (_userInput._advancedMode && (param.second.fieldAccess & FIELD_ACCESS_ADVANCED)))
-        {
+            (_userInput._advancedMode && (param.second.fieldAccess & FIELD_ACCESS_ADVANCED))) {
             sltpLanes[laneNumber].push_back(getSltpFieldStr(param.second));
         }
     }
 }
 
-void MlxlinkCommander::prepareSltpNdrGen(std::vector<std::vector<string>>& sltpLanes, u_int32_t laneNumber)
+void MlxlinkCommander::prepareSltpNdrGen(std::vector < std::vector < string >>& sltpLanes, u_int32_t laneNumber)
 {
     u_int32_t activeSpeed = _protoActive == IB ? _activeSpeed : _activeSpeedEx;
-    for (auto const& param : _mlxlinkMaps->_SltpNdrParams)
-    {
-        if (param.second.validationMask & activeSpeed)
-        {
+
+    for (auto const& param : _mlxlinkMaps->_SltpNdrParams) {
+        if (param.second.validationMask & activeSpeed) {
             sltpLanes[laneNumber].push_back(getSltpFieldStr(param.second));
         }
     }
 }
 
-void MlxlinkCommander::prepareSltpXdrGen(std::vector<std::vector<string>>& sltpLanes, u_int32_t laneNumber)
+void MlxlinkCommander::prepareSltpXdrGen(std::vector < std::vector < string >>& sltpLanes, u_int32_t laneNumber)
 {
     (void)sltpLanes;
     (void)laneNumber;
 }
 
-template<typename T, typename Q>
+template < typename T, typename Q >
 string MlxlinkCommander::getValueAndThresholdsStr(T value, Q lowTH, Q highTH)
 {
     stringstream out;
-    if (_ddmSupported)
-    {
+
+    if (_ddmSupported) {
         out << value << " [" << lowTH << ".." << highTH << "]";
-    }
-    else
-    {
+    } else {
         out << "N/A";
     }
     return out.str();
@@ -1911,14 +1708,14 @@ void MlxlinkCommander::operatingInfoPage()
     {
         sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_OPERATIONAL_INFO_PAGE);
         u_int32_t phyMngrFsmState = getFieldValue("phy_mngr_fsm_state");
-        int loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ? getFieldValue("loopback_mode") : -1;
+        int       loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ? getFieldValue("loopback_mode") : -1;
         u_int32_t ethAnFsmState = getFieldValue("eth_an_fsm_state");
         u_int32_t ib_phy_fsm_state = getFieldValue("ib_phy_fsm_state");
-        string color =
-          MlxlinkRecord::state2Color(phyMngrFsmState == PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)phyMngrFsmState);
+        string    color =
+            MlxlinkRecord::state2Color(phyMngrFsmState ==
+                                       PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)phyMngrFsmState);
         _protoActive = getFieldValue("proto_active");
-        if (_protoActive == NVLINK)
-        {
+        if (_protoActive == NVLINK) {
             _isNVLINK = true;
             _protoActive = IB;
         }
@@ -1928,12 +1725,11 @@ void MlxlinkCommander::operatingInfoPage()
         _portPolling = phyMngrFsmState == PHY_MNGR_POLLING;
         _protoCapability = getFieldValue("cable_ext_eth_proto_cap");
 
-        if (_protoActive == IB)
-        {
+        if (_protoActive == IB) {
             _protoCapability = getFieldValue("cable_link_speed_cap");
             _activeSpeed = getFieldValue("link_speed_active");
             _protoAdmin = (phyMngrFsmState != 0) ? getFieldValue("core_to_phy_link_proto_enabled") :
-                                                   getFieldValue("phy_manager_link_proto_enabled");
+                          getFieldValue("phy_manager_link_proto_enabled");
         }
 
         getPtys();
@@ -1950,7 +1746,7 @@ void MlxlinkCommander::operatingInfoPage()
                     !_prbsTestMode);
         setPrintVal(_operatingInfoCmd, "Physical state",
                     _protoActive == ETH ? getStrByValue(ethAnFsmState, _mlxlinkMaps->_ethANFsmState) :
-                                          getStrByValue(ib_phy_fsm_state, _mlxlinkMaps->_ibPhyFsmState),
+                    getStrByValue(ib_phy_fsm_state, _mlxlinkMaps->_ibPhyFsmState),
                     color, !_prbsTestMode);
         setPrintVal(_operatingInfoCmd, "Speed", _speedStrG, color, !_prbsTestMode, _linkUP);
         setPrintVal(_operatingInfoCmd, "Width", to_string(_numOfLanes) + "x", color, !_prbsTestMode, _linkUP);
@@ -1962,17 +1758,16 @@ void MlxlinkCommander::operatingInfoPage()
         setPrintVal(_operatingInfoCmd, "Auto Negotiation", _mlxlinkMaps->_anDisableList[_anDisable] + _speedForce,
                     getAnDisableColor(_anDisable), true, !_prbsTestMode);
 
-        // Checking cable DDM capability
-        if (!_isSwControled && (_userInput._networkCmds != 0 || _userInput._ddm || _userInput._dump ||
+        /* Checking cable DDM capability */
+        if (!_isSwControled && ((_userInput._networkCmds != 0) || _userInput._ddm || _userInput._dump ||
                                 _userInput._write || _userInput._read || _userInput.isModuleConfigParamsProvided ||
-                                _userInput.isPrbsSelProvided || _userInput._csvBer != ""))
-        {
+                                _userInput.isPrbsSelProvided || (_userInput._csvBer != ""))) {
             sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_MODULE_INFO_PAGE);
 
             _ddmSupported = getFieldValue("temperature") && _numOfLanes;
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException(string(exc.what()));
     }
@@ -1983,20 +1778,19 @@ void MlxlinkCommander::supportedInfoPage()
     try
     {
         setPrintTitle(_supportedInfoCmd, HEADER_SUPPORTED_INFO, PDDR_SUPPORTED_INFO_LAST, !_prbsTestMode);
-        u_int32_t speeds_mask = _protoAdminEx ? _protoAdminEx : _protoAdmin;
-        string supported_speeds = SupportedSpeeds2Str(_protoActive, speeds_mask, (bool)_protoAdminEx);
-        string color = MlxlinkRecord::supported2Color(supported_speeds);
+        u_int32_t    speeds_mask = _protoAdminEx ? _protoAdminEx : _protoAdmin;
+        string       supported_speeds = SupportedSpeeds2Str(_protoActive, speeds_mask, (bool)_protoAdminEx);
+        string       color = MlxlinkRecord::supported2Color(supported_speeds);
         stringstream value;
         value << "0x" << std::hex << setfill('0') << setw(8) << speeds_mask << " (" << supported_speeds << ")"
               << setfill(' ');
         string extStr = "";
-        if (_protoCapabilityEx && _protoActive == ETH)
-        {
+        if (_protoCapabilityEx && (_protoActive == ETH)) {
             extStr = " (Ext.)";
         }
         string title = "Enabled Link Speed" + extStr;
         setPrintVal(_supportedInfoCmd, title, value.str(), color, true, !_prbsTestMode, true);
-        // Supported cable speed
+        /* Supported cable speed */
         supported_speeds = SupportedSpeeds2Str(_protoActive, _protoCapability, _protoCapabilityEx);
         color = MlxlinkRecord::supported2Color(supported_speeds);
         value.str("");
@@ -2006,7 +1800,7 @@ void MlxlinkCommander::supportedInfoPage()
         title = "Supported Cable Speed" + extStr;
         setPrintVal(_supportedInfoCmd, title, value.str(), color, true, !_prbsTestMode, true);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException(string(exc.what()));
     }
@@ -2020,11 +1814,10 @@ void MlxlinkCommander::troubInfoPage()
                    _groupOpcode);
 
         u_int32_t monitorOpcode = getFieldValue("monitor_opcode");
-        string color = status2Color(monitorOpcode);
+        string    color = status2Color(monitorOpcode);
         setPrintTitle(_troubInfoCmd, "Troubleshooting Info", PDDR_TRUOBLESHOOTING_INFO_LAST, !_prbsTestMode);
 
-        if (monitorOpcode == CABLE_IS_UNPLUGGED)
-        {
+        if (monitorOpcode == CABLE_IS_UNPLUGGED) {
             _mngCableUnplugged = true;
         }
         stringstream statusOp;
@@ -2034,36 +1827,32 @@ void MlxlinkCommander::troubInfoPage()
         string groupOpcode = getGroupStr(monitorOpcode);
         setPrintVal(_troubInfoCmd, "Group Opcode", groupOpcode, color, true, !_prbsTestMode);
 
-        string message = "";
-        char txt[16], c;
+        string    message = "";
+        char      txt[16], c;
         u_int32_t message_buf;
-        bool finalize = false;
+        bool      finalize = false;
 
-        for (int i = 0; i < PDDR_STATUS_MESSAGE_LENGTH_SWITCH; i++)
-        {
+        for (int i = 0; i < PDDR_STATUS_MESSAGE_LENGTH_SWITCH; i++) {
             string path = "status_message[";
             sprintf(txt, "%d", i);
             path.append(txt);
             path.append("]");
             message_buf = getFieldValue(path);
-            for (int k = 24; k > -1; k -= 8)
-            {
+            for (int k = 24; k > -1; k -= 8) {
                 c = (char)(message_buf >> k);
-                if (c == '\0')
-                {
+                if (c == '\0') {
                     finalize = true;
                     break;
                 }
                 message.push_back(c);
             }
-            if (finalize == true)
-            {
+            if (finalize == true) {
                 break;
             }
         }
         setPrintVal(_troubInfoCmd, "Recommendation", message, color, true, !_prbsTestMode);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException(string(exc.what()));
     }
@@ -2077,19 +1866,16 @@ void MlxlinkCommander::showPddr()
         supportedInfoPage();
         troubInfoPage();
         runningVersion();
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             showTestMode();
-        }
-        else
-        {
+        } else {
             std::cout << _operatingInfoCmd;
             std::cout << _supportedInfoCmd;
             std::cout << _troubInfoCmd;
             std::cout << _toolInfoCmd;
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         throw MlxRegException(string("Showing PDDR raised the following exception: \n") + string(exc.what()));
     }
@@ -2099,24 +1885,20 @@ void MlxlinkCommander::getPtys()
 {
     sendPrmReg(ACCESS_REG_PTYS, GET, "proto_mask=%d", _protoActive);
 
-    if (_protoActive == ETH)
-    {
+    if (_protoActive == ETH) {
         _activeSpeedEx = getFieldValue("ext_eth_proto_oper");
         _activeSpeed = getFieldValue("eth_proto_oper");
         _protoAdmin = getFieldValue("eth_proto_admin");
         _protoAdminEx = getFieldValue("ext_eth_proto_admin");
         _protoCapabilityEx = getFieldValue("ext_eth_proto_capability");
         _deviceCapability =
-          _protoCapabilityEx ? getFieldValue("ext_eth_proto_capability") : getFieldValue("eth_proto_capability");
-    }
-    else
-    {
+            _protoCapabilityEx ? getFieldValue("ext_eth_proto_capability") : getFieldValue("eth_proto_capability");
+    } else {
         _deviceCapability = getFieldValue("ib_proto_capability");
     }
 
     _anDisable = getFieldValue("an_disable_admin");
-    if (_anDisable)
-    {
+    if (_anDisable) {
         u_int32_t val = _protoAdminEx ? _protoAdminEx : _protoAdmin;
         _speedForce = " - " + SupportedSpeeds2Str(_protoActive, val, (bool)_protoAdminEx);
     }
@@ -2124,8 +1906,8 @@ void MlxlinkCommander::getPtys()
 
 void MlxlinkCommander::showTestMode()
 {
-    std::map<std::string, std::string> pprtMap = getPprt();
-    std::map<std::string, std::string> ppttMap = getPptt();
+    std::map < std::string, std::string > pprtMap = getPprt();
+    std::map < std::string, std::string > ppttMap = getPptt();
 
     setPrintTitle(_testModeInfoCmd, "Test Mode Info", TEST_MODE_INFO_LAST);
     setPrintVal(_testModeInfoCmd, "RX PRBS Mode", pprtMap["pprtPrbsMode"]);
@@ -2140,19 +1922,18 @@ void MlxlinkCommander::showTestMode()
 
 int MlxlinkCommander::prbsModeToMask(const string& mode)
 {
-    // SQUARE_WAVE and SQUARE_WAVEA have the same enum
+    /* SQUARE_WAVE and SQUARE_WAVEA have the same enum */
     string modeToCheck = mode;
-    if (mode == "SQUARE_WAVE")
-    {
+
+    if (mode == "SQUARE_WAVE") {
         modeToCheck += "A";
     }
     int mask = PRBS31;
-    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin();
+
+    for (map < u_int32_t, string > ::iterator it = _mlxlinkMaps->_prbsModesList.begin();
          it != _mlxlinkMaps->_prbsModesList.end();
-         it++)
-    {
-        if (modeToCheck == it->second)
-        {
+         it++) {
+        if (modeToCheck == it->second) {
             mask = it->first;
             break;
         }
@@ -2163,35 +1944,36 @@ int MlxlinkCommander::prbsModeToMask(const string& mode)
 string MlxlinkCommander::prbsMaskToMode(u_int32_t mask, u_int32_t modeSelector)
 {
     string val = "N/A";
+
     val = _mlxlinkMaps->_prbsModesList[mask];
-    if (modeSelector == PRBS_RX && mask == SQUARE_WAVEA)
-    {
-        val = deleteLastChar(val); // return SQUARE_WAVE without A
+    if ((modeSelector == PRBS_RX) && (mask == SQUARE_WAVEA)) {
+        val = deleteLastChar(val); /* return SQUARE_WAVE without A */
     }
     return val;
 }
 
-std::map<std::string, std::string> MlxlinkCommander::getPprt()
+std::map < std::string, std::string > MlxlinkCommander::getPprt()
 {
-    std::map<string, string> pprtMap;
+    std::map < string, string > pprtMap;
 
     sendPrmReg(ACCESS_REG_PPRT, GET, "e=%d", PPRT_PPTT_ENABLE);
 
     u_int32_t statusMask = getFieldValue("prbs_lock_status");
+
     statusMask |= (getFieldValue("prbs_lock_status_ext") << 4);
 
     pprtMap["pprtPrbsMode"] = prbsMaskToMode(getFieldValue("prbs_mode_admin"), PRBS_RX);
     pprtMap["pprtLaneRate"] = getStrByValue(getFieldValue("lane_rate_oper"), _mlxlinkMaps->_prbsLaneRateList);
     pprtMap["pprtTuningStatus"] =
-      getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
+        getStrByValue(getFieldValue("prbs_rx_tuning_status"), _mlxlinkMaps->_prbsRxTuningStatus);
     pprtMap["pprtLockStatus"] = prbsMaskToLockStatus(statusMask, _numOfLanes);
 
     return pprtMap;
 }
 
-std::map<std::string, std::string> MlxlinkCommander::getPptt()
+std::map < std::string, std::string > MlxlinkCommander::getPptt()
 {
-    std::map<string, string> ppttMap;
+    std::map < string, string > ppttMap;
 
     sendPrmReg(ACCESS_REG_PPTT, GET, "e=%d", PPRT_PPTT_ENABLE);
 
@@ -2211,8 +1993,7 @@ void MlxlinkCommander::prepareBerInfo()
     setPrintVal(_berInfoCmd, "Time Since Last Clear [Min]",
                 AmberField::getValueFromFields(_ppcntFields, "Time_since_last_clear_[Min]"), ANSI_COLOR_RESET, true,
                 _linkUP);
-    if (_protoActive == IB)
-    {
+    if (_protoActive == IB) {
         setPrintVal(_berInfoCmd, "Symbol Errors", AmberField::getValueFromFields(_ppcntFields, "Symbol_Errors"),
                     ANSI_COLOR_RESET, true, _linkUP);
         setPrintVal(_berInfoCmd, "Symbol BER", AmberField::getValueFromFields(_ppcntFields, "Symbol_BER"),
@@ -2225,13 +2006,13 @@ void MlxlinkCommander::prepareBerInfo()
                 ANSI_COLOR_RESET, true, _linkUP);
 
     string phyRawErr = AmberField::getValueFromFields(_ppcntFields, "Raw_Errors_lane", false);
+
     findAndReplace(phyRawErr, "_", ",");
     phyRawErr = getValuesOfActiveLanes(phyRawErr);
 
     setPrintVal(_berInfoCmd, "Raw Physical Errors Per Lane", phyRawErr, ANSI_COLOR_RESET, true, _linkUP, true);
 
-    if (_protoActive == ETH)
-    {
+    if (_protoActive == ETH) {
         sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_PHY_GROUP);
 
         u_int32_t linkDownCounter = getFieldValue("link_down_events");
@@ -2249,19 +2030,20 @@ void MlxlinkCommander::prepareBerInfoEDR()
     sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
 
     double lastClearTimer =
-      (double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) /
-      60000.0;
+        (double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) /
+        60000.0;
+
     sprintf(lastClearTimerBuff, "%.01f", lastClearTimer);
     string symbolErrors =
-      to_string(add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low")));
+        to_string(add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low")));
 
     setPrintVal(_berInfoCmd, "Time Since Last Clear [Min]", lastClearTimerBuff, ANSI_COLOR_RESET, true, _linkUP);
     setPrintVal(_berInfoCmd, "Effective Physical Errors", symbolErrors, ANSI_COLOR_RESET, true, _linkUP);
 
-    std::vector<string> rawErrorsPerLane;
+    std::vector < string > rawErrorsPerLane;
     string phy_raw_err = "";
-    for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-    {
+
+    for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
         string laneStr = to_string(lane);
         phy_raw_err = to_string(add32BitTo64(getFieldValue("phy_raw_errors_lane" + laneStr + "_high"),
                                              getFieldValue("phy_raw_errors_lane" + laneStr + "_low")));
@@ -2275,8 +2057,7 @@ void MlxlinkCommander::prepareBerInfoEDR()
     setPrintVal(_berInfoCmd, "Raw Physical BER", getFieldStr("raw_ber_coef") + "E-" + getFieldStr("raw_ber_magnitude"),
                 ANSI_COLOR_RESET, true, _linkUP);
 
-    if (_protoActive == ETH)
-    {
+    if (_protoActive == ETH) {
         sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_PHY_GROUP);
 
         u_int32_t linkDownCounter = getFieldValue("link_down_events");
@@ -2291,32 +2072,26 @@ void MlxlinkCommander::showBer()
 {
     try
     {
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             showTestModeBer();
             return;
         }
-        if (_userInput._pcie)
-        {
+        if (_userInput._pcie) {
             showMpcntPerformance(_dpn);
             return;
         }
         setPrintTitle(_berInfoCmd, "Physical Counters and BER Info",
                       _productTechnology >= PRODUCT_16NM ? BER_INFO_NDR_LAST : BER_INFO_LAST);
 
-        if (_productTechnology < PRODUCT_16NM)
-        {
+        if (_productTechnology < PRODUCT_16NM) {
             prepareBerInfoEDR();
-        }
-        else
-        {
+        } else {
             prepareBerInfo();
             setPrintVal(_berInfoCmd, "Raw Physical BER", AmberField::getValueFromFields(_ppcntFields, "Raw_BER"),
                         ANSI_COLOR_RESET, true, _linkUP);
         }
 
-        if (_protoActive == IB)
-        {
+        if (_protoActive == IB) {
             sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_IB_PORT_COUNTERS_GROUP);
 
             setPrintVal(_berInfoCmd, "Link Down Counter", getFieldStr("link_downed_counter"), ANSI_COLOR_RESET, true,
@@ -2327,10 +2102,10 @@ void MlxlinkCommander::showBer()
 
         cout << _berInfoCmd;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing BER via PPCNT raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing BER via PPCNT raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
@@ -2338,33 +2113,34 @@ void MlxlinkCommander::showTestModeBer()
 {
     sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
 
-    std::vector<string> errors;
-    for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-    {
+    std::vector < string > errors;
+    for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
         errors.push_back(to_string(add32BitTo64(getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_high"),
                                                 getFieldValue("phy_raw_errors_lane" + to_string(lane) + "_low"))));
     }
 
-    char buff[64];
+    char   buff[64];
     double val =
-      (double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) /
-      60000.0;
+        (double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) /
+        60000.0;
+
     sprintf(buff, "%.01f", val);
 
     setPrintTitle(_testModeBerInfoCmd, "Physical Counters and BER Info (PRBS)", TEST_MODE_BER_INFO_LAST);
     setPrintVal(_testModeBerInfoCmd, "Time Since Last Clear [Min]", buff);
     setPrintVal(_testModeBerInfoCmd, "PRBS Errors", getStringFromVector(errors));
-    setPrintVal(_testModeBerInfoCmd, "PRBS BER", getFieldStr("raw_ber_coef") + "E-" + getFieldStr("raw_ber_magnitude"));
+    setPrintVal(_testModeBerInfoCmd, "PRBS BER",
+                getFieldStr("raw_ber_coef") + "E-" + getFieldStr("raw_ber_magnitude"));
 
     cout << _testModeBerInfoCmd;
 }
 
 void MlxlinkCommander::getPcieNdrCounters()
 {
-    if (_productTechnology >= PRODUCT_16NM)
-    {
+    if (_productTechnology >= PRODUCT_16NM) {
         string berStr =
-          to_string(getFieldValue("effective_ber_coef")) + "E-" + to_string(getFieldValue("effective_ber_magnitude"));
+            to_string(getFieldValue("effective_ber_coef")) + "E-" +
+            to_string(getFieldValue("effective_ber_magnitude"));
         setPrintVal(_mpcntPerfInfCmd, "Effective ber", berStr);
     }
 }
@@ -2387,19 +2163,13 @@ void MlxlinkCommander::showMpcntPerformance(DPN& dpn)
 
 void MlxlinkCommander::checkPCIeValidity()
 {
-    if (!_userInput._sendDpn)
-    {
-        if (_validDpns.size() == 0)
-        {
+    if (!_userInput._sendDpn) {
+        if (_validDpns.size() == 0) {
             throw MlxRegException("No valid depth, node and pcie_index detected!");
-        }
-        else if (_validDpns.size() == 1)
-        {
+        } else if (_validDpns.size() == 1) {
             _dpn = _validDpns[0];
             _localPort = getLocalPortFromMPIR(_dpn);
-        }
-        else if (_validDpns.size() > 1 && !_userInput._portSpecified)
-        {
+        } else if ((_validDpns.size() > 1) && !_userInput._portSpecified) {
             throw MlxRegException("The --depth, --pcie_index and --node must be specified!");
         }
     }
@@ -2407,49 +2177,40 @@ void MlxlinkCommander::checkPCIeValidity()
 
 void MlxlinkCommander::prepare40_28_16nmEyeInfo(u_int32_t numOfLanes)
 {
-    std::vector<string> physicalGrades;
-    std::vector<string> heightLengths;
-    std::vector<string> phaseWidths;
+    std::vector < string > physicalGrades;
+    std::vector < string > heightLengths;
+    std::vector < string > phaseWidths;
     string phaseEONegStr = "N/A";
     string offsetEONegStr = "N/A";
-    bool validPhaseHeight = _productTechnology <= PRODUCT_16NM || _userInput._pcie;
+    bool   validPhaseHeight = _productTechnology <= PRODUCT_16NM || _userInput._pcie;
 
     string height_eo_pos("height_eo_pos");
     string height_eo_neg("height_eo_neg");
     string phase_eo_pos("phase_eo_pos");
     string phase_eo_neg("phase_eo_neg");
-    if (_productTechnology == PRODUCT_16NM)
-    {
+    if (_productTechnology == PRODUCT_16NM) {
         height_eo_pos.append("_mid");
         height_eo_neg.append("_mid");
         phase_eo_pos.append("_mid");
         phase_eo_neg.append("_mid");
     }
-    for (u_int32_t lane = 0; lane < numOfLanes; lane++)
-    {
+    for (u_int32_t lane = 0; lane < numOfLanes; lane++) {
         sendPrmReg(ACCESS_REG_SLRG, GET, "lane=%d", lane);
 
         physicalGrades.push_back(MlxlinkRecord::addSpaceForSlrg(to_string(getFieldValue("grade"))));
-        if (validPhaseHeight)
-        {
+        if (validPhaseHeight) {
             int offsetEOPos = getHeight(getFieldValue(height_eo_pos));
             int offsetEONeg = getHeight(getFieldValue(height_eo_neg));
-            if (_productTechnology == PRODUCT_16NM && (offsetEOPos + offsetEONeg) == 0)
-            {
+            if ((_productTechnology == PRODUCT_16NM) && ((offsetEOPos + offsetEONeg) == 0)) {
                 offsetEONegStr = "N/A";
-            }
-            else
-            {
+            } else {
                 offsetEONegStr = to_string(offsetEOPos + offsetEONeg);
             }
             int phaseEOPos = getPhase(getFieldValue(phase_eo_pos));
             int phaseEONeg = getPhase(getFieldValue(phase_eo_neg));
-            if (_productTechnology == PRODUCT_16NM && (phaseEOPos + phaseEONeg) == 0)
-            {
+            if ((_productTechnology == PRODUCT_16NM) && ((phaseEOPos + phaseEONeg) == 0)) {
                 phaseEONegStr = "N/A";
-            }
-            else
-            {
+            } else {
                 phaseEONegStr = to_string(phaseEOPos + phaseEONeg);
             }
         }
@@ -2457,7 +2218,12 @@ void MlxlinkCommander::prepare40_28_16nmEyeInfo(u_int32_t numOfLanes)
         phaseWidths.push_back(MlxlinkRecord::addSpaceForSlrg(phaseEONegStr));
     }
 
-    setPrintVal(_eyeOpeningInfoCmd, "Physical Grade", getStringFromVector(physicalGrades), ANSI_COLOR_RESET, true, true,
+    setPrintVal(_eyeOpeningInfoCmd,
+                "Physical Grade",
+                getStringFromVector(physicalGrades),
+                ANSI_COLOR_RESET,
+                true,
+                true,
                 true);
     setPrintVal(_eyeOpeningInfoCmd, "Height Eye Opening [mV]", getStringFromVector(heightLengths), ANSI_COLOR_RESET,
                 true, true, true);
@@ -2467,21 +2233,17 @@ void MlxlinkCommander::prepare40_28_16nmEyeInfo(u_int32_t numOfLanes)
 
 void MlxlinkCommander::startSlrgPciScan(u_int32_t numOfLanesToUse)
 {
-    // Start EOM measurements per lane
-    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++)
-    {
+    /* Start EOM measurements per lane */
+    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++) {
         sendPrmReg(ACCESS_REG_SLRG, GET, "lane=%d,fom_measurment=%d", lane, SLRG_EOM_COMPOSITE);
     }
-    // For each lane, wait until process finish
-    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++)
-    {
+    /* For each lane, wait until process finish */
+    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++) {
         u_int32_t it = 0;
-        while (it < SLRG_PCIE_7NM_TIMEOUT)
-        {
+        while (it < SLRG_PCIE_7NM_TIMEOUT) {
             sendPrmReg(ACCESS_REG_SLRG, GET, "lane=%d", lane);
 
-            if (getFieldValue("status"))
-            {
+            if (getFieldValue("status")) {
                 break;
             }
 
@@ -2493,25 +2255,20 @@ void MlxlinkCommander::startSlrgPciScan(u_int32_t numOfLanesToUse)
 
 void MlxlinkCommander::prepare7nmEyeInfo(u_int32_t numOfLanesToUse)
 {
-    std::vector<string> legand, initialFom, lastFom, upperFom, midFom, lowerFom;
+    std::vector < string > legand, initialFom, lastFom, upperFom, midFom, lowerFom;
     u_int32_t status = 0;
     u_int32_t fomMeasurement = SLRG_EOM_NONE;
 
-    if (!_userInput._pcie)
-    {
+    if (!_userInput._pcie) {
         fomMeasurement = SLRG_EOM_COMPOSITE;
-        if (!isNRZSpeed(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
-        {
+        if (!isNRZSpeed((_protoActive == IB) ? _activeSpeed : _activeSpeedEx, _protoActive)) {
             fomMeasurement |= (SLRG_EOM_UPPER | SLRG_EOM_MIDDLE | SLRG_EOM_LOWER);
         }
-    }
-    else
-    {
+    } else {
         startSlrgPciScan(numOfLanesToUse);
     }
 
-    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++)
-    {
+    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++) {
         status = 0;
 
         sendPrmReg(ACCESS_REG_SLRG, GET, "lane=%d,fom_measurment=%d", lane, fomMeasurement);
@@ -2527,9 +2284,11 @@ void MlxlinkCommander::prepare7nmEyeInfo(u_int32_t numOfLanesToUse)
     }
 
     string fomMode = _mlxlinkMaps->_slrgFomMode[getFieldValue("fom_mode")];
+
     setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
     setPrintVal(_eyeOpeningInfoCmd, "Lane", getStringFromVector(legand), ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", getStringFromVector(initialFom), ANSI_COLOR_RESET, true, true, true);
+    setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", getStringFromVector(initialFom), ANSI_COLOR_RESET, true, true,
+                true);
     setPrintVal(_eyeOpeningInfoCmd, "Last FOM", getStringFromVector(lastFom), ANSI_COLOR_RESET, true, true, true);
     setPrintVal(_eyeOpeningInfoCmd, "Upper Grades", getStringFromVector(upperFom), ANSI_COLOR_RESET,
                 (fomMeasurement & SLRG_EOM_UPPER), true, true);
@@ -2541,66 +2300,55 @@ void MlxlinkCommander::prepare7nmEyeInfo(u_int32_t numOfLanesToUse)
 
 void MlxlinkCommander::showEye()
 {
-    if (_userInput._pcie)
-    {
+    if (_userInput._pcie) {
         checkPCIeValidity();
     }
 
     try
     {
-        if (_userInput._pcie)
-        {
+        if (_userInput._pcie) {
             sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", _dpn.depth, _dpn.pcieIndex, _dpn.node);
 
-            if (getFieldValue("link_speed_active") < GEN3)
-            {
+            if (getFieldValue("link_speed_active") < GEN3) {
                 throw MlxRegException("Eye information available for Gen3 and above");
             }
         }
 
         u_int32_t numOfLanesToUse = (_userInput._pcie) ? _numOfLanesPcie : _numOfLanes;
-        string showEyeTitle = "EYE Opening Info";
-        if (_userInput._pcie)
-        {
+        string    showEyeTitle = "EYE Opening Info";
+        if (_userInput._pcie) {
             showEyeTitle += " (PCIe)";
         }
         setPrintTitle(_eyeOpeningInfoCmd, showEyeTitle, EYE_OPENING_INFO_LAST);
-        if (_productTechnology <= PRODUCT_16NM)
-        {
+        if (_productTechnology <= PRODUCT_16NM) {
             prepare40_28_16nmEyeInfo(numOfLanesToUse);
-        }
-        else if (_productTechnology == PRODUCT_7NM || _productTechnology == PRODUCT_5NM)
-        {
+        } else if ((_productTechnology == PRODUCT_7NM) || (_productTechnology == PRODUCT_5NM)) {
             prepare7nmEyeInfo(numOfLanesToUse);
         }
         cout << _eyeOpeningInfoCmd;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing Eye via SLRG raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing Eye via SLRG raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
 string MlxlinkCommander::fecMaskToUserInputStr(u_int32_t fecCapMask)
 {
     u_int32_t mask = 0;
-    string validFecStr = "";
-    string shortFec = "";
-    for (double bitIdx = 0; bitIdx < 16; bitIdx++)
-    {
+    string    validFecStr = "";
+    string    shortFec = "";
+
+    for (double bitIdx = 0; bitIdx < 16; bitIdx++) {
         mask = (u_int32_t)pow(2.0, bitIdx);
-        if (fecCapMask & mask)
-        {
-            if (_mlxlinkMaps->_fecModeMask.count(mask))
-            {
+        if (fecCapMask & mask) {
+            if (_mlxlinkMaps->_fecModeMask.count(mask)) {
                 shortFec = _mlxlinkMaps->_fecModeMask[mask].second;
-                if (shortFec.find("PLR") != string::npos)
-                {
+                if (shortFec.find("PLR") != string::npos) {
                     continue;
                 }
-                if (shortFec.find("-544") != string::npos || shortFec.find("-272") != string::npos)
-                {
+                if ((shortFec.find("-544") != string::npos) || (shortFec.find("-272") != string::npos)) {
                     shortFec = shortFec.substr(0, 2);
                 }
                 validFecStr += shortFec + "(" + _mlxlinkMaps->_fecModeMask[mask].first + ")/";
@@ -2608,6 +2356,7 @@ string MlxlinkCommander::fecMaskToUserInputStr(u_int32_t fecCapMask)
         }
     }
     string auFec = _mlxlinkMaps->_fecModeMask[0].second + "(" + _mlxlinkMaps->_fecModeMask[0].first + ")";
+
     validFecStr = validFecStr.empty() ? "" : (auFec + "/" + deleteLastChar(validFecStr));
     return validFecStr;
 }
@@ -2616,20 +2365,17 @@ string MlxlinkCommander::getSupportedFecForSpeed(const string& speed)
 {
     string fecCap = "0x0 (N/A)";
     string protoStr = _protoActive == IB ? "ib_" : "";
-    if (!_prbsTestMode)
-    {
+
+    if (!_prbsTestMode) {
         string speedToCheck = speed;
         speedToCheck = toLowerCase(speedToCheck);
-        if (speedToCheck == "10g" || speedToCheck == "40g")
-        {
+        if ((speedToCheck == "10g") || (speedToCheck == "40g")) {
             speedToCheck = "10g_40g";
         }
-        if (speedToCheck == "50g_2x")
-        {
+        if (speedToCheck == "50g_2x") {
             speedToCheck = "50g";
         }
-        if (speedToCheck == "100g_4x")
-        {
+        if (speedToCheck == "100g_4x") {
             speedToCheck = "100g";
         }
         fecCap = fecMaskToStr(getFieldValue(protoStr + "fec_override_cap_" + speedToCheck));
@@ -2640,16 +2386,14 @@ string MlxlinkCommander::getSupportedFecForSpeed(const string& speed)
 string MlxlinkCommander::fecMaskToStr(u_int32_t mask)
 {
     char strMask[32];
+
     snprintf(strMask, sizeof(strMask), "0x%x (", mask);
 
     string fecStr = string(strMask);
 
-    if (mask)
-    {
+    if (mask) {
         fecStr += getStrByMaskFromPair(mask, _mlxlinkMaps->_fecModeMask, ", ");
-    }
-    else
-    {
+    } else {
         fecStr = "0x0 (N/A";
     }
     fecStr += ")";
@@ -2664,80 +2408,71 @@ void MlxlinkCommander::showFEC()
         sendPrmReg(ACCESS_REG_PPLM, GET);
 
         string supportedSpeedsStr = SupportedSpeeds2Str(_protoActive, _deviceCapability, _protoCapabilityEx);
-        vector<string> supportedSpeeds = MlxlinkRecord::split(supportedSpeedsStr, ",");
+        vector < string > supportedSpeeds = MlxlinkRecord::split(supportedSpeedsStr, ",");
 
-        for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++)
-        {
-            if (isIn((*it).first, supportedSpeeds))
-            {
+        for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++) {
+            if (isIn((*it).first, supportedSpeeds)) {
                 it->second = getSupportedFecForSpeed((*it).first);
             }
         }
 
         setPrintTitle(_fecCapInfoCmd, HEADER_FEC_INFO, supportedSpeeds.size() + 1);
 
-        bool noFecDetected = true;
+        bool   noFecDetected = true;
         string bitEthIndecator = "bE";
-        for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++)
-        {
-            if (!(*it).second.empty())
-            {
+        for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++) {
+            if (!(*it).second.empty()) {
                 noFecDetected = false;
             }
-            if (isIn((*it).first, supportedSpeeds))
-            {
+            if (isIn((*it).first, supportedSpeeds)) {
                 setPrintVal(_fecCapInfoCmd,
                             "FEC Capability " + (*it).first +
-                              ((_productTechnology < PRODUCT_16NM && _protoActive == ETH) ? bitEthIndecator : ""),
+                            ((_productTechnology < PRODUCT_16NM && _protoActive == ETH) ? bitEthIndecator : ""),
                             (*it).second, ANSI_COLOR_RESET, true, true, true);
             }
         }
-        if (noFecDetected)
-        {
+        if (noFecDetected) {
             MlxlinkRecord::printWar("FEC information is not available for InfiniBand protocol", _jsonRoot);
-        }
-        else
-        {
+        } else {
             cout << _fecCapInfoCmd;
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing FEC raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing FEC raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
 string MlxlinkCommander::getSltpHeader()
 {
     string sep = ",";
-    vector<string> sltpHeader;
-    map<u_int32_t, PRM_FIELD> sltpParam;
+
+    vector < string > sltpHeader;
+    map < u_int32_t, PRM_FIELD > sltpParam;
     u_int32_t activeSpeed = _protoActive == IB ? _activeSpeed : _activeSpeedEx;
 
-    switch (_productTechnology)
-    {
-        case PRODUCT_7NM:
-            sltpParam = _mlxlinkMaps->_SltpNdrParams;
-            break;
-        case PRODUCT_16NM:
-            sltpParam = _mlxlinkMaps->_SltpHdrParams;
-            break;
-        default:
-            sltpParam = _mlxlinkMaps->_SltpEdrParams;
-            activeSpeed = _protoActive;
-            break;
+    switch (_productTechnology) {
+    case PRODUCT_7NM:
+        sltpParam = _mlxlinkMaps->_SltpNdrParams;
+        break;
+
+    case PRODUCT_16NM:
+        sltpParam = _mlxlinkMaps->_SltpHdrParams;
+        break;
+
+    default:
+        sltpParam = _mlxlinkMaps->_SltpEdrParams;
+        activeSpeed = _protoActive;
+        break;
     }
 
-    for (auto const& param : sltpParam)
-    {
-        if ((param.second.validationMask & activeSpeed) || _userInput._pcie)
-        {
+    for (auto const& param : sltpParam) {
+        if ((param.second.validationMask & activeSpeed) || _userInput._pcie) {
             if ((param.second.fieldAccess & FIELD_ACCESS_R) ||
-                (_userInput._advancedMode && (param.second.fieldAccess & FIELD_ACCESS_ADVANCED)))
-            {
+                (_userInput._advancedMode && (param.second.fieldAccess & FIELD_ACCESS_ADVANCED))) {
                 sltpHeader.push_back(
-                  MlxlinkRecord::addSpace(param.second.uiField, param.second.uiField.size() + 1, false));
+                    MlxlinkRecord::addSpace(param.second.uiField, param.second.uiField.size() + 1, false));
             }
         }
     }
@@ -2747,62 +2482,63 @@ string MlxlinkCommander::getSltpHeader()
 
 void MlxlinkCommander::showSltp()
 {
-    if (_userInput._pcie)
-    {
+    if (_userInput._pcie) {
         checkPCIeValidity();
     }
     try
     {
-        bool valid = true;
+        bool      valid = true;
         u_int32_t numOfLanesToUse = (_userInput._pcie) ? _numOfLanesPcie : _numOfLanes;
-        std::vector<std::vector<string>> sltpLanes(numOfLanesToUse, std::vector<string>());
+        std::vector < std::vector < string >> sltpLanes(numOfLanesToUse, std::vector < string > ());
         string showSltpTitle = "Serdes Tuning Transmitter Info";
         string sltpHeader = getSltpHeader();
 
-        if (_userInput._pcie)
-        {
+        if (_userInput._pcie) {
             showSltpTitle += " (PCIe)";
         }
         setPrintTitle(_sltpInfoCmd, showSltpTitle, numOfLanesToUse + 1);
 
-        if (!_linkUP && !_userInput._pcie && !_prbsTestMode)
-        {
+        if (!_linkUP && !_userInput._pcie && !_prbsTestMode) {
             setPrintVal(_sltpInfoCmd, "Serdes TX parameters", sltpHeader, ANSI_COLOR_RESET, true, false, true);
             cout << _sltpInfoCmd;
             return;
         }
         setPrintVal(_sltpInfoCmd, "Serdes TX parameters", sltpHeader, ANSI_COLOR_RESET, true, true, true);
 
-        for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++)
-        {
+        for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++) {
             sendPrmReg(ACCESS_REG_SLTP, GET, "lane=%d,c_db=%d", lane, _userInput._db);
 
-            switch (_productTechnology)
-            {
-                case PRODUCT_5NM:
-                    prepareSltpXdrGen(sltpLanes, lane);
-                    break;
-                case PRODUCT_7NM:
-                    prepareSltpNdrGen(sltpLanes, lane);
-                    break;
-                default:
-                    prepareSltpEdrHdrGen(sltpLanes, lane);
+            switch (_productTechnology) {
+            case PRODUCT_5NM:
+                prepareSltpXdrGen(sltpLanes, lane);
+                break;
+
+            case PRODUCT_7NM:
+                prepareSltpNdrGen(sltpLanes, lane);
+                break;
+
+            default:
+                prepareSltpEdrHdrGen(sltpLanes, lane);
             }
 
-            if (!getFieldValue("status"))
-            {
+            if (!getFieldValue("status")) {
                 valid = false;
             }
 
-            setPrintVal(_sltpInfoCmd, "Lane " + to_string(lane), getStringFromVector(sltpLanes[lane]), ANSI_COLOR_RESET,
-                        true, valid, true);
+            setPrintVal(_sltpInfoCmd,
+                        "Lane " + to_string(lane),
+                        getStringFromVector(sltpLanes[lane]),
+                        ANSI_COLOR_RESET,
+                        true,
+                        valid,
+                        true);
         }
         cout << _sltpInfoCmd;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing SLTP raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing SLTP raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
@@ -2810,7 +2546,7 @@ void MlxlinkCommander::showDeviceData()
 {
     try
     {
-        std::vector<string> showDeviceDataValues;
+        std::vector < string > showDeviceDataValues;
         bool success = false;
 
         try
@@ -2818,7 +2554,7 @@ void MlxlinkCommander::showDeviceData()
             sendPrmReg(ACCESS_REG_MSGI, GET);
             success = true;
         }
-        catch (...)
+        catch(...)
         {
         }
 
@@ -2832,23 +2568,22 @@ void MlxlinkCommander::showDeviceData()
 
         cout << _showDeviceInfoCmd;
 
-        if (_isHCA)
-        {
+        if (_isHCA) {
             MlxlinkRecord::printWar("Note: P/N, Product Name, S/N and Revision are supported only in switches",
                                     _jsonRoot);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing Device Data via MSGI raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing Device Data via MSGI raised the following exception: ") + string(exc.what()) +
+            string("\n");
     }
 }
 
 void MlxlinkCommander::showBerMonitorInfo()
 {
-    if (_isHCA)
-    {
+    if (_isHCA) {
         throw MlxRegException("\"--" BER_MONITOR_INFO_FLAG "\" option is not supported for HCA");
     }
     try
@@ -2871,10 +2606,11 @@ void MlxlinkCommander::showBerMonitorInfo()
 
         cout << _showBerMonitorInfo;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing BER Monitor via PPBMC raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing BER Monitor via PPBMC raised the following exception: ") + string(exc.what()) +
+            string("\n");
     }
 }
 
@@ -2884,9 +2620,8 @@ void MlxlinkCommander::showExternalPhy()
     {
         gearboxBlock(PEPC_SHOW_FLAG);
 
-        if (_isHCA || _devID == DeviceSwitchIB || _devID == DeviceSwitchIB2 || _devID == DeviceQuantum ||
-            _devID == DeviceQuantum2 || _devID == DeviceQuantum3 || _devID == DeviceBW00)
-        {
+        if (_isHCA || (_devID == DeviceSwitchIB) || (_devID == DeviceSwitchIB2) || (_devID == DeviceQuantum) ||
+            (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100)) {
             throw MlxRegException("\"--" PEPC_SHOW_FLAG "\" option is not supported for HCA and InfiniBand switches");
         }
 
@@ -2899,75 +2634,67 @@ void MlxlinkCommander::showExternalPhy()
 
         cout << _extPhyInfoCmd;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing External PHY via PEPC raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing External PHY via PEPC raised the following exception: ") + string(exc.what()) +
+            string("\n");
     }
 }
 
 void MlxlinkCommander::initValidDPNList()
 {
-    bool valid = false;
+    bool      valid = false;
     u_int32_t maxNumOfHost = 4;
     u_int32_t maxNumOfDsPort = 16;
     u_int32_t maxDepth = 4;
     u_int32_t depth, pcieIndex, node;
-    string bdf = "";
+    string    bdf = "";
 
-    if (_validDpns.empty())
-    {
-        for (pcieIndex = 0; pcieIndex < maxNumOfHost; pcieIndex++)
-        {
+    if (_validDpns.empty()) {
+        for (pcieIndex = 0; pcieIndex < maxNumOfHost; pcieIndex++) {
             try
             {
                 sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", 0, pcieIndex, 0);
                 valid = getFieldValue("bdf0");
             }
-            catch (...)
+            catch(...)
             {
                 valid = false;
             }
-            if (valid && getFieldValue("port_type") == PORT_TYPE_EP)
-            {
+            if (valid && (getFieldValue("port_type") == PORT_TYPE_EP)) {
                 _validDpns.push_back(DPN(0, pcieIndex, 0, getBDFStr(getFieldValue("bdf0"))));
-            }
-            else
-            {
-                if (valid && getFieldValue("port_type") == PORT_TYPE_US)
-                {
+            } else {
+                if (valid && (getFieldValue("port_type") == PORT_TYPE_US)) {
                     _validDpns.push_back(DPN(0, pcieIndex, 0, getBDFStr(getFieldValue("bdf0"))));
                 }
-                for (depth = 1; depth < maxDepth; depth++)
-                {
+                for (depth = 1; depth < maxDepth; depth++) {
                     try
                     {
                         sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", depth, pcieIndex, 0);
-                        if (getFieldValue("port_type") == PORT_TYPE_DS)
-                        {
+                        if (getFieldValue("port_type") == PORT_TYPE_DS) {
                             _validDpns.push_back(DPN(depth, pcieIndex, 0, getBDFStr(getFieldValue("bdf0"))));
-                            for (node = 1; node < maxNumOfDsPort; node++)
-                            {
+                            for (node = 1; node < maxNumOfDsPort; node++) {
                                 try
                                 {
                                     sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", depth,
                                                pcieIndex, node);
-                                    _validDpns.push_back(DPN(depth, pcieIndex, node, getBDFStr(getFieldValue("bdf0"))));
+                                    _validDpns.push_back(DPN(depth, pcieIndex, node,
+                                                             getBDFStr(getFieldValue("bdf0"))));
                                 }
-                                catch (...)
+                                catch(...)
                                 {
                                     break;
                                 }
                             }
                         }
                     }
-                    catch (...)
+                    catch(...)
                     {
                     }
                 }
             }
-            if (!_isHCA)
-            {
+            if (!_isHCA) {
                 break;
             }
         }
@@ -2978,17 +2705,15 @@ void MlxlinkCommander::showPcieLinks()
 {
     try
     {
-        if (_validDpns.size() == 0)
-        {
+        if (_validDpns.size() == 0) {
             throw MlxRegException("No valid DPN's detected!");
         }
         setPrintTitle(_validPcieLinks, "Valid PCIe Links", _validDpns.size() + 1);
         setPrintVal(_validPcieLinks, "Legend", "depth ,pcie_index ,node ,port ,bdf", ANSI_COLOR_RESET, true, true,
                     true);
-        for (u_int32_t i = 0; i < _validDpns.size(); i++)
-        {
+        for (u_int32_t i = 0; i < _validDpns.size(); i++) {
             char dpnStr[128];
-            int localPort = getLocalPortFromMPIR(_validDpns[i]);
+            int  localPort = getLocalPortFromMPIR(_validDpns[i]);
             snprintf(dpnStr, sizeof(dpnStr), "%-5d ,%-10d ,%-4d ,%-4d ,%s", _validDpns[i].depth,
                      _validDpns[i].pcieIndex, _validDpns[i].node, localPort, _validDpns[i].bdf.c_str());
             setPrintVal(_validPcieLinks, "Link " + to_string(i + 1), dpnStr, ANSI_COLOR_RESET, localPort >= 0, true,
@@ -2996,10 +2721,10 @@ void MlxlinkCommander::showPcieLinks()
         }
         cout << _validPcieLinks;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing valid PCIe links raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing valid PCIe links raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
@@ -3007,54 +2732,49 @@ void MlxlinkCommander::showPcie()
 {
     try
     {
-        if (_userInput._links)
-        {
+        if (_userInput._links) {
             return;
         }
-        if (!_userInput._sendDpn && !_userInput._portSpecified)
-        {
-            if (_validDpns.size() == 0)
-            {
+        if (!_userInput._sendDpn && !_userInput._portSpecified) {
+            if (_validDpns.size() == 0) {
                 throw MlxRegException("No valid DPN's detected!");
             }
             int localPort = 0;
-            for (u_int32_t i = 0; i < _validDpns.size(); i++)
-            {
+            for (u_int32_t i = 0; i < _validDpns.size(); i++) {
                 localPort = getLocalPortFromMPIR(_validDpns[i]);
-                if (localPort >= 0)
-                {
+                if (localPort >= 0) {
                     showPcieState(_validDpns[i]);
                 }
-                if (_userInput.isPcieErrInjProvided)
-                {
+                if (_userInput.isPcieErrInjProvided) {
                     break;
                 }
             }
-        }
-        else
-        {
+        } else {
             showPcieState(_dpn);
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Showing Pcie via MPEIN raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Showing Pcie via MPEIN raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
 void MlxlinkCommander::showPcieState(DPN& dpn)
 {
     MlxlinkCmdPrint pcieInfoCmd;
+
     sendPrmReg(ACCESS_REG_MPEIN, GET, "depth=%d,pcie_index=%d,node=%d", dpn.depth, dpn.pcieIndex, dpn.node);
 
     string linkSpeedEnabled = " (" + pcieSpeedStr(getFieldValue("link_speed_enabled")) + ")";
     string linkWidthEnabled = " (" + to_string((getFieldValue("link_width_enabled"))) + "X)";
+
     _numOfLanesPcie = getFieldValue("link_width_active");
 
     setPrintTitle(pcieInfoCmd, "PCIe Operational (Enabled) Info", PCIE_INFO_LAST);
 
     char dpnStr[15];
+
     sprintf(dpnStr, "%d, %d, %d", dpn.depth, dpn.pcieIndex, dpn.node);
     setPrintVal(pcieInfoCmd, "Depth, pcie index, node", dpnStr);
     setPrintVal(pcieInfoCmd, "Link Speed Active (Enabled)",
@@ -3070,45 +2790,35 @@ void MlxlinkCommander::collectAMBER()
 {
     try
     {
-        if (_productTechnology >= PRODUCT_16NM)
-        {
+        if (_productTechnology >= PRODUCT_16NM) {
             MlxlinkRecord::printCmdLine("Collecting amBER and producing report to " + _userInput._csvBer, _jsonRoot);
 
             initAmBerCollector();
 
-            if (!_isHCA)
-            {
-                // If port provided, collect one port only
-                if (_userInput._portSpecified)
-                {
-                    PortGroup pg{_localPort, _userInput._labelPort, 0, _userInput._splitPort};
-                    if (_devID == DeviceQuantum2 || _devID == DeviceQuantum3 || _devID == DeviceBW00)
-                    {
+            if (!_isHCA) {
+                /* If port provided, collect one port only */
+                if (_userInput._portSpecified) {
+                    PortGroup pg {_localPort, _userInput._labelPort, 0, _userInput._splitPort};
+                    if ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100)) {
                         pg.secondSplit = _userInput._secondSplitProvided ? _userInput._secondSplitPort : 0;
                     }
                     _amberCollector->_localPorts.push_back(pg);
-                }
-                else if (_devID != DeviceBW00)
-                {
-                    // collect all ports info if the port flag wasn't provided
+                } else if (_devID != DeviceGB100) {
+                    /* collect all ports info if the port flag wasn't provided */
                     u_int32_t numOfPorts = 0;
 
-                    vector<string> labelPorts;
+                    vector < string > labelPorts;
                     _ignorePortStatus = false;
 
-                    if (_devID == DeviceBW00 || _devID == DeviceSpectrum3 || _devID == DeviceQuantum3)
-                    {
+                    if ((_devID == DeviceGB100) || (_devID == DeviceSpectrum3) || (_devID == DeviceQuantum3)) {
                         sendPrmReg(ACCESS_REG_MGIR, GET);
                         numOfPorts = getFieldValue("num_ports");
-                    }
-                    else
-                    {
+                    } else {
                         sendPrmReg(ACCESS_REG_MGPIR, GET);
                         numOfPorts = getFieldValue("num_of_modules");
                     }
 
-                    for (u_int32_t labelPort = 1; labelPort <= numOfPorts; labelPort++)
-                    {
+                    for (u_int32_t labelPort = 1; labelPort <= numOfPorts; labelPort++) {
                         labelPorts.push_back(to_string(labelPort));
                     }
 
@@ -3118,17 +2828,15 @@ void MlxlinkCommander::collectAMBER()
             }
 
             _amberCollector->startCollector();
-        }
-        else
-        {
+        } else {
             throw MlxRegException(AMBER_COLLECT_FLAG " is not available for "
-                                                     "this device, please use " BER_COLLECT_FLAG " flag instead");
+                                  "this device, please use " BER_COLLECT_FLAG " flag instead");
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Collecting AMBER raised the following exception: \n") + string(exc.what()) + string("\n");
+            string("Collecting AMBER raised the following exception: \n") + string(exc.what()) + string("\n");
     }
 }
 
@@ -3136,10 +2844,9 @@ void MlxlinkCommander::collectBER()
 {
     try
     {
-        if (_productTechnology >= PRODUCT_16NM)
-        {
+        if (_productTechnology >= PRODUCT_16NM) {
             throw MlxRegException(BER_COLLECT_FLAG " is not available for "
-                                                   "this device, please use " AMBER_COLLECT_FLAG " flag instead");
+                                  "this device, please use " AMBER_COLLECT_FLAG " flag instead");
         }
 
         MlxlinkRecord::printCmdLine("Collecting BER and producing report to " + _userInput._csvBer, _jsonRoot);
@@ -3148,17 +2855,13 @@ void MlxlinkCommander::collectBER()
         ifstream ifile(fileName);
         ofstream berFile(fileName, std::ofstream::app);
 
-        vector<AmberField> fields = getBerFields();
+        vector < AmberField > fields = getBerFields();
 
-        if (!ifile.good())
-        {
-            for (const auto& field : fields)
-            {
-                if (field.isVisible())
-                {
+        if (!ifile.good()) {
+            for (const auto& field : fields) {
+                if (field.isVisible()) {
                     berFile << field.getUiField();
-                    if (field.getFieldIndex() < fields.size())
-                    {
+                    if (field.getFieldIndex() < fields.size()) {
                         berFile << ",";
                     }
                 }
@@ -3166,14 +2869,11 @@ void MlxlinkCommander::collectBER()
             berFile << endl;
         }
 
-        // Preparing CSV values
-        for (const auto& field : fields)
-        {
-            if (field.isVisible())
-            {
+        /* Preparing CSV values */
+        for (const auto& field : fields) {
+            if (field.isVisible()) {
                 berFile << field.getUiValue();
-                if (field.getFieldIndex() < fields.size())
-                {
+                if (field.getFieldIndex() < fields.size()) {
                     berFile << ",";
                 }
             }
@@ -3181,38 +2881,35 @@ void MlxlinkCommander::collectBER()
         berFile << endl;
         berFile.close();
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Collecting BER and producing report raised the following exception: \n") +
                                string(exc.what()) + string("\n");
     }
 }
 
-vector<AmberField> MlxlinkCommander::getBerFields()
+vector < AmberField > MlxlinkCommander::getBerFields()
 {
-    vector<AmberField> fields;
+    vector < AmberField > fields;
     try
     {
         string active_fec = _prbsTestMode ? "N/A" : _mlxlinkMaps->_fecModeActive[_fecActive];
         findAndReplace(active_fec, ",", " ");
         string devicePN = getDevicePN();
         string deviceFW = _fwVersion;
-        if (!_isSwControled)
-        {
+        if (!_isSwControled) {
             getCableParams();
         }
 
 
-        std::map<string, string> errorsVector = getRawEffectiveErrors();
+        std::map < string, string > errorsVector = getRawEffectiveErrors();
         string protocol = _prbsTestMode ? getPrbsModeRX() : _speedStrG;
-        float speed = _prbsTestMode ? getPrbsRateRX() : _speedBerCsv;
-        if (_protoActive == IB)
-        {
+        float  speed = _prbsTestMode ? getPrbsRateRX() : _speedBerCsv;
+        if (_protoActive == IB) {
             speed = (speed * _numOfLanes) / MAX_LANES_NUMBER;
         }
         string port = to_string(_userInput._labelPort);
-        if (_userInput._splitProvided)
-        {
+        if (_userInput._splitProvided) {
             port += "/" + to_string(_userInput._splitPort);
         }
 
@@ -3252,7 +2949,7 @@ vector<AmberField> MlxlinkCommander::getBerFields()
         fields.push_back(AmberField("Cable SN", _cableSN));
         fields.push_back(AmberField("RX End BW [Gb/s]", "N/A"));
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Collecting BER and producing report raised the following exception: \n") +
                                string(exc.what()) + string("\n");
@@ -3262,8 +2959,9 @@ vector<AmberField> MlxlinkCommander::getBerFields()
 
 u_int32_t MlxlinkCommander::readBitFromField(const string& fieldName, u_int32_t bitIndex)
 {
-    char blockName[128];
+    char      blockName[128];
     u_int32_t blockSelector = bitIndex / MAX_DWORD_BLOCK_SIZE;
+
     sprintf(blockName, "%s[%d]", fieldName.c_str(), blockSelector);
 
     u_int32_t bitMask = (u_int32_t)pow(2.0, (int)(bitIndex - (blockSelector * MAX_DWORD_BLOCK_SIZE)));
@@ -3276,21 +2974,18 @@ void MlxlinkCommander::showTxGroupMapping()
 {
     try
     {
-        if (_devID != DeviceSpectrum2 && _devID != DeviceQuantum && _devID != DeviceQuantum2 &&
-            _devID != DeviceQuantum3 && _devID != DeviceBW00)
-        {
+        if ((_devID != DeviceSpectrum2) && (_devID != DeviceQuantum) && (_devID != DeviceQuantum2) &&
+            (_devID != DeviceQuantum3) && (_devID != DeviceGB100)) {
             throw MlxRegException("Port group mapping supported for Spectrum-2 and Quantum switches only!");
         }
 
         sendPrmReg(ACCESS_REG_PGMR, GET, "local_port=%d,group=%d,pg_sel=%d", 1, _userInput._showGroup, TX_GROUP);
 
-        vector<u_int32_t> localPorts;
+        vector < u_int32_t > localPorts;
         u_int32_t localPortMask = 0;
-        for (size_t i = 1; i <= maxLocalPort(); i++)
-        {
+        for (size_t i = 1; i <= maxLocalPort(); i++) {
             localPortMask = readBitFromField("ports_mapping_of_group", i - 1);
-            if (localPortMask)
-            {
+            if (localPortMask) {
                 localPorts.push_back(i);
             }
         }
@@ -3304,7 +2999,7 @@ void MlxlinkCommander::showTxGroupMapping()
 
         cout << _portGroupMapping;
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Showing ports group mapping raised the "
                                       "following exception: ") +
@@ -3312,20 +3007,24 @@ void MlxlinkCommander::showTxGroupMapping()
     }
 }
 
-std::map<string, string> MlxlinkCommander::getRawEffectiveErrorsinTestMode()
+std::map < string, string > MlxlinkCommander::getRawEffectiveErrorsinTestMode()
 {
-    std::map<string, string> errorsVector;
+    std::map < string, string > errorsVector;
 
     sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_PHY_GROUP);
 
     errorsVector["phy_corrected_bits_lane0"] =
-      to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane0_high"), getFieldValue("edpl_bip_errors_lane0_low")));
+        to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane0_high"),
+                               getFieldValue("edpl_bip_errors_lane0_low")));
     errorsVector["phy_corrected_bits_lane1"] =
-      to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane1_high"), getFieldValue("edpl_bip_errors_lane1_low")));
+        to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane1_high"),
+                               getFieldValue("edpl_bip_errors_lane1_low")));
     errorsVector["phy_corrected_bits_lane2"] =
-      to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane2_high"), getFieldValue("edpl_bip_errors_lane2_low")));
+        to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane2_high"),
+                               getFieldValue("edpl_bip_errors_lane2_low")));
     errorsVector["phy_corrected_bits_lane3"] =
-      to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane3_high"), getFieldValue("edpl_bip_errors_lane3_low")));
+        to_string(add32BitTo64(getFieldValue("edpl_bip_errors_lane3_high"),
+                               getFieldValue("edpl_bip_errors_lane3_low")));
     errorsVector["phy_corrected_bits_lane4"] = "0";
     errorsVector["phy_corrected_bits_lane5"] = "0";
     errorsVector["phy_corrected_bits_lane6"] = "0";
@@ -3334,43 +3033,41 @@ std::map<string, string> MlxlinkCommander::getRawEffectiveErrorsinTestMode()
     return errorsVector;
 }
 
-std::map<string, string> MlxlinkCommander::getRawEffectiveErrors()
+std::map < string, string > MlxlinkCommander::getRawEffectiveErrors()
 {
-    std::map<string, string> errorsVector;
-    if (_prbsTestMode)
-    {
+    std::map < string, string > errorsVector;
+    if (_prbsTestMode) {
         errorsVector = getRawEffectiveErrorsinTestMode();
-    }
-    else
-    {
+    } else {
         sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
 
         errorsVector["phy_corrected_bits_lane0"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane0_high"), getFieldValue("phy_raw_errors_lane0_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane0_high"), getFieldValue("phy_raw_errors_lane0_low")));
         errorsVector["phy_corrected_bits_lane1"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane1_high"), getFieldValue("phy_raw_errors_lane1_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane1_high"), getFieldValue("phy_raw_errors_lane1_low")));
         errorsVector["phy_corrected_bits_lane2"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane2_high"), getFieldValue("phy_raw_errors_lane2_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane2_high"), getFieldValue("phy_raw_errors_lane2_low")));
         errorsVector["phy_corrected_bits_lane3"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane3_high"), getFieldValue("phy_raw_errors_lane3_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane3_high"), getFieldValue("phy_raw_errors_lane3_low")));
         errorsVector["phy_corrected_bits_lane4"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane4_high"), getFieldValue("phy_raw_errors_lane4_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane4_high"), getFieldValue("phy_raw_errors_lane4_low")));
         errorsVector["phy_corrected_bits_lane5"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane5_high"), getFieldValue("phy_raw_errors_lane5_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane5_high"), getFieldValue("phy_raw_errors_lane5_low")));
         errorsVector["phy_corrected_bits_lane6"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane6_high"), getFieldValue("phy_raw_errors_lane6_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane6_high"), getFieldValue("phy_raw_errors_lane6_low")));
         errorsVector["phy_corrected_bits_lane7"] = to_string(
-          add32BitTo64(getFieldValue("phy_raw_errors_lane7_high"), getFieldValue("phy_raw_errors_lane7_low")));
+            add32BitTo64(getFieldValue("phy_raw_errors_lane7_high"), getFieldValue("phy_raw_errors_lane7_low")));
     }
 
     errorsVector["time_since_last_clear_sec"] = to_string(
-      (add32BitTo64((float)getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low"))) /
-      1000.0 / 60.0);
+        (add32BitTo64((float)getFieldValue("time_since_last_clear_high"), getFieldValue(
+                          "time_since_last_clear_low"))) /
+        1000.0 / 60.0);
     errorsVector["raw_errors_counter"] =
-      to_string(add32BitTo64(getFieldValue("phy_corrected_bits_high"), getFieldValue("phy_corrected_bits_low")));
+        to_string(add32BitTo64(getFieldValue("phy_corrected_bits_high"), getFieldValue("phy_corrected_bits_low")));
     errorsVector["raw_ber"] = getFieldStr("raw_ber_coef") + "E-" + getFieldStr("raw_ber_magnitude");
     errorsVector["eff_errors_counter"] =
-      to_string(add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low")));
+        to_string(add32BitTo64(getFieldValue("phy_symbol_errors_high"), getFieldValue("phy_symbol_errors_low")));
     errorsVector["eff_ber"] = getFieldStr("effective_ber_coef") + "E-" + getFieldStr("effective_ber_magnitude");
 
     return errorsVector;
@@ -3379,19 +3076,17 @@ std::map<string, string> MlxlinkCommander::getRawEffectiveErrors()
 string MlxlinkCommander::getSupportedPrbsRates(u_int32_t modeSelector)
 {
     string regName = ACCESS_REG_PPRT;
-    if (modeSelector == PRBS_TX)
-    {
+
+    if (modeSelector == PRBS_TX) {
         regName = ACCESS_REG_PPTT;
     }
     sendPrmReg(regName, GET);
 
     u_int32_t capsMask = getFieldValue("lane_rate_cap");
-    string modeCapStr = "";
+    string    modeCapStr = "";
 
-    for (auto it = _mlxlinkMaps->_prbsLaneRate.begin(); it != _mlxlinkMaps->_prbsLaneRate.end(); it++)
-    {
-        if (capsMask & (it->second).capMask)
-        {
+    for (auto it = _mlxlinkMaps->_prbsLaneRate.begin(); it != _mlxlinkMaps->_prbsLaneRate.end(); it++) {
+        if (capsMask & (it->second).capMask) {
             modeCapStr += it->first + string(",");
         }
     }
@@ -3402,29 +3097,28 @@ string MlxlinkCommander::getSupportedPrbsRates(u_int32_t modeSelector)
 string MlxlinkCommander::getSupportedPrbsModes(u_int32_t modeSelector)
 {
     string regName = ACCESS_REG_PPRT;
-    if (modeSelector == PRBS_TX)
-    {
+
+    if (modeSelector == PRBS_TX) {
         regName = ACCESS_REG_PPTT;
     }
     sendPrmReg(regName, GET);
 
     u_int32_t capsMask = getFieldValue("prbs_modes_cap");
+
     capsMask = modeSelector == PRBS_RX ? capsMask & 0x1ffe3fff : capsMask;
     string modeCapStr = "";
-    // Iterating over the supported modes according to capability mask
-    // And preparing them in one string
+    /* Iterating over the supported modes according to capability mask */
+    /* And preparing them in one string */
     u_int32_t mask = 0;
-    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin();
+
+    for (map < u_int32_t, string > ::iterator it = _mlxlinkMaps->_prbsModesList.begin();
          it != _mlxlinkMaps->_prbsModesList.end();
-         it++)
-    {
+         it++) {
         mask = PRBS31_CAP << it->first;
-        if (capsMask & mask)
-        {
+        if (capsMask & mask) {
             modeCapStr += it->second;
-            if (modeSelector == PRBS_RX && mask == SQUARE_WAVEA_CAP)
-            {
-                // return SQUARE_WAVE without A for RX pattern
+            if ((modeSelector == PRBS_RX) && (mask == SQUARE_WAVEA_CAP)) {
+                /* return SQUARE_WAVE without A for RX pattern */
                 modeCapStr = deleteLastChar(modeCapStr);
             }
             modeCapStr += ",";
@@ -3450,72 +3144,58 @@ u_int32_t MlxlinkCommander::getPrbsRateRX()
 float MlxlinkCommander::getRawBERLimit()
 {
     float limit;
-    if (_userInput._testMode == "NOMINAL" || _userInput._testMode == "Nominal")
-    {
-        switch (_speedBerCsv)
-        {
-            case 25:
-            case 50:
-            case 100:
-                if (_mlxlinkMaps->_fecModeActive[_fecActive] == _mlxlinkMaps->_fecModeActive[0])
-                {
-                    limit = pow(10.0, NOMINAL_25G_NO_FEC);
-                }
-                else if (_cableAtten12G <= 15)
-                {
-                    limit = pow(10.0, NOMINAL_25G_LOW_ATTN);
-                }
-                else
-                {
-                    limit = pow(10.0, NOMINAL_25G_HIGH_ATTN);
-                }
-                break;
 
-            case 10:
-                limit = pow(10.0, NOMINAL_10G);
-                break;
+    if ((_userInput._testMode == "NOMINAL") || (_userInput._testMode == "Nominal")) {
+        switch (_speedBerCsv) {
+        case 25:
+        case 50:
+        case 100:
+            if (_mlxlinkMaps->_fecModeActive[_fecActive] == _mlxlinkMaps->_fecModeActive[0]) {
+                limit = pow(10.0, NOMINAL_25G_NO_FEC);
+            } else if (_cableAtten12G <= 15) {
+                limit = pow(10.0, NOMINAL_25G_LOW_ATTN);
+            } else {
+                limit = pow(10.0, NOMINAL_25G_HIGH_ATTN);
+            }
+            break;
 
-            case 56:
-            case 40:
-                limit = pow(10.0, NOMINAL_56G_40G);
-                break;
+        case 10:
+            limit = pow(10.0, NOMINAL_10G);
+            break;
 
-            default:
-                limit = pow(10.0, NOMINAL_DEFAULT);
+        case 56:
+        case 40:
+            limit = pow(10.0, NOMINAL_56G_40G);
+            break;
+
+        default:
+            limit = pow(10.0, NOMINAL_DEFAULT);
         }
-    }
-    else
-    {
-        switch (_speedBerCsv)
-        {
-            case 25:
-            case 50:
-            case 100:
-                if (_mlxlinkMaps->_fecModeActive[_fecActive] == _mlxlinkMaps->_fecModeActive[0])
-                {
-                    limit = 3.0 * pow(10.0, CORNER_25G_NO_FEC);
-                }
-                else if (_cableAtten12G <= 15)
-                {
-                    limit = pow(10.0, CORNER_25G_LOW_ATTN);
-                }
-                else
-                {
-                    limit = pow(10.0, CORNER_25G_HIGH_ATTN);
-                }
-                break;
+    } else {
+        switch (_speedBerCsv) {
+        case 25:
+        case 50:
+        case 100:
+            if (_mlxlinkMaps->_fecModeActive[_fecActive] == _mlxlinkMaps->_fecModeActive[0]) {
+                limit = 3.0 * pow(10.0, CORNER_25G_NO_FEC);
+            } else if (_cableAtten12G <= 15) {
+                limit = pow(10.0, CORNER_25G_LOW_ATTN);
+            } else {
+                limit = pow(10.0, CORNER_25G_HIGH_ATTN);
+            }
+            break;
 
-            case 10:
-                limit = pow(10.0, CORNER_10G);
-                break;
+        case 10:
+            limit = pow(10.0, CORNER_10G);
+            break;
 
-            case 56:
-            case 40:
-                limit = pow(10.0, CORNER_56G_40G);
-                break;
+        case 56:
+        case 40:
+            limit = pow(10.0, CORNER_56G_40G);
+            break;
 
-            default:
-                limit = pow(10.0, CORNER_DEFAULT);
+        default:
+            limit = pow(10.0, CORNER_DEFAULT);
         }
     }
     return limit;
@@ -3532,7 +3212,7 @@ string MlxlinkCommander::getDevicePN()
     {
         sendPrmReg(ACCESS_REG_MSGI, GET);
     }
-    catch (...)
+    catch(...)
     {
         return "N/A";
     }
@@ -3540,7 +3220,7 @@ string MlxlinkCommander::getDevicePN()
     return getAscii("part_number", 20);
 }
 
-// Config functions
+/* Config functions */
 
 void MlxlinkCommander::clearCounters()
 {
@@ -3550,20 +3230,20 @@ void MlxlinkCommander::clearCounters()
 
         sendPrmReg(ACCESS_REG_PPCNT, SET, "clr=%d,grp=%d", 1, PPCNT_ALL_GROUPS);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Clearing counters via PPCNT raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Clearing counters via PPCNT raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
 bool MlxlinkCommander::isForceDownSupported()
 {
     bool supported = false;
-    if (_isHCA)
-    {
-        // checking force_down cap
-        u_int64_t fdCapMask = PCAM_FORCE_DOWN_CAP_MASK; // feature_cap_mask.Bit 45 (feature_cap_mask[2].bit 13)
+
+    if (_isHCA) {
+        /* checking force_down cap */
+        u_int64_t fdCapMask = PCAM_FORCE_DOWN_CAP_MASK; /* feature_cap_mask.Bit 45 (feature_cap_mask[2].bit 13) */
 
         sendPrmReg(ACCESS_REG_PCAM, GET);
 
@@ -3577,15 +3257,15 @@ void MlxlinkCommander::sendGBPaosCmd(PAOS_ADMIN adminStatus, bool forceDown)
     try
     {
         string forceDownCmd = "";
-        if (forceDown)
-        {
+        if (forceDown) {
             forceDownCmd = ",fpd=1";
         }
         sendPrmReg(ACCESS_REG_PPAOS, SET, "phy_status_admin=%d%s", adminStatus == PAOS_UP, forceDownCmd.c_str());
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         string portCommand = (adminStatus == PAOS_DOWN) ? "down" : "up";
+
         throw MlxRegException("Sending port " + portCommand + " command failed, " + string(exc.what()));
     }
 }
@@ -3594,27 +3274,23 @@ void MlxlinkCommander::sendPaosCmd(PAOS_ADMIN adminStatus, bool forceDown)
 {
     try
     {
-        if (_isGboxPort)
-        {
+        if (_isGboxPort) {
             sendGBPaosCmd(adminStatus, forceDown);
-        }
-        else
-        {
-            // Send force down for test mode only
+        } else {
+            /* Send force down for test mode only */
             string forceDownCmd = "";
-            if (!_userInput._prbsMode.empty())
-            {
-                if (forceDown)
-                {
+            if (!_userInput._prbsMode.empty()) {
+                if (forceDown) {
                     forceDownCmd = ",fd=1";
                 }
             }
             sendPrmReg(ACCESS_REG_PAOS, SET, "admin_status=%d,ase=%d%s", adminStatus, 1, forceDownCmd.c_str());
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         string portCommand = (adminStatus == PAOS_DOWN) ? "down" : "up";
+
         throw MlxRegException("Sending port " + portCommand + " command failed");
     }
 }
@@ -3624,29 +3300,28 @@ void MlxlinkCommander::sendPaos()
     try
     {
         PAOS_CMD paosCmd = paos_to_int(_userInput._paosCmd);
-        switch (paosCmd)
-        {
-            case UP:
-                sendPaosUP();
-                return;
+        switch (paosCmd) {
+        case UP:
+            sendPaosUP();
+            return;
 
-            case DN:
-                sendPaosDown();
-                return;
+        case DN:
+            sendPaosDown();
+            return;
 
-            case TG:
-                sendPaosToggle();
-                return;
+        case TG:
+            sendPaosToggle();
+            return;
 
-            case NO:
-            default:
-                return;
+        case NO:
+        default:
+            return;
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Sending PAOS raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Sending PAOS raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
@@ -3655,37 +3330,32 @@ void MlxlinkCommander::sendPaosDown(bool toggleCommand)
     MlxlinkRecord::printCmdLine("Configuring Port State (Down)", _jsonRoot);
 
     bool forceDown = isForceDownSupported();
-    // try to force down the port
+
+    /* try to force down the port */
     sendPaosCmd(PAOS_DOWN, forceDown);
-    msleep(1000); // wait for 1 sec before checking the status
-    // Verify the link status after down command
-    if (!checkPaosDown())
-    {
-        if (_isHCA)
-        {
-            // in case of using old fw version (older than xx.28.xxxx)
-            if (!forceDown && !_userInput._prbsMode.empty())
-            {
+    msleep(1000); /* wait for 1 sec before checking the status */
+    /* Verify the link status after down command */
+    if (!checkPaosDown()) {
+        if (_isHCA) {
+            /* in case of using old fw version (older than xx.28.xxxx) */
+            if (!forceDown && !_userInput._prbsMode.empty()) {
                 string message = "Enabling PRBS is not supported in the "
                                  "current FW version. Please contact Nvidia networking division support.";
                 throw MlxRegException(message);
-            }
-            else if (!toggleCommand)
-            {
+            } else if (!toggleCommand) {
                 string protocol = (_protoActive == IB) ? "IB" : "ETH";
                 string message = "port is not Down, for some reasons:\n";
                 message +=
-                  "1- The link is configured to be up, run this command if KEEP_" + protocol + "_LINK_UP_Px is True:\n";
+                    "1- The link is configured to be up, run this command if KEEP_" + protocol +
+                    "_LINK_UP_Px is True:\n";
                 message +=
-                  "   mlxconfig -d " + _userInput._device + " set KEEP_" + protocol + "_LINK_UP_P<port_number>=0\n";
+                    "   mlxconfig -d " + _userInput._device + " set KEEP_" + protocol + "_LINK_UP_P<port_number>=0\n";
                 message += "2- Port management is enabled (management protocol requiring the link to remain up, PAOS "
                            "won't manage to disable the port)\n";
                 message += "3- In case of multi-host please verify all hosts are not holding the port up";
                 throw MlxRegException(message);
             }
-        }
-        else
-        {
+        } else {
             throw MlxRegException("Port is not Down, Aborting...");
         }
     }
@@ -3707,53 +3377,40 @@ void MlxlinkCommander::handlePrbs()
 {
     try
     {
-        if (_userInput._prbsMode == "EN")
-        {
+        if (_userInput._prbsMode == "EN") {
             checkPprtPptt();
-            if (_prbsTestMode)
-            {
+            if (_prbsTestMode) {
                 sendPrbsPpaos(false);
             }
             sendPaosDown();
-            if (checkPaosDown())
-            {
+            if (checkPaosDown()) {
                 MlxlinkRecord::printCmdLine("Configuring Port to Physical Test Mode", _jsonRoot);
                 resetPprtPptt();
                 sendPprtPptt();
                 sendPrbsPpaos(true);
-            }
-            else
-            {
+            } else {
                 throw MlxRegException("Port is not down, unable to enter test mode");
             }
-        }
-        else if (_userInput._prbsMode == "DS")
-        {
+        } else if (_userInput._prbsMode == "DS") {
             MlxlinkRecord::printCmdLine("Configuring Port to Regular Operation", _jsonRoot);
-            if (_prbsTestMode)
-            {
+            if (_prbsTestMode) {
                 sendPrbsPpaos(false);
             }
             resetPprtPptt();
             sendPaosToggle();
-        }
-        else if (_userInput._prbsMode == "TU")
-        {
-            if (_prbsTestMode)
-            {
+        } else if (_userInput._prbsMode == "TU") {
+            if (_prbsTestMode) {
                 MlxlinkRecord::printCmdLine("Performing Tuning", _jsonRoot);
                 startTuning();
-            }
-            else
-            {
+            } else {
                 throw MlxRegException("Port is not configured for physical test mode. Please see help");
             }
         }
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Handling PRBS raised the following exception: ") + string(exc.what()) + string("\n");
+            string("Handling PRBS raised the following exception: ") + string(exc.what()) + string("\n");
     }
 }
 
@@ -3761,33 +3418,29 @@ void MlxlinkCommander::checkPRBSModeCap(u_int32_t modeSelector, u_int32_t capMas
 {
     string modeToCheck = _userInput._pprtMode;
     string prbsModeStr = "RX";
-    if (modeSelector == PRBS_TX)
-    {
+
+    if (modeSelector == PRBS_TX) {
         modeToCheck = _userInput._ppttMode;
         prbsModeStr = "TX";
     }
-    // for RX mode: SQUARE_WAVE and SQUARE_WAVEA have the same enum
-    if (modeSelector == PRBS_RX && modeToCheck == "SQUARE_WAVE")
-    {
+    /* for RX mode: SQUARE_WAVE and SQUARE_WAVEA have the same enum */
+    if ((modeSelector == PRBS_RX) && (modeToCheck == "SQUARE_WAVE")) {
         modeToCheck += "A";
     }
 
-    // Fetching mode capability from mode list
+    /* Fetching mode capability from mode list */
     u_int32_t modeCap = 0;
 
-    for (map<u_int32_t, string>::iterator it = _mlxlinkMaps->_prbsModesList.begin();
+    for (map < u_int32_t, string > ::iterator it = _mlxlinkMaps->_prbsModesList.begin();
          it != _mlxlinkMaps->_prbsModesList.end();
-         it++)
-    {
-        if (modeToCheck == it->second)
-        {
+         it++) {
+        if (modeToCheck == it->second) {
             modeCap = PRBS31_CAP << it->first;
             break;
         }
     }
-    // checking if the fetched capability supported in cap mask or not
-    if (!(modeCap & capMask))
-    {
+    /* checking if the fetched capability supported in cap mask or not */
+    if (!(modeCap & capMask)) {
         string errStr = "Device does not support " + prbsModeStr + " PRBS pattern \"" +
                         (modeSelector == PRBS_TX ? _userInput._ppttMode : _userInput._pprtMode) +
                         "\" in physical test mode.";
@@ -3804,34 +3457,25 @@ void MlxlinkCommander::checkPrbsRegsCap(const string& prbsReg, const string& lan
 
     sendPrmReg(prbsReg, GET);
 
-    bool invalidRateStr = !laneRate.empty() && !_mlxlinkMaps->_prbsLaneRate[laneRate].capMask;
-
+    bool      invalidRateStr = !laneRate.empty() && !_mlxlinkMaps->_prbsLaneRate[laneRate].capMask;
     u_int32_t laneRateCap = _mlxlinkMaps->_prbsLaneRate[laneRate].capMask ?
-                              _mlxlinkMaps->_prbsLaneRate[laneRate].capMask :
-                              (u_int32_t)LANE_RATE_EDR_CAP;
-
+                            _mlxlinkMaps->_prbsLaneRate[laneRate].capMask :
+                            (u_int32_t)LANE_RATE_EDR_CAP;
     string laneRateStr = laneRate.empty() ? "EDR/25G/50G/100G (25.78125 Gb/s)" : laneRate;
 
-    if (invalidRateStr || !(laneRateCap & getFieldValue("lane_rate_cap")))
-    {
+    if (invalidRateStr || !(laneRateCap & getFieldValue("lane_rate_cap"))) {
         string errStr = "Device does not support lane rate " + laneRateStr + " in physical test mode.\n";
         string rxRates = getSupportedPrbsRates(PRBS_RX);
         string txRates = getSupportedPrbsRates(PRBS_TX);
-        if (rxRates.empty())
-        {
+        if (rxRates.empty()) {
             rxRates = "No Valid RX PRBS lane rate";
-        }
-        else
-        {
+        } else {
             rxRates = "Valid RX PRBS lane rates: " + rxRates;
         }
         errStr += rxRates + "\n";
-        if (txRates.empty())
-        {
+        if (txRates.empty()) {
             txRates = "No Valid TX PRBS lane rate";
-        }
-        else
-        {
+        } else {
             txRates = "Valid TX PRBS lane rates: " + txRates;
         }
         errStr += txRates + "\n";
@@ -3841,10 +3485,8 @@ void MlxlinkCommander::checkPrbsRegsCap(const string& prbsReg, const string& lan
 
     checkPRBSModeCap(modeSelector, getFieldValue("prbs_modes_cap"));
 
-    if (!_userInput._prbsLanesToSet.empty())
-    {
-        if (getFieldValue("ls") != 1)
-        {
+    if (!_userInput._prbsLanesToSet.empty()) {
+        if (getFieldValue("ls") != 1) {
             throw MlxRegException("Device does not support per lane configuration");
         }
     }
@@ -3852,15 +3494,12 @@ void MlxlinkCommander::checkPrbsRegsCap(const string& prbsReg, const string& lan
 
 void MlxlinkCommander::checkPprtPptt()
 {
-    if (!_userInput._prbsLanesToSet.empty())
-    {
+    if (!_userInput._prbsLanesToSet.empty()) {
         u_int32_t maxLaneIndex = _numOfLanes - 1;
-        for (map<u_int32_t, bool>::iterator it = _userInput._prbsLanesToSet.begin();
+        for (map < u_int32_t, bool > ::iterator it = _userInput._prbsLanesToSet.begin();
              it != _userInput._prbsLanesToSet.end();
-             it++)
-        {
-            if (it->second && (it->first > maxLaneIndex))
-            {
+             it++) {
+            if (it->second && (it->first > maxLaneIndex)) {
                 throw MlxRegException("Invalid lane index: %d", it->first);
             }
         }
@@ -3869,12 +3508,10 @@ void MlxlinkCommander::checkPprtPptt()
     checkPrbsRegsCap("PPRT", _userInput._pprtRate);
     checkPrbsRegsCap("PPTT", _userInput._ppttRate);
 
-    if (_userInput._prbsTxInv)
-    {
+    if (_userInput._prbsTxInv) {
         checkPrbsPolCap("PPTT");
     }
-    if (_userInput._prbsRxInv)
-    {
+    if (_userInput._prbsRxInv) {
         checkPrbsPolCap("PPRT");
     }
 }
@@ -3882,15 +3519,14 @@ void MlxlinkCommander::checkPprtPptt()
 void MlxlinkCommander::checkPrbsPolCap(const string& prbsReg)
 {
     string invalidPol = "TX";
-    if (prbsReg == "PPRT")
-    {
+
+    if (prbsReg == "PPRT") {
         invalidPol = "RX";
     }
 
     sendPrmReg(prbsReg, GET);
 
-    if (!getFieldValue("p_c"))
-    {
+    if (!getFieldValue("p_c")) {
         throw MlxRegException("PRBS " + invalidPol + " polarity inversion not supported");
     }
 }
@@ -3907,39 +3543,32 @@ void MlxlinkCommander::startTuning()
 }
 
 void MlxlinkCommander::prbsConfiguration(const string& prbsReg,
-                                         bool enable,
-                                         u_int32_t laneRate,
-                                         u_int32_t prbsMode,
-                                         bool perLaneConfig,
-                                         bool prbsPolInv)
+                                         bool          enable,
+                                         u_int32_t     laneRate,
+                                         u_int32_t     prbsMode,
+                                         bool          perLaneConfig,
+                                         bool          prbsPolInv)
 {
     const string rateToUpdate = (prbsReg == "PPRT") ? "lane_rate_oper" : "lane_rate_admin";
-
-    auto buildPrbsRegArgs = [&]() -> string
+    auto         buildPrbsRegArgs = [&]()->string
     {
         stringstream cmd;
-        if (prbsPolInv)
-        {
+        if (prbsPolInv) {
             cmd << ",p=1";
         }
-        if (laneRate >= PRBS_HDR && laneRate <= PRBS_XDR)
-        {
+        if ((laneRate >= PRBS_HDR) && (laneRate <= PRBS_XDR)) {
             cmd << ",modulation=" << PRBS_PAM4_ENCODING;
         }
         cmd << ",e=" << enable << "," << rateToUpdate << "=" << laneRate << ",prbs_mode_admin=" << prbsMode;
         return cmd.str();
     };
 
-    if (perLaneConfig)
-    {
-        for (const auto& lane : _userInput._prbsLanesToSet)
-        {
+    if (perLaneConfig) {
+        for (const auto& lane : _userInput._prbsLanesToSet) {
             const string prbsRegArgs = buildPrbsRegArgs();
             sendPrmReg(prbsReg, SET, "le=%d,lane=%d%s", perLaneConfig, lane.first, prbsRegArgs.c_str());
         }
-    }
-    else
-    {
+    } else {
         const string prbsRegArgs = buildPrbsRegArgs();
         sendPrmReg(prbsReg, SET, prbsRegArgs.c_str());
     }
@@ -3947,50 +3576,51 @@ void MlxlinkCommander::prbsConfiguration(const string& prbsReg,
 
 void MlxlinkCommander::sendPprtPptt()
 {
-    bool perLaneConfig = (!_userInput._prbsLanesToSet.empty()) && (_userInput._prbsLanesToSet.size() != _numOfLanes);
+    bool perLaneConfig = (!_userInput._prbsLanesToSet.empty()) &&
+                         (_userInput._prbsLanesToSet.size() != _numOfLanes);
     u_int32_t rxRate = _mlxlinkMaps->_prbsLaneRate[_userInput._pprtRate].capMask ?
-                         _mlxlinkMaps->_prbsLaneRate[_userInput._pprtRate].value :
-                         (u_int32_t)PRBS_EDR;
+                       _mlxlinkMaps->_prbsLaneRate[_userInput._pprtRate].value :
+                       (u_int32_t)PRBS_EDR;
     u_int32_t txRate = _mlxlinkMaps->_prbsLaneRate[_userInput._ppttRate].capMask ?
-                         _mlxlinkMaps->_prbsLaneRate[_userInput._ppttRate].value :
-                         (u_int32_t)PRBS_EDR;
-    prbsConfiguration("PPRT", true, rxRate, prbsModeToMask(_userInput._pprtMode), perLaneConfig, _userInput._prbsRxInv);
-    prbsConfiguration("PPTT", true, txRate, prbsModeToMask(_userInput._ppttMode), perLaneConfig, _userInput._prbsTxInv);
+                       _mlxlinkMaps->_prbsLaneRate[_userInput._ppttRate].value :
+                       (u_int32_t)PRBS_EDR;
+
+    prbsConfiguration("PPRT", true, rxRate, prbsModeToMask(_userInput._pprtMode), perLaneConfig,
+                      _userInput._prbsRxInv);
+    prbsConfiguration("PPTT", true, txRate, prbsModeToMask(_userInput._ppttMode), perLaneConfig,
+                      _userInput._prbsTxInv);
 }
 
 void MlxlinkCommander::resetPprtPptt()
 {
     try
     {
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             prbsConfiguration("PPRT", false, PRBS_EDR, PRBS31, false, false);
             prbsConfiguration("PPTT", false, PRBS_EDR, PRBS31, false, false);
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
-        // Not necessary to handle if clearing PPRT and PPTT failed
-        // They already cleared before enabling the test mode
+        /* Not necessary to handle if clearing PPRT and PPTT failed */
+        /* They already cleared before enabling the test mode */
     }
 }
 
 void MlxlinkCommander::validateSpeedStr()
 {
-    // Normalize IB speeds (Ignore IB- from infiniband speeds)
-    for (vector<string>::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++)
-    {
+    /* Normalize IB speeds (Ignore IB- from infiniband speeds) */
+    for (vector < string > ::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++) {
         size_t found = (*it).find("IB-");
-        if (found != std::string::npos)
-        {
+        if (found != std::string::npos) {
             *it = (*it).erase(found, found + 3);
         }
     }
-    // get list of all valid speeds (ETH, ETH extended, and IB)
+    /* get list of all valid speeds (ETH, ETH extended, and IB) */
     string validSpeedStr = "";
-    // include NRZ speeds only for devices not supporting extended speeds
-    if (!(_protoCapabilityEx && _protoActive == ETH))
-    {
+
+    /* include NRZ speeds only for devices not supporting extended speeds */
+    if (!(_protoCapabilityEx && (_protoActive == ETH))) {
         validSpeedStr = SupportedSpeeds2Str(ETH, BIT_MASK_ALL_DWORD, false);
     }
     validSpeedStr += "," + SupportedSpeeds2Str(ETH, BIT_MASK_ALL_DWORD, true);
@@ -3998,22 +3628,19 @@ void MlxlinkCommander::validateSpeedStr()
     string speedToCheck = "";
     size_t fromIndex = 0;
     size_t toIndex = 0;
-    for (vector<string>::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++)
-    {
+
+    for (vector < string > ::iterator it = _userInput._ptysSpeeds.begin(); it != _userInput._ptysSpeeds.end(); it++) {
         fromIndex = validSpeedStr.find(*it);
         toIndex = validSpeedStr.find_first_of(',', fromIndex);
-        if (fromIndex != string::npos)
-        {
+        if (fromIndex != string::npos) {
             speedToCheck = validSpeedStr.substr(fromIndex, toIndex - fromIndex);
         }
-        if (toUpperCase(speedToCheck) != *it)
-        {
+        if (toUpperCase(speedToCheck) != *it) {
             throw MlxRegException("%s is invalid speed configuration", (*it).c_str());
         }
     }
 
-    if (isIn(string("56G"), _userInput._ptysSpeeds) && _userInput._linkModeForce == true)
-    {
+    if (isIn(string("56G"), _userInput._ptysSpeeds) && (_userInput._linkModeForce == true)) {
         throw MlxRegException("No support of 56G FORCE mode");
     }
 }
@@ -4022,8 +3649,7 @@ void MlxlinkCommander::sendPtys()
 {
     try
     {
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             throw MlxRegException("Cannot Configure Port Speeds in Physical Test Mode. Please Disable First");
         }
 
@@ -4032,35 +3658,26 @@ void MlxlinkCommander::sendPtys()
         validateSpeedStr();
 
         u_int32_t ptysMask = 0x0;
-        string ptysExtraCmd = "";
-        string protoAdminField = "";
-        for (u_int32_t i = 0; i < _userInput._ptysSpeeds.size(); i++)
-        {
+        string    ptysExtraCmd = "";
+        string    protoAdminField = "";
+        for (u_int32_t i = 0; i < _userInput._ptysSpeeds.size(); i++) {
             ptysMask |= ptysSpeedToMask(_userInput._ptysSpeeds[i]);
         }
-        if (_userInput._linkModeForce == true)
-        {
+        if (_userInput._linkModeForce == true) {
             gearboxBlock(PTYS_LINK_MODE_FORCE_FLAG);
 
             ptysExtraCmd += ",an_disable_admin=1";
         }
-        if (_protoActive == IB)
-        {
-            if (_userInput._linkModeForce == false)
-            {
+        if (_protoActive == IB) {
+            if (_userInput._linkModeForce == false) {
                 ptysMask |= 0x1;
             }
             ptysExtraCmd += ",ib_link_width_admin=7";
             protoAdminField = "ib_proto_admin";
-        }
-        else
-        {
-            if (_productTechnology >= PRODUCT_16NM)
-            {
+        } else {
+            if (_productTechnology >= PRODUCT_16NM) {
                 protoAdminField = "ext_eth_proto_admin";
-            }
-            else
-            {
+            } else {
                 protoAdminField = "eth_proto_admin";
             }
         }
@@ -4068,11 +3685,11 @@ void MlxlinkCommander::sendPtys()
         sendPrmReg(ACCESS_REG_PTYS, SET, "proto_mask=%d,%s=%d%s", _protoActive, protoAdminField.c_str(), ptysMask,
                    ptysExtraCmd.c_str());
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         string errMsg = string(exc.what());
-        if (errMsg.find(OPERATIONAL_ERROR_STR) != string::npos)
-        {
+
+        if (errMsg.find(OPERATIONAL_ERROR_STR) != string::npos) {
             errMsg = "Invalid speed configurations";
         }
         _allUnhandledErrors += string("Sending PTYS (Configuring port speeds) "
@@ -4083,21 +3700,16 @@ void MlxlinkCommander::sendPtys()
 
 u_int32_t MlxlinkCommander::ptysSpeedToMask(const string& speed)
 {
-    bool extended = _productTechnology >= PRODUCT_16NM;
+    bool      extended = _productTechnology >= PRODUCT_16NM;
     u_int32_t speedMask = 0;
 
     checkSupportedSpeed(speed, _protoCapability, extended);
 
-    if (_protoActive == IB)
-    {
+    if (_protoActive == IB) {
         speedMask = ptysSpeedToMaskIB(speed);
-    }
-    else if (extended)
-    {
+    } else if (extended) {
         speedMask = ptysSpeedToExtMaskETH(speed);
-    }
-    else
-    {
+    } else {
         speedMask = ptysSpeedToMaskETH(speed);
     }
 
@@ -4108,29 +3720,24 @@ void MlxlinkCommander::checkSupportedSpeed(const string& speed, u_int32_t protoC
 {
     u_int32_t mask = 0;
     u_int32_t diffProto = 0;
-    string errStr = "";
-    string supportedSpeedStr = "";
-    if (!extSpeed)
-    {
+    string    errStr = "";
+    string    supportedSpeedStr = "";
+
+    if (!extSpeed) {
         mask = (_protoActive == IB) ? ptysSpeedToMaskIB(speed) : ptysSpeedToMaskETH(speed);
         diffProto = (_protoActive == IB) ? ptysSpeedToMaskETH(speed) : ptysSpeedToMaskIB(speed);
-    }
-    else
-    {
+    } else {
         mask = (_protoActive == IB) ? ptysSpeedToMaskIB(speed) : ptysSpeedToExtMaskETH(speed);
         diffProto = (_protoActive == IB) ? ptysSpeedToExtMaskETH(speed) : ptysSpeedToMaskIB(speed);
     }
     supportedSpeedStr = SupportedSpeeds2Str(_protoActive, protoCap, extSpeed);
-    if (!supportedSpeedStr.empty())
-    {
+    if (!supportedSpeedStr.empty()) {
         errStr = "Supported Speeds Are: " + supportedSpeedStr;
     }
-    if (diffProto)
-    {
+    if (diffProto) {
         throw MlxRegException(speed + " is not supported by Protocol!\n" + errStr);
     }
-    if (!(mask & protoCap) && _linkUP)
-    {
+    if (!(mask & protoCap) && _linkUP) {
         throw MlxRegException(speed + " is not supported by Device!\n" + errStr);
     }
 }
@@ -4139,41 +3746,35 @@ void MlxlinkCommander::sendPplm()
 {
     try
     {
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             throw MlxRegException("Cannot Configure FEC in Physical Test Mode. Please Disable First.");
         }
         MlxlinkRecord::printCmdLine("Configuring Port FEC", _jsonRoot);
-        if (_protoActive == IB && _ignoreIbFECCheck)
-        {
+        if ((_protoActive == IB) && _ignoreIbFECCheck) {
             throw MlxRegException("FEC Configuration is Valid for ETHERNET only!");
         }
-        if (!_linkUP && _userInput._speedFec == "")
-        {
+        if (!_linkUP && (_userInput._speedFec == "")) {
             throw MlxRegException("When Port is Not Active, You Must Specify the Speed to Configure FEC (--fec_speed "
                                   "<speed>)");
         }
 
-        checkPplmCap(); // after calling checkPplmCap, _userInput._speedFec will be changed to the correct fec speed
+        checkPplmCap(); /* after calling checkPplmCap, _userInput._speedFec will be changed to the correct fec speed */
 
-        string fecSpeedStr = speedToFecSpeedStr(_speedStrG, _numOfLanes);
-        string speedToConfigure = (_linkUP && _userInput._speedFec == "") ? fecSpeedStr : _userInput._speedFec;
+        string    fecSpeedStr = speedToFecSpeedStr(_speedStrG, _numOfLanes);
+        string    speedToConfigure = (_linkUP && _userInput._speedFec == "") ? fecSpeedStr : _userInput._speedFec;
         u_int32_t fecAdmin = fecToBit(_userInput._pplmFec, speedToConfigure);
-        string pplmFecCmd = "";
-        if (speedToConfigure == "50g" || speedToConfigure == "25g")
-        { // 25g and 50g must be set the same
+        string    pplmFecCmd = "";
+        if ((speedToConfigure == "50g") || (speedToConfigure == "25g")) { /* 25g and 50g must be set the same */
             pplmFecCmd += "fec_override_admin_25g=" + to_string(fecAdmin);
             pplmFecCmd += ",fec_override_admin_50g=" + to_string(fecAdmin);
-        }
-        else
-        {
+        } else {
             pplmFecCmd = string(_protoActive == IB ? "ib_" : "") + "fec_override_admin_" + speedToConfigure;
             pplmFecCmd += "=" + to_string(fecAdmin);
         }
 
         sendPrmReg(ACCESS_REG_PPLM, SET, pplmFecCmd.c_str());
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Sending PPLM (Configuring port FEC) raised the following exception: ") +
                                string(exc.what()) + string("\n");
@@ -4184,69 +3785,50 @@ string MlxlinkCommander::speedToFecSpeedStr(const string& speed, u_int32_t numOf
 {
     string fecSpeedStrFormat = "";
     string numberOfLanesStr = to_string(numOfLanes) + "x";
-    if (_protoActive == IB)
-    {
+
+    if (_protoActive == IB) {
         string speedStr = speed;
-        if (speedStr.find("IB-") != string::npos)
-        {
+        if (speedStr.find("IB-") != string::npos) {
             speedStr = speedStr.substr(3);
         }
         fecSpeedStrFormat = toLowerCase(speedStr);
-    }
-    else
-    {
-        if (speed == "800G")
-        {
+    } else {
+        if (speed == "800G") {
             fecSpeedStrFormat = "800g_" + numberOfLanesStr;
         }
-        if (speed == "400G")
-        {
+        if (speed == "400G") {
             fecSpeedStrFormat = "400g_" + numberOfLanesStr;
         }
-        if (speed == "200G")
-        {
+        if (speed == "200G") {
             fecSpeedStrFormat = "200g_" + numberOfLanesStr;
         }
-        if (speed == "100G")
-        {
-            if (numOfLanes == 4)
-            {
+        if (speed == "100G") {
+            if (numOfLanes == 4) {
                 fecSpeedStrFormat = "100g";
-            }
-            else
-            {
+            } else {
                 fecSpeedStrFormat = "100g_" + numberOfLanesStr;
             }
         }
-        if (speed == "50G")
-        {
-            if (numOfLanes == 1)
-            {
+        if (speed == "50G") {
+            if (numOfLanes == 1) {
                 fecSpeedStrFormat = "50g_" + numberOfLanesStr;
-            }
-            else
-            {
+            } else {
                 fecSpeedStrFormat = "50g";
             }
         }
-        if (speed == "100GbE")
-        {
+        if (speed == "100GbE") {
             fecSpeedStrFormat = "100g";
         }
-        if (speed == "50GbE")
-        {
+        if (speed == "50GbE") {
             fecSpeedStrFormat = "50g";
         }
-        if (speed == "25GbE" || speed == "25G")
-        {
+        if ((speed == "25GbE") || (speed == "25G")) {
             fecSpeedStrFormat = "25g";
         }
-        if (speed == "40GbE" || speed == "40G" || speed == "10GbE" || speed == "10G")
-        {
+        if ((speed == "40GbE") || (speed == "40G") || (speed == "10GbE") || (speed == "10G")) {
             fecSpeedStrFormat = "10g_40g";
         }
-        if (speed == "56GbE")
-        {
+        if (speed == "56GbE") {
             fecSpeedStrFormat = "56g";
         }
     }
@@ -4255,26 +3837,20 @@ string MlxlinkCommander::speedToFecSpeedStr(const string& speed, u_int32_t numOf
 
 u_int32_t MlxlinkCommander::fecToBit(const string& fec, const string& speedStrG)
 {
-    string fecToCheck = fec;
+    string    fecToCheck = fec;
     u_int32_t fecAdmin = FEC_MODE_MASK_AU;
 
-    // Work with different RS and LL FEC for HDR, NDR and ETH PAM4 speeds
-    if ((speedStrG == "ndr" || speedStrG == "hdr") ||
-        (speedStrG.find("x") != string::npos && speedStrG != "100g_4x" && speedStrG != "50g_2x"))
-    {
-        if (fec == _mlxlinkMaps->_fecModeMask[FEC_MODE_MASK_RS_528].second)
-        {
+    /* Work with different RS and LL FEC for HDR, NDR and ETH PAM4 speeds */
+    if (((speedStrG == "ndr") || (speedStrG == "hdr")) ||
+        ((speedStrG.find("x") != string::npos) && (speedStrG != "100g_4x") && (speedStrG != "50g_2x"))) {
+        if (fec == _mlxlinkMaps->_fecModeMask[FEC_MODE_MASK_RS_528].second) {
             fecToCheck += "-544";
-        }
-        else if (fec == _mlxlinkMaps->_fecModeMask[FEC_MODE_MASK_LL_271].second && speedStrG != "hdr")
-        {
+        } else if ((fec == _mlxlinkMaps->_fecModeMask[FEC_MODE_MASK_LL_271].second) && (speedStrG != "hdr")) {
             fecToCheck += "-272";
         }
     }
-    for (auto it = _mlxlinkMaps->_fecModeMask.begin(); it != _mlxlinkMaps->_fecModeMask.end(); it++)
-    {
-        if (it->second.second == fecToCheck)
-        {
+    for (auto it = _mlxlinkMaps->_fecModeMask.begin(); it != _mlxlinkMaps->_fecModeMask.end(); it++) {
+        if (it->second.second == fecToCheck) {
             fecAdmin = it->first;
         }
     }
@@ -4291,7 +3867,7 @@ u_int32_t MlxlinkCommander::getFecCapForCheck(const string& speedStr)
     {
         fecCapMask = getFieldValue(string(_protoActive == IB ? "ib_" : "") + "fec_override_cap_" + speedStr);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         throw MlxRegException("\nFEC configuration is not available for this speed: " + speedStr);
     }
@@ -4303,39 +3879,30 @@ void MlxlinkCommander::checkPplmCap()
 {
     string speedFec = _userInput._speedFec;
     string uiSpeed = _userInput._speedFec;
-    if (_linkUP && _userInput._speedFec.empty())
-    {
+
+    if (_linkUP && _userInput._speedFec.empty()) {
         speedFec = speedToFecSpeedStr(_speedStrG, _numOfLanes);
         uiSpeed = _speedStrG;
     }
-    // Validate the speed
-    if (!_userInput._speedFec.empty())
-    {
-        vector<string> supportedSpeeds =
-          MlxlinkRecord::split(SupportedSpeeds2Str(_protoActive, _deviceCapability, _protoCapabilityEx), ",");
+    /* Validate the speed */
+    if (!_userInput._speedFec.empty()) {
+        vector < string > supportedSpeeds =
+            MlxlinkRecord::split(SupportedSpeeds2Str(_protoActive, _deviceCapability, _protoCapabilityEx), ",");
         string speedToCheck = _userInput._speedFec;
         speedToCheck = toUpperCase(speedToCheck);
-        if (_protoCapabilityEx)
-        {
-            if (speedToCheck == "50G")
-            {
+        if (_protoCapabilityEx) {
+            if (speedToCheck == "50G") {
                 speedToCheck += "_2X";
-            }
-            else if (speedToCheck == "100G")
-            {
+            } else if (speedToCheck == "100G") {
                 speedToCheck += "_4X";
             }
         }
-        if (!isIn(speedToCheck, supportedSpeeds))
-        {
+        if (!isIn(speedToCheck, supportedSpeeds)) {
             string validSpeeds = "";
-            if (!supportedSpeeds.empty())
-            {
+            if (!supportedSpeeds.empty()) {
                 validSpeeds = ", valid FEC speed configurations are [";
-                for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++)
-                {
-                    if (isIn(it->first, supportedSpeeds))
-                    {
+                for (auto it = _mlxlinkMaps->_fecPerSpeed.begin(); it != _mlxlinkMaps->_fecPerSpeed.end(); it++) {
+                    if (isIn(it->first, supportedSpeeds)) {
                         validSpeeds += it->first + ",";
                     }
                 }
@@ -4345,36 +3912,29 @@ void MlxlinkCommander::checkPplmCap()
             throw MlxRegException("\nFEC speed %s is not valid%s", uiSpeed.c_str(), validSpeeds.c_str());
         }
     }
-    // Validate the FEC for the speed
-    if (speedFec == "10g" || speedFec == "40g")
-    {
+    /* Validate the FEC for the speed */
+    if ((speedFec == "10g") || (speedFec == "40g")) {
         speedFec = "10g_40g";
     }
-    if (speedFec == "50g_2x")
-    {
+    if (speedFec == "50g_2x") {
         speedFec = "50g";
     }
-    if (speedFec == "100g_4x")
-    {
+    if (speedFec == "100g_4x") {
         speedFec = "100g";
     }
     _userInput._speedFec = speedFec;
     u_int32_t fecCap = getFecCapForCheck(_userInput._speedFec);
-    if (_userInput._pplmFec != "AU" && !(fecToBit(_userInput._pplmFec, _userInput._speedFec) & fecCap))
-    {
+
+    if ((_userInput._pplmFec != "AU") && !(fecToBit(_userInput._pplmFec, _userInput._speedFec) & fecCap)) {
         string supportedFec = fecMaskToUserInputStr(fecCap);
         string validFecs = fecMaskToUserInputStr(BIT_MASK_ALL_DWORD);
         string errorMsg = _userInput._pplmFec + " FEC is not supported in " + uiSpeed + " speed, ";
-        if (validFecs.find(_userInput._pplmFec) == string::npos || _userInput._pplmFec.size() <= 1)
-        {
+        if ((validFecs.find(_userInput._pplmFec) == string::npos) || (_userInput._pplmFec.size() <= 1)) {
             errorMsg = _userInput._pplmFec + " FEC configuration is not valid, ";
         }
-        if (supportedFec.empty())
-        {
+        if (supportedFec.empty()) {
             errorMsg += "it's not available for this speed";
-        }
-        else
-        {
+        } else {
             errorMsg += "valid FEC configurations are [" + supportedFec + "]";
         }
         throw MlxRegException("\n" + errorMsg);
@@ -4406,33 +3966,27 @@ u_int32_t MlxlinkCommander::getLaneSpeed(u_int32_t lane)
 void MlxlinkCommander::validateNumOfParamsForNDRGen()
 {
     u_int32_t params;
-    string errMsg = "Invalid set of Transmitter Parameters, ";
+    string    errMsg = "Invalid set of Transmitter Parameters, ";
+
     errMsg += "valid parameters for the active speed are: ";
-    if ((!_activeSpeed && _devID == DeviceSpectrum4) ||
-        isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
-    {
+    if ((!_activeSpeed && (_devID == DeviceSpectrum4)) ||
+        isSpeed100GPerLane((_protoActive == IB) ? _activeSpeed : _activeSpeedEx, _protoActive)) {
         params = SLTP_NDR_LAST;
         errMsg += "fir_pre3,fir_pre2,fir_pre1,fir_main,fir_post1";
-    }
-    else if (isSpeed50GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
-    {
+    } else if (isSpeed50GPerLane((_protoActive == IB) ? _activeSpeed : _activeSpeedEx, _protoActive)) {
         params = SLTP_NDR_FIR_POST1;
         errMsg += "fir_pre2,fir_pre1,fir_main,fir_post1";
-    }
-    else
-    {
+    } else {
         params = SLTP_NDR_FIR_MAIN;
         errMsg += "fir_pre1,fir_main,fir_post1";
     }
-    if (_userInput._sltpParams.size() != params)
-    {
+    if (_userInput._sltpParams.size() != params) {
         throw MlxRegException(errMsg);
     }
-    for (map<u_int32_t, u_int32_t>::iterator it = _userInput._sltpParams.begin(); it != _userInput._sltpParams.end();
-         it++)
-    {
-        if (((int)it->second) > MAX_SBYTE || ((int)it->second) < MIN_SBYTE)
-        {
+    for (map < u_int32_t, u_int32_t > ::iterator it = _userInput._sltpParams.begin();
+         it != _userInput._sltpParams.end();
+         it++) {
+        if ((((int)it->second) > MAX_SBYTE) || (((int)it->second) < MIN_SBYTE)) {
             throw MlxRegException("Invalid Transmitter Parameters values");
         }
     }
@@ -4441,49 +3995,41 @@ void MlxlinkCommander::validateNumOfParamsForNDRGen()
 void MlxlinkCommander::checkSltpParamsSize()
 {
     u_int32_t sltpParamsSize = SLTP_EDR_OB_REG;
-    if (_productTechnology == PRODUCT_16NM)
-    {
+
+    if (_productTechnology == PRODUCT_16NM) {
         sltpParamsSize = SLTP_HDR_OB_ALEV_OUT;
-        for (map<u_int32_t, u_int32_t>::iterator it = _userInput._sltpParams.begin();
+        for (map < u_int32_t, u_int32_t > ::iterator it = _userInput._sltpParams.begin();
              it != _userInput._sltpParams.end();
-             it++)
-        {
-            if (((int)it->second) > MAX_SBYTE || ((int)it->second) < MIN_SBYTE)
-            {
+             it++) {
+            if ((((int)it->second) > MAX_SBYTE) || (((int)it->second) < MIN_SBYTE)) {
                 throw MlxRegException("Invalid Transmitter Parameters values");
             }
         }
-    }
-    else if (_productTechnology >= PRODUCT_7NM)
-    {
+    } else if (_productTechnology >= PRODUCT_7NM) {
         validateNumOfParamsForNDRGen();
-    }
-    else if (_userInput._advancedMode)
-    {
+    } else if (_userInput._advancedMode) {
         sltpParamsSize = SLTP_EDR_LAST;
     }
-    if (_userInput._sltpParams.size() != sltpParamsSize && _productTechnology != PRODUCT_7NM &&
-        _productTechnology != PRODUCT_5NM)
-    {
+    if ((_userInput._sltpParams.size() != sltpParamsSize) && (_productTechnology != PRODUCT_7NM) &&
+        (_productTechnology != PRODUCT_5NM)) {
         throw MlxRegException("Invalid set of Transmitter Parameters");
     }
 }
 
 string MlxlinkCommander::updateSltpEdrHdrFields()
 {
-    map<u_int32_t, PRM_FIELD> sltpParam = _mlxlinkMaps->_SltpEdrParams;
+    map < u_int32_t, PRM_FIELD > sltpParam = _mlxlinkMaps->_SltpEdrParams;
     string sltpParamCmd = "";
-    char hdrEdrParamBuff[32] = "";
-    if (_productTechnology == PRODUCT_16NM)
-    {
+    char   hdrEdrParamBuff[32] = "";
+
+    if (_productTechnology == PRODUCT_16NM) {
         sltpParam = _mlxlinkMaps->_SltpHdrParams;
     }
 
-    for (auto const& param : sltpParam)
-    {
-        if (param.second.fieldAccess & (FIELD_ACCESS_W | FIELD_ACCESS_ADVANCED))
-        {
-            snprintf(hdrEdrParamBuff, 32, "%s=%d,", param.second.prmField.c_str(), _userInput._sltpParams[param.first]);
+    for (auto const& param : sltpParam) {
+        if (param.second.fieldAccess & (FIELD_ACCESS_W | FIELD_ACCESS_ADVANCED)) {
+            snprintf(hdrEdrParamBuff, 32, "%s=%d,", param.second.prmField.c_str(),
+                     _userInput._sltpParams[param.first]);
             sltpParamCmd += string(hdrEdrParamBuff);
         }
     }
@@ -4493,24 +4039,19 @@ string MlxlinkCommander::updateSltpEdrHdrFields()
 
 string MlxlinkCommander::updateSltpNdrFields()
 {
-    string sltpParamsCmd = "";
+    string    sltpParamsCmd = "";
     u_int32_t activeSpeed = _protoActive == IB ? _activeSpeed : _activeSpeedEx;
-    u_int32_t paramShift = 2; // Assuming that the active speed is NRZ, so user params will represent NRZ params
-    char paramValueBuff[32] = "";
+    u_int32_t paramShift = 2; /* Assuming that the active speed is NRZ, so user params will represent NRZ params */
+    char      paramValueBuff[32] = "";
 
-    if (isSpeed100GPerLane(activeSpeed, _protoActive))
-    {
+    if (isSpeed100GPerLane(activeSpeed, _protoActive)) {
         paramShift = 0;
-    }
-    else if (isSpeed50GPerLane(activeSpeed, _protoActive))
-    {
+    } else if (isSpeed50GPerLane(activeSpeed, _protoActive)) {
         paramShift = 1;
     }
 
-    for (auto const& param : _mlxlinkMaps->_SltpNdrParams)
-    {
-        if (param.second.validationMask & activeSpeed)
-        {
+    for (auto const& param : _mlxlinkMaps->_SltpNdrParams) {
+        if (param.second.validationMask & activeSpeed) {
             snprintf(paramValueBuff, sizeof(paramValueBuff), "%s=%d", param.second.prmField.c_str(),
                      _userInput._sltpParams[param.first - paramShift]);
             sltpParamsCmd += string(paramValueBuff);
@@ -4530,23 +4071,24 @@ string MlxlinkCommander::getSltpStatus()
 {
     sendPrmReg(ACCESS_REG_SLTP, GET);
 
-    string statusStr = "Invalid parameters";
+    string    statusStr = "Invalid parameters";
     u_int32_t status = getFieldValue("ob_bad_stat");
-    if (status)
-    {
-        switch (_productTechnology)
-        {
-            case PRODUCT_40NM:
-            case PRODUCT_28NM:
-                statusStr = _mlxlinkMaps->_SLTPBadSetStatus2Str[status];
-                break;
-            case PRODUCT_16NM:
-                statusStr = _mlxlinkMaps->_SLTP16BadSetStatus2Str[status];
-                break;
-            case PRODUCT_7NM:
-            case PRODUCT_5NM:
-                statusStr = _mlxlinkMaps->_SLTP7BadSetStatus2Str[status];
-                break;
+
+    if (status) {
+        switch (_productTechnology) {
+        case PRODUCT_40NM:
+        case PRODUCT_28NM:
+            statusStr = _mlxlinkMaps->_SLTPBadSetStatus2Str[status];
+            break;
+
+        case PRODUCT_16NM:
+            statusStr = _mlxlinkMaps->_SLTP16BadSetStatus2Str[status];
+            break;
+
+        case PRODUCT_7NM:
+        case PRODUCT_5NM:
+            statusStr = _mlxlinkMaps->_SLTP7BadSetStatus2Str[status];
+            break;
         }
     }
     return statusStr;
@@ -4558,65 +4100,58 @@ void MlxlinkCommander::sendSltp()
 
     checkSltpParamsSize();
 
-    if (_userInput._sltpLane && _userInput._lane >= _numOfLanes)
-    {
+    if (_userInput._sltpLane && (_userInput._lane >= _numOfLanes)) {
         throw MlxRegException("Could Not find Lane " + to_string(_userInput._lane));
     }
-    if (_userInput._txPolicy && _productTechnology < PRODUCT_7NM)
-    {
+    if (_userInput._txPolicy && (_productTechnology < PRODUCT_7NM)) {
         throw MlxRegException("--" SLTP_TX_POLICY_FLAG " flag is not valid for this device");
     }
 
     try
     {
-        if ((_devID == DeviceSpectrum2 || _devID == DeviceQuantum || _devID == DeviceQuantum2 ||
-             _devID == DeviceQuantum3 || _devID == DeviceBW00) &&
-            _userInput._db)
-        {
+        if (((_devID == DeviceSpectrum2) || (_devID == DeviceQuantum) || (_devID == DeviceQuantum2) ||
+             (_devID == DeviceQuantum3) || (_devID == DeviceGB100)) &&
+            _userInput._db) {
             u_int32_t portGroup = getPortGroup(_localPort);
             MlxlinkRecord::printWar("Port " + to_string(_userInput._labelPort) + " is mapped to group " +
-                                      to_string(portGroup) +
-                                      ".\nPlease "
-                                      "notice that the new settings will be implemented in all ports "
-                                      "mapped to group " +
-                                      to_string(portGroup),
+                                    to_string(portGroup) +
+                                    ".\nPlease "
+                                    "notice that the new settings will be implemented in all ports "
+                                    "mapped to group " +
+                                    to_string(portGroup),
                                     _jsonRoot);
         }
         u_int32_t laneSpeed = 0;
-        string sltpParamsCmd = "";
-        for (u_int32_t lane = 0; lane < _numOfLanes; lane++)
-        {
-            if (_userInput._sltpLane && _userInput._lane != lane)
-            {
+        string    sltpParamsCmd = "";
+        for (u_int32_t lane = 0; lane < _numOfLanes; lane++) {
+            if (_userInput._sltpLane && (_userInput._lane != lane)) {
                 continue;
             }
-            if (_userInput._db && lane != 0)
-            {
+            if (_userInput._db && (lane != 0)) {
                 break;
             }
 
             laneSpeed = getLaneSpeed(lane);
 
-            switch (_productTechnology)
-            {
-                case PRODUCT_5NM:
-                    sltpParamsCmd = updateSltpXdrFields();
-                    break;
-                case PRODUCT_7NM:
-                    sltpParamsCmd = updateSltpNdrFields();
-                    break;
-                case PRODUCT_16NM:
-                    getSltpAlevOut(lane);
-                    sltpParamsCmd = updateSltpEdrHdrFields();
-                    break;
-                default:
-                {
-                    if (!_userInput._advancedMode)
-                    {
-                        getSltpRegAndLeva(lane);
-                    }
-                    sltpParamsCmd = updateSltpEdrHdrFields();
+            switch (_productTechnology) {
+            case PRODUCT_5NM:
+                sltpParamsCmd = updateSltpXdrFields();
+                break;
+
+            case PRODUCT_7NM:
+                sltpParamsCmd = updateSltpNdrFields();
+                break;
+
+            case PRODUCT_16NM:
+                getSltpAlevOut(lane);
+                sltpParamsCmd = updateSltpEdrHdrFields();
+                break;
+
+            default:
+                if (!_userInput._advancedMode) {
+                    getSltpRegAndLeva(lane);
                 }
+                sltpParamsCmd = updateSltpEdrHdrFields();
                 break;
             }
 
@@ -4624,9 +4159,10 @@ void MlxlinkCommander::sendSltp()
                        _userInput._txPolicy, _userInput._db || _userInput._txPolicy, sltpParamsCmd.c_str());
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         string errorMsg = getSltpStatus();
+
         _allUnhandledErrors += string("Configuring Port Transmitter Parameters raised the following exception:\n"
                                       "Failed to send parameter set: ") +
                                errorMsg + "\n";
@@ -4637,10 +4173,9 @@ string MlxlinkCommander::getLoopbackStr(u_int32_t loopbackCapMask)
 {
     string loopbackStr = _mlxlinkMaps->_loopbackModeList[LOOPBACK_MODE_NO].first + "(" +
                          _mlxlinkMaps->_loopbackModeList[LOOPBACK_MODE_NO].second + ")/";
-    for (const auto& lbConf : _mlxlinkMaps->_loopbackModeList)
-    {
-        if ((lbConf.first & loopbackCapMask) && !lbConf.second.second.empty())
-        {
+
+    for (const auto& lbConf : _mlxlinkMaps->_loopbackModeList) {
+        if ((lbConf.first & loopbackCapMask) && !lbConf.second.second.empty()) {
             loopbackStr += lbConf.second.first + "(" + lbConf.second.second + ")/";
         }
     }
@@ -4653,18 +4188,17 @@ void MlxlinkCommander::checkPplrCap()
 
     u_int32_t loopBackCap = getFieldValue("lb_cap");
     u_int32_t loopBackVal = getLoopbackMode(_userInput._pplrLB);
-    if (loopBackVal != LOOPBACK_MODE_NO)
-    {
-        if (!(loopBackCap & getLoopbackMode(_userInput._pplrLB)))
-        {
+
+    if (loopBackVal != LOOPBACK_MODE_NO) {
+        if (!(loopBackCap & getLoopbackMode(_userInput._pplrLB))) {
             string supportedLoopbacks = getLoopbackStr(loopBackCap);
             throw MlxRegException(
-              "\n%s Loopback configuration is not supported, supported Loopback configurations are [%s]",
-              _userInput._pplrLB.c_str(), supportedLoopbacks.c_str());
+                "\n%s Loopback configuration is not supported, supported Loopback configurations are [%s]",
+                _userInput._pplrLB.c_str(),
+                supportedLoopbacks.c_str());
         }
     }
-    if (loopBackVal == LOOPBACK_MODE_REMOTE && _productTechnology < PRODUCT_7NM)
-    {
+    if ((loopBackVal == LOOPBACK_MODE_REMOTE) && (_productTechnology < PRODUCT_7NM)) {
         string warMsg = "Remote loopback mode pre-request (all should be satisfied):\n";
         warMsg += "1. Remote loopback is supported only in force mode.\n";
         warMsg += "   please use the --link_mode_force flag if force mode not configured\n";
@@ -4684,7 +4218,7 @@ void MlxlinkCommander::sendPplr()
 
         sendPrmReg(ACCESS_REG_PPLR, SET, "lb_en=%d", getLoopbackMode(_userInput._pplrLB));
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors += string("Sending PPLR (Configuring port loopback) raised the following exception: ") +
                                string(exc.what()) + string("\n");
@@ -4694,10 +4228,10 @@ void MlxlinkCommander::sendPplr()
 u_int32_t MlxlinkCommander::getLoopbackMode(const string& lb)
 {
     auto it = find_if(_mlxlinkMaps->_loopbackModeList.begin(), _mlxlinkMaps->_loopbackModeList.end(),
-                      [lb](pair<u_int32_t, pair<string, string>> lpConf) { return lb == lpConf.second.first; });
+                      [lb](pair < u_int32_t, pair < string, string >> lpConf) { return lb == lpConf.second.first;
+                      });
 
-    if (it == _mlxlinkMaps->_loopbackModeList.end())
-    {
+    if (it == _mlxlinkMaps->_loopbackModeList.end()) {
         throw MlxRegException("Invalid loopback option: %s, see tool usage \"%s --help\"", lb.c_str(), MLXLINK_EXEC);
     }
 
@@ -4710,34 +4244,32 @@ void MlxlinkCommander::sendPepc()
     {
         gearboxBlock(PEPC_SET_FLAG);
 
-        if (_isHCA || _devID == DeviceSwitchIB || _devID == DeviceSwitchIB2 || _devID == DeviceQuantum ||
-            _devID == DeviceQuantum2 || _devID == DeviceQuantum3 || _devID == DeviceBW00)
-        {
+        if (_isHCA || (_devID == DeviceSwitchIB) || (_devID == DeviceSwitchIB2) || (_devID == DeviceQuantum) ||
+            (_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceGB100)) {
             throw MlxRegException("\"--" PEPC_SET_FLAG "\" option is not supported for HCA and InfiniBand switches");
         }
         MlxlinkRecord::printCmdLine("Configuring External PHY", _jsonRoot);
         string regName = "PEPC";
 
-        // Get old values of PEPC fields
+        /* Get old values of PEPC fields */
         sendPrmReg(ACCESS_REG_PEPC, GET);
 
         u_int32_t forceMode_int = getFieldValue("twisted_pair_force_mode");
         u_int32_t anMode_int = getFieldValue("twisted_pair_an_mode");
 
-        // Set new values of PEPC fields
+        /* Set new values of PEPC fields */
         u_int32_t forceMode = forceMode_int;
-        if (_userInput._sendPepcForceMode)
-        {
+        if (_userInput._sendPepcForceMode) {
             forceMode = pepc_force_mode_to_int(_userInput._forceMode);
         }
 
         sendPrmReg(ACCESS_REG_PEPC, SET, "twisted_pair_an_mode=%d,twisted_pair_force_mode=%d", anMode_int, forceMode);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         _allUnhandledErrors +=
-          string("Sending PEPC (Configuring External PHY parameters) raised the following exception: ") +
-          string(exc.what()) + string("\n");
+            string("Sending PEPC (Configuring External PHY parameters) raised the following exception: ") +
+            string(exc.what()) + string("\n");
     }
 }
 
@@ -4752,9 +4284,8 @@ void MlxlinkCommander::setTxGroupMapping()
 {
     try
     {
-        if (_devID != DeviceSpectrum2 && _devID != DeviceQuantum && _devID != DeviceQuantum2 &&
-            _devID != DeviceQuantum3 && _devID != DeviceBW00)
-        {
+        if ((_devID != DeviceSpectrum2) && (_devID != DeviceQuantum) && (_devID != DeviceQuantum2) &&
+            (_devID != DeviceQuantum3) && (_devID != DeviceGB100)) {
             throw MlxRegException("Port group mapping supported for Spectrum-2 and Quantum switches only!");
         }
 
@@ -4764,8 +4295,7 @@ void MlxlinkCommander::setTxGroupMapping()
         u_int32_t blockSelector, bitMask;
         u_int32_t blocksToSet[4] = {0, 0, 0, 0};
         u_int32_t localPort = 0;
-        for (vector<PortGroup>::iterator it = _localPortsPerGroup.begin(); it != _localPortsPerGroup.end(); it++)
-        {
+        for (vector < PortGroup > ::iterator it = _localPortsPerGroup.begin(); it != _localPortsPerGroup.end(); it++) {
             localPort = it->localPort;
             blockSelector = (localPort - 1) / MAX_DWORD_BLOCK_SIZE;
             bitMask = (u_int32_t)pow(2.0, (int)((localPort - 1) - (blockSelector * MAX_DWORD_BLOCK_SIZE)));
@@ -4777,50 +4307,48 @@ void MlxlinkCommander::setTxGroupMapping()
                    "ports_mapping_of_group[2]=%d,ports_mapping_of_group[3]=%d",
                    1, TX_GROUP, _userInput._setGroup, blocksToSet[0], blocksToSet[1], blocksToSet[2], blocksToSet[3]);
     }
-    catch (const std::exception& exc)
+    catch(const std::exception& exc)
     {
         string errorMsg = string(exc.what());
-        if (errorMsg == OPERATIONAL_ERROR_STR)
-        {
+
+        if (errorMsg == OPERATIONAL_ERROR_STR) {
             errorMsg = "Invalid configuration values";
         }
         _allUnhandledErrors +=
-          string("Configuring ports group mapping raised the following exception: ") + errorMsg + string("\n");
+            string("Configuring ports group mapping raised the following exception: ") + errorMsg + string("\n");
     }
 }
 
-///////////////////////////////////////////////
+/*///////////////////////////////////////////// */
 
-// Cable operation
-// Cable helper functions
+/* Cable operation */
+/* Cable helper functions */
 
 bool MlxlinkCommander::isPassiveQSFP()
 {
-    switch (_cableIdentifier)
-    {
-        case IDENTIFIER_QSFP28:
-        case IDENTIFIER_QSFP_PLUS:
-            return (_cableMediaType == PASSIVE);
+    switch (_cableIdentifier) {
+    case IDENTIFIER_QSFP28:
+    case IDENTIFIER_QSFP_PLUS:
+        return (_cableMediaType == PASSIVE);
     }
     return false;
 }
 
 bool MlxlinkCommander::isSFP51Paging()
 {
-    // TODO check page 0 byte 64 bit 4, if set, then SFP51, else SFP.
+    /* TODO check page 0 byte 64 bit 4, if set, then SFP51, else SFP. */
     bool sfpQsaCable = (_cableIdentifier == IDENTIFIER_SFP || _cableIdentifier == IDENTIFIER_QSA);
     bool readSfp51 = false;
-    if (_ddmSupported && sfpQsaCable)
-    {
+
+    if (_ddmSupported && sfpQsaCable) {
         readSfp51 = true;
     }
     return readSfp51;
 }
 
-void MlxlinkCommander::printOuptputVector(vector<MlxlinkCmdPrint>& cmdOut)
+void MlxlinkCommander::printOuptputVector(vector < MlxlinkCmdPrint >& cmdOut)
 {
-    for (vector<MlxlinkCmdPrint>::iterator ptr = cmdOut.begin(); ptr < cmdOut.end(); ptr++)
-    {
+    for (vector < MlxlinkCmdPrint > ::iterator ptr = cmdOut.begin(); ptr < cmdOut.end(); ptr++) {
         cout << *ptr;
     }
 }
@@ -4829,8 +4357,7 @@ void MlxlinkCommander::initCablesCommander()
 {
     gearboxBlock(CABLE_FLAG);
 
-    if (_plugged && !_mngCableUnplugged)
-    {
+    if (_plugged && !_mngCableUnplugged) {
         _cablesCommander = new MlxlinkCablesCommander(_jsonRoot);
         _cablesCommander->_mf = _mf;
         _cablesCommander->_regLib = _regLib;
@@ -4843,9 +4370,7 @@ void MlxlinkCommander::initCablesCommander()
         _cablesCommander->_mlxlinkMaps = _mlxlinkMaps;
         _cablesCommander->_sfp51Paging = isSFP51Paging();
         _cablesCommander->_passiveQsfp = isPassiveQSFP();
-    }
-    else
-    {
+    } else {
         throw MlxRegException("No plugged cable detected");
     }
 }
@@ -4855,10 +4380,10 @@ void MlxlinkCommander::showCableDump()
     try
     {
         initCablesCommander();
-        vector<MlxlinkCmdPrint> dumpOutput = _cablesCommander->getPagesToDump();
+        vector < MlxlinkCmdPrint > dumpOutput = _cablesCommander->getPagesToDump();
         printOuptputVector(dumpOutput);
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Dumping EEPROM pages raised the following exception: " + exc.what_s() + "\n";
     }
@@ -4869,21 +4394,17 @@ void MlxlinkCommander::showCableDDM()
     try
     {
         initCablesCommander();
-        if (_isSwControled)
-        {
+        if (_isSwControled) {
             _cablesCommander->setSwControlMode();
         }
-        if (_ddmSupported)
-        {
-            vector<MlxlinkCmdPrint> ddmOutput = _cablesCommander->getCableDDM();
+        if (_ddmSupported) {
+            vector < MlxlinkCmdPrint > ddmOutput = _cablesCommander->getCableDDM();
             printOuptputVector(ddmOutput);
-        }
-        else
-        {
+        } else {
             throw MlxRegException("Cable does not support DDM");
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Showing DDM info raised the following exception: ";
         _allUnhandledErrors += exc.what_s();
@@ -4891,15 +4412,14 @@ void MlxlinkCommander::showCableDDM()
     }
 }
 
-vector<u_int8_t> MlxlinkCommander::validateBytes(const vector<string>& strBytes)
+vector < u_int8_t > MlxlinkCommander::validateBytes(const vector < string > &strBytes)
 {
-    vector<u_int8_t> intData;
+    vector < u_int8_t > intData;
     u_int32_t byteVal = 0;
-    for (u_int32_t i = 0; i < strBytes.size(); i++)
-    {
+
+    for (u_int32_t i = 0; i < strBytes.size(); i++) {
         strToUint32((char*)strBytes[i].c_str(), byteVal);
-        if (byteVal > 255)
-        {
+        if (byteVal > 255) {
             throw MlxRegException("Invalid byte value %d. It must be within range [0-255].", byteVal);
         }
         intData.push_back(byteVal);
@@ -4913,13 +4433,12 @@ void MlxlinkCommander::writeCableEEPROM()
     {
         initCablesCommander();
         MlxlinkRecord::printCmdLine("Writing To Cable EEPROM", _jsonRoot);
-        if (_plugged && !_mngCableUnplugged)
-        {
-            vector<u_int8_t> bytesToWrite = validateBytes(_userInput._bytesToWrite);
+        if (_plugged && !_mngCableUnplugged) {
+            vector < u_int8_t > bytesToWrite = validateBytes(_userInput._bytesToWrite);
             _cablesCommander->writeToEEPROM(_userInput._page, _userInput._offset, bytesToWrite);
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Writing cable EEPROM raised the following exception: ";
         _allUnhandledErrors += exc.what_s();
@@ -4933,10 +4452,10 @@ void MlxlinkCommander::readCableEEPROM()
     {
         initCablesCommander();
         MlxlinkCmdPrint bytesOutput =
-          _cablesCommander->readFromEEPRM(_userInput._page, _userInput._offset, _userInput._len);
+            _cablesCommander->readFromEEPRM(_userInput._page, _userInput._offset, _userInput._len);
         cout << bytesOutput;
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Reading cable EEPROM raised the following exception: " + exc.what_s() + "\n";
     }
@@ -4947,30 +4466,21 @@ void MlxlinkCommander::performControlParams()
     try
     {
         initCablesCommander();
-        if (_cableMediaType == ACTIVE || _cableMediaType == OPTICAL_MODULE)
-        {
-            if (_userInput.configParamsToSet.empty())
-            {
+        if ((_cableMediaType == ACTIVE) || (_cableMediaType == OPTICAL_MODULE)) {
+            if (_userInput.configParamsToSet.empty()) {
                 _cablesCommander->showControlParams();
-            }
-            else
-            {
-                if (_linkUP)
-                {
+            } else {
+                if (_linkUP) {
                     throw MlxRegException("Control parameters can be configured when the port is Disabled only\n");
-                }
-                else
-                {
+                } else {
                     _cablesCommander->setControlParams(_userInput.configParamsToSet);
                 }
             }
-        }
-        else
-        {
+        } else {
             throw MlxRegException("Control parameters are valid over Active/Optical modules only");
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Reading cable EEPROM raised the following exception: ";
         _allUnhandledErrors += exc.what_s();
@@ -4983,60 +4493,43 @@ void MlxlinkCommander::performModulePrbsCommands()
     try
     {
         initCablesCommander();
-        if (_cmisCable)
-        {
-            if (_cableMediaType == ACTIVE || _cableMediaType == OPTICAL_MODULE)
-            {
-                if (_userInput.modulePrbsParams[MODULE_PRBS_SELECT] != "HOST" &&
-                    _userInput.modulePrbsParams[MODULE_PRBS_SELECT] != "MEDIA")
-                {
+        if (_cmisCable) {
+            if ((_cableMediaType == ACTIVE) || (_cableMediaType == OPTICAL_MODULE)) {
+                if ((_userInput.modulePrbsParams[MODULE_PRBS_SELECT] != "HOST") &&
+                    (_userInput.modulePrbsParams[MODULE_PRBS_SELECT] != "MEDIA")) {
                     throw MlxRegException("Invalid module side PRBS select, please check the help menu");
                 }
                 _cablesCommander->_modulePrbsParams = _userInput.modulePrbsParams;
-                if (_userInput.isPrbsModeProvided)
-                {
+                if (_userInput.isPrbsModeProvided) {
                     ModuleAccess_t prbsModuleAccess = MODULE_PRBS_ACCESS_BOTH;
-                    if (_userInput.isPrbsChProvided && !_userInput.isPrbsGenProvided)
-                    {
+                    if (_userInput.isPrbsChProvided && !_userInput.isPrbsGenProvided) {
                         prbsModuleAccess = MODULE_PRBS_ACCESS_CH;
-                    }
-                    else if (!_userInput.isPrbsChProvided && _userInput.isPrbsGenProvided)
-                    {
+                    } else if (!_userInput.isPrbsChProvided && _userInput.isPrbsGenProvided) {
                         prbsModuleAccess = MODULE_PRBS_ACCESS_GEN;
-                    }
-                    else if (_userInput.isPrbsChProvided && _userInput.isPrbsGenProvided)
-                    {
+                    } else if (_userInput.isPrbsChProvided && _userInput.isPrbsGenProvided) {
                         prbsModuleAccess = MODULE_PRBS_ACCESS_CH_GEN;
                     }
                     _cablesCommander->handlePrbsTestMode(_userInput.modulePrbsParams[MODULE_PRBS_MODE],
                                                          prbsModuleAccess);
-                }
-                else
-                {
+                } else {
                     _cablesCommander->showPrbsTestMode();
                 }
 
-                if (_userInput.isPrbsShowDiagProvided)
-                {
+                if (_userInput.isPrbsShowDiagProvided) {
                     _cablesCommander->showPrpsDiagInfo();
                 }
 
-                if (_userInput.isPrbsClearDiagProvided)
-                {
+                if (_userInput.isPrbsClearDiagProvided) {
                     _cablesCommander->clearPrbsDiagInfo();
                 }
-            }
-            else
-            {
+            } else {
                 throw MlxRegException("The PRBS test mode supported over Active/Optical modules only");
             }
-        }
-        else
-        {
+        } else {
             throw MlxRegException("The PRBS test mode supported for CMIS modules only");
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += "Module PRBS test mode raised the following exception: ";
         _allUnhandledErrors += exc.what_s();
@@ -5049,8 +4542,7 @@ void MlxlinkCommander::initEyeOpener()
     try
     {
         gearboxBlock(MARGIN_SCAN_FLAG);
-        if (_linkUP || _userInput._pcie)
-        {
+        if (_linkUP || _userInput._pcie) {
             _eyeOpener = new MlxlinkEyeOpener(_jsonRoot);
             _eyeOpener->_mf = _mf;
             _eyeOpener->_regLib = _regLib;
@@ -5066,14 +4558,10 @@ void MlxlinkCommander::initEyeOpener()
             _eyeOpener->isPam4Speed = _isPam4Speed || ((_linkSpeed == IB_LINK_SPEED_HDR) && (_protoActive == IB));
             _eyeOpener->activeSpeedStr = _speedStrG;
 
-            if (_userInput.measureTime < 0)
-            {
-                if (_userInput._pcie)
-                {
+            if (_userInput.measureTime < 0) {
+                if (_userInput._pcie) {
                     _userInput.measureTime = DFLT_MSUR_TIME_PCIE;
-                }
-                else
-                {
+                } else {
                     _userInput.measureTime = DFLT_MSUR_TIME_PORT;
                 }
             }
@@ -5082,13 +4570,11 @@ void MlxlinkCommander::initEyeOpener()
             _eyeOpener->setNonInteractiveMode(_userInput.force);
 
             _eyeOpener->enableGradeScan();
-        }
-        else
-        {
+        } else {
             throw MlxRegException("port must be active");
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += string("Reading SerDes receive eye grade raised the following"
                                       " exception:\n") +
@@ -5111,48 +4597,39 @@ void MlxlinkCommander::handleRxErrInj()
     {
         gearboxBlock(PREI_RX_ERR_INJ_FLAG);
 
-        if (!_isHCA)
-        {
+        if (!_isHCA) {
             throw MlxRegException("This feature supporting NIC's only");
         }
-        if (_productTechnology != PRODUCT_28NM)
-        {
+        if (_productTechnology != PRODUCT_28NM) {
             throw MlxRegException("This feature supporting 28nm products only");
         }
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             throw MlxRegException("This feature not working while PRBS test mode is active");
         }
-        if (!_linkUP)
-        {
+        if (!_linkUP) {
             throw MlxRegException("Port must be active");
         }
-        if (!isSpeed25GPerLane(_activeSpeed, _protoActive))
-        {
+        if (!isSpeed25GPerLane(_activeSpeed, _protoActive)) {
             throw MlxRegException("This feature supporting 25G per lane speeds only");
         }
-        if (_fecActive != FEC_MODE_NO_FEC)
-        {
+        if (_fecActive != FEC_MODE_NO_FEC) {
             throw MlxRegException("This feature supporting links running with NO-FEC only");
         }
 
         initErrInj();
 
-        if (_userInput.mixerOffset0 >= 0 || _userInput.mixerOffset1 >= 0)
-        {
+        if ((_userInput.mixerOffset0 >= 0) || (_userInput.mixerOffset1 >= 0)) {
             _errInjector->_mixerOffset0 = _userInput.mixerOffset0;
             _errInjector->_mixerOffset1 = _userInput.mixerOffset1;
             _errInjector->updateMixerOffsets();
-        }
-        else
-        {
+        } else {
             _errInjector->showMixersOffset();
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors +=
-          string("Reading RX error injection raised the following exception:\n") + string(exc.what()) + string("\n");
+            string("Reading RX error injection raised the following exception:\n") + string(exc.what()) + string("\n");
     }
 }
 
@@ -5163,7 +4640,7 @@ bool MlxlinkCommander::isMpeinjSupported()
         sendPrmReg(ACCESS_REG_MPEINJ, GET, "depth=%d,pcie_index=%d,node=%d", _dpn.depth, _dpn.pcieIndex, _dpn.node);
         return true;
     }
-    catch (...)
+    catch(...)
     {
         return false;
     }
@@ -5171,19 +4648,15 @@ bool MlxlinkCommander::isMpeinjSupported()
 
 void MlxlinkCommander::handlePCIeErrInj()
 {
-    if (!isMpeinjSupported())
-    {
+    if (!isMpeinjSupported()) {
         throw MlxRegException("The current device does not support PCIe Error Injection!");
     }
 
     initErrInj();
 
-    if (_userInput.errorType.empty())
-    {
+    if (_userInput.errorType.empty()) {
         _errInjector->showPcieErrInjState(_dpn);
-    }
-    else
-    {
+    } else {
         _errInjector->startPcieErrInj(_dpn, _userInput.errorType, _userInput.errorDuration, _userInput.injDelay,
                                       _userInput.dbdf, _userInput.parameters);
     }
@@ -5192,11 +4665,12 @@ void MlxlinkCommander::handlePCIeErrInj()
 bool MlxlinkCommander::isPPHCRSupported()
 {
     bool supported = true;
+
     try
     {
         sendPrmReg(ACCESS_REG_PPHCR, GET, "local_port=1,pnat=1");
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         supported = false;
     }
@@ -5207,20 +4681,16 @@ void MlxlinkCommander::initPortInfo()
 {
     try
     {
-        if (_prbsTestMode)
-        {
+        if (_prbsTestMode) {
             throw MlxRegException("FEC Histogram is valid with normal link operation only");
         }
-        if (!isPPHCRSupported())
-        {
+        if (!isPPHCRSupported()) {
             throw MlxRegException("FEC Histogram is not supported for the current device");
         }
-        if (_userInput._pcie)
-        {
+        if (_userInput._pcie) {
             throw MlxRegException("FEC Histogram is not available for PCIe links");
         }
-        if (!_linkUP)
-        {
+        if (!_linkUP) {
             throw MlxRegException("FEC Histogram is valid with active link operation only");
         }
 
@@ -5231,16 +4701,13 @@ void MlxlinkCommander::initPortInfo()
         _portInfo->_fecActive = _fecActive;
         _portInfo->init();
 
-        if (_userInput.showFecHistogram)
-        {
+        if (_userInput.showFecHistogram) {
             _portInfo->showHistogram();
-        }
-        else if (_userInput.clearFecHistogram)
-        {
+        } else if (_userInput.clearFecHistogram) {
             _portInfo->clearHistogram();
         }
     }
-    catch (MlxRegException& exc)
+    catch(MlxRegException & exc)
     {
         _allUnhandledErrors += string("Providing FEC histogram cause the following"
                                       " exception:\n") +
@@ -5268,8 +4735,7 @@ void MlxlinkCommander::setAmBerCollectorFields()
 
 void MlxlinkCommander::initAmBerCollector()
 {
-    if (!_amberCollector)
-    {
+    if (!_amberCollector) {
         _amberCollector = new MlxlinkAmBerCollector(_jsonRoot);
         setAmBerCollectorFields();
     }
@@ -5298,11 +4764,11 @@ void MlxlinkCommander::prepareJsonOut()
     _portGroupMapping.toJsonFormat(_jsonRoot);
 
     bool errorExist = _allUnhandledErrors != "";
+
     _jsonRoot[JSON_STATUS_SECTION][JSON_STATUS_CODE] = errorExist ? 1 : 0;
     _jsonRoot[JSON_STATUS_SECTION][JSON_MSG] = errorExist ? _allUnhandledErrors : "success";
 
-    if (!_jsonRoot[JSON_RESULT_SECTION][JSON_OUTPUT_SECTION])
-    {
+    if (!_jsonRoot[JSON_RESULT_SECTION][JSON_OUTPUT_SECTION]) {
         _jsonRoot[JSON_RESULT_SECTION][JSON_OUTPUT_SECTION] = "N/A";
     }
 }

--- a/mlxreg/mlxreg_lib/mlxreg_lib.cpp
+++ b/mlxreg/mlxreg_lib/mlxreg_lib.cpp
@@ -28,7 +28,7 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
-
+ *
  *
  */
 
@@ -56,68 +56,61 @@ MlxRegLib::MlxRegLib(mfile* mf, string extAdbFile, bool isExternal)
     _isExternal = isExternal;
     try
     {
-        if (_isExternal && extAdbFile == "")
-        {
+        if (_isExternal && (extAdbFile == "")) {
             dm_dev_id_t devID = getDevId();
-            extAdbFile = PrmAdbDB::getDefaultDBName(dm_dev_is_switch(devID));
+            extAdbFile = PrmAdbDB::getDefaultDBName(devID);
         }
         initAdb(extAdbFile);
     }
-    catch (MlxRegException& adbInitExp)
+    catch(MlxRegException & adbInitExp)
     {
-        if (_adb)
-        {
+        if (_adb) {
             delete _adb;
         }
         throw adbInitExp;
     }
     string unionNode = REG_ACCESS_UNION_NODE;
     string rootNode = unionNode + "_selector";
-    if (_isExternal)
-    {
+
+    if (_isExternal) {
         rootNode = rootNode + "_ext";
     }
 
     _regAccessRootNode = _adb->createLayout(rootNode);
-    if (!_regAccessRootNode)
-    {
+    if (!_regAccessRootNode) {
         throw MlxRegException("No supported access registers found");
     }
     _regAccessUnionNode = _regAccessRootNode->getChildByPath(unionNode);
-    if (!_regAccessUnionNode)
-    {
+    if (!_regAccessUnionNode) {
         throw MlxRegException("No supported access registers found");
     }
-    if (!_regAccessUnionNode->isUnion())
-    {
+    if (!_regAccessUnionNode->isUnion()) {
         throw MlxRegException("No supported access registers found");
     }
     try
     {
         _regAccessMap = _regAccessUnionNode->unionSelector->getEnumMap();
     }
-    catch (AdbException& exp)
+    catch(AdbException & exp)
     {
         throw MlxRegException("Failed to extract registers info. %s", exp.what());
     }
-    // Set error map
-    std::map<int, std::string> errmap;
+    /* Set error map */
+    std::map < int, std::string > errmap;
     errmap[MRLS_SUCCESS] = "Success";
     errmap[MRLS_GENERAL] = "General error";
     updateErrCodes(errmap);
 }
 
 /************************************
- * Function: ~MlxRegLib
- ************************************/
+* Function: ~MlxRegLib
+************************************/
 MlxRegLib::~MlxRegLib()
 {
-    if (_regAccessRootNode)
-    {
+    if (_regAccessRootNode) {
         delete _regAccessRootNode;
     }
-    if (_adb)
-    {
+    if (_adb) {
         delete _adb;
     }
 }
@@ -130,10 +123,10 @@ dm_dev_id_t MlxRegLib::getDevId()
 dm_dev_id_t MlxRegLib::getDevId(mfile* mf)
 {
     dm_dev_id_t devID = DeviceUnknown;
-    u_int32_t hwDevID = 0;
-    u_int32_t hwChipRev = 0;
-    if (dm_get_device_id(mf, &devID, &hwDevID, &hwChipRev))
-    {
+    u_int32_t   hwDevID = 0;
+    u_int32_t   hwChipRev = 0;
+
+    if (dm_get_device_id(mf, &devID, &hwDevID, &hwChipRev)) {
         throw MlxRegException("Failed to read device ID");
     }
     return devID;
@@ -142,71 +135,68 @@ dm_dev_id_t MlxRegLib::getDevId(mfile* mf)
 bool MlxRegLib::isDeviceSupported(mfile* mf)
 {
     dm_dev_id_t devID = getDevId(mf);
+
     return !dm_is_4th_gen(devID);
 }
 
 void MlxRegLib::initAdb(string extAdbFile)
 {
     _adb = new Adb();
-    if (extAdbFile != "")
-    {
-        if (!_adb->load(extAdbFile, false, false, false))
-        {
+    if (extAdbFile != "") {
+        if (!_adb->load(extAdbFile, false, false, false)) {
             throw MlxRegException("Failure in loading Adabe file. %s", _adb->getLastError().c_str());
         }
-    }
-    else
-    {
+    } else {
         throw MlxRegException("No Adabe was provided, please provide Adabe file to continue");
     }
 }
 
 /************************************
- * Function: findAdbNode
- ************************************/
+* Function: findAdbNode
+************************************/
 AdbInstance* MlxRegLib::findAdbNode(string name)
 {
-    if (_regAccessMap.find(name) == _regAccessMap.end())
-    {
+    if (_regAccessMap.find(name) == _regAccessMap.end()) {
         throw MlxRegException("Can't find access register name: %s", name.c_str());
     }
     return _regAccessUnionNode->getUnionSelectedNodeName(name);
 }
 
 /************************************
- * Function: showRegister
- ************************************/
-MlxRegLibStatus MlxRegLib::showRegister(string regName, std::vector<AdbInstance*>& fields)
+* Function: showRegister
+************************************/
+MlxRegLibStatus MlxRegLib::showRegister(string regName, std::vector < AdbInstance* >& fields)
 {
     AdbInstance* adbNode = findAdbNode(regName);
+
     fields = adbNode->getLeafFields(true);
     return MRLS_SUCCESS;
 }
 
 /************************************
- * Function: showRegisters
- ************************************/
-MlxRegLibStatus MlxRegLib::showRegisters(std::vector<string>& regs)
+* Function: showRegisters
+************************************/
+MlxRegLibStatus MlxRegLib::showRegisters(std::vector < string >& regs)
 {
-    for (std::map<string, u_int64_t>::iterator it = _regAccessMap.begin(); it != _regAccessMap.end(); ++it)
-    {
+    for (std::map < string, u_int64_t > ::iterator it = _regAccessMap.begin(); it != _regAccessMap.end(); ++it) {
         regs.push_back(it->first);
     }
     return MRLS_SUCCESS;
 }
 
 /************************************
- * Function: sendMaccessReg
- ************************************/
-int MlxRegLib::sendMaccessReg(u_int16_t regId, int method, std::vector<u_int32_t>& data)
+* Function: sendMaccessReg
+************************************/
+int MlxRegLib::sendMaccessReg(u_int16_t regId, int method, std::vector < u_int32_t >& data)
 {
     int status = 0;
     int rc;
-    std::vector<u_int32_t> temp_data;
+
+    std::vector < u_int32_t > temp_data;
     copy(data.begin(), data.end(), back_inserter(temp_data));
     int i = RETRIES_COUNT;
-    do
-    {
+
+    do{
         rc = maccess_reg(_mf,
                          regId,
                          (maccess_reg_method_t)method,
@@ -215,8 +205,7 @@ int MlxRegLib::sendMaccessReg(u_int16_t regId, int method, std::vector<u_int32_t
                          (sizeof(u_int32_t) * data.size()),
                          (sizeof(u_int32_t) * data.size()),
                          &status);
-        if ((rc != ME_ICMD_STATUS_IFC_BUSY && status != ME_REG_ACCESS_BAD_PARAM) || !(_mf->flags & MDEVS_REM))
-        {
+        if (((rc != ME_ICMD_STATUS_IFC_BUSY) && (status != ME_REG_ACCESS_BAD_PARAM)) || !(_mf->flags & MDEVS_REM)) {
             break;
         }
         data.clear();
@@ -228,119 +217,116 @@ int MlxRegLib::sendMaccessReg(u_int16_t regId, int method, std::vector<u_int32_t
 }
 
 /************************************
- * Function: sendRegister
- ************************************/
-MlxRegLibStatus MlxRegLib::sendRegister(string regName, int method, std::vector<u_int32_t>& data)
+* Function: sendRegister
+************************************/
+MlxRegLibStatus MlxRegLib::sendRegister(string regName, int method, std::vector < u_int32_t >& data)
 {
     u_int16_t regId = (u_int16_t)_regAccessMap.find(regName)->second;
-    int rc;
+    int       rc;
+
     rc = sendMaccessReg(regId, method, data);
-    if (rc)
-    {
+    if (rc) {
         throw MlxRegException("Failed to send access register: %s", m_err2str((MError)rc));
     }
     return MRLS_SUCCESS;
 }
 
 /************************************
- * Function: sendRegister
- ************************************/
-MlxRegLibStatus MlxRegLib::sendRegister(u_int16_t regId, int method, std::vector<u_int32_t>& data)
+* Function: sendRegister
+************************************/
+MlxRegLibStatus MlxRegLib::sendRegister(u_int16_t regId, int method, std::vector < u_int32_t >& data)
 {
     int rc;
+
     rc = sendMaccessReg(regId, method, data);
-    if (rc)
-    {
+    if (rc) {
         throw MlxRegException("Failed send access register: %s", m_err2str((MError)rc));
     }
     return MRLS_SUCCESS;
 }
 
 /************************************
- * Function: getLastErrMsg
- ************************************/
+* Function: getLastErrMsg
+************************************/
 string MlxRegLib::getLastErrMsg()
 {
     std::stringstream sstm;
-    int lastErrCode = getLastErrCode();
-    string errCodeStr = err2Str(lastErrCode);
-    string errStr = err();
+    int               lastErrCode = getLastErrCode();
+    string            errCodeStr = err2Str(lastErrCode);
+    string            errStr = err();
+
     sstm << errCodeStr;
-    if (errStr != errCodeStr)
-    {
+    if (errStr != errCodeStr) {
         sstm << ": " << errStr;
     }
     return sstm.str();
 }
 
 /************************************
- * Function: isRegSizeSupported
- ************************************/
+* Function: isRegSizeSupported
+************************************/
 bool MlxRegLib::isRegSizeSupported(string regName)
 {
     AdbInstance* adbNode = _regAccessUnionNode->getUnionSelectedNodeName(regName);
+
     return (((adbNode->size >> 3) <= (u_int32_t)mget_max_reg_size(_mf, MACCESS_REG_METHOD_SET)) ||
             ((adbNode->size >> 3) <= (u_int32_t)mget_max_reg_size(_mf, MACCESS_REG_METHOD_GET)));
 }
 
 /************************************
- * Function: isAccessRegisterSupported
- ************************************/
+* Function: isAccessRegisterSupported
+************************************/
 void MlxRegLib::isAccessRegisterSupported(mfile* mf)
 {
-    int status;
+    int                                    status;
     struct icmd_hca_icmd_query_cap_general icmd_cap;
-    int i = RETRIES_COUNT;
+    int                                    i = RETRIES_COUNT;
 
     if (mf->tp == MST_FWCTL_CONTROL_DRIVER) {
         return;
     }
 
-    do
-    {
+    do{
         memset(&icmd_cap, 0, sizeof(icmd_cap));
         status = get_icmd_query_cap(mf, &icmd_cap);
-        if (!(status || icmd_cap.allow_icmd_access_reg_on_all_registers == 0))
+        if (!(status || (icmd_cap.allow_icmd_access_reg_on_all_registers == 0))) {
             break;
+        }
         msleep(SLEEP_INTERVAL);
     } while (i-- > 0);
 
-    if (status || icmd_cap.allow_icmd_access_reg_on_all_registers == 0)
-    {
+    if (status || (icmd_cap.allow_icmd_access_reg_on_all_registers == 0)) {
         throw MlxRegException("FW burnt on device does not support generic access register");
     }
 }
 /************************************
- * Function: isAccessRegisterGMPSupported
- ************************************/
+* Function: isAccessRegisterGMPSupported
+************************************/
 bool MlxRegLib::isAccessRegisterGMPSupported(maccess_reg_method_t reg_method)
 {
     return (bool)(supports_reg_access_gmp(_mf, reg_method));
 }
 
 /************************************
- * Function: isIBDevice
- ************************************/
+* Function: isIBDevice
+************************************/
 bool MlxRegLib::isIBDevice()
 {
     return (bool)(_mf->flags & MDEVS_IB);
 }
 
 /************************************
- * Function: dumpRegisterData
- ************************************/
-MlxRegLibStatus MlxRegLib::dumpRegisterData(string output_file_name, std::vector<u_int32_t>& data)
+* Function: dumpRegisterData
+************************************/
+MlxRegLibStatus MlxRegLib::dumpRegisterData(string output_file_name, std::vector < u_int32_t >& data)
 {
     FILE* outputFile = fopen(output_file_name.c_str(), "w");
-    if (outputFile)
-    {
-        for (std::vector<u_int32_t>::size_type i = 0; i != data.size(); i++)
-        {
+
+    if (outputFile) {
+        for (std::vector < u_int32_t > ::size_type i = 0; i != data.size(); i++) {
             fprintf(outputFile, "%08x\n", CPU_TO_BE32(data[i]));
         }
-    }
-    else
-    {
+    } else {
         throw MlxRegException("Failed to open file");
     }
     fclose(outputFile);

--- a/mtcr_freebsd/Makefile.am
+++ b/mtcr_freebsd/Makefile.am
@@ -55,6 +55,8 @@ libmtcr_ul_la_SOURCES = \
     $(top_srcdir)/mtcr_ul/packets_common.h\
     $(top_srcdir)/mtcr_ul/packets_layout.c \
     $(top_srcdir)/mtcr_ul/packets_layout.h \
+    $(top_srcdir)/mtcr_ul/mtcr_gpu.c \
+    $(top_srcdir)/mtcr_ul/mtcr_gpu.h \
     mtcr_mf.h \
     mtcr_ul.c \
     mtcr_ul_com_defs.h

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -76,19 +76,18 @@
 #include <sys/file.h>
 
 #define MST_VPD_DFLT_TIMEOUT 2000
-#define PCI_VPD_ADDR 0x2
-#define PCI_CAP_ID_VPD 0x3
-#define PCI_VPD_DATA 0x4
-#define HW_ID_ADDR 0xf0014
+#define PCI_VPD_ADDR         0x2
+#define PCI_CAP_ID_VPD       0x3
+#define PCI_VPD_DATA         0x4
+#define HW_ID_ADDR           0xf0014
 
 #define _PATH_DEVPCI "/dev/pci"
 
-typedef enum
-{
+typedef enum {
     Clear_Vsec_Semaphore = 0x1
 } adv_opt_t;
 
-#define FREEBSD_LOCK_FILE_DIR "/tmp/mft_lockfiles"
+#define FREEBSD_LOCK_FILE_DIR    "/tmp/mft_lockfiles"
 #define FREEBSD_LOCK_FILE_FORMAT "/tmp/mft_lockfiles/%s"
 
 #define CHECK_LOCK(rc) \
@@ -101,20 +100,16 @@ typedef enum
 static int _flock_int(int fdlock, int operation)
 {
     int cnt = 0;
-    if (fdlock == 0)
-    {
-        // in case we failed to create the lock file we ignore the locking mechanism
+
+    if (fdlock == 0) {
+        /* in case we failed to create the lock file we ignore the locking mechanism */
         return 0;
     }
-    do
-    {
-        if (flock(fdlock, operation | LOCK_NB) == 0)
-        {
+    do{
+        if (flock(fdlock, operation | LOCK_NB) == 0) {
             return 0;
-        }
-        else if (errno != EWOULDBLOCK)
-        {
-            break; // BAD! lock/free failed
+        } else if (errno != EWOULDBLOCK) {
+            break; /* BAD! lock/free failed */
         }
         mft_usleep(10);
         cnt++;
@@ -126,24 +121,21 @@ static int _flock_int(int fdlock, int operation)
 static int _create_lock(mfile* mf, char* devname)
 {
     char fname[64] = {0};
-    int rc;
-    int fd = 0;
+    int  rc;
+    int  fd = 0;
 
     snprintf(fname, sizeof(fname) - 1, FREEBSD_LOCK_FILE_FORMAT, devname);
     rc = mkdir("/tmp", 0777);
-    if (rc && errno != EEXIST)
-    {
+    if (rc && (errno != EEXIST)) {
         goto cl_clean_up;
     }
     rc = mkdir(FREEBSD_LOCK_FILE_DIR, 0777);
-    if (rc && errno != EEXIST)
-    {
+    if (rc && (errno != EEXIST)) {
         goto cl_clean_up;
     }
 
     fd = open(fname, O_RDONLY | O_CREAT, 0777);
-    if (fd < 0)
-    {
+    if (fd < 0) {
         goto cl_clean_up;
     }
 
@@ -159,61 +151,67 @@ cl_clean_up:
 void mtcr_connectx_flush(void* ptr, int fdlock)
 {
     u_int32_t value;
-    int rc = _flock_int(fdlock, LOCK_EX);
-    if (rc)
-    {
+    int       rc = _flock_int(fdlock, LOCK_EX);
+
+    if (rc) {
         return;
     }
     *((u_int32_t*)((char*)ptr + 0xf0380)) = 0x0;
-    do
-    {
-        asm volatile("" ::: "memory");
+    do{
+        asm volatile ("" ::: "memory");
         value = __be32_to_cpu(*((u_int32_t*)((char*)ptr + 0xf0380)));
     } while (value);
     rc = _flock_int(fdlock, LOCK_UN);
-    if (rc)
-    {
+    if (rc) {
         return;
     }
 }
 
 int read_device_id(mfile* mf, u_int32_t* device_id)
 {
-    return mread4(mf, HW_ID_ADDR, device_id);
+    if (!mf || !device_id) {
+        return -1;
+    }
+
+    int      rc = 0;
+    unsigned hw_id_address = mf->cr_space_offset + HW_ID_ADDR;
+
+    mf->rev_id = EXTRACT(*device_id, 16, 4);
+    *device_id = (*device_id & 0xffff);
+    mf->hw_dev_id = (*device_id & 0xffff);
+
+    return mread4(mf, hw_id_address, device_id);
 }
 
 int mtcr_check_signature(mfile* mf)
 {
     unsigned signature;
-    int rc;
+    int      rc;
+
     rc = read_device_id(mf, &signature);
-    if (rc != 4)
-    {
-        if (!errno)
-        {
+    if (rc != 4) {
+        if (!errno) {
             errno = EIO;
         }
         return -1;
     }
 
-    switch (signature & 0xffff)
-    {
-        case 0x190: /* 400 */
-            if (signature == 0xa00190 && mf->ptr)
-            {
-                mf->connectx_flush = 1;
-                mtcr_connectx_flush(mf->ptr, mf->fdlock);
-            }
+    switch (signature & 0xffff) {
+    case 0x190:     /* 400 */
+        if ((signature == 0xa00190) && mf->ptr) {
+            mf->connectx_flush = 1;
+            mtcr_connectx_flush(mf->ptr, mf->fdlock);
+        }
 
-        case 0x5a44: /* 23108 */
-        case 0x6278: /* 25208 */
-        case 0x5e8c: /* 24204 */
-        case 0x6274: /* 25204 */
-            return 0;
+    case 0x5a44:     /* 23108 */
+    case 0x6278:     /* 25208 */
+    case 0x5e8c:     /* 24204 */
+    case 0x6274:     /* 25204 */
+        return 0;
 
-        default:
-            errno = ENOTTY;
-            return -1;
+    default:
+        errno = ENOTTY;
+        return -1;
     }
 }
 
@@ -265,65 +263,62 @@ int mtcr_check_signature(mfile* mf)
         }                                                         \
     } while (0)
 
-#define PCI_CONF_ADDR (0x00000058)
-#define PCI_CONF_DATA (0x0000005c)
+#define PCI_CONF_ADDR               (0x00000058)
+#define PCI_CONF_DATA               (0x0000005c)
 #define MLNX_VENDOR_SPECIFIC_CAP_ID 0x9
 
 /* PCI address space related enum*/
-enum
-{
-    PCI_CAP_PTR = 0x34,
-    PCI_HDR_SIZE = 0x40,
+enum {
+    PCI_CAP_PTR        = 0x34,
+    PCI_HDR_SIZE       = 0x40,
     PCI_EXT_SPACE_ADDR = 0xff,
 
-    PCI_CTRL_OFFSET = 0x4, // for space / semaphore / auto-increment bit
-    PCI_COUNTER_OFFSET = 0x8,
+    PCI_CTRL_OFFSET      = 0x4, /* for space / semaphore / auto-increment bit */
+    PCI_COUNTER_OFFSET   = 0x8,
     PCI_SEMAPHORE_OFFSET = 0xc,
-    PCI_ADDR_OFFSET = 0x10,
-    PCI_DATA_OFFSET = 0x14,
+    PCI_ADDR_OFFSET      = 0x10,
+    PCI_DATA_OFFSET      = 0x14,
 
     PCI_FLAG_BIT_OFFS = 31,
 
     PCI_SPACE_BIT_OFFS = 0,
-    PCI_SPACE_BIT_LEN = 16,
+    PCI_SPACE_BIT_LEN  = 16,
 
     PCI_STATUS_BIT_OFFS = 29,
-    PCI_STATUS_BIT_LEN = 3,
+    PCI_STATUS_BIT_LEN  = 3,
 
     PCI_HEADER_OFFS = 0x0,
     PCI_SUBSYS_OFFS = 0x2c,
-    PCI_CLASS_OFFS = 0x8,
+    PCI_CLASS_OFFS  = 0x8,
 };
 
 /* Mellanox vendor specific enum */
-enum
-{
-    CAP_ID = 0x9,
+enum {
+    CAP_ID          = 0x9,
     IFC_MAX_RETRIES = 0x10000,
     SEM_MAX_RETRIES = 0x1000
 };
 
 /* PCI operation enum(read or write)*/
-enum
-{
-    READ_OP = 0,
+enum {
+    READ_OP  = 0,
     WRITE_OP = 1,
 };
 
 int read_config(mfile* mf, unsigned int reg, uint32_t* data, int width)
 {
     struct pci_io pi = {};
+
     pi.pi_sel = mf->sel;
     pi.pi_reg = reg;
     pi.pi_width = width;
 
-    if (ioctl(mf->fd, PCIOCREAD, &pi) < 0)
-    {
+    if (ioctl(mf->fd, PCIOCREAD, &pi) < 0) {
         errno = EIO;
         return -1;
     }
 
-    // printf("%s:  dev:%d reg=%x width=%d data=%x\n", __FUNCTION__, pi.pi_sel.pc_dev, reg, width, pi.pi_data);
+    /* printf("%s:  dev:%d reg=%x width=%d data=%x\n", __FUNCTION__, pi.pi_sel.pc_dev, reg, width, pi.pi_data); */
     *data = (pi.pi_data);
 
     return 0;
@@ -332,15 +327,15 @@ int read_config(mfile* mf, unsigned int reg, uint32_t* data, int width)
 int write_config(mfile* mf, unsigned int reg, uint32_t data, int width)
 {
     struct pci_io pi = {};
+
     pi.pi_sel = mf->sel;
     pi.pi_reg = reg;
     pi.pi_width = width;
     pi.pi_data = data;
 
-    // printf("%s: dev:%d reg:%x width:%d data:%x\n", __FUNCTION__, pi.pi_sel.pc_dev, pi.pi_reg, pi.pi_width,
-    // pi.pi_data);
-    if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0)
-    {
+    /* printf("%s: dev:%d reg:%x width:%d data:%x\n", __FUNCTION__, pi.pi_sel.pc_dev, pi.pi_reg, pi.pi_width, */
+    /* pi.pi_data); */
+    if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0) {
         errno = EIO;
         return -1;
     }
@@ -354,34 +349,31 @@ int write_config(mfile* mf, unsigned int reg, uint32_t data, int width)
 
 static int is_wo_pciconf_gw(mfile* mf)
 {
-    unsigned offset = HW_ID_ADDR;
+    unsigned  offset = HW_ID_ADDR;
     u_int32_t data = 0;
-    int lock_rc;
+    int       lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     int rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-    if (rc < 0)
-    {
+
+    if (rc < 0) {
         goto cleanup;
     }
     rc = read_config(mf, PCI_CONF_ADDR, &data, 4);
-    if (rc < 0)
-    {
+    if (rc < 0) {
         rc = 0;
         goto cleanup;
     }
-    // printf("-D- Data: %#x\n", data);
-    if (data == WO_REG_ADDR_DATA)
-    {
+    /* printf("-D- Data: %#x\n", data); */
+    if (data == WO_REG_ADDR_DATA) {
         rc = 1;
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return rc;
     }
     return rc;
@@ -396,60 +388,52 @@ cleanup:
 /* Read Write new functions (4Bytes, Block)*/
 int pci_find_capability(mfile* mf, int cap_id)
 {
-    unsigned offset;
+    unsigned      offset;
     unsigned char visited[256] = {0}; /* Prevent infinite loops */
-    uint32_t reg;
-    int ret;
-    int curr_cap;
+    uint32_t      reg;
+    int           ret;
+    int           curr_cap;
+    int           lock_rc;
 
-    int lock_rc;
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     ret = read_config(mf, PCI_CAP_PTR, &reg, 4);
 
-    if (ret)
-    {
+    if (ret) {
         ret = 0;
         goto cleanup;
     }
 
     offset = ((unsigned char*)&reg)[0];
-    while (1)
-    {
-        if (offset < PCI_HDR_SIZE || offset > PCI_EXT_SPACE_ADDR)
-        {
+    while (1) {
+        if ((offset < PCI_HDR_SIZE) || (offset > PCI_EXT_SPACE_ADDR)) {
             ret = 0;
             goto cleanup;
         }
         ret = read_config(mf, offset, &reg, 4);
-        if (ret)
-        {
+        if (ret) {
             ret = 0;
             goto cleanup;
         }
 
         visited[offset] = 1;
         curr_cap = ((unsigned char*)&reg)[0];
-        if (curr_cap == cap_id)
-        {
+        if (curr_cap == cap_id) {
             ret = offset;
             goto cleanup;
         }
 
         offset = ((unsigned char*)&reg)[1];
-        if (visited[offset])
-        {
+        if (visited[offset]) {
             ret = 0;
             goto cleanup;
         }
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return ret;
     }
     return ret;
@@ -459,35 +443,30 @@ static int _vendor_specific_sem(mfile* mf, int state)
 {
     uint32_t lock_val;
     uint32_t counter = 0;
-    int retries = 0;
-    if (!state)
-    {
-        // unlock
+    int      retries = 0;
+
+    if (!state) {
+        /* unlock */
         WRITE4_PCI(mf, 0, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "unlock semaphore", return -1);
-    }
-    else
-    {
-        // lock
-        do
-        {
-            if (retries > SEM_MAX_RETRIES)
-            {
+    } else {
+        /* lock */
+        do{
+            if (retries > SEM_MAX_RETRIES) {
                 return -1;
             }
-            // read semaphore untill 0x0
+            /* read semaphore untill 0x0 */
             READ4_PCI(mf, &lock_val, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "read counter", return -1);
-            if (lock_val)
-            {
-                // semaphore is taken
+            if (lock_val) {
+                /* semaphore is taken */
                 retries++;
-                msleep(1); // wait for current op to end
+                msleep(1); /* wait for current op to end */
                 continue;
             }
-            // read ticket
+            /* read ticket */
             READ4_PCI(mf, &counter, mf->vsec_addr + PCI_COUNTER_OFFSET, "read counter", return -1);
-            // write ticket to semaphore dword
+            /* write ticket to semaphore dword */
             WRITE4_PCI(mf, counter, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "write counter to semaphore", return -1);
-            // read back semaphore make sure ticket == semaphore else repeat
+            /* read back semaphore make sure ticket == semaphore else repeat */
             READ4_PCI(mf, &lock_val, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "read counter", return -1);
             retries++;
         } while (counter != lock_val);
@@ -497,12 +476,11 @@ static int _vendor_specific_sem(mfile* mf, int state)
 
 static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 {
-    int retries = 0;
+    int      retries = 0;
     uint32_t flag;
-    do
-    {
-        if (retries > IFC_MAX_RETRIES)
-        {
+
+    do{
+        if (retries > IFC_MAX_RETRIES) {
             return -1;
         }
 
@@ -510,10 +488,9 @@ static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 
         flag = EXTRACT(flag, PCI_FLAG_BIT_OFFS, 1);
         retries++;
-        if ((retries & 0xf) == 0)
-        {
-            // dont sleep always
-            // usleep_range(1,5);
+        if ((retries & 0xf) == 0) {
+            /* dont sleep always */
+            /* usleep_range(1,5); */
         }
     } while (flag != expected_val);
     return 0;
@@ -521,15 +498,15 @@ static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 
 static int _set_addr_space(mfile* mf, u_int16_t space)
 {
-    // read modify write
+    /* read modify write */
     uint32_t val;
+
     READ4_PCI(mf, &val, mf->vsec_addr + PCI_CTRL_OFFSET, "read domain", return -1);
     val = MERGE(val, space, PCI_SPACE_BIT_OFFS, PCI_SPACE_BIT_LEN);
     WRITE4_PCI(mf, val, mf->vsec_addr + PCI_CTRL_OFFSET, "write domain", return -1);
-    // read status and make sure space is supported
+    /* read status and make sure space is supported */
     READ4_PCI(mf, &val, mf->vsec_addr + PCI_CTRL_OFFSET, "read status", return -1);
-    if (EXTRACT(val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0)
-    {
+    if (EXTRACT(val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0) {
         return -1;
     }
     return 0;
@@ -537,32 +514,28 @@ static int _set_addr_space(mfile* mf, u_int16_t space)
 
 static int _pciconf_rw(mfile* mf, unsigned int offset, uint32_t* data, int rw)
 {
-    int ret = 0;
+    int      ret = 0;
     uint32_t address = offset;
 
-    // last 2 bits must be zero as we only allow 30 bits addresses
-    if (EXTRACT(address, 30, 2))
-    {
+    /* last 2 bits must be zero as we only allow 30 bits addresses */
+    if (EXTRACT(address, 30, 2)) {
         return -1;
     }
 
     address = MERGE(address, (rw ? 1 : 0), PCI_FLAG_BIT_OFFS, 1);
-    if (rw == WRITE_OP)
-    {
-        // write data
+    if (rw == WRITE_OP) {
+        /* write data */
         WRITE4_PCI(mf, *data, mf->vsec_addr + PCI_DATA_OFFSET, "write value", return -1);
-        // write address
+        /* write address */
         WRITE4_PCI(mf, address, mf->vsec_addr + PCI_ADDR_OFFSET, "write offset", return -1);
-        // wait on flag
+        /* wait on flag */
         ret = _wait_on_flag(mf, 0);
-    }
-    else
-    {
-        // write address
+    } else {
+        /* write address */
         WRITE4_PCI(mf, address, mf->vsec_addr + PCI_ADDR_OFFSET, "write offset", return -1);
-        // wait on flag
+        /* wait on flag */
         ret = _wait_on_flag(mf, 1);
-        // read data
+        /* read data */
         READ4_PCI(mf, data, mf->vsec_addr + PCI_DATA_OFFSET, "read value", return -1);
     }
     return ret;
@@ -572,24 +545,22 @@ static int _send_pci_cmd_int(mfile* mf, int space, unsigned int offset, uint32_t
 {
     int ret = 0;
 
-    // take semaphore
+    /* take semaphore */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
-        // printf("-D- Failed to take Semaphore!\n");
+    if (ret) {
+        /* printf("-D- Failed to take Semaphore!\n"); */
         return ret;
     }
-    // set address space
+    /* set address space */
     ret = _set_addr_space(mf, space);
-    if (ret)
-    {
-        // printf("-D- Failed to set space!\n");
+    if (ret) {
+        /* printf("-D- Failed to set space!\n"); */
         goto cleanup;
     }
-    // read/write the data
+    /* read/write the data */
     ret = _pciconf_rw(mf, offset, data, rw);
 cleanup:
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
     return ret;
 }
@@ -599,27 +570,23 @@ static int _block_op(mfile* mf, int space, unsigned int offset, int size, uint32
     int i;
     int ret = 0;
     int wrote_or_read = size;
-    if (size % 4)
-    {
+
+    if (size % 4) {
         return -1;
     }
-    // lock semaphore and set address space
+    /* lock semaphore and set address space */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
-    // set address space
+    /* set address space */
     ret = _set_addr_space(mf, space);
-    if (ret)
-    {
+    if (ret) {
         wrote_or_read = -1;
         goto cleanup;
     }
-    for (i = 0; i < size; i += 4)
-    {
-        if (_pciconf_rw(mf, offset + i, &(data[(i >> 2)]), rw))
-        {
+    for (i = 0; i < size; i += 4) {
+        if (_pciconf_rw(mf, offset + i, &(data[(i >> 2)]), rw)) {
             wrote_or_read = i;
             goto cleanup;
         }
@@ -634,8 +601,7 @@ static int mwrite4_new(mfile* mf, unsigned int offset, uint32_t data)
     int ret;
 
     ret = _send_pci_cmd_int(mf, mf->address_space, offset, &data, WRITE_OP);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
     return 4;
@@ -646,8 +612,7 @@ static int mread4_new(mfile* mf, unsigned int offset, uint32_t* data)
     int ret;
 
     ret = _send_pci_cmd_int(mf, mf->address_space, offset, data, READ_OP);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
     return 4;
@@ -665,18 +630,17 @@ static int mread4_block_new(mfile* mf, unsigned int offset, int size, uint32_t* 
 
 static int vsec_spaces_supported(mfile* mf)
 {
-    // take semaphore
+    /* take semaphore */
     int supported = 1;
     int ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+
+    if (ret) {
         return supported;
     }
-    if (_set_addr_space(mf, AS_CR_SPACE) || _set_addr_space(mf, AS_ICMD) || _set_addr_space(mf, AS_SEMAPHORE))
-    {
+    if (_set_addr_space(mf, AS_CR_SPACE) || _set_addr_space(mf, AS_ICMD) || _set_addr_space(mf, AS_SEMAPHORE)) {
         supported = 0;
     }
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
     return supported;
 }
@@ -695,56 +659,45 @@ int device_exists(const char* devname);
 #if __FreeBSD_version > 700000
 int getsel(const char* str, struct pcisel* selout)
 {
-    char* ep = strchr(str, '@');
-    char* epbase;
+    char        * ep = strchr(str, '@');
+    char        * epbase;
     struct pcisel sel;
     unsigned long selarr[4];
-    int i;
-    // printf("__FreeBSD_version > 700000 detected.\n");
+    int           i;
 
-    if (ep == NULL)
-    {
+    /* printf("__FreeBSD_version > 700000 detected.\n"); */
+
+    if (ep == NULL) {
         ep = (char*)str;
-    }
-    else
-    {
+    } else {
         ep++;
     }
 
     epbase = ep;
 
-    if (strncmp(ep, "pci", 3) == 0)
-    {
+    if (strncmp(ep, "pci", 3) == 0) {
         ep += 3;
         i = 0;
-        do
-        {
+        do{
             selarr[i++] = strtoul(ep, &ep, 10);
         } while ((*ep == ':' || *ep == '.') && *++ep != '\0' && i < 4);
 
-        if (i > 2)
-        {
+        if (i > 2) {
             sel.pc_func = selarr[--i];
-        }
-        else
-        {
+        } else {
             sel.pc_func = 0;
         }
         sel.pc_dev = selarr[--i];
         sel.pc_bus = selarr[--i];
-        if (i > 0)
-        {
+        if (i > 0) {
             sel.pc_domain = selarr[--i];
-        }
-        else
-        {
+        } else {
             sel.pc_domain = 0;
         }
     }
-    if (*ep != '\x0' || ep == epbase)
-    {
+    if ((*ep != '\x0') || (ep == epbase)) {
         return 1;
-        // errx(1, "cannot parse selector %s ep:'%s' epbase:%s, %d", str, ep, epbase, *ep);
+        /* errx(1, "cannot parse selector %s ep:'%s' epbase:%s, %d", str, ep, epbase, *ep); */
     }
 
     *selout = sel;
@@ -754,80 +707,69 @@ int getsel(const char* str, struct pcisel* selout)
 #else
 int getsel(const char* str, struct pcisel* selout)
 {
-    char* ep = strchr(str, '@');
-    char* epbase;
+    char        * ep = strchr(str, '@');
+    char        * epbase;
     struct pcisel sel;
 
-    // printf("__FreeBSD_version < 700000 detected: %d\n", __FreeBSD_version);
+    /* printf("__FreeBSD_version < 700000 detected: %d\n", __FreeBSD_version); */
 
-    if (ep == NULL)
-    {
+    if (ep == NULL) {
         ep = (char*)str;
-    }
-    else
-    {
+    } else {
         ep++;
     }
 
     epbase = ep;
 
-    if (strncmp(ep, "pci", 3) == 0)
-    {
+    if (strncmp(ep, "pci", 3) == 0) {
         ep += 3;
         sel.pc_bus = strtoul(ep, &ep, 0);
-        if (!ep || *ep++ != ':')
-        {
+        if (!ep || (*ep++ != ':')) {
             errno = EINVAL;
             return 1;
-            // errx(1, "cannot parse selector %s", str);
+            /* errx(1, "cannot parse selector %s", str); */
         }
         sel.pc_dev = strtoul(ep, &ep, 0);
-        if (!ep || *ep != ':')
-        {
+        if (!ep || (*ep != ':')) {
             sel.pc_func = 0;
-        }
-        else
-        {
+        } else {
             ep++;
             sel.pc_func = strtoul(ep, &ep, 0);
         }
-        if (*ep == ':')
-        {
+        if (*ep == ':') {
             ep++;
         }
     }
-    if (*ep != '\x0' || ep == epbase)
-    {
+    if ((*ep != '\x0') || (ep == epbase)) {
         return 1;
-        // errx(1, "cannot parse selector %s", str);
+        /* errx(1, "cannot parse selector %s", str); */
     }
 
     *selout = sel;
 
     return 0;
 }
-#endif
+#endif /* if __FreeBSD_version > 700000 */
 
 int mtcr_open_config(mfile* mf, const char* name)
 {
-    // printf("open_config %s %s mf:%p\n", name, _PATH_DEVPCI, mf);
+    /* printf("open_config %s %s mf:%p\n", name, _PATH_DEVPCI, mf); */
 
-    if (!mf)
-    {
+    if (!mf) {
         printf("Internal: Uninitialized mfile\n");
         exit(1);
     }
 
     mf->fd = open(_PATH_DEVPCI, O_RDWR, 0);
-    if (mf->fd < 0)
-    {
+    if (mf->fd < 0) {
         printf("err opening: %s", _PATH_DEVPCI);
         return -1;
     }
 
-    // printf("open_config name:%s fd:%d\n", name, mf->fd);
+    /* printf("open_config name:%s fd:%d\n", name, mf->fd); */
     int ret = getsel(name, &mf->sel);
-    // printf("open_config getsel done %d\n", mf->sel.pc_dev);
+
+    /* printf("open_config getsel done %d\n", mf->sel.pc_dev); */
     mf->tp = MST_PCICONF;
 
     return ret;
@@ -836,89 +778,77 @@ int mtcr_open_config(mfile* mf, const char* name)
 mfile* mopen_int(const char* name, u_int32_t adv_opt)
 {
     char* real_name = (char*)name;
-    int is_cable = 0;
+    int   is_cable = 0;
+
 #ifndef MST_UL
     int port = 0;
 #endif
-    if (getuid() != 0)
-    {
+    if (getuid() != 0) {
         errno = EACCES;
         return NULL;
     }
-    // printf("%s: open %s\n", __FUNCTION__, name);
+    /* printf("%s: open %s\n", __FUNCTION__, name); */
 #ifndef MST_UL
-    char tmp_name[512] = {0};
+    char  tmp_name[512] = {0};
     char* p_cable = strstr(name, "_cable");
-    if (p_cable != 0)
-    {
+    if (p_cable != 0) {
         strncpy(tmp_name, name, 512 - 1);
         tmp_name[p_cable - name] = 0;
         is_cable = 1;
         real_name = tmp_name;
 
-        // printf("-D- splitting name: %s\n", real_name);
-        if (strstr(p_cable + 1, "_") != NULL)
-        {
+        /* printf("-D- splitting name: %s\n", real_name); */
+        if (strstr(p_cable + 1, "_") != NULL) {
             p_cable += 7;
-            if (*p_cable != '\0')
-            {
+            if (*p_cable != '\0') {
                 port = atoi(p_cable);
             }
         }
     }
 #endif
-    if (!device_exists(real_name))
-    {
+    if (!device_exists(real_name)) {
         errno = ENOENT;
         return NULL;
     }
     mfile* mf = malloc(sizeof(mfile));
     memset(mf, 0, sizeof(mfile));
-    if (!mf)
-    {
+    if (!mf) {
         return NULL;
     }
     mf->sock = -1;
     mf->user_page_list.page_amount = 0;
 
     mf->flags = MDEVS_TAVOR_CR;
-    if (!mtcr_open_config(mf, real_name))
-    {
+    if (!mtcr_open_config(mf, real_name)) {
         _create_lock(mf, real_name);
         mf->wo_addr = is_wo_pciconf_gw(mf);
-        // printf("-D- is_wo_pciconf_gw: %d\n", mf->wo_addr);
+        /* printf("-D- is_wo_pciconf_gw: %d\n", mf->wo_addr); */
         mf->vsec_addr = pci_find_capability(mf, MLNX_VENDOR_SPECIFIC_CAP_ID);
         mf->vpd_cap_addr = pci_find_capability(mf, PCI_CAP_ID_VPD);
         mf->is_cable = is_cable;
         mf->vsec_supp = 0;
-        if (mf->vsec_addr)
-        {
-            if (adv_opt & Clear_Vsec_Semaphore)
-            {
+        if (mf->vsec_addr) {
+            if (adv_opt & Clear_Vsec_Semaphore) {
                 _vendor_specific_sem(mf, 0);
             }
             mf->vsec_supp = vsec_spaces_supported(mf);
             mf->address_space = AS_CR_SPACE;
         }
-        // printf("mtcr_open_config Succeeded VSEC_SUPP: %d\n", mf->vsec_supp);
+        /* printf("mtcr_open_config Succeeded VSEC_SUPP: %d\n", mf->vsec_supp); */
 #ifndef MST_UL
-        if (mf->is_cable)
-        {
+        if (mf->is_cable) {
             mf->flags = MDEVS_CABLE;
             mf->dl_context = mtcr_utils_load_dl_ctx(DL_CABLES);
             dl_handle_t* hdl = (dl_handle_t*)mf->dl_context;
-            if (!hdl || !hdl->mcables.mcables_open || hdl->mcables.mcables_open(mf, port))
-            {
+            if (!hdl || !hdl->mcables.mcables_open || hdl->mcables.mcables_open(mf, port)) {
                 mclose(mf);
                 return 0;
             }
         }
 #endif
         return mf;
-    }
-    else
-    {
-        // printf("mtcr_open_config failed\n");
+    } else {
+        /* printf("mtcr_open_config failed\n"); */
         errno = ENOENT;
         free(mf);
         return NULL;
@@ -938,14 +868,11 @@ mfile* mopend(char const* name, DType dtype)
 mfile* mopen_adv(const char* name, MType mtype)
 {
     mfile* mf = mopend(name, MST_TAVOR);
-    if (mf)
-    {
-        if (mf->tp & mtype)
-        {
+
+    if (mf) {
+        if (mf->tp & mtype) {
             return mf;
-        }
-        else
-        {
+        } else {
             errno = EPERM;
             mclose(mf);
             return NULL;
@@ -956,7 +883,7 @@ mfile* mopen_adv(const char* name, MType mtype)
 
 mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_func, void* extra_data)
 {
-    // not relevant for freebsd
+    /* not relevant for freebsd */
     (void)fw_cmd_context;
     (void)fw_cmd_func;
     (void)dma_func;
@@ -970,34 +897,29 @@ mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_func, voi
  */
 int mclose(mfile* mf)
 {
-    if (!mf)
-    {
+    if (!mf) {
         return 0;
     }
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = -1;
         CALL_DL_FUNC(mcables, mcables_close, ret, mf);
-        if (ret != -1)
-        {
+        if (ret != -1) {
             mtcr_utils_free_dl_ctx(mf->dl_context);
         }
     }
 #endif
-    // printf("closing\n");
+    /* printf("closing\n"); */
     close(mf->fd);
-    if (mf->fdlock)
-    {
+    if (mf->fdlock) {
         close(mf->fdlock);
     }
 
-    if (mf->user_page_list.page_amount)
-    {
+    if (mf->user_page_list.page_amount) {
         release_dma_pages(mf, mf->user_page_list.page_amount);
     }
 
-    // printf("freeing\n");
+    /* printf("freeing\n"); */
     free(mf);
     return 0;
 }
@@ -1010,36 +932,33 @@ int mclose(mfile* mf)
 int mread4_old(mfile* mf, unsigned int offset, u_int32_t* value)
 {
     int rc;
+
     offset = __cpu_to_le32(offset);
-    if (mf->wo_addr)
-    {
+    if (mf->wo_addr) {
         offset |= 0x1;
     }
 
     int lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-    if (rc)
-    {
+    if (rc) {
         goto cleanup;
     }
 
     rc = read_config(mf, PCI_CONF_DATA, value, 4);
 
-    if (rc)
-    {
+    if (rc) {
         goto cleanup;
     }
 
     *value = __le32_to_cpu(*value);
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc || rc)
-    {
+    if (lock_rc || rc) {
         return 0;
     }
     return 4;
@@ -1048,22 +967,17 @@ cleanup:
 int mread4(mfile* mf, unsigned int offset, u_int32_t* value)
 {
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int rc = 0;
         CALL_DL_FUNC(mcables, mcables_read4, rc, mf, offset, value);
-        if (!rc)
-        {
+        if (!rc) {
             return 4;
-        }
-        else
-        {
+        } else {
             return -1;
         }
     }
 #endif
-    if (mf->vsec_supp)
-    {
+    if (mf->vsec_supp) {
         return mread4_new(mf, offset, value);
     }
     return mread4_old(mf, offset, value);
@@ -1093,8 +1007,8 @@ int mwrite64(mfile* mf, unsigned int offset, void* data, int length)
     return -1;
 }
 
-// read_config(int fd, struct pcisel *sel, unsigned long reg, int width);
-// write_config(mf->fd, int fd, struct pcisel *sel, unsigned long reg, unsigned long data, int width)
+/* read_config(int fd, struct pcisel *sel, unsigned long reg, int width); */
+/* write_config(mf->fd, int fd, struct pcisel *sel, unsigned long reg, unsigned long data, int width) */
 
 /*
  * Write 4 bytes, return number of succ. written bytes or -1 on failure
@@ -1107,42 +1021,34 @@ int mwrite4_old(mfile* mf, unsigned int offset, u_int32_t value)
     value = __cpu_to_le32(value);
 
     int lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
-    if (mf->wo_addr)
-    {
+    if (mf->wo_addr) {
         rc = write_config(mf, PCI_CONF_DATA, (unsigned long)value, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
         rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
-    }
-    else
-    {
+    } else {
         rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
         rc = write_config(mf, PCI_CONF_DATA, (unsigned long)value, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
     }
 
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc || rc)
-    {
+    if (lock_rc || rc) {
         return 0;
     }
     return 4;
@@ -1151,40 +1057,33 @@ cleanup:
 int mwrite4(mfile* mf, unsigned int offset, u_int32_t value)
 {
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int rc = 0;
         CALL_DL_FUNC(mcables, mcables_write4, rc, mf, offset, value);
-        if (!rc)
-        {
+        if (!rc) {
             return 4;
-        }
-        else
-        {
+        } else {
             return -1;
         }
     }
 #endif
-    if (mf->vsec_supp)
-    {
+    if (mf->vsec_supp) {
         return mwrite4_new(mf, offset, value);
     }
     return mwrite4_old(mf, offset, value);
 }
-//////////// NEW   ////////////////////
+/*////////// NEW   //////////////////// */
 
 static int mread_chunk_as_multi_mread4(mfile* mf, unsigned int offset, void* data, int length)
 {
     int i;
-    if (length % 4)
-    {
+
+    if (length % 4) {
         return -EINVAL;
     }
-    for (i = 0; i < length; i += 4)
-    {
+    for (i = 0; i < length; i += 4) {
         u_int32_t value;
-        if (mread4(mf, offset + i, &value) != 4)
-        {
+        if (mread4(mf, offset + i, &value) != 4) {
             return -1;
         }
         memcpy((char*)data + i, &value, 4);
@@ -1195,16 +1094,14 @@ static int mread_chunk_as_multi_mread4(mfile* mf, unsigned int offset, void* dat
 static int mwrite_chunk_as_multi_mwrite4(mfile* mf, unsigned int offset, void* data, int length)
 {
     int i;
-    if (length % 4)
-    {
+
+    if (length % 4) {
         return -EINVAL;
     }
-    for (i = 0; i < length; i += 4)
-    {
+    for (i = 0; i < length; i += 4) {
         u_int32_t value;
         memcpy(&value, (char*)data + i, 4);
-        if (mwrite4(mf, offset + i, value) != 4)
-        {
+        if (mwrite4(mf, offset + i, value) != 4) {
             return -1;
         }
     }
@@ -1214,22 +1111,20 @@ static int mwrite_chunk_as_multi_mwrite4(mfile* mf, unsigned int offset, void* d
 int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 {
     int rc = byte_len;
+
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = 0;
         CALL_DL_FUNC(mcables, mcables_read4_block, ret, mf, offset, data, byte_len);
-        if (ret != 0)
-        {
-            rc -= ret; // Return less than byte_len to ensure error in reading
+        if (ret != 0) {
+            rc -= ret; /* Return less than byte_len to ensure error in reading */
         }
         return rc;
     }
 #endif
-    if (mf->vsec_supp)
-    {
+    if (mf->vsec_supp) {
         int rc = mread4_block_new(mf, offset, byte_len, data);
-        // printf("-D- MREAD BLOCK LEN: %d, RC: %d\n", byte_len, rc);
+        /* printf("-D- MREAD BLOCK LEN: %d, RC: %d\n", byte_len, rc); */
         return rc;
     }
     rc = mread_chunk_as_multi_mread4(mf, offset, data, byte_len);
@@ -1239,20 +1134,18 @@ int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 {
     int rc = byte_len;
+
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = 0;
         CALL_DL_FUNC(mcables, mcables_write4_block, ret, mf, offset, data, byte_len);
-        if (ret != 0)
-        {
-            rc -= ret; // Return less than byte_len to ensure error in reading
+        if (ret != 0) {
+            rc -= ret; /* Return less than byte_len to ensure error in reading */
         }
         return rc;
     }
 #endif
-    if (mf->vsec_supp)
-    {
+    if (mf->vsec_supp) {
         return mwrite4_block_new(mf, offset, byte_len, data);
     }
     rc = mwrite_chunk_as_multi_mwrite4(mf, offset, data, byte_len);
@@ -1277,7 +1170,8 @@ int mi2c_detect(mfile* mf, u_int8_t slv_arr[SLV_ADDRS_NUM])
     (void)slv_arr;
     return 1;
 }
-int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data,
+                   int length)
 {
     (void)mf;
     (void)i2c_slave;
@@ -1288,7 +1182,12 @@ int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsi
     return 0;
 }
 
-int mwrite_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mwrite_i2cblock(mfile       * mf,
+                    unsigned char i2c_slave,
+                    u_int8_t      addr_width,
+                    unsigned int  offset,
+                    void        * data,
+                    int           length)
 {
     (void)mf;
     (void)i2c_slave;
@@ -1299,22 +1198,22 @@ int mwrite_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, uns
     return 0;
 }
 
-// TODO: Introduce a module to keep platform-independent routines like this one below
+/* TODO: Introduce a module to keep platform-independent routines like this one below */
 void mtcr_fix_endianness(u_int32_t* buf, int len)
 {
     int i;
 
-    for (i = 0; i < (len / 4); ++i)
-    {
-        // printf("-D- before: buf[%d] = %#x\n", i, buf[i]);
+    for (i = 0; i < (len / 4); ++i) {
+        /* printf("-D- before: buf[%d] = %#x\n", i, buf[i]); */
         buf[i] = __be32_to_cpu(buf[i]);
-        // printf("-D- before: buf[%d] = %#x\n", i, buf[i]);
+        /* printf("-D- before: buf[%d] = %#x\n", i, buf[i]); */
     }
 }
 
 int mread_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
 {
     int rc;
+
     rc = mread4_block(mf, offset, (u_int32_t*)data, byte_len);
     mtcr_fix_endianness((u_int32_t*)data, byte_len);
     return rc;
@@ -1328,8 +1227,7 @@ int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
 
 int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 {
-    if (mf == NULL || devs_flags == NULL)
-    {
+    if ((mf == NULL) || (devs_flags == NULL)) {
         errno = -EINVAL;
         return 1;
     }
@@ -1340,8 +1238,7 @@ int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 
 int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 {
-    if (mf == NULL || mtype == NULL)
-    {
+    if ((mf == NULL) || (mtype == NULL)) {
         errno = -EINVAL;
         return 1;
     }
@@ -1353,13 +1250,11 @@ int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
 {
     unsigned char ret;
-    if (mf)
-    {
+
+    if (mf) {
         ret = mf->i2c_slave;
         mf->i2c_slave = new_i2c_slave;
-    }
-    else
-    {
+    } else {
         ret = 0xff;
     }
     return ret;
@@ -1367,8 +1262,7 @@ unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
 
 int mget_i2c_slave(mfile* mf, unsigned char* new_i2c_slave_p)
 {
-    if (mf)
-    {
+    if (mf) {
         *new_i2c_slave_p = mf->i2c_slave;
         return 0;
     }
@@ -1380,36 +1274,33 @@ int mget_i2c_slave(mfile* mf, unsigned char* new_i2c_slave_p)
 
 static int get_device_ids(const char* dev_name, dev_info* dinfo)
 {
-    mfile* mf = mopen(dev_name);
-    int rc = 0;
+    mfile   * mf = mopen(dev_name);
+    int       rc = 0;
     u_int32_t buf = 0;
-    if (!mf)
-    {
+
+    if (!mf) {
         return 1;
     }
 
     int lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+
+    if (lock_rc) {
         return 1;
     }
     rc = read_config(mf, PCI_HEADER_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.vend_id = EXTRACT(buf, 0, 16);
     dinfo->pci.dev_id = EXTRACT(buf, 16, 16);
 
     rc = read_config(mf, PCI_CLASS_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.class_id = EXTRACT(buf, 8, 24);
     rc = read_config(mf, PCI_SUBSYS_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.subsys_vend_id = EXTRACT(buf, 0, 16);
@@ -1418,24 +1309,25 @@ static int get_device_ids(const char* dev_name, dev_info* dinfo)
 exit:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
     mclose(mf);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 1;
     }
     return rc;
 }
-static int
-  get_dev_dbdf(const char* dev_name, unsigned int* domain, unsigned int* bus, unsigned int* dev, unsigned int* func)
+static int get_dev_dbdf(const char  * dev_name,
+                        unsigned int* domain,
+                        unsigned int* bus,
+                        unsigned int* dev,
+                        unsigned int* func)
 {
     char* dbdf_str = strstr(dev_name, "pci");
-    int rc = 0;
-    if (!dbdf_str)
-    {
+    int   rc = 0;
+
+    if (!dbdf_str) {
         return 1;
     }
     rc = sscanf(dbdf_str, "pci%u:%u:%u:%u", domain, bus, dev, func);
-    if (rc != 4)
-    {
+    if (rc != 4) {
         return 1;
     }
     return 0;
@@ -1444,9 +1336,9 @@ static int
 int get_device_flags(const char* name)
 {
     int mask = 0;
+
     mask = MDEVS_TAVOR_CR;
-    if (strstr(name, "cable"))
-    {
+    if (strstr(name, "cable")) {
         mask = MDEVS_CABLE;
     }
     return mask;
@@ -1474,37 +1366,33 @@ int get_device_flags(const char* name)
 
 int mdevices_v(char* buf, int len, int mask, int verbosity)
 {
-    int i;
-    int s, b, d, f, tmp;
-    int rc = 0;
-    int cnt = 0;
+    int   i;
+    int   s, b, d, f, tmp;
+    int   rc = 0;
+    int   cnt = 0;
     FILE* fp;
-    char dev_line[1035];
+    char  dev_line[1035];
     char* p = buf;
-    if (mask & MDEVS_TAVOR_CR)
-    {
+
+    if (mask & MDEVS_TAVOR_CR) {
         /* Get all Mellanox devices - this cmd will return the needed devices one in every line */
         fp =
-          popen("pciconf -lv | grep -B 1 Mellanox | grep pci | cut -f1 | cut -f2 -d \"@\" | cut -f1-4 -d \":\"", "r");
-        if (fp == NULL)
-        {
+            popen("pciconf -lv | grep -B 1 Mellanox | grep pci | cut -f1 | cut -f2 -d \"@\" | cut -f1-4 -d \":\"",
+                  "r");
+        if (fp == NULL) {
             return -1;
         }
 
         /* Read the output one line at a time */
-        while (fgets(dev_line, sizeof(dev_line) - 1, fp) != NULL)
-        {
+        while (fgets(dev_line, sizeof(dev_line) - 1, fp) != NULL) {
             tmp = sscanf(dev_line, "pci%d:%d:%d:%d\n", &s, &b, &d, &f);
-            (void)tmp; // TODO: check sscanf ret value
-            if (!verbosity && f != 0)
-            {
+            (void)tmp; /* TODO: check sscanf ret value */
+            if (!verbosity && (f != 0)) {
                 continue;
             }
-            for (i = 0; !(dev_line[i] == '\n'); i++)
-            {
+            for (i = 0; !(dev_line[i] == '\n'); i++) {
                 *p++ = dev_line[i];
-                if (++cnt >= len)
-                {
+                if (++cnt >= len) {
                     pclose(fp);
                     return -1;
                 }
@@ -1515,22 +1403,18 @@ int mdevices_v(char* buf, int len, int mask, int verbosity)
         /* close */
         pclose(fp);
     }
-    if (mask & MDEVS_CABLE)
-    {
+    if (mask & MDEVS_CABLE) {
         /*
          * Get cables
          */
-        DIR* dir = opendir(CABLES_DIR);
+        DIR          * dir = opendir(CABLES_DIR);
         struct dirent* dirent;
-        if (dir != NULL)
-        {
+        if (dir != NULL) {
             dirent = readdir(dir);
-            while (dirent != NULL)
-            {
+            while (dirent != NULL) {
                 char* name = dirent->d_name;
                 /* According to mask */
-                if (get_device_flags(name) & MDEVS_CABLE)
-                {
+                if (get_device_flags(name) & MDEVS_CABLE) {
                     PUTS(name);
                     PUTC('\0');
                     rc++;
@@ -1551,27 +1435,24 @@ int mdevices(char* buf, int len, int mask)
 static void remove_newline_chars(char* str)
 {
     int i;
-    for (i = strlen(str) - 1; i >= 0 && (str[i] == '\n' || str[i] == '\r'); i--)
-    {
+
+    for (i = strlen(str) - 1; i >= 0 && (str[i] == '\n' || str[i] == '\r'); i--) {
         str[i] = '\0';
     }
 }
 
-// replace with a new string
-// free the old one
+/* replace with a new string */
+/* free the old one */
 static char* manipulate_ib_dev_line(char* line)
 {
-    if (!line)
-    {
+    if (!line) {
         return NULL;
     }
     char* old_str = line;
     char* new_str = NULL;
 
-    while (*line != '.')
-    {
-        if (!(*line))
-        {
+    while (*line != '.') {
+        if (!(*line)) {
             goto cleanup;
         }
         line++;
@@ -1580,43 +1461,31 @@ static char* manipulate_ib_dev_line(char* line)
 
     char* end = line;
     char* num = NULL;
-    int count_dots = 0;
-    while (1)
-    {
-        if (!(*end))
-        {
+    int   count_dots = 0;
+
+    while (1) {
+        if (!(*end)) {
             goto cleanup;
-        }
-        else if (*end == '.')
-        {
-            if (count_dots)
-            {
+        } else if (*end == '.') {
+            if (count_dots) {
                 *end = '\0';
                 break;
-            }
-            else
-            {
+            } else {
                 count_dots++;
-                if (*(end + 1))
-                {
+                if (*(end + 1)) {
                     num = end + 1;
-                }
-                else
-                {
+                } else {
                     goto cleanup;
                 }
             }
-        }
-        else if (*end == '_')
-        {
+        } else if (*end == '_') {
             *(end + 1) = '\0';
         }
         end++;
     }
     line = strcat(line, num);
     new_str = (char*)malloc(strlen(line) + 1);
-    if (!new_str)
-    {
+    if (!new_str) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -1627,16 +1496,15 @@ cleanup:
     return new_str;
 }
 
-// number_of_first_entries_to_skip should be 0 for regular array destruction
+/* number_of_first_entries_to_skip should be 0 for regular array destruction */
 static void destroy_str_arr(char** arr, int number_of_first_entries_to_skip)
 {
-    if (!arr)
-    {
+    if (!arr) {
         return;
     }
     int i;
-    for (i = number_of_first_entries_to_skip; arr[i]; i++)
-    {
+
+    for (i = number_of_first_entries_to_skip; arr[i]; i++) {
         free(arr[i]);
         arr[i] = NULL;
     }
@@ -1644,30 +1512,27 @@ static void destroy_str_arr(char** arr, int number_of_first_entries_to_skip)
     arr = NULL;
 }
 
-// copying file lines into a an array of char*, while manipulating each line with a special function (if supplied)
-// caller should destroy the array
+/* copying file lines into a an array of char*, while manipulating each line with a special function (if supplied) */
+/* caller should destroy the array */
 static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
 {
-    char* line = NULL;
+    char * line = NULL;
     size_t len = 0;
-    int lines_allocated = 8; // can realloc later
-    int error = 0;
-    int i = 0;
-
+    int    lines_allocated = 8; /* can realloc later */
+    int    error = 0;
+    int    i = 0;
     char** arr = (char**)malloc((lines_allocated + 1) * sizeof(char*));
-    if (!arr)
-    {
+
+    if (!arr) {
         errno = ENOMEM;
         error = 1;
         goto cleanup;
     }
     memset(arr, 0, (lines_allocated + 1) * sizeof(char*));
 
-    while (getline(&line, &len, fp) != -1)
-    {
+    while (getline(&line, &len, fp) != -1) {
         arr[i] = (char*)malloc(len * sizeof(char));
-        if (!arr[i])
-        {
+        if (!arr[i]) {
             errno = ENOMEM;
             error = 1;
             goto cleanup;
@@ -1678,21 +1543,17 @@ static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
         len = 0;
 
         remove_newline_chars(arr[i]);
-        if (string_mainpulation_func_ptr)
-        {
+        if (string_mainpulation_func_ptr) {
             arr[i] = (*string_mainpulation_func_ptr)(arr[i]);
         }
-        if (!arr[i])
-        {
+        if (!arr[i]) {
             continue;
         }
         i++;
-        if (i >= lines_allocated)
-        {
+        if (i >= lines_allocated) {
             lines_allocated *= 2;
             char** tmp = realloc(arr, (lines_allocated + 1) * sizeof(char*));
-            if (!tmp)
-            {
+            if (!tmp) {
                 errno = ENOMEM;
                 error = 1;
                 goto cleanup;
@@ -1701,18 +1562,15 @@ static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
         }
     }
 cleanup:
-    // This is done so the caller can free all the array cells without knowing its size
-    // Iterate until NULL termination
-    if (arr)
-    {
+    /* This is done so the caller can free all the array cells without knowing its size */
+    /* Iterate until NULL termination */
+    if (arr) {
         arr[i] = NULL;
     }
-    if (line)
-    {
+    if (line) {
         free(line);
     }
-    if (error || i == 0)
-    {
+    if (error || (i == 0)) {
         destroy_str_arr(arr, 0);
         return NULL;
     }
@@ -1720,24 +1578,25 @@ cleanup:
     return arr;
 }
 
-// Execute cmd and get output in a strings array, after desired output manipulation
-// via a speacial manipulation function (if supplied)
-// if there is relevant input to the special function pass it as well.
+/* Execute cmd and get output in a strings array, after desired output manipulation */
+/* via a speacial manipulation function (if supplied) */
+/* if there is relevant input to the special function pass it as well. */
 static char** exec_cmd_get_output(char* cmd, char* (*string_mainpulation_func_ptr)(char*))
 {
     char* wrapped_cmd = (char*)malloc(strlen(cmd) + strlen(" 2>/dev/null") + 2);
-    if (!wrapped_cmd)
-    {
+
+    if (!wrapped_cmd) {
         return NULL;
     }
     sprintf(wrapped_cmd, "%s %s", cmd, " 2>/dev/null");
     FILE* fp = popen(wrapped_cmd, "r");
+
     free(wrapped_cmd);
-    if (!fp)
-    {
+    if (!fp) {
         return NULL;
     }
     char** output = file2array(fp, string_mainpulation_func_ptr);
+
     pclose(fp);
     return output;
 }
@@ -1745,7 +1604,8 @@ static char** exec_cmd_get_output(char* cmd, char* (*string_mainpulation_func_pt
 static char* exec_cmd_get_output_first_line(char* cmd, char* (*string_mainpulation_func_ptr)(char*))
 {
     char** res = exec_cmd_get_output(cmd, string_mainpulation_func_ptr);
-    char* out = res[0];
+    char * out = res[0];
+
     destroy_str_arr(res, 1);
     return out;
 }
@@ -1754,12 +1614,13 @@ static char** get_ports(char* ib_dev)
 {
     char* cmd = (char*)malloc(strlen("sysctl sys.class.infiniband..ports | awk -F. '{print $6}' | uniq | sort") +
                               strlen(ib_dev) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl sys.class.infiniband.%s.ports | awk -F. '{print $6}' | uniq | sort", ib_dev);
     char** out = exec_cmd_get_output(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1767,13 +1628,14 @@ static char** get_ports(char* ib_dev)
 static char* get_link_layer(char* ib_dev, char* port)
 {
     char* cmd =
-      (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..link_layer") + strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+        (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..link_layer") + strlen(ib_dev) + strlen(port) + 1);
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sys.class.infiniband.%s.ports.%s.link_layer", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1782,12 +1644,13 @@ static char* get_eth_net_dev(char* ib_dev, char* port)
 {
     char* cmd = (char*)malloc(strlen("sysctl -n sysctl sys.class.infiniband..ports..gid_attrs.ndevs.0") +
                               strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sysctl sys.class.infiniband.%s.ports.%s.gid_attrs.ndevs.0", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1802,67 +1665,56 @@ static char* get_gid(char* ib_dev, char* port)
     char* cmd = (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..gids.0 |"
                                      " cut -b 21- | sed -e 's/://g'") +
                               strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sys.class.infiniband.%s.ports.%s.gids.0 | cut -b 21- | sed -e 's/://g'", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
 
 static char* lladdr_to_gid_format(char* lladdr)
 {
-    if (!lladdr)
-    {
+    if (!lladdr) {
         return NULL;
     }
 
     int end = strlen(lladdr) - 1;
     int i;
     int dot_count = 0;
-    for (i = end; i >= 0; i--)
-    {
-        if (lladdr[i] == '.')
-        {
+
+    for (i = end; i >= 0; i--) {
+        if (lladdr[i] == '.') {
             dot_count++;
         }
-        if (dot_count == 8)
-        {
+        if (dot_count == 8) {
             lladdr = &lladdr[i];
             break;
         }
-        if (i == 0)
-        {
+        if (i == 0) {
             return NULL;
         }
     }
-    if (*(lladdr + 1) && *(lladdr + 2) && *(lladdr + 2) != '.')
-    {
+    if (*(lladdr + 1) && *(lladdr + 2) && (*(lladdr + 2) != '.')) {
         lladdr++;
     }
     char* curptr = lladdr;
-    while (*curptr)
-    {
-        if (*curptr == '.')
-        {
-            if (*(curptr + 1) && ((*(curptr + 2) == '.') || !(*(curptr + 2))))
-            {
+
+    while (*curptr) {
+        if (*curptr == '.') {
+            if (*(curptr + 1) && ((*(curptr + 2) == '.') || !(*(curptr + 2)))) {
                 *curptr = '0';
                 curptr++;
-            }
-            else
-            {
+            } else {
                 *curptr = '\0';
-                if (*(curptr + 1))
-                {
+                if (*(curptr + 1)) {
                     lladdr = strcat(lladdr, curptr + 1);
                 }
             }
-        }
-        else
-        {
+        } else {
             curptr++;
         }
     }
@@ -1872,12 +1724,13 @@ static char* lladdr_to_gid_format(char* lladdr)
 static char* get_lladdr(char* ifc)
 {
     char* cmd = (char*)malloc(strlen("ifconfig  | grep lladdr | awk '{print $2}'") + strlen(ifc) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "ifconfig %s | grep lladdr | awk '{print $2}'", ifc);
     char* lladdr = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return lladdr_to_gid_format(lladdr);
 }
@@ -1885,23 +1738,20 @@ static char* get_lladdr(char* ifc)
 static char* get_inband_net_dev(char* ib_dev, char* port, char** ifcs)
 {
     char* gid = get_gid(ib_dev, port);
-    if (!gid)
-    {
+
+    if (!gid) {
         return NULL;
     }
     int i;
-    for (i = 0; ifcs[i]; i++)
-    {
-        if (strstr(ifcs[i], "ib") == ifcs[i])
-        {
+
+    for (i = 0; ifcs[i]; i++) {
+        if (strstr(ifcs[i], "ib") == ifcs[i]) {
             char* lladdr = get_lladdr(ifcs[i]);
-            if (!strcmp(lladdr, gid))
-            {
+            if (!strcmp(lladdr, gid)) {
                 free(lladdr);
                 free(gid);
                 char* netdev = (char*)malloc(strlen(ifcs[i]) + 1);
-                if (!netdev)
-                {
+                if (!netdev) {
                     errno = ENOMEM;
                     return NULL;
                 }
@@ -1917,71 +1767,58 @@ static char* get_inband_net_dev(char* ib_dev, char* port, char** ifcs)
 
 static char** get_net_devs(char** ib_devs)
 {
-    if (!ib_devs)
-    {
+    if (!ib_devs) {
         return NULL;
     }
     char** ifcs = get_ifcs();
-    if (!ifcs)
-    {
+
+    if (!ifcs) {
         return NULL;
     }
     char** ports = NULL;
-    char* link_layer = NULL;
-    int i;
-    int error = 0;
-    int lines_allocated = 8; // can realloc later
-
+    char * link_layer = NULL;
+    int    i;
+    int    error = 0;
+    int    lines_allocated = 8; /* can realloc later */
     char** net_devs = (char**)malloc((lines_allocated + 1) * sizeof(char*));
-    if (!net_devs)
-    {
+
+    if (!net_devs) {
         errno = ENOMEM;
         error = 1;
         goto cleanup;
     }
     memset(net_devs, 0, (lines_allocated + 1) * sizeof(char*));
     int k = 0;
-    for (i = 0; ib_devs[i]; i++)
-    {
+
+    for (i = 0; ib_devs[i]; i++) {
         ports = get_ports(ib_devs[i]);
-        if (!ports)
-        {
+        if (!ports) {
             error = 1;
             goto cleanup;
         }
         int j;
-        for (j = 0; ports[j]; j++)
-        {
+        for (j = 0; ports[j]; j++) {
             link_layer = get_link_layer(ib_devs[i], ports[j]);
-            if (!link_layer)
-            {
+            if (!link_layer) {
                 error = 1;
                 goto cleanup;
             }
             char* netdev;
-            if (!strcmp(link_layer, "Ethernet"))
-            {
+            if (!strcmp(link_layer, "Ethernet")) {
                 netdev = get_eth_net_dev(ib_devs[i], ports[j]);
-            }
-            else if (!strcmp(link_layer, "InfiniBand"))
-            {
+            } else if (!strcmp(link_layer, "InfiniBand")) {
                 netdev = get_inband_net_dev(ib_devs[i], ports[j], ifcs);
-            }
-            else
-            {
+            } else {
                 error = 1;
                 goto cleanup;
             }
-            if (netdev)
-            {
+            if (netdev) {
                 net_devs[k] = netdev;
                 k++;
-                if (k > lines_allocated)
-                {
+                if (k > lines_allocated) {
                     lines_allocated *= 2;
                     char** tmp = realloc(net_devs, (lines_allocated + 1) * sizeof(char*));
-                    if (!tmp)
-                    {
+                    if (!tmp) {
                         errno = ENOMEM;
                         error = 1;
                         goto cleanup;
@@ -1993,8 +1830,7 @@ static char** get_net_devs(char** ib_devs)
     }
     net_devs[k] = NULL;
 cleanup:
-    if (error)
-    {
+    if (error) {
         destroy_str_arr(net_devs, 0);
         net_devs = NULL;
     }
@@ -2008,12 +1844,13 @@ cleanup:
 static char** get_ib_devs(char conf_dev[512])
 {
     char* cmd = (char*)malloc(strlen("sysctl -a | grep mlx | grep pci | grep ") + strlen(conf_dev) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -a | grep mlx | grep pci | grep %s", conf_dev);
     char** ib_devs = exec_cmd_get_output(cmd, manipulate_ib_dev_line);
+
     free(cmd);
     return ib_devs;
 }
@@ -2027,21 +1864,18 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
 {
     char* devs = 0;
     char* dev_name;
-    int size = 2048;
-    int rc;
-    int i;
+    int   size = 2048;
+    int   rc;
+    int   i;
 
-    // Get list of devices
-    do
-    {
-        if (devs)
-        {
+    /* Get list of devices */
+    do{
+        if (devs) {
             free(devs);
         }
         size *= 2;
         devs = malloc(size);
-        if (!devs)
-        {
+        if (!devs) {
             errno = ENOMEM;
             return NULL;
         }
@@ -2049,16 +1883,15 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
     } while (rc == -1);
     *len = rc;
     dev_info* dev_info_arr = malloc(sizeof(dev_info) * rc);
-    if (!dev_info_arr)
-    {
+
+    if (!dev_info_arr) {
         errno = ENOMEM;
         free(devs);
         return NULL;
     }
     memset(dev_info_arr, 0, sizeof(dev_info) * rc);
     dev_name = devs;
-    for (i = 0; i < *len; i++)
-    {
+    for (i = 0; i < *len; i++) {
         unsigned int domain = 0;
         unsigned int bus = 0;
         unsigned int dev = 0;
@@ -2066,27 +1899,23 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
         dev_info_arr[i].type = get_device_flags(dev_name);
         strcpy(dev_info_arr[i].dev_name, dev_name);
         strcpy(dev_info_arr[i].pci.conf_dev, dev_name);
-        if (dev_info_arr[i].type & MDEVS_TAVOR_CR)
-        {
-            if (get_dev_dbdf(dev_name, &domain, &bus, &dev, &func))
-            {
+        if (dev_info_arr[i].type & MDEVS_TAVOR_CR) {
+            if (get_dev_dbdf(dev_name, &domain, &bus, &dev, &func)) {
                 goto next;
             }
             dev_info_arr[i].pci.domain = domain;
             dev_info_arr[i].pci.bus = bus;
             dev_info_arr[i].pci.dev = dev;
             dev_info_arr[i].pci.func = func;
-            if (get_device_ids(dev_name, &dev_info_arr[i]))
-            {
+            if (get_device_ids(dev_name, &dev_info_arr[i])) {
                 goto next;
             }
         }
-        if (verbosity)
-        {
+        if (verbosity) {
             dev_info_arr[i].pci.ib_devs = get_ib_devs(dev_info_arr[i].pci.conf_dev);
             dev_info_arr[i].pci.net_devs = get_net_devs(dev_info_arr[i].pci.ib_devs);
         }
-    next:
+next:
         dev_name += strlen(dev_name) + 1;
     }
     free(devs);
@@ -2097,16 +1926,12 @@ void mdevices_info_destroy(dev_info* dev_info, int len)
 {
     int i;
 
-    if (dev_info)
-    {
-        for (i = 0; i < len; i++)
-        {
-            if (dev_info[i].pci.ib_devs)
-            {
+    if (dev_info) {
+        for (i = 0; i < len; i++) {
+            if (dev_info[i].pci.ib_devs) {
                 destroy_str_arr(dev_info[i].pci.ib_devs, 0);
             }
-            if (dev_info[i].pci.net_devs)
-            {
+            if (dev_info[i].pci.net_devs) {
                 destroy_str_arr(dev_info[i].pci.net_devs, 0);
             }
         }
@@ -2116,122 +1941,116 @@ void mdevices_info_destroy(dev_info* dev_info, int len)
 }
 
 #define TLV_OPERATION_SIZE 4
-#define OP_TLV_SIZE 16
+#define OP_TLV_SIZE        16
 #define REG_TLV_HEADER_LEN 4
 
-enum
-{
+enum {
     MAD_CLASS_REG_ACCESS = 1,
 };
-enum
-{
-    TLV_END = 0,
+enum {
+    TLV_END       = 0,
     TLV_OPERATION = 1,
-    TLV_DR = 2,
-    TLV_REG = 3,
+    TLV_DR        = 2,
+    TLV_REG       = 3,
     TLV_USER_DATA = 4,
 };
 
-#define REGISTER_HEADERS_SIZE 20
-#define INBAND_MAX_REG_SIZE 44
-#define ICMD_MAX_REG_SIZE (ICMD_MAX_CMD_SIZE - REGISTER_HEADERS_SIZE)
-#define FWCTX_MAX_REG_SIZE 16
+#define REGISTER_HEADERS_SIZE  20
+#define INBAND_MAX_REG_SIZE    44
+#define ICMD_MAX_REG_SIZE      (ICMD_MAX_CMD_SIZE - REGISTER_HEADERS_SIZE)
+#define FWCTX_MAX_REG_SIZE     16
 #define TOOLS_HCR_MAX_REG_SIZE (TOOLS_HCR_MAX_MBOX - REGISTER_HEADERS_SIZE)
 
 static int supports_icmd(mfile* mf);
 static int supports_tools_cmdif_reg(mfile* mf);
 static int init_operation_tlv(struct OperationTlv* operation_tlv, u_int16_t reg_id, u_int8_t method);
 static int mreg_send_wrapper(mfile* mf, u_int8_t* data, int r_icmd_size, int w_icmd_size);
-static int mreg_send_raw(mfile* mf,
-                         u_int16_t reg_id,
+static int mreg_send_raw(mfile              * mf,
+                         u_int16_t            reg_id,
                          maccess_reg_method_t method,
-                         void* reg_data,
-                         u_int32_t reg_size,
-                         u_int32_t r_size_reg,
-                         u_int32_t w_size_reg,
-                         int* reg_status);
+                         void               * reg_data,
+                         u_int32_t            reg_size,
+                         u_int32_t            r_size_reg,
+                         u_int32_t            w_size_reg,
+                         int                * reg_status);
 int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method);
 
-// maccess_reg: Do a reg_access for the mf device.
-// - reg_data is both in and out
-// TODO: When the reg operation succeeds but the reg status is != 0,
-//       a specific
+/* maccess_reg: Do a reg_access for the mf device. */
+/* - reg_data is both in and out */
+/* TODO: When the reg operation succeeds but the reg status is != 0, */
+/*       a specific */
 
-int maccess_reg(mfile* mf,
-                u_int16_t reg_id,
+int maccess_reg(mfile              * mf,
+                u_int16_t            reg_id,
                 maccess_reg_method_t reg_method,
-                void* reg_data,
-                u_int32_t reg_size,
-                u_int32_t r_size_reg,
-                u_int32_t w_size_reg,
-                int* reg_status)
+                void               * reg_data,
+                u_int32_t            reg_size,
+                u_int32_t            r_size_reg,
+                u_int32_t            w_size_reg,
+                int                * reg_status)
 {
     int rc;
-    if (mf == NULL || reg_data == NULL || reg_status == NULL || reg_size <= 0)
-    {
+
+    if ((mf == NULL) || (reg_data == NULL) || (reg_status == NULL) || (reg_size <= 0)) {
         return ME_BAD_PARAMS;
     }
-    // check register size
+    /* check register size */
     u_int32_t max_size = (u_int32_t)mget_max_reg_size(mf, reg_method);
-    if (reg_size > max_size)
-    {
-        // reg too big
+
+    if (reg_size > max_size) {
+        /* reg too big */
         return ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT;
     }
     rc = mreg_send_raw(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg, reg_status);
 
-    if (rc)
-    {
+    if (rc) {
         return rc;
-    }
-    else if (*reg_status)
-    {
-        switch (*reg_status)
-        {
-            case 1:
-                return ME_REG_ACCESS_DEV_BUSY;
+    } else if (*reg_status) {
+        switch (*reg_status) {
+        case 1:
+            return ME_REG_ACCESS_DEV_BUSY;
 
-            case 2:
-                return ME_REG_ACCESS_VER_NOT_SUPP;
+        case 2:
+            return ME_REG_ACCESS_VER_NOT_SUPP;
 
-            case 3:
-                return ME_REG_ACCESS_UNKNOWN_TLV;
+        case 3:
+            return ME_REG_ACCESS_UNKNOWN_TLV;
 
-            case 4:
-                return ME_REG_ACCESS_REG_NOT_SUPP;
+        case 4:
+            return ME_REG_ACCESS_REG_NOT_SUPP;
 
-            case 5:
-                return ME_REG_ACCESS_CLASS_NOT_SUPP;
+        case 5:
+            return ME_REG_ACCESS_CLASS_NOT_SUPP;
 
-            case 6:
-                return ME_REG_ACCESS_METHOD_NOT_SUPP;
+        case 6:
+            return ME_REG_ACCESS_METHOD_NOT_SUPP;
 
-            case 7:
-                return ME_REG_ACCESS_BAD_PARAM;
+        case 7:
+            return ME_REG_ACCESS_BAD_PARAM;
 
-            case 8:
-                return ME_REG_ACCESS_RES_NOT_AVLBL;
+        case 8:
+            return ME_REG_ACCESS_RES_NOT_AVLBL;
 
-            case 9:
-                return ME_REG_ACCESS_MSG_RECPT_ACK;
+        case 9:
+            return ME_REG_ACCESS_MSG_RECPT_ACK;
 
-            case 0x22:
-                return ME_REG_ACCESS_CONF_CORRUPT;
+        case 0x22:
+            return ME_REG_ACCESS_CONF_CORRUPT;
 
-            case 0x24:
-                return ME_REG_ACCESS_LEN_TOO_SMALL;
+        case 0x24:
+            return ME_REG_ACCESS_LEN_TOO_SMALL;
 
-            case 0x20:
-                return ME_REG_ACCESS_BAD_CONFIG;
+        case 0x20:
+            return ME_REG_ACCESS_BAD_CONFIG;
 
-            case 0x21:
-                return ME_REG_ACCESS_ERASE_EXEEDED;
+        case 0x21:
+            return ME_REG_ACCESS_ERASE_EXEEDED;
 
-            case 0x70:
-                return ME_REG_ACCESS_INTERNAL_ERROR;
+        case 0x70:
+            return ME_REG_ACCESS_INTERNAL_ERROR;
 
-            default:
-                return ME_REG_ACCESS_UNKNOWN_ERR;
+        default:
+            return ME_REG_ACCESS_UNKNOWN_ERR;
         }
     }
     return ME_OK;
@@ -2249,60 +2068,54 @@ static int init_operation_tlv(struct OperationTlv* operation_tlv, u_int16_t reg_
     return 0;
 }
 
-///////////////////  Function that sends the register via the correct interface ///////////////////////////
+/*/////////////////  Function that sends the register via the correct interface /////////////////////////// */
 
 static int mreg_send_wrapper(mfile* mf, u_int8_t* data, int r_icmd_size, int w_icmd_size)
 {
     int rc;
-    if (supports_icmd(mf))
-    {
+
+    if (supports_icmd(mf)) {
         rc = icmd_send_command_int(mf, FLASH_REG_ACCESS, data, w_icmd_size, r_icmd_size, 0);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
-    }
-    else if (supports_tools_cmdif_reg(mf))
-    {
+    } else if (supports_tools_cmdif_reg(mf)) {
         rc = tools_cmdif_reg_access(mf, data, w_icmd_size, r_icmd_size);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
-    }
-    else
-    {
+    } else {
         return ME_NOT_IMPLEMENTED;
     }
     return ME_OK;
 }
 
-static int mreg_send_raw(mfile* mf,
-                         u_int16_t reg_id,
+static int mreg_send_raw(mfile              * mf,
+                         u_int16_t            reg_id,
                          maccess_reg_method_t method,
-                         void* reg_data,
-                         u_int32_t reg_size,
-                         u_int32_t r_size_reg,
-                         u_int32_t w_size_reg,
-                         int* reg_status)
+                         void               * reg_data,
+                         u_int32_t            reg_size,
+                         u_int32_t            r_size_reg,
+                         u_int32_t            w_size_reg,
+                         int                * reg_status)
 {
-    // printf("-D- reg_id = %d, reg_size = %d, r_size_reg = %d , w_size_reg =
-    // %d\n",reg_id,reg_size,r_size_reg,w_size_reg);
-    int mad_rc, cmdif_size = 0;
+    /* printf("-D- reg_id = %d, reg_size = %d, r_size_reg = %d , w_size_reg = */
+    /* %d\n",reg_id,reg_size,r_size_reg,w_size_reg); */
+    int                 mad_rc, cmdif_size = 0;
     struct OperationTlv tlv;
-    struct reg_tlv tlv_info;
-    u_int8_t buffer[1024];
+    struct reg_tlv      tlv_info;
+    u_int8_t            buffer[1024];
 
     init_operation_tlv(&(tlv), reg_id, method);
-    // Fill Reg TLV
+    /* Fill Reg TLV */
     memset(&tlv_info, 0, sizeof(tlv_info));
     tlv_info.Type = TLV_REG;
-    tlv_info.len = (reg_size + REG_TLV_HEADER_LEN) >> 2; // length is in dwords
-    // Pack the mad
+    tlv_info.len = (reg_size + REG_TLV_HEADER_LEN) >> 2; /* length is in dwords */
+    /* Pack the mad */
 
     cmdif_size += OperationTlv_pack(&tlv, buffer);
     cmdif_size += reg_tlv_pack(&tlv_info, buffer + OP_TLV_SIZE);
-    // put the reg itself into the buffer
+    /* put the reg itself into the buffer */
     memcpy(buffer + OP_TLV_SIZE + REG_TLV_HEADER_LEN, reg_data, reg_size);
     cmdif_size += reg_size;
 
@@ -2313,18 +2126,18 @@ static int mreg_send_raw(mfile* mf,
     fprintf(stdout, "\tReg Tlv\n");
     reg_tlv_dump(&tlv_info, stdout);
 #endif
-    // printf("-D- reg_info.len = |%d, OP_TLV: %d, REG_TLV= %d, cmdif_size = %d\n", reg_info.len, OP_TLV_SIZE,
-    // REG_RLV_HEADER_LEN, cmdif_size); update r/w_size_reg with the size of op tlv and reg tlv as we need to read/write
-    // them as well
+    /* printf("-D- reg_info.len = |%d, OP_TLV: %d, REG_TLV= %d, cmdif_size = %d\n", reg_info.len, OP_TLV_SIZE, */
+    /* REG_RLV_HEADER_LEN, cmdif_size); update r/w_size_reg with the size of op tlv and reg tlv as we need to read/write */
+    /* them as well */
     r_size_reg += OP_TLV_SIZE + REG_TLV_HEADER_LEN;
     w_size_reg += OP_TLV_SIZE + REG_TLV_HEADER_LEN;
-    // printf("-D- reg_size = %d, r_size_reg = %d , w_size_reg = %d\n",reg_size,r_size_reg,w_size_reg);
+    /* printf("-D- reg_size = %d, r_size_reg = %d , w_size_reg = %d\n",reg_size,r_size_reg,w_size_reg); */
 
     mad_rc = mreg_send_wrapper(mf, buffer, r_size_reg, w_size_reg);
-    // Unpack the mad
+    /* Unpack the mad */
     OperationTlv_unpack(&tlv, buffer);
     reg_tlv_unpack(&tlv_info, buffer + OP_TLV_SIZE);
-    // copy register back from the buffer
+    /* copy register back from the buffer */
     memcpy(reg_data, buffer + OP_TLV_SIZE + REG_TLV_HEADER_LEN, reg_size);
 
 #ifdef _ENABLE_DEBUG_
@@ -2334,10 +2147,9 @@ static int mreg_send_raw(mfile* mf,
     fprintf(stdout, "\tReg Tlv\n");
     reg_tlv_dump(&tlv_info, stdout);
 #endif
-    // Check the return value
+    /* Check the return value */
     *reg_status = tlv.status;
-    if (mad_rc)
-    {
+    if (mad_rc) {
         return mad_rc;
     }
 
@@ -2345,27 +2157,24 @@ static int mreg_send_raw(mfile* mf,
 }
 
 
-
-#define CONNECTX3_HW_ID 0x1f5
+#define CONNECTX3_HW_ID     0x1f5
 #define CONNECTX3_PRO_HW_ID 0x1f7
 
 static int supports_icmd(mfile* mf)
 {
     u_int32_t dev_id;
 
-    if (read_device_id(mf, &dev_id) != 4)
-    {
-        // cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd
+    if (read_device_id(mf, &dev_id) != 4) {
+        /* cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd */
         return 0;
     }
-    switch (dev_id & 0xffff)
-    { // that the hw device id
-        case CONNECTX3_HW_ID:
-        case CONNECTX3_PRO_HW_ID:
-            return 0;
+    switch (dev_id & 0xffff) { /* that the hw device id */
+    case CONNECTX3_HW_ID:
+    case CONNECTX3_PRO_HW_ID:
+        return 0;
 
-        default:
-            break;
+    default:
+        break;
     }
     return 1;
 }
@@ -2374,219 +2183,210 @@ static int supports_tools_cmdif_reg(mfile* mf)
 {
     u_int32_t dev_id;
 
-    if (read_device_id(mf, &dev_id) != 4)
-    {
+    if (read_device_id(mf, &dev_id) != 4) {
         return 0;
     }
-    switch (dev_id & 0xffff)
-    {                             // that the hw device id
-        case CONNECTX3_HW_ID:     // Cx3
-        case CONNECTX3_PRO_HW_ID: // Cx3-pro
-            if (tools_cmdif_is_supported(mf) == ME_OK)
-            {
-                return 1;
-            }
-            return 0;
+    switch (dev_id & 0xffff) {    /* that the hw device id */
+    case CONNECTX3_HW_ID:         /* Cx3 */
+    case CONNECTX3_PRO_HW_ID:     /* Cx3-pro */
+        if (tools_cmdif_is_supported(mf) == ME_OK) {
+            return 1;
+        }
+        return 0;
 
-        default:
-            return 0;
+    default:
+        return 0;
     }
 }
 
 int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method)
 {
-    if (mf->acc_reg_params.max_reg_size[reg_method])
-    {
+    if (mf->acc_reg_params.max_reg_size[reg_method]) {
         return mf->acc_reg_params.max_reg_size[reg_method];
-    }
-    else if (supports_icmd(mf))
-    {
-        // we support icmd and we dont use IB interface -> we use icmd for reg access
-        // TOOD: get size dynamically from icmd_params once we have support by fw for mfba with size field greater than
-        // 8 bits
+    } else if (supports_icmd(mf)) {
+        /* we support icmd and we dont use IB interface -> we use icmd for reg access */
+        /* TOOD: get size dynamically from icmd_params once we have support by fw for mfba with size field greater than */
+        /* 8 bits */
         mf->acc_reg_params.max_reg_size[reg_method] = ICMD_MAX_REG_SIZE;
-    }
-    else if (supports_tools_cmdif_reg(mf))
-    {
+    } else if (supports_tools_cmdif_reg(mf)) {
         mf->acc_reg_params.max_reg_size[reg_method] = TOOLS_HCR_MAX_REG_SIZE;
     }
     return mf->acc_reg_params.max_reg_size[reg_method];
 }
 
 /************************************
- * Function: m_err2str
- ************************************/
+* Function: m_err2str
+************************************/
 const char* m_err2str(MError status)
 {
-    switch (status)
-    {
-        case ME_OK:
-            return "ME_OK";
+    switch (status) {
+    case ME_OK:
+        return "ME_OK";
 
-        case ME_ERROR:
-            return "General error";
+    case ME_ERROR:
+        return "General error";
 
-        case ME_BAD_PARAMS:
-            return "ME_BAD_PARAMS";
+    case ME_BAD_PARAMS:
+        return "ME_BAD_PARAMS";
 
-        case ME_CR_ERROR:
-            return "ME_CR_ERROR";
+    case ME_CR_ERROR:
+        return "ME_CR_ERROR";
 
-        case ME_NOT_IMPLEMENTED:
-            return "ME_NOT_IMPLEMENTED";
+    case ME_NOT_IMPLEMENTED:
+        return "ME_NOT_IMPLEMENTED";
 
-        case ME_SEM_LOCKED:
-            return "Semaphore locked";
+    case ME_SEM_LOCKED:
+        return "Semaphore locked";
 
-        case ME_MEM_ERROR:
-            return "ME_MEM_ERROR";
+    case ME_MEM_ERROR:
+        return "ME_MEM_ERROR";
 
-        case ME_UNSUPPORTED_OPERATION:
-            return "ME_UNSUPPORTED_OPERATION";
+    case ME_UNSUPPORTED_OPERATION:
+        return "ME_UNSUPPORTED_OPERATION";
 
-        case ME_MAD_SEND_FAILED:
-            return "ME_MAD_SEND_FAILED";
+    case ME_MAD_SEND_FAILED:
+        return "ME_MAD_SEND_FAILED";
 
-        case ME_UNKOWN_ACCESS_TYPE:
-            return "ME_UNKOWN_ACCESS_TYPE";
+    case ME_UNKOWN_ACCESS_TYPE:
+        return "ME_UNKOWN_ACCESS_TYPE";
 
-        case ME_UNSUPPORTED_ACCESS_TYPE:
-            return "ME_UNSUPPORTED_ACCESS_TYPE";
+    case ME_UNSUPPORTED_ACCESS_TYPE:
+        return "ME_UNSUPPORTED_ACCESS_TYPE";
 
-        case ME_UNSUPPORTED_DEVICE:
-            return "ME_UNSUPPORTED_DEVICE";
+    case ME_UNSUPPORTED_DEVICE:
+        return "ME_UNSUPPORTED_DEVICE";
 
-        // Reg access errors
-        case ME_REG_ACCESS_BAD_STATUS_ERR:
-            return "ME_REG_ACCESS_BAD_STATUS_ERR";
+    /* Reg access errors */
+    case ME_REG_ACCESS_BAD_STATUS_ERR:
+        return "ME_REG_ACCESS_BAD_STATUS_ERR";
 
-        case ME_REG_ACCESS_BAD_METHOD:
-            return "Bad method";
+    case ME_REG_ACCESS_BAD_METHOD:
+        return "Bad method";
 
-        case ME_REG_ACCESS_NOT_SUPPORTED:
-            return "The Register access is not supported by the device";
+    case ME_REG_ACCESS_NOT_SUPPORTED:
+        return "The Register access is not supported by the device";
 
-        case ME_REG_ACCESS_DEV_BUSY:
-            return "Device is busy";
+    case ME_REG_ACCESS_DEV_BUSY:
+        return "Device is busy";
 
-        case ME_REG_ACCESS_VER_NOT_SUPP:
-            return "Version not supported";
+    case ME_REG_ACCESS_VER_NOT_SUPP:
+        return "Version not supported";
 
-        case ME_REG_ACCESS_UNKNOWN_TLV:
-            return "Unknown TLV";
+    case ME_REG_ACCESS_UNKNOWN_TLV:
+        return "Unknown TLV";
 
-        case ME_REG_ACCESS_REG_NOT_SUPP:
-            return "Register not supported";
+    case ME_REG_ACCESS_REG_NOT_SUPP:
+        return "Register not supported";
 
-        case ME_REG_ACCESS_CLASS_NOT_SUPP:
-            return "Class not supported";
+    case ME_REG_ACCESS_CLASS_NOT_SUPP:
+        return "Class not supported";
 
-        case ME_REG_ACCESS_METHOD_NOT_SUPP:
-            return "Method not supported";
+    case ME_REG_ACCESS_METHOD_NOT_SUPP:
+        return "Method not supported";
 
-        case ME_REG_ACCESS_BAD_PARAM:
-            return "Bad parameter";
+    case ME_REG_ACCESS_BAD_PARAM:
+        return "Bad parameter";
 
-        case ME_REG_ACCESS_RES_NOT_AVLBL:
-            return "Resource unavailable";
+    case ME_REG_ACCESS_RES_NOT_AVLBL:
+        return "Resource unavailable";
 
-        case ME_REG_ACCESS_MSG_RECPT_ACK:
-            return "Message receipt ack";
+    case ME_REG_ACCESS_MSG_RECPT_ACK:
+        return "Message receipt ack";
 
-        case ME_REG_ACCESS_UNKNOWN_ERR:
-            return "Unknown register error";
+    case ME_REG_ACCESS_UNKNOWN_ERR:
+        return "Unknown register error";
 
-        case ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
-            return "Register is too large";
+    case ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
+        return "Register is too large";
 
-        case ME_REG_ACCESS_CONF_CORRUPT:
-            return "Config Section Corrupted";
+    case ME_REG_ACCESS_CONF_CORRUPT:
+        return "Config Section Corrupted";
 
-        case ME_REG_ACCESS_LEN_TOO_SMALL:
-            return "The given Register length is too small for the Tlv";
+    case ME_REG_ACCESS_LEN_TOO_SMALL:
+        return "The given Register length is too small for the Tlv";
 
-        case ME_REG_ACCESS_BAD_CONFIG:
-            return "The configuration is rejected";
+    case ME_REG_ACCESS_BAD_CONFIG:
+        return "The configuration is rejected";
 
-        case ME_REG_ACCESS_ERASE_EXEEDED:
-            return "The erase count exceeds its limit";
+    case ME_REG_ACCESS_ERASE_EXEEDED:
+        return "The erase count exceeds its limit";
 
-        case ME_REG_ACCESS_INTERNAL_ERROR:
-            return "Firmware internal error";
+    case ME_REG_ACCESS_INTERNAL_ERROR:
+        return "Firmware internal error";
 
-        // ICMD access errors
-        case ME_ICMD_STATUS_CR_FAIL:
-            return "ME_ICMD_STATUS_CR_FAIL";
+    /* ICMD access errors */
+    case ME_ICMD_STATUS_CR_FAIL:
+        return "ME_ICMD_STATUS_CR_FAIL";
 
-        case ME_ICMD_STATUS_SEMAPHORE_TO:
-            return "ME_ICMD_STATUS_SEMAPHORE_TO";
+    case ME_ICMD_STATUS_SEMAPHORE_TO:
+        return "ME_ICMD_STATUS_SEMAPHORE_TO";
 
-        case ME_ICMD_STATUS_EXECUTE_TO:
-            return "ME_ICMD_STATUS_EXECUTE_TO";
+    case ME_ICMD_STATUS_EXECUTE_TO:
+        return "ME_ICMD_STATUS_EXECUTE_TO";
 
-        case ME_ICMD_STATUS_IFC_BUSY:
-            return "ME_ICMD_STATUS_IFC_BUSY";
+    case ME_ICMD_STATUS_IFC_BUSY:
+        return "ME_ICMD_STATUS_IFC_BUSY";
 
-        case ME_ICMD_STATUS_ICMD_NOT_READY:
-            return "ME_ICMD_STATUS_ICMD_NOT_READY";
+    case ME_ICMD_STATUS_ICMD_NOT_READY:
+        return "ME_ICMD_STATUS_ICMD_NOT_READY";
 
-        case ME_ICMD_UNSUPPORTED_ICMD_VERSION:
-            return "ME_ICMD_UNSUPPORTED_ICMD_VERSION";
+    case ME_ICMD_UNSUPPORTED_ICMD_VERSION:
+        return "ME_ICMD_UNSUPPORTED_ICMD_VERSION";
 
-        case ME_ICMD_NOT_SUPPORTED:
-            return "ME_REG_ACCESS_ICMD_NOT_SUPPORTED";
+    case ME_ICMD_NOT_SUPPORTED:
+        return "ME_REG_ACCESS_ICMD_NOT_SUPPORTED";
 
-        case ME_ICMD_INVALID_OPCODE:
-            return "ME_ICMD_INVALID_OPCODE";
+    case ME_ICMD_INVALID_OPCODE:
+        return "ME_ICMD_INVALID_OPCODE";
 
-        case ME_ICMD_INVALID_CMD:
-            return "ME_ICMD_INVALID_CMD";
+    case ME_ICMD_INVALID_CMD:
+        return "ME_ICMD_INVALID_CMD";
 
-        case ME_ICMD_OPERATIONAL_ERROR:
-            return "ME_ICMD_OPERATIONAL_ERROR";
+    case ME_ICMD_OPERATIONAL_ERROR:
+        return "ME_ICMD_OPERATIONAL_ERROR";
 
-        case ME_ICMD_BAD_PARAM:
-            return "ME_ICMD_BAD_PARAM";
+    case ME_ICMD_BAD_PARAM:
+        return "ME_ICMD_BAD_PARAM";
 
-        case ME_ICMD_BUSY:
-            return "ME_ICMD_BUSY";
+    case ME_ICMD_BUSY:
+        return "ME_ICMD_BUSY";
 
-        case ME_ICMD_ICM_NOT_AVAIL:
-            return "ME_ICMD_ICM_NOT_AVAIL";
+    case ME_ICMD_ICM_NOT_AVAIL:
+        return "ME_ICMD_ICM_NOT_AVAIL";
 
-        case ME_ICMD_WRITE_PROTECT:
-            return "ME_ICMD_WRITE_PROTECT";
+    case ME_ICMD_WRITE_PROTECT:
+        return "ME_ICMD_WRITE_PROTECT";
 
-        case ME_ICMD_UNKNOWN_STATUS:
-            return "ME_ICMD_UNKNOWN_STATUS";
+    case ME_ICMD_UNKNOWN_STATUS:
+        return "ME_ICMD_UNKNOWN_STATUS";
 
-        case ME_ICMD_SIZE_EXCEEDS_LIMIT:
-            return "ME_ICMD_SIZE_EXCEEDS_LIMIT";
+    case ME_ICMD_SIZE_EXCEEDS_LIMIT:
+        return "ME_ICMD_SIZE_EXCEEDS_LIMIT";
 
-        // MAD IFC errors
-        case ME_MAD_BUSY:
-            return "Temporarily busy. MAD discarded. This is not an error";
+    /* MAD IFC errors */
+    case ME_MAD_BUSY:
+        return "Temporarily busy. MAD discarded. This is not an error";
 
-        case ME_MAD_REDIRECT:
-            return "Redirection. This is not an error";
+    case ME_MAD_REDIRECT:
+        return "Redirection. This is not an error";
 
-        case ME_MAD_BAD_VER:
-            return "Bad version";
+    case ME_MAD_BAD_VER:
+        return "Bad version";
 
-        case ME_MAD_METHOD_NOT_SUPP:
-            return "Method not supported";
+    case ME_MAD_METHOD_NOT_SUPP:
+        return "Method not supported";
 
-        case ME_MAD_METHOD_ATTR_COMB_NOT_SUPP:
-            return "Method and attribute combination isn't supported";
+    case ME_MAD_METHOD_ATTR_COMB_NOT_SUPP:
+        return "Method and attribute combination isn't supported";
 
-        case ME_MAD_BAD_DATA:
-            return "Bad attribute modifer or field";
+    case ME_MAD_BAD_DATA:
+        return "Bad attribute modifer or field";
 
-        case ME_MAD_GENERAL_ERR:
-            return "Unknown MAD error";
+    case ME_MAD_GENERAL_ERR:
+        return "Unknown MAD error";
 
-        default:
-            return "Unknown error code";
+    default:
+        return "Unknown error code";
     }
 }
 
@@ -2634,15 +2434,14 @@ int mget_addr_space(mfile* mf)
 }
 int mset_addr_space(mfile* mf, int space)
 {
-    switch (space)
-    {
-        case AS_CR_SPACE:
-        case AS_ICMD:
-        case AS_SEMAPHORE:
-            break;
+    switch (space) {
+    case AS_CR_SPACE:
+    case AS_ICMD:
+    case AS_SEMAPHORE:
+        break;
 
-        default:
-            return -1;
+    default:
+        return -1;
     }
     mf->address_space = space;
     return 0;
@@ -2652,31 +2451,27 @@ int device_exists(const char* devname)
 {
     char* devs = NULL;
     char* pdevs;
-    int size = 512;
-    int rc = 0;
-    int i = 0;
-    int res = 0;
-    // Get list of devices
-    do
-    {
-        if (devs)
-        {
+    int   size = 512;
+    int   rc = 0;
+    int   i = 0;
+    int   res = 0;
+
+    /* Get list of devices */
+    do{
+        if (devs) {
             free(devs);
         }
         size *= 2;
         devs = malloc(size);
-        if (!devs)
-        {
+        if (!devs) {
             errno = ENOMEM;
             return 0;
         }
         rc = mdevices_v(devs, size, MDEVS_ALL, 1);
     } while (rc == -1);
     pdevs = devs;
-    while (i < rc)
-    {
-        if (!strcmp(devname, pdevs))
-        {
+    while (i < rc) {
+        if (!strcmp(devname, pdevs)) {
             res = 1;
             goto cleanup;
         }
@@ -2684,8 +2479,7 @@ int device_exists(const char* devname)
         i++;
     }
 cleanup:
-    if (devs)
-    {
+    if (devs) {
         free(devs);
     }
     return res;
@@ -2694,14 +2488,13 @@ cleanup:
 int mclear_pci_semaphore(const char* name)
 {
     mfile* mf;
-    int rc = ME_OK;
+    int    rc = ME_OK;
+
     mf = mopen_int(name, Clear_Vsec_Semaphore);
-    if (!mf)
-    {
+    if (!mf) {
         return ME_ERROR;
     }
-    if (mf->tp != MST_PCICONF)
-    {
+    if (mf->tp != MST_PCICONF) {
         rc = ME_UNSUPPORTED_ACCESS_TYPE;
     }
     mclose(mf);
@@ -2710,68 +2503,57 @@ int mclear_pci_semaphore(const char* name)
 
 int mvpd_read4_int(mfile* mf, unsigned int offset, u_int8_t value[4])
 {
-    int vpd_cap = mf->vpd_cap_addr;
+    int      vpd_cap = mf->vpd_cap_addr;
     uint16_t write_addr;
     uint32_t read_addr;
-    int res;
-    int count_to_timeout;
-    int done = 0;
+    int      res;
+    int      count_to_timeout;
+    int      done = 0;
 
-    if (!mf || !value)
-    {
+    if (!mf || !value) {
         return ME_BAD_PARAMS;
     }
-    if (!vpd_cap)
-    {
+    if (!vpd_cap) {
         return ME_UNSUPPORTED_OPERATION;
     }
     int lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+
+    if (lock_rc) {
         perror("READ VPD");
         return ME_ERROR;
     }
     /* sets F bit to zero and write VPD addr */
     write_addr = (0x7fff & offset);
     res = write_config(mf, vpd_cap + PCI_VPD_ADDR, write_addr, 2);
-    if (res)
-    {
+    if (res) {
         res = ME_CR_ERROR;
         goto cleanup;
     }
 
     /* wait for data until F bit is set with one */
-    for (count_to_timeout = 0; count_to_timeout < MST_VPD_DFLT_TIMEOUT; count_to_timeout++)
-    {
+    for (count_to_timeout = 0; count_to_timeout < MST_VPD_DFLT_TIMEOUT; count_to_timeout++) {
         res = read_config(mf, vpd_cap + PCI_VPD_ADDR, &read_addr, 2);
-        if (res)
-        {
+        if (res) {
             res = ME_CR_ERROR;
             goto cleanup;
         }
-        if (read_addr & 0x8000)
-        {
+        if (read_addr & 0x8000) {
             done = 1;
             break;
         }
         sched_yield();
     }
-    if (done)
-    {
+    if (done) {
         res = read_config(mf, vpd_cap + PCI_VPD_DATA, (uint32_t*)value, 4);
-        if (res)
-        {
+        if (res) {
             res = ME_CR_ERROR;
         }
-    }
-    else
-    {
+    } else {
         res = ME_TIMEOUT;
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         perror("READ VPD");
         return ME_ERROR;
     }
@@ -2780,22 +2562,18 @@ cleanup:
 
 int mvpd_read4(mfile* mf, unsigned int offset, u_int8_t value[4])
 {
-    if (offset % 4)
-    {
-        u_int8_t qword[8] = {0};
-        int rc = 0;
+    if (offset % 4) {
+        u_int8_t     qword[8] = {0};
+        int          rc = 0;
         unsigned int aligned_offset = (offset / 4) * 4;
         rc = mvpd_read4_int(mf, aligned_offset, qword);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
         rc = mvpd_read4_int(mf, aligned_offset + 4, qword + 4);
         memcpy(value, qword + (offset % 4), 4);
         return 0;
-    }
-    else
-    {
+    } else {
         return mvpd_read4_int(mf, offset, value);
     }
 }
@@ -2822,77 +2600,67 @@ int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount)
     int page_counter = 0;
     int ret_code = ME_OK;
 
-    // Parameter validation.
-    if (!mf || !page_info)
-    {
+    /* Parameter validation. */
+    if (!mf || !page_info) {
         return ME_BAD_PARAMS;
     }
 
-    // Open the memory device file.
+    /* Open the memory device file. */
     int file_descriptor = open("/dev/mem", O_RDWR);
 
-    // Pin the memory in the kernel space.
-    for (page_counter = 0; page_counter < page_amount; page_counter++)
-    {
-        // Allocate the buffer.
+    /* Pin the memory in the kernel space. */
+    for (page_counter = 0; page_counter < page_amount; page_counter++) {
+        /* Allocate the buffer. */
         char* current_page = aligned_alloc(PAGE_SIZE, PAGE_SIZE);
 
-        // Page allocated ?
-        if (!current_page)
-        {
+        /* Page allocated ? */
+        if (!current_page) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
         page_allocated_counter++;
 
-        if ((uintptr_t)current_page % PAGE_SIZE)
-        {
+        if ((uintptr_t)current_page % PAGE_SIZE) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // We need to call mlock after the pages allocation in order to
-        //   lock the virtual address space into RAM and preventing that
-        //   memory from being paged to the swap area.
-        if (mlock(current_page, PAGE_SIZE))
-        {
+        /* We need to call mlock after the pages allocation in order to */
+        /*   lock the virtual address space into RAM and preventing that */
+        /*   memory from being paged to the swap area. */
+        if (mlock(current_page, PAGE_SIZE)) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // Save the virtual address in order to deallocate
-        //   the memory at the close function.
+        /* Save the virtual address in order to deallocate */
+        /*   the memory at the close function. */
         mf->user_page_list.page_list[page_counter] = current_page;
 
-        // Building the ioctl structure.
+        /* Building the ioctl structure. */
         struct mem_extract memory_user = {};
         memory_user.me_vaddr = (uintptr_t)current_page;
 
-        // Pin the user memory in the kernel space.
+        /* Pin the user memory in the kernel space. */
         int return_code = ioctl(file_descriptor, MEM_EXTRACT_PADDR, &memory_user);
 
-        if (return_code || (memory_user.me_state != ME_STATE_MAPPED))
-        {
+        if (return_code || (memory_user.me_state != ME_STATE_MAPPED)) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // Save the PA and VA for the tool.
+        /* Save the PA and VA for the tool. */
         page_info->page_addresses_array[page_counter].dma_address = memory_user.me_paddr;
         page_info->page_addresses_array[page_counter].virtual_address = (uintptr_t)current_page;
     }
 
-    // Close the device file /dev/mem.
+    /* Close the device file /dev/mem. */
     close(file_descriptor);
 
-    if (ret_code)
-    {
+    if (ret_code) {
         release_dma_pages(mf, page_allocated_counter);
-    }
-
-    else
-    {
+    } else {
         mf->user_page_list.page_amount = page_amount;
     }
 
@@ -2901,26 +2669,23 @@ int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount)
 
 int release_dma_pages(mfile* mf, int page_amount)
 {
-    // Parameter validation.
-    if (!mf)
-    {
+    /* Parameter validation. */
+    if (!mf) {
         return -1;
     }
 
-    // Deallocate the pages.
-    for (int page_counter = 0; page_counter < page_amount; page_counter++)
-    {
-        if (!mf->user_page_list.page_list[page_counter])
-        {
+    /* Deallocate the pages. */
+    for (int page_counter = 0; page_counter < page_amount; page_counter++) {
+        if (!mf->user_page_list.page_list[page_counter]) {
             continue;
         }
 
-        // Unlocking the virtual address of the page,
-        //    so that pages in the specified virtual address range may
-        //    once more to be swapped out if required by the kernel memory manager.
+        /* Unlocking the virtual address of the page, */
+        /*    so that pages in the specified virtual address range may */
+        /*    once more to be swapped out if required by the kernel memory manager. */
         munlock(mf->user_page_list.page_list[page_counter], PAGE_SIZE);
 
-        // Free the user space memory.
+        /* Free the user space memory. */
         free(mf->user_page_list.page_list[page_counter]);
 
         mf->user_page_list.page_list[page_counter] = NULL;
@@ -2962,29 +2727,26 @@ int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data)
 {
     int ret = 0;
 
-    // Parameters validation.
-    if (!mf || !data)
-    {
+    /* Parameters validation. */
+    if (!mf || !data) {
         return -1;
     }
 
-    // take semaphore.
+    /* take semaphore. */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+    if (ret) {
         return ret;
     }
 
-    // set address space.
+    /* set address space. */
     ret = _set_addr_space(mf, mf->address_space);
 
-    if (!ret)
-    {
-        // read the data.
+    if (!ret) {
+        /* read the data. */
         READ4_PCI(mf, data, offset, "read value", return -1);
     }
 
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
 
     return ret;
@@ -3010,7 +2772,11 @@ int mcables_remote_operation_client_side(mfile* mf, u_int32_t address, u_int32_t
     return 0;
 }
 
-int mlxcables_remote_operation_client_side(mfile* mf, const char* device_name, char op, char flags, const char* reg_name)
+int mlxcables_remote_operation_client_side(mfile     * mf,
+                                           const char* device_name,
+                                           char        op,
+                                           char        flags,
+                                           const char* reg_name)
 {
     (void)mf;
     (void)device_name;
@@ -3022,8 +2788,7 @@ int mlxcables_remote_operation_client_side(mfile* mf, const char* device_name, c
 
 int is_remote_dev(mfile* mf)
 {
-    if (mf)
-    {
+    if (mf) {
         return mf->is_remote;
     }
 
@@ -3033,32 +2798,33 @@ int is_remote_dev(mfile* mf)
 
 int is_zombiefish_device(mfile* mf)
 {
-    size_t gis_address = 0; // gis == global image status
+    size_t    gis_address = 0; /* gis == global image status */
     u_int32_t gis = 0;
-    uint32_t gis_operational = 0; // for NICs and HCAs
-
+    uint32_t  gis_operational = 0; /* for NICs and HCAs */
     u_int32_t hw_dev_id = 0;
+
     if (mread4_old(mf, HW_ID_ADDR, &hw_dev_id) != 4) {
         return 0;
     }
 
-    switch (hw_dev_id & 0xffff)
-    {
-        case DeviceConnectX8_HwId:
-            gis_address = 0xE3044;
-            break;
-        case DeviceQuantum3_HwId:
-            gis_operational = 0x5E;
-            gis_address = 0x152080;
-            break;
-        default:
-            return 0; // Device does not support Zombiefish mode
+    switch (hw_dev_id & 0xffff) {
+    case DeviceConnectX8_HwId:
+        gis_address = 0xE3044;
+        break;
+
+    case DeviceQuantum3_HwId:
+        gis_operational = 0x5E;
+        gis_address = 0x152080;
+        break;
+
+    default:
+        return 0;     /* Device does not support Zombiefish mode */
     }
 
     int rc = mread4_old(mf, gis_address, &gis);
-    if (rc != 4)
-    {
-        // printf("-E- Failed to read global_image_status from CR space.\n");
+
+    if (rc != 4) {
+        /* printf("-E- Failed to read global_image_status from CR space.\n"); */
         return 0;
     }
 

--- a/mtcr_ul/mtcr_gpu.c
+++ b/mtcr_ul/mtcr_gpu.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *
+ */
+
+#include "common/compatibility.h"
+#include "dev_mgt/tools_dev_types.h"
+
+typedef struct pci_id_range_st {
+    unsigned int lower_bound;
+    unsigned int upper_bound;
+} pci_id_range;
+
+pci_id_range GB100_PCI_IDS[] = {
+    {0x2900, 0x29FF}, {0x2B00, 0x2BFF}, {0x2C00, 0x2CFF}, {0x2D00, 0x2DFF},
+    {0x2E00, 0x2EFF}, {0x2F00, 0x2F7F}, {0x3180, 0x31FF}, {0x3200, 0x327F},
+    {0x3300, 0x33FF}, {0x3400, 0x347F}
+};
+
+pci_id_range GR100_PCI_IDS[] = {
+    {0x3000, 0x30FF}, {0x3280, 0x32FF}
+};
+
+int is_gb100_pci_device(u_int16_t pci_device_id)
+{
+    for (unsigned int i = 0; i < sizeof(GB100_PCI_IDS) / sizeof(pci_id_range); i++) {
+        if ((pci_device_id >= GB100_PCI_IDS[i].lower_bound) && (pci_device_id <= GB100_PCI_IDS[i].upper_bound)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int is_gr100_pci_device(u_int16_t pci_device_id)
+{
+    for (unsigned int i = 0; i < sizeof(GR100_PCI_IDS) / sizeof(pci_id_range); i++) {
+        if ((pci_device_id >= GR100_PCI_IDS[i].lower_bound) && (pci_device_id <= GR100_PCI_IDS[i].upper_bound)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+int is_gpu_pci_device(u_int16_t pci_device_id)
+{
+    return (is_gb100_pci_device(pci_device_id) || is_gr100_pci_device(pci_device_id));
+}
+
+bool is_gb100_device(u_int16_t hw_dev_id)
+{
+    return hw_dev_id == DeviceGB100_HwId;
+}
+
+bool is_gr100_device(u_int16_t hw_dev_id)
+{
+    return hw_dev_id == DeviceGR100_HwId;
+}
+
+bool is_gpu_device(u_int16_t hw_dev_id)
+{
+    return (is_gb100_device(hw_dev_id) || is_gr100_device(hw_dev_id));
+}
+
+u_int16_t get_hw_dev_id_by_pci_id(u_int16_t pci_device_id)
+{
+    if (is_gb100_pci_device(pci_device_id)) {
+        return DeviceGB100_HwId;
+    } else if (is_gr100_pci_device(pci_device_id)) {
+        return DeviceGR100_HwId;
+    }
+    return 0;
+}

--- a/mtcr_ul/mtcr_gpu.h
+++ b/mtcr_ul/mtcr_gpu.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2013-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef _MTCR_GPU /* guard */
+#define _MTCR_GPU
+
+int is_gpu_pci_device(u_int16_t pci_device_id);
+bool is_gpu_device(u_int16_t hw_dev_id);
+
+#endif /* _MTCR_GPU guard */

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -64,14 +64,13 @@ int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 int msw_reset(mfile* mf)
 {
 #ifndef NO_INBAND
-    switch (mf->tp)
-    {
-        case MST_IB:
-            return mib_swreset(mf);
+    switch (mf->tp) {
+    case MST_IB:
+        return mib_swreset(mf);
 
-        default:
-            errno = EPERM;
-            return -1;
+    default:
+        errno = EPERM;
+        return -1;
     }
 #else
     (void)mf;
@@ -104,27 +103,20 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
 void mdevices_info_destroy(dev_info* dev_info, int len)
 {
     int i, j;
-    if (dev_info)
-    {
-        for (i = 0; i < len; i++)
-        {
-            if (dev_info[i].type == MDEVS_TAVOR_CR && dev_info[i].pci.ib_devs)
-            {
-                for (j = 0; dev_info[i].pci.ib_devs[j]; j++)
-                {
-                    if (dev_info[i].pci.ib_devs[j])
-                    {
+
+    if (dev_info) {
+        for (i = 0; i < len; i++) {
+            if ((dev_info[i].type == MDEVS_TAVOR_CR) && dev_info[i].pci.ib_devs) {
+                for (j = 0; dev_info[i].pci.ib_devs[j]; j++) {
+                    if (dev_info[i].pci.ib_devs[j]) {
                         free(dev_info[i].pci.ib_devs[j]);
                     }
                 }
                 free(dev_info[i].pci.ib_devs);
             }
-            if (dev_info[i].type == MDEVS_TAVOR_CR && dev_info[i].pci.net_devs)
-            {
-                for (j = 0; dev_info[i].pci.net_devs[j]; j++)
-                {
-                    if (dev_info[i].pci.net_devs[j])
-                    {
+            if ((dev_info[i].type == MDEVS_TAVOR_CR) && dev_info[i].pci.net_devs) {
+                for (j = 0; dev_info[i].pci.net_devs[j]; j++) {
+                    if (dev_info[i].pci.net_devs[j]) {
                         free(dev_info[i].pci.net_devs[j]);
                     }
                 }
@@ -142,8 +134,7 @@ mfile* mopen(const char* name)
 
 mfile* mopend(const char* name, DType dtype)
 {
-    if (dtype != MST_TAVOR)
-    {
+    if (dtype != MST_TAVOR) {
         return NULL;
     }
     return mopen(name);
@@ -157,14 +148,11 @@ int mclose(mfile* mf)
 mfile* mopen_adv(const char* name, MType mtype)
 {
     mfile* mf = mopend(name, MST_TAVOR);
-    if (mf)
-    {
-        if (mf->tp & mtype)
-        {
+
+    if (mf) {
+        if (mf->tp & mtype) {
             return mf;
-        }
-        else
-        {
+        } else {
             errno = EPERM;
             mclose(mf);
             return NULL;
@@ -175,7 +163,7 @@ mfile* mopen_adv(const char* name, MType mtype)
 
 mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* extra_data)
 {
-    // not implemented
+    /* not implemented */
     TOOLS_UNUSED(fw_cmd_context);
     TOOLS_UNUSED(fw_cmd_func);
     TOOLS_UNUSED(extra_data);
@@ -184,12 +172,9 @@ mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* extra_data)
 
 void get_pci_dev_rdma(mfile* mf, char* buf)
 {
-    if (mf != NULL && mf->dinfo != NULL && strlen(mf->dinfo->pci.ib_devs[0]) > 0)
-    {
+    if ((mf != NULL) && (mf->dinfo != NULL) && (strlen(mf->dinfo->pci.ib_devs[0]) > 0)) {
         snprintf(buf, 32, "%s", mf->dinfo->pci.ib_devs[0]);
-    }
-    else
-    {
+    } else {
         *buf = '\0';
     }
 }
@@ -237,14 +222,14 @@ int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
     return mwrite_buffer_ul(mf, offset, data, byte_len);
 }
 
-int maccess_reg(mfile* mf,
-                u_int16_t reg_id,
+int maccess_reg(mfile              * mf,
+                u_int16_t            reg_id,
                 maccess_reg_method_t reg_method,
-                void* reg_data,
-                u_int32_t reg_size,
-                u_int32_t r_size_reg,
-                u_int32_t w_size_reg,
-                int* reg_status)
+                void               * reg_data,
+                u_int32_t            reg_size,
+                u_int32_t            r_size_reg,
+                u_int32_t            w_size_reg,
+                int                * reg_status)
 {
     return maccess_reg_ul(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg, reg_status);
 }
@@ -271,12 +256,10 @@ MTCR_API int mget_addr_space(mfile* mf)
 
 MTCR_API int mset_addr_space(mfile* mf, int space)
 {
-    if (space < 0 || space >= AS_END)
-    {
+    if ((space < 0) || (space >= AS_END)) {
         return -1;
     }
-    if (VSEC_SUPPORTED_UL(mf) && (mf->vsec_cap_mask & (1 << space_to_cap_offset(space))))
-    {
+    if (VSEC_SUPPORTED_UL(mf) && (mf->vsec_cap_mask & (1 << space_to_cap_offset(space)))) {
         mf->address_space = space;
         return 0;
     }
@@ -285,8 +268,7 @@ MTCR_API int mset_addr_space(mfile* mf, int space)
 
 int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 {
-    if (mf == NULL || devs_flags == NULL)
-    {
+    if ((mf == NULL) || (devs_flags == NULL)) {
         errno = EINVAL;
         return 1;
     }
@@ -297,8 +279,7 @@ int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 
 int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 {
-    if (mf == NULL || mtype == NULL)
-    {
+    if ((mf == NULL) || (mtype == NULL)) {
         errno = EINVAL;
         return 1;
     }

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -50,7 +50,9 @@
 #define _FILE_OFFSET_BITS 64
 #endif
 
-#define MTCR_MAP_SIZE 0x100000
+
+#define MTCR_MAP_SIZE             0x4000000
+#define GPU_NETIR_CR_SPACE_OFFSET 0x3000000
 #define DBG_PRINTF(...)                   \
     do                                    \
     {                                     \
@@ -95,6 +97,7 @@
 #include "mtcr_ul_com.h"
 #include "mtcr_int_defs.h"
 #include "mtcr_ib.h"
+#include "mtcr_gpu.h"
 #include "packets_layout.h"
 #include "mtcr_tools_cif.h"
 #include "mtcr_icmd_cif.h"
@@ -142,6 +145,31 @@ int init_dev_info_ul(mfile* mf, const char* dev_name, unsigned domain, unsigned 
     }
 
 #define MAX_RETRY_CNT 4096
+
+void update_device_endianness(mfile* mf)
+{
+    u_int16_t pci_device_id = mf->dinfo->pci.dev_id;
+
+    if (is_gpu_pci_device(pci_device_id)) {
+        mf->big_endian = 1;
+    } else {
+        mf->big_endian = 0;
+    }
+}
+
+void update_device_cr_space_offset(mfile* mf)
+{
+    if (mf) {
+        mf->cr_space_offset = 0;
+        if (mf->dinfo) {
+            u_int16_t pci_device_id = mf->dinfo->pci.dev_id;
+            if (is_gpu_pci_device(pci_device_id)) {
+                mf->cr_space_offset = GPU_NETIR_CR_SPACE_OFFSET;
+            }
+        }
+    }
+}
+
 
 static int _flock_int(int fdlock, int operation)
 {
@@ -304,7 +332,7 @@ static int mtcr_check_signature(mfile* mf)
     int      rc;
     char   * connectx_flush = getenv("CONNECTX_FLUSH");
 
-    rc = mread4_ul(mf, 0xF0014, &signature);
+    rc = mread4_ul(mf, 0x30F0014, &signature);
     if (rc != 4) {
         if (!errno) {
             errno = EIO;
@@ -526,6 +554,7 @@ static int mtcr_mmap(mfile* mf, const char* name, off_t off, int ioctl_needed)
         return -1;
     }
 
+
     mf->bar_virtual_addr = mmap(NULL, MTCR_MAP_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, mf->fd, off);
 
     if (!mf->bar_virtual_addr || (mf->bar_virtual_addr == MAP_FAILED)) {
@@ -541,7 +570,7 @@ int mtcr_pcicr_mread4(mfile* mf, unsigned int offset, u_int32_t* value)
 {
     ul_ctx_t* ctx = mf->ul_ctx;
 
-    if (offset >= MTCR_MAP_SIZE) {
+    if (offset - mf->cr_space_offset >= MTCR_MAP_SIZE) {
         errno = EINVAL;
         return 0;
     }
@@ -551,9 +580,15 @@ int mtcr_pcicr_mread4(mfile* mf, unsigned int offset, u_int32_t* value)
         }
         ctx->need_flush = 0;
     }
+
     u_int32_t tmp = ((u_int32_t*)mf->bar_virtual_addr)[offset / 4];
 
-    *value = __be32_to_cpu(tmp);
+    if (!mf->big_endian) {
+        *value = __be32_to_cpu(tmp);
+    } else {
+        *value = tmp;
+    }
+
     return 4;
 }
 
@@ -561,11 +596,17 @@ int mtcr_pcicr_mwrite4(mfile* mf, unsigned int offset, u_int32_t value)
 {
     ul_ctx_t* ctx = mf->ul_ctx;
 
-    if (offset >= MTCR_MAP_SIZE) {
+    if (offset - mf->cr_space_offset >= MTCR_MAP_SIZE) {
         errno = EINVAL;
         return 0;
     }
-    *((u_int32_t*)((char*)mf->bar_virtual_addr + offset)) = __cpu_to_be32(value);
+
+    if (!mf->big_endian) {
+        *((u_int32_t*)((char*)mf->bar_virtual_addr + offset)) = __cpu_to_be32(value);
+    } else {
+        *((u_int32_t*)((char*)mf->bar_virtual_addr + offset)) = value;
+    }
+
     ctx->need_flush = ctx->connectx_flush;
     return 4;
 }
@@ -776,13 +817,10 @@ int mtcr_fwctl_driver_mread4(mfile* mf, unsigned int offset, u_int32_t* value)
 {
     int rc = -1;
 
-    if (offset == HW_ID_ADDR)
-    {
+    if (offset == HW_ID_ADDR) {
         *value = mf->device_hw_id;
         rc = 4;
-    }
-    else
-    {
+    } else {
         FWCTL_DEBUG_PRINT(mf, "fwctl driver doesn't support VSEC access.\n")
     }
 
@@ -1699,7 +1737,7 @@ static MType mtcr_parse_name(const char* name,
         goto name_parsed;
     }
 
-    if(strstr(name, "fwctl")) {
+    if (strstr(name, "fwctl")) {
         return MST_FWCTL_CONTROL_DRIVER;
     }
 
@@ -1822,9 +1860,16 @@ static long live_fish_id_database[] = {0x191, 0x246, 0x249, 0x24b, 0x24d, 0x24e,
                                        0x25b, /* Quantum3 */
                                        -1};
 
-int is_supported_devid(long devid)
+int is_supported_devid(long devid, mfile* mf)
 {
     int i = 0;
+
+    if (is_gpu_pci_device(devid)) {
+        if (mf != NULL) {
+            mf->tp = MST_PCI;
+        }
+        return 1;
+    }
 
     while (supported_dev_ids[i] != -1) {
         if (devid == supported_dev_ids[i]) {
@@ -1842,7 +1887,7 @@ int is_supported_devid(long devid)
     return 0;
 }
 
-int is_supported_device(char* devname)
+int is_supported_device(char* devname, mfile* mf)
 {
     char  fname[64] = {0};
     char  inbuf[64] = {0};
@@ -1857,7 +1902,7 @@ int is_supported_device(char* devname)
     }
     if (fgets(inbuf, sizeof(inbuf), f)) {
         long devid = strtol(inbuf, NULL, 0);
-        ret_val = is_supported_devid(devid);
+        ret_val = is_supported_devid(devid, mf);
     }
     fclose(f);
     return ret_val;
@@ -1872,6 +1917,7 @@ int mdevices_v_ul(char* buf, int len, int mask, int verbosity)
 {
 #define MDEVS_TAVOR_CR     0x20
 #define MLNX_PCI_VENDOR_ID 0x15b3
+#define NVDA_PCI_VENDOR_ID 0x10de
 
     FILE         * f;
     DIR          * d;
@@ -1918,7 +1964,8 @@ int mdevices_v_ul(char* buf, int len, int mask, int verbosity)
         }
         if (fgets(inbuf, sizeof(inbuf), f)) {
             long venid = strtoul(inbuf, NULL, 0);
-            if ((venid == MLNX_PCI_VENDOR_ID) && is_supported_device(dir->d_name)) {
+            if (((venid == MLNX_PCI_VENDOR_ID) || (venid == NVDA_PCI_VENDOR_ID)) &&
+                is_supported_device(dir->d_name, NULL)) {
                 rsz = sz + 1; /* dev name size + place for Null char */
                 if ((pos + rsz) > len) {
                     ndevs = -1;
@@ -2487,14 +2534,19 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
         }
 
         sprintf(pcidev, "%4.4x:%2.2x:%2.2x.%1.1x", domain, bus, dev, func);
-        if (!is_supported_device(pcidev)) {
+        if (!is_supported_device(pcidev, mf)) {
             errno = ENOTSUP;
             goto open_failed;
         }
 
+        dev_type = mf->tp;
+
         if (init_dev_info_ul(mf, name, domain, bus, dev, func)) {
             goto open_failed;
         }
+
+        update_device_cr_space_offset(mf);
+        update_device_endianness(mf);
     }
 
     sprintf(cbuf, "/sys/bus/pci/devices/%4.4x:%2.2x:%2.2x.%1.1x/config", domain, bus, dev, func);
@@ -3165,13 +3217,17 @@ static int mreg_send_wrapper(mfile* mf, u_int8_t* data, int r_icmd_size, int w_i
             if (rc) {
                 return rc;
             }
-        } else { /* send register via inband (maccess_reg_mad will open the device as inband thus consecutives calls will go to */
-                 /* the first if) */
+        } else if (mf->tp == MST_IB) { /* send register via inband (maccess_reg_mad will open the device as inband thus consecutives calls will go to */
+            /* the first if) */
             rc = maccess_reg_mad(mf, data);
             if (rc) {
                 /* printf("-E- 2. Access reg mad failed with rc = %#x\n", rc); */
                 return ME_MAD_SEND_FAILED;
             }
+        }
+
+        else {
+            return icmd_send_command_int(mf, FLASH_REG_ACCESS, data, w_icmd_size, r_icmd_size, 0);
         }
 #else
         rc = icmd_send_command_int(mf, FLASH_REG_ACCESS, data, w_icmd_size, r_icmd_size, 0);
@@ -3272,7 +3328,7 @@ static int supports_icmd(mfile* mf)
         return 1;
     }
 
-    if (mread4_ul(mf, HW_ID_ADDR, &dev_id) != 4) { /* cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd */
+    if (read_device_id(mf, &dev_id) != 4) { /* cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd */
         return 0;
     }
     switch (dev_id & 0xffff) { /* that the hw device id */
@@ -3734,8 +3790,7 @@ int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data)
 
 int is_remote_dev(mfile* mf)
 {
-    if (mf)
-    {
+    if (mf) {
         return mf->is_remote;
     }
 
@@ -3744,34 +3799,50 @@ int is_remote_dev(mfile* mf)
 
 int is_zombiefish_device(mfile* mf)
 {
-    size_t gis_address = 0; // gis == global image status
+    size_t    gis_address = 0; /* gis == global image status */
     u_int32_t gis = 0;
-    uint32_t gis_operational = 0; // for NICs and HCAs
-
+    uint32_t  gis_operational = 0; /* for NICs and HCAs */
     u_int32_t hw_dev_id = 0;
+
     if (mread4_ul(mf, HW_ID_ADDR, &hw_dev_id) != 4) {
         return 0;
     }
 
-    switch (hw_dev_id & 0xffff)
-    {
-        case DeviceConnectX8_HwId:
-            gis_address = 0xE3044;
-            break;
-        case DeviceQuantum3_HwId:
-            gis_operational = 0x5E;
-            gis_address = 0x152080;
-            break;
-        default:
-            return 0; // Device does not support Zombiefish mode
+    switch (hw_dev_id & 0xffff) {
+    case DeviceConnectX8_HwId:
+        gis_address = 0xE3044;
+        break;
+
+    case DeviceQuantum3_HwId:
+        gis_operational = 0x5E;
+        gis_address = 0x152080;
+        break;
+
+    default:
+        return 0;     /* Device does not support Zombiefish mode */
     }
 
     int rc = mread4_ul(mf, gis_address, &gis);
-    if (rc != 4)
-    {
+
+    if (rc != 4) {
         DBG_PRINTF("-E- Failed to read global_image_status from CR space.\n");
         return 0;
     }
 
     return (gis != gis_operational);
+}
+
+int read_device_id(mfile* mf, u_int32_t* device_id)
+{
+    if (!mf || !device_id) {
+        return -1;
+    }
+
+    unsigned hw_id_address = mf->cr_space_offset + HW_ID_ADDR;
+
+    mf->rev_id = EXTRACT(*device_id, 16, 4);
+    *device_id = (*device_id & 0xffff);
+    mf->hw_dev_id = (*device_id & 0xffff);
+
+    return mread4(mf, hw_id_address, device_id);
 }

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -170,6 +170,8 @@ extern "C"
     void mtcr_fix_endianness(u_int32_t* buf, int len);
 
     int is_zombiefish_device(mfile* mf);
+    
+    int read_device_id(mfile* mf, u_int32_t* device_id);
 
 #ifdef __cplusplus
 }

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -42,6 +42,7 @@
 #include "common/tools_time.h"
 #include "mtcr_icmd_cif.h"
 #include "packets_common.h"
+#include "mtcr_gpu.h"
 #ifndef __FreeBSD__
 #include "mtcr_ib_res_mgt.h"
 #include "tools_dev_types.h"
@@ -50,86 +51,93 @@
 #include "mtcr_mem_ops.h"
 #include "mtcr_ul_com.h"
 
-#define ICMD_QUERY_CAP_CMD_ID 0x8400
-#define ICMD_QUERY_CAP_CMD_SZ 0x8
+#define ICMD_QUERY_CAP_CMD_ID        0x8400
+#define ICMD_QUERY_CAP_CMD_SZ        0x8
 #define ICMD_QUERY_CAP_EXMB_ICMD_OFF 0x8
 
-// _DEBUG_MODE   // un-comment this to enable debug prints
+/* _DEBUG_MODE   // un-comment this to enable debug prints */
 
-#define ICMD_DEFAULT_TIMEOUT 5120
-#define STAT_CFG_NOT_DONE_ADDR_CIB 0xb0004
-#define STAT_CFG_NOT_DONE_ADDR_CX4 0xb0004
-#define STAT_CFG_NOT_DONE_ADDR_SW_IB 0x80010
+
+#define ICMD_DEFAULT_TIMEOUT           5120
+#define STAT_CFG_NOT_DONE_ADDR_CIB     0xb0004
+#define STAT_CFG_NOT_DONE_ADDR_CX4     0xb0004
+#define STAT_CFG_NOT_DONE_ADDR_SW_IB   0x80010
 #define STAT_CFG_NOT_DONE_ADDR_QUANTUM 0x100010
-#define STAT_CFG_NOT_DONE_ADDR_CX5 0xb5e04
-#define STAT_CFG_NOT_DONE_ADDR_CX6 0xb5f04
-#define STAT_CFG_NOT_DONE_ADDR_CX7 0xb5f04
-#define STAT_CFG_NOT_DONE_BITOFF_CIB 31
-#define STAT_CFG_NOT_DONE_BITOFF_CX4 31
+#define STAT_CFG_NOT_DONE_ADDR_CX5     0xb5e04
+#define STAT_CFG_NOT_DONE_ADDR_CX6     0xb5f04
+#define STAT_CFG_NOT_DONE_ADDR_CX7     0xb5f04
+#define STAT_CFG_NOT_DONE_ADDR_GPU     0x3100010
+#define STAT_CFG_NOT_DONE_BITOFF_CIB   31
+#define STAT_CFG_NOT_DONE_BITOFF_CX4   31
 #define STAT_CFG_NOT_DONE_BITOFF_SW_IB 0
-#define STAT_CFG_NOT_DONE_BITOFF_CX5 31
-#define STAT_CFG_NOT_DONE_BITOFF_CX7 31
-#define SEMAPHORE_ADDR_CIB 0xe27f8   // sem62
-#define SEMAPHORE_ADDR_CX4 0xe250c   // sem67 bit31 is the semaphore bit here (only one semaphore in this dword)
-#define SEMAPHORE_ADDR_SW_IB 0xa24f8 // sem 62
-#define SEMAPHORE_ADDR_QUANTUM 0xa68f8
-#define SEMAPHORE_ADDR_QUANTUM2 0xa52f8
-#define SEMAPHORE_ADDR_QUANTUM3 0xa52f8 // 0x25b
-#define SEMAPHORE_ADDR_BW00 0xa52f8
-#define SEMAPHORE_ADDR_CX5 0xe74e0
-#define SEMAPHORE_ADDR_CX7 0xe5660
-#define HCR_ADDR_CIB 0x0
-#define HCR_ADDR_CX4 HCR_ADDR_CIB
-#define HCR_ADDR_CX5 HCR_ADDR_CIB
-#define HCR_ADDR_CX7 HCR_ADDR_CIB
-#define HCR_ADDR_SW_IB 0x80000
-#define HCR_ADDR_QUANTUM 0x100000
-#define ICMD_VERSION_BITOFF 24
-#define ICMD_VERSION_BITLEN 8
-#define CMD_PTR_ADDR_CIB 0x0
-#define CMD_PTR_ADDR_SW_IB 0x80000
-#define CMD_PTR_ADDR_QUANTUM 0x100000
-#define CMD_PTR_ADDR_CX4 CMD_PTR_ADDR_CIB
-#define CMD_PTR_ADDR_CX5 CMD_PTR_ADDR_CIB
-#define CMD_PTR_ADDR_CX7 CMD_PTR_ADDR_CIB
-#define CMD_PTR_BITOFF 0
-#define CMD_PTR_BITLEN 24
-#define CTRL_OFFSET 0x3fc
-#define BUSY_BITOFF 0
-#define BUSY_BITLEN 1
-#define EXMB_BITOFF 1
-#define EXMB_BITLEN 1
-#define OPCODE_BITOFF 16
-#define OPCODE_BITLEN 16
-#define STATUS_BITOFF 8
-#define STATUS_BITLEN 8
-#define VCR_CTRL_ADDR 0x0
-#define VCR_SEMAPHORE62 0x0      // semaphore Domain
-#define VCR_CMD_ADDR 0x100000    // mailbox addr
-#define VCR_CMD_SIZE_ADDR 0x1000 // mailbox size
+#define STAT_CFG_NOT_DONE_BITOFF_CX5   31
+#define STAT_CFG_NOT_DONE_BITOFF_CX7   31
+#define SEMAPHORE_ADDR_CIB             0xe27f8 /* sem62 */
+#define SEMAPHORE_ADDR_CX4             0xe250c /* sem67 bit31 is the semaphore bit here (only one semaphore in this dword) */
+#define SEMAPHORE_ADDR_SW_IB           0xa24f8 /* sem 62 */
+#define SEMAPHORE_ADDR_QUANTUM         0xa68f8
+#define SEMAPHORE_ADDR_QUANTUM2        0xa52f8
+#define SEMAPHORE_ADDR_QUANTUM3        0xa52f8 /* 0x25b */
+#define SEMAPHORE_ADDR_GB100           0xa52f8
+#define SEMAPHORE_ADDR_CX5             0xe74e0
+#define SEMAPHORE_ADDR_CX7             0xe5660
+#define SEMAPHORE_ADDR_GPU             0x308F4F8
+#define HCR_ADDR_CIB                   0x0
+#define HCR_ADDR_CX4                   HCR_ADDR_CIB
+#define HCR_ADDR_CX5                   HCR_ADDR_CIB
+#define HCR_ADDR_CX7                   HCR_ADDR_CIB
+#define HCR_ADDR_SW_IB                 0x80000
+#define HCR_ADDR_QUANTUM               0x100000
+#define HCR_ADDR_GPU                   0x3100044
+#define ICMD_VERSION_BITOFF            24
+#define ICMD_VERSION_BITOFF_GPU        0
+#define ICMD_VERSION_BITLEN            8
+#define CMD_PTR_ADDR_CIB               0x0
+#define CMD_PTR_ADDR_SW_IB             0x80000
+#define CMD_PTR_ADDR_QUANTUM           0x100000
+#define CMD_PTR_ADDR_CX4               CMD_PTR_ADDR_CIB
+#define CMD_PTR_ADDR_CX5               CMD_PTR_ADDR_CIB
+#define CMD_PTR_ADDR_CX7               CMD_PTR_ADDR_CIB
+#define CMD_PTR_ADDR_GPU               0x3100000
+#define CMD_PTR_BITOFF                 0
+#define CMD_PTR_BITLEN                 24
+#define CMD_PTR_BITLEN_GPU             32
+#define CTRL_OFFSET                    0x3fc
+#define BUSY_BITOFF                    0
+#define BUSY_BITLEN                    1
+#define EXMB_BITOFF                    1
+#define EXMB_BITLEN                    1
+#define OPCODE_BITOFF                  16
+#define OPCODE_BITLEN                  16
+#define STATUS_BITOFF                  8
+#define STATUS_BITLEN                  8
+#define VCR_CTRL_ADDR                  0x0
+#define VCR_SEMAPHORE62                0x0 /* semaphore Domain */
+#define VCR_CMD_ADDR                   0x100000 /* mailbox addr */
+#define VCR_CMD_SIZE_ADDR              0x1000 /* mailbox size */
 
 #define EXT_MBOX_DMA_OFF 0x8
 
-#define SEMAPHORE_ADDR_GBOX 0xa6850
-#define CMD_PTR_ADDR_GBOX 0x90010
-#define GBOX_GW_OPCODE_OFFSET 256
-#define GBOX_GW_REG_OPCODE_OFFSET 252
-#define GBOX_GW_REQUEST_DATA_BLOCK_OFFSET 0
+#define SEMAPHORE_ADDR_GBOX                0xa6850
+#define CMD_PTR_ADDR_GBOX                  0x90010
+#define GBOX_GW_OPCODE_OFFSET              256
+#define GBOX_GW_REG_OPCODE_OFFSET          252
+#define GBOX_GW_REQUEST_DATA_BLOCK_OFFSET  0
 #define GBOX_GW_RESPONSE_DATA_BLOCK_OFFSET 260
-#define GBOX_MAX_DATA_SIZE 256
-#define GBOX_STAT_CFG_NOT_DONE_ADDR 0x90000
-#define GBOX_REG_ACCESS_CMD_OPCODE 0x0ff
-#define GBOX_BUSY_BITOFF 31
-#define GBOX_OPCODE_BITOFF 16
-#define GBOX_OPCODE_BITLEN 10
-#define GBOX_REG_ACC_W_SIZE_BITOFF 0
-#define GBOX_REG_ACC_W_SIZE_BITLEN 8
-#define GBOX_STATUS_BITOFF 28
-#define GBOX_STATUS_BITLEN 3
-#define GBOX_STATUS1_BITOFF 8
-#define GBOX_STATUS1_BITLEN 7
-#define GBOX_READ_SIZE_BITOFF 0
-#define GBOX_READ_SIZE_BITLEN 8
+#define GBOX_MAX_DATA_SIZE                 256
+#define GBOX_STAT_CFG_NOT_DONE_ADDR        0x90000
+#define GBOX_REG_ACCESS_CMD_OPCODE         0x0ff
+#define GBOX_BUSY_BITOFF                   31
+#define GBOX_OPCODE_BITOFF                 16
+#define GBOX_OPCODE_BITLEN                 10
+#define GBOX_REG_ACC_W_SIZE_BITOFF         0
+#define GBOX_REG_ACC_W_SIZE_BITLEN         8
+#define GBOX_STATUS_BITOFF                 28
+#define GBOX_STATUS_BITLEN                 3
+#define GBOX_STATUS1_BITOFF                8
+#define GBOX_STATUS1_BITLEN                7
+#define GBOX_READ_SIZE_BITOFF              0
+#define GBOX_READ_SIZE_BITLEN              8
 /*
  * General Macros
  */
@@ -156,11 +164,11 @@
  */
 #define MWRITE_BUF(mf, offset, data, byte_len)                                                 \
     (((unsigned)(mwrite_buffer((mf), (offset), (data), (byte_len))) != (unsigned)(byte_len)) ? \
-       ME_ICMD_STATUS_CR_FAIL :                                                                \
-       ME_OK)
+     ME_ICMD_STATUS_CR_FAIL :                                                                  \
+     ME_OK)
 #define MREAD_BUF(mf, offset, data, byte_len)                                                                          \
     (((unsigned)(mread_buffer((mf), (offset), (data), (byte_len))) != (unsigned)(byte_len)) ? ME_ICMD_STATUS_CR_FAIL : \
-                                                                                              ME_OK)
+     ME_OK)
 
 #define MWRITE4(mf, offset, value) \
     (((unsigned)(mwrite4((mf), (offset), (value))) != 4U) ? ME_ICMD_STATUS_CR_FAIL : ME_OK)
@@ -185,8 +193,7 @@ static int MWRITE4_ICMD(mfile* mf, int offset, u_int32_t value)
 {
     SET_SPACE_FOR_ICMD_ACCESS(mf);
     DBG_PRINTF("-D- MWRITE4_ICMD: off: %x, addr_space: %x\n", offset, mf->address_space);
-    if (mwrite4(mf, offset, value) != 4)
-    {
+    if (mwrite4(mf, offset, value) != 4) {
         mset_addr_space(mf, AS_CR_SPACE);
         return ME_ICMD_STATUS_CR_FAIL;
     }
@@ -198,8 +205,7 @@ static int MREAD4_ICMD(mfile* mf, int offset, u_int32_t* ptr)
 {
     SET_SPACE_FOR_ICMD_ACCESS(mf);
     DBG_PRINTF("-D- MREAD4_ICMD: off: %x, addr_space: %x\r\n", offset, mf->address_space);
-    if (mread4(mf, offset, ptr) != 4)
-    {
+    if (mread4(mf, offset, ptr) != 4) {
         RESTORE_SPACE(mf);
         return ME_ICMD_STATUS_CR_FAIL;
     }
@@ -239,8 +245,7 @@ static int MREAD4_ICMD(mfile* mf, int offset, u_int32_t* ptr)
 int MWRITE4_SEMAPHORE(mfile* mf, int offset, int value)
 {
     SET_SPACE_FOR_SEMAPHORE_ACCESS(mf);
-    if (mwrite4(mf, offset, value) != 4)
-    {
+    if (mwrite4(mf, offset, value) != 4) {
         RESTORE_SPACE(mf);
         return ME_ICMD_STATUS_CR_FAIL;
     }
@@ -251,8 +256,7 @@ int MWRITE4_SEMAPHORE(mfile* mf, int offset, int value)
 int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr)
 {
     SET_SPACE_FOR_SEMAPHORE_ACCESS(mf);
-    if (mread4(mf, offset, ptr) != 4)
-    {
+    if (mread4(mf, offset, ptr) != 4) {
         RESTORE_SPACE(mf);
         return ME_ICMD_STATUS_CR_FAIL;
     }
@@ -260,9 +264,8 @@ int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr)
     return ME_OK;
 }
 
-enum
-{
-    RW_READ = 0x1,
+enum {
+    RW_READ  = 0x1,
     RW_WRITE = 0x0
 };
 
@@ -272,29 +275,30 @@ enum
  *  according to Hw devid
  */
 
-#define HW_ID_ADDR 0xf0014
-#define CIB_HW_ID 511
-#define CX4_HW_ID 521
-#define CX4LX_HW_ID 523
-#define CX5_HW_ID 525
-#define CX6_HW_ID 527
-#define CX6DX_HW_ID 530
-#define CX6LX_HW_ID 534
-#define CX7_HW_ID 536
-#define CX8_HW_ID 542
-#define BF_HW_ID 529
-#define BF2_HW_ID 532
-#define BF3_HW_ID 540
-#define BF4_HW_ID 544
-#define SW_IB_HW_ID 583
-#define SW_EN_HW_ID 585
-#define SW_IB2_HW_ID 587
-#define QUANTUM_HW_ID 589
+#define HW_ID_ADDR      0xf0014
+#define CIB_HW_ID       511
+#define CX4_HW_ID       521
+#define CX4LX_HW_ID     523
+#define CX5_HW_ID       525
+#define CX6_HW_ID       527
+#define CX6DX_HW_ID     530
+#define CX6LX_HW_ID     534
+#define CX7_HW_ID       536
+#define CX8_HW_ID       542
+#define BF_HW_ID        529
+#define BF2_HW_ID       532
+#define BF3_HW_ID       540
+#define BF4_HW_ID       544
+#define SW_IB_HW_ID     583
+#define SW_EN_HW_ID     585
+#define SW_IB2_HW_ID    587
+#define QUANTUM_HW_ID   589
 #define SPECTRUM2_HW_ID 590
 #define SPECTRUM3_HW_ID 592
-#define QUANTUM2_HW_ID 599
-#define QUANTUM3_HW_ID 603 // 0x25b
-#define BW00_HW_ID 0x2900
+#define QUANTUM2_HW_ID  599
+#define QUANTUM3_HW_ID  603 /* 0x25b */
+#define GB100_HW_ID     0x2900
+#define GR100_HW_ID     0x3000
 #define SPECTRUM4_HW_ID 596
 #define AMOS_GBOX_HW_ID 594
 
@@ -315,11 +319,11 @@ u_int32_t gbox_gw_start_addr = 0xffff;
 static int get_version(mfile* mf, u_int32_t hcr_address)
 {
     u_int32_t reg = 0x0;
-    if (MREAD4(mf, hcr_address, &reg))
-    {
+
+    if (MREAD4(mf, hcr_address, &reg)) {
         return ME_ICMD_STATUS_CR_FAIL;
     }
-    reg = EXTRACT(reg, ICMD_VERSION_BITOFF, ICMD_VERSION_BITLEN);
+    reg = EXTRACT(reg, mf->icmd.version_bit_offset, ICMD_VERSION_BITLEN);
     return reg;
 }
 
@@ -327,6 +331,7 @@ static MError check_busy_bit(mfile* mf, int busy_bit_offset, u_int32_t* reg)
 {
     DBG_PRINTF("Check Go bit\n");
     int rc = MREAD4_ICMD(mf, mf->icmd.ctrl_addr, reg);
+
     CHECK_RC(rc);
 
     return EXTRACT((*reg), busy_bit_offset, BUSY_BITLEN);
@@ -341,24 +346,19 @@ static MError set_busy_bit(mfile* mf, u_int32_t* reg, int busy_bit_offset)
 static int set_sleep()
 {
     char* icmd_sleep_env;
-    int icmd_sleep = -1;
+    int   icmd_sleep = -1;
 
-    if (increase_poll_time)
-    {
-        // increase_poll_time is set by low_cpu flag. To reduce CPU utilization
+    if (increase_poll_time) {
+        /* increase_poll_time is set by low_cpu flag. To reduce CPU utilization */
         icmd_sleep_env = "10\0";
-    }
-    else
-    {
+    } else {
         icmd_sleep_env = getenv("MFT_CMD_SLEEP");
     }
 
-    if (icmd_sleep_env)
-    {
+    if (icmd_sleep_env) {
         char* endptr;
         icmd_sleep = strtol(icmd_sleep_env, &endptr, 10);
-        if (*endptr != '\0')
-        {
+        if (*endptr != '\0') {
             icmd_sleep = -1;
         }
     }
@@ -369,16 +369,14 @@ static int set_sleep()
 static int set_icmd_timeout()
 {
     char* icmd_timeout_env;
-    int icmd_timeout = ICMD_DEFAULT_TIMEOUT;
+    int   icmd_timeout = ICMD_DEFAULT_TIMEOUT;
 
     icmd_timeout_env = getenv("MFT_ICMD_TIMEOUT");
 
-    if (icmd_timeout_env)
-    {
+    if (icmd_timeout_env) {
         char* endptr;
         icmd_timeout = strtol(icmd_timeout_env, &endptr, 10);
-        if (endptr != NULL && *endptr != '\0')
-        {
+        if ((endptr != NULL) && (*endptr != '\0')) {
             icmd_timeout = ICMD_DEFAULT_TIMEOUT;
         }
     }
@@ -391,61 +389,59 @@ static int set_icmd_timeout()
  */
 static int translate_status(int status)
 {
-    switch (status)
-    {
-        case 0x0:
-            return ME_OK;
+    switch (status) {
+    case 0x0:
+        return ME_OK;
 
-        case 0x1:
-            return ME_ICMD_INVALID_OPCODE;
+    case 0x1:
+        return ME_ICMD_INVALID_OPCODE;
 
-        case 0x2:
-            return ME_ICMD_INVALID_CMD;
+    case 0x2:
+        return ME_ICMD_INVALID_CMD;
 
-        case 0x3:
-            return ME_ICMD_OPERATIONAL_ERROR;
+    case 0x3:
+        return ME_ICMD_OPERATIONAL_ERROR;
 
-        case 0x4:
-            return ME_ICMD_BAD_PARAM;
+    case 0x4:
+        return ME_ICMD_BAD_PARAM;
 
-        case 0x5:
-            return ME_ICMD_BUSY;
+    case 0x5:
+        return ME_ICMD_BUSY;
 
-        case 0x6:
-            return ME_ICMD_ICM_NOT_AVAIL;
+    case 0x6:
+        return ME_ICMD_ICM_NOT_AVAIL;
 
-        case 0x7:
-            return ME_ICMD_WRITE_PROTECT;
+    case 0x7:
+        return ME_ICMD_WRITE_PROTECT;
 
-        default:
-            return ME_ICMD_UNKNOWN_STATUS;
+    default:
+        return ME_ICMD_UNKNOWN_STATUS;
     }
 }
 
 static int translate_gbox_icmd_status(int status)
 {
-    switch (status)
-    {
-        case 0x0:
-            return ME_OK;
+    switch (status) {
+    case 0x0:
+        return ME_OK;
 
-        case 0x1:
-            return ME_ERROR;
+    case 0x1:
+        return ME_ERROR;
 
-        case 0x2:
-            return ME_UNKOWN_ACCESS_TYPE;
+    case 0x2:
+        return ME_UNKOWN_ACCESS_TYPE;
 
-        case 0x3:
-            return ME_ICMD_BAD_PARAM;
+    case 0x3:
+        return ME_ICMD_BAD_PARAM;
 
-        case 0x6:
-            return ME_TIMEOUT;
+    case 0x6:
+        return ME_TIMEOUT;
 
-        case 0x7:
-            return ME_ICMD_NOT_SUPPORTED;
+    case 0x7:
+        return ME_ICMD_NOT_SUPPORTED;
 
-        default:
-            return ME_ICMD_UNKNOWN_STATUS;
+    default:
+        return ME_ICMD_UNKNOWN_STATUS;
     }
 }
 
@@ -455,78 +451,60 @@ static int translate_gbox_icmd_status(int status)
 static int set_and_poll_on_busy_bit(mfile* mf, int enhanced, int busy_bit_offset, u_int32_t* reg)
 {
     u_int32_t busy;
-    int i, wait;
-    MError rc;
+    int       i, wait;
+    MError    rc;
 
-    // set go bit
+    /* set go bit */
     rc = set_busy_bit(mf, reg, busy_bit_offset);
     CHECK_RC(rc);
     DBG_PRINTF("Busy-bit raised. Waiting for command to exec...\n");
 
-    // set sleep time if needed
+    /* set sleep time if needed */
     int icmd_sleep = set_sleep();
-
     int icmd_timeout = set_icmd_timeout();
 
-    // wait for command to execute
+    /* wait for command to execute */
     i = 0;
     wait = 1;
-    do
-    {
-        if (++i > icmd_timeout)
-        {
-            // this number of iterations should take ~~30sec, which is the defined command t/o
+    do{
+        if (++i > icmd_timeout) {
+            /* this number of iterations should take ~~30sec, which is the defined command t/o */
             DBG_PRINTF("Execution timed-out\n");
             return ME_ICMD_STATUS_EXECUTE_TO;
         }
 
-        if ((i < 100) || (i % 100 == 0))
-        {
+        if ((i < 100) || (i % 100 == 0)) {
             DBG_PRINTF("Waiting for busy-bit to clear (iteration #%d)...\n", i);
         }
 
-        if (icmd_sleep > 0)
-        {
-            if (i == 3)
-            {
+        if (icmd_sleep > 0) {
+            if (i == 3) {
                 msleep(icmd_sleep);
-            }
-            else if (i > 3)
-            {
+            } else if (i > 3) {
                 msleep(wait);
-                if (wait < 8)
-                {
-                    wait *= 2; // exponential backoff - up-to 8ms between polls
+                if (wait < 8) {
+                    wait *= 2; /* exponential backoff - up-to 8ms between polls */
                 }
             }
-            if (increase_poll_time)
-            {
-                // adding msleep to reduce the CPU utilization (low_cpu flag)
+            if (increase_poll_time) {
+                /* adding msleep to reduce the CPU utilization (low_cpu flag) */
                 msleep(10);
             }
-        }
-        else
-        {
-            if (!enhanced)
-            {
-                if (i > 5)
-                {
-                    // after some iteration put sleeps between busy-wait
-                    msleep(wait); // don't hog the cpu with busy-wait
-                    if (wait < 8)
-                    {
-                        wait *= 2; // exponential backoff - up-to 8ms between polls
+        } else {
+            if (!enhanced) {
+                if (i > 5) {
+                    /* after some iteration put sleeps between busy-wait */
+                    msleep(wait); /* don't hog the cpu with busy-wait */
+                    if (wait < 8) {
+                        wait *= 2; /* exponential backoff - up-to 8ms between polls */
                     }
                 }
-            }
-            else
-            {
+            } else {
                 mft_usleep(1);
             }
         }
 
         busy = check_busy_bit(mf, busy_bit_offset, reg);
-
     } while (busy);
 
     DBG_PRINTF("Command completed!\n");
@@ -540,9 +518,9 @@ static int set_and_poll_on_busy_bit(mfile* mf, int enhanced, int busy_bit_offset
 static int set_opcode(mfile* mf, u_int16_t opcode)
 {
     u_int32_t reg = 0x0;
-    u_int8_t exmb = mf->icmd.dma_icmd;
+    u_int8_t  exmb = mf->icmd.dma_icmd;
+    int       rc = MREAD4_ICMD(mf, mf->icmd.ctrl_addr, &reg);
 
-    int rc = MREAD4_ICMD(mf, mf->icmd.ctrl_addr, &reg);
     CHECK_RC(rc);
 
     reg = MERGE(reg, opcode, OPCODE_BITOFF, OPCODE_BITLEN);
@@ -559,11 +537,10 @@ static int set_opcode(mfile* mf, u_int16_t opcode)
 static int icmd_is_cmd_ifc_ready(mfile* mf, int enhanced)
 {
     u_int32_t reg = 0x0;
-    if (!enhanced || mf->icmd.icmd_ready == MTCR_STATUS_UNKNOWN)
-    {
+
+    if (!enhanced || (mf->icmd.icmd_ready == MTCR_STATUS_UNKNOWN)) {
         u_int32_t bit_val = 0;
-        if (MREAD4(mf, mf->icmd.static_cfg_not_done_addr, &reg))
-        {
+        if (MREAD4(mf, mf->icmd.static_cfg_not_done_addr, &reg)) {
             return ME_ICMD_STATUS_CR_FAIL;
         }
         bit_val = EXTRACT(reg, mf->icmd.static_cfg_not_done_offs, 1);
@@ -577,29 +554,24 @@ static int icmd_is_cmd_ifc_ready(mfile* mf, int enhanced)
 static int icmd_clear_semaphore_com(mfile* mf)
 {
 #ifndef __FreeBSD__
-    int is_leaseable;
+    int      is_leaseable;
     u_int8_t lease_exp;
-    if ((mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CIB || mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CX4) &&
-        mf->icmd.ib_semaphore_lock_supported)
-    {
-        if (!mf->icmd.lock_key)
-        {
+    if (((mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CIB) || (mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CX4)) &&
+        mf->icmd.ib_semaphore_lock_supported) {
+        if (!mf->icmd.lock_key) {
             return ME_OK;
         }
         DBG_PRINTF("VS_MAD SEM Release .. ");
         if (mib_semaphore_lock_vs_mad(mf, SMP_SEM_RELEASE, SMP_ICMD_SEM_ADDR, mf->icmd.lock_key, &(mf->icmd.lock_key),
-                                      &is_leaseable, &lease_exp, SEM_LOCK_SET))
-        {
+                                      &is_leaseable, &lease_exp, SEM_LOCK_SET)) {
             DBG_PRINTF("Failed!\n");
             return ME_ICMD_STATUS_CR_FAIL;
         }
-        if (mf->icmd.lock_key != 0)
-        {
+        if (mf->icmd.lock_key != 0) {
             return ME_ICMD_STATUS_CR_FAIL;
         }
         DBG_PRINTF("Succeeded!\n");
-    }
-    else
+    } else
 #endif
     {
         MWRITE4_SEMAPHORE(mf, mf->icmd.semaphore_addr, 0);
@@ -614,8 +586,9 @@ static int icmd_clear_semaphore_com(mfile* mf)
 int icmd_clear_semaphore(mfile* mf)
 {
     DBG_PRINTF("Clearing semaphore\n");
-    // open icmd interface by demand
+    /* open icmd interface by demand */
     int ret = icmd_open(mf);
+
     CHECK_RC(ret);
     return icmd_clear_semaphore_com(mf);
 }
@@ -630,47 +603,39 @@ int icmd_clear_semaphore(mfile* mf)
 static int icmd_take_semaphore_com(mfile* mf, u_int32_t expected_read_val)
 {
     u_int32_t read_val = 0x0;
-    unsigned retries = 0;
+    unsigned  retries = 0;
 
     DBG_PRINTF("Taking semaphore...\n");
-    do
-    { // loop while the semaphore is taken by someone else
-        if (++retries > 256)
-        {
+    do{ /* loop while the semaphore is taken by someone else */
+        if (++retries > 256) {
             return ME_ICMD_STATUS_SEMAPHORE_TO;
         }
 #ifndef __FreeBSD__
-        int is_leaseable;
+        int      is_leaseable;
         u_int8_t lease_exp;
-        if ((mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CIB || mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CX4) &&
-            mf->icmd.ib_semaphore_lock_supported)
-        {
+        if (((mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CIB) || (mf->icmd.semaphore_addr == SEMAPHORE_ADDR_CX4)) &&
+            mf->icmd.ib_semaphore_lock_supported) {
             DBG_PRINTF("VS_MAD SEM LOCK .. ");
             read_val = mib_semaphore_lock_vs_mad(mf, SMP_SEM_LOCK, SMP_ICMD_SEM_ADDR, 0, &(mf->icmd.lock_key),
                                                  &is_leaseable, &lease_exp, SEM_LOCK_SET);
-            if (read_val && read_val != ME_MAD_BUSY)
-            {
+            if (read_val && (read_val != ME_MAD_BUSY)) {
                 DBG_PRINTF("Failed!\n");
                 return ME_ICMD_STATUS_ICMD_NOT_READY;
             }
             /* Fail to obtain the lock */
-            if (mf->icmd.lock_key == 0)
-            {
+            if (mf->icmd.lock_key == 0) {
                 read_val = 1;
             }
             DBG_PRINTF("Succeeded!\n");
-        }
-        else
+        } else
 #endif
         {
-            if (mf->vsec_supp)
-            {
-                // write expected val before reading it
+            if (mf->vsec_supp) {
+                /* write expected val before reading it */
                 MWRITE4_SEMAPHORE(mf, mf->icmd.semaphore_addr, expected_read_val);
             }
             MREAD4_SEMAPHORE(mf, mf->icmd.semaphore_addr, &read_val);
-            if (read_val == expected_read_val)
-            {
+            if (read_val == expected_read_val) {
                 break;
             }
         }
@@ -685,31 +650,27 @@ static int icmd_take_semaphore_com(mfile* mf, u_int32_t expected_read_val)
 
 int icmd_take_semaphore(mfile* mf)
 {
-    // open icmd interface by demand
-    int ret;
+    /* open icmd interface by demand */
+    int              ret;
     static u_int32_t pid = 0;
+
     ret = icmd_open(mf);
     CHECK_RC(ret);
 
-    if (mf->vsec_supp)
-    {
-        if (!pid)
-        {
+    if (mf->vsec_supp) {
+        if (!pid) {
             pid = getpid();
         }
         return icmd_take_semaphore_com(mf, pid);
-    }
-    else
-    {
+    } else {
         return icmd_take_semaphore_com(mf, 0);
     }
 }
 
 static int check_msg_size(mfile* mf, int write_data_size, int read_data_size)
 {
-    // check data size does not exceed mailbox size
-    if (write_data_size > (int)mf->icmd.max_cmd_size || read_data_size > (int)mf->icmd.max_cmd_size)
-    {
+    /* check data size does not exceed mailbox size */
+    if ((write_data_size > (int)mf->icmd.max_cmd_size) || (read_data_size > (int)mf->icmd.max_cmd_size)) {
         DBG_PRINTF("write_data_size <%x-%x> mf->icmd.max_cmd_size .. ", write_data_size, mf->icmd.max_cmd_size);
         DBG_PRINTF("read_data_size <%x-%x> mf->icmd.max_cmd_size\n", read_data_size, mf->icmd.max_cmd_size);
         return ME_ICMD_SIZE_EXCEEDS_LIMIT;
@@ -717,17 +678,18 @@ static int check_msg_size(mfile* mf, int write_data_size, int read_data_size)
     return ME_OK;
 }
 
-static int icmd_send_command_com(mfile* mf,
-                                 IN int opcode,
+static int icmd_send_command_com(mfile     * mf,
+                                 IN int      opcode,
                                  INOUT void* data,
-                                 IN int write_data_size,
-                                 IN int read_data_size,
-                                 IN int skip_write,
-                                 IN int enhanced)
+                                 IN int      write_data_size,
+                                 IN int      read_data_size,
+                                 IN int      skip_write,
+                                 IN int      enhanced)
 {
-    int ret;
+    int  ret;
     bool rollback_byte_order_conversion = false;
-    // open icmd interface by demand
+
+    /* open icmd interface by demand */
     ret = icmd_open(mf);
     CHECK_RC(ret);
 
@@ -736,8 +698,7 @@ static int icmd_send_command_com(mfile* mf,
 
     ret = icmd_is_cmd_ifc_ready(mf, enhanced);
     CHECK_RC(ret);
-    if (!enhanced)
-    {
+    if (!enhanced) {
         ret = icmd_take_semaphore(mf);
         CHECK_RC(ret);
     }
@@ -745,26 +706,22 @@ static int icmd_send_command_com(mfile* mf,
     ret = set_opcode(mf, opcode);
     CHECK_RC_GO_TO(ret, cleanup);
 
-    if (!skip_write)
-    {
+    if (!skip_write) {
         DBG_PRINTF("-D- Writing command to mailbox\n");
-        if (mf->icmd.dma_icmd)
-        {
-            if (mtcr_memaccess(mf, 0, read_data_size, data, 1, MEM_ICMD))
-            {
+        if (mf->icmd.dma_icmd) {
+            if (mtcr_memaccess(mf, 0, read_data_size, data, 1, MEM_ICMD)) {
                 ret = ME_ICMD_STATUS_CR_FAIL;
                 goto cleanup;
             }
-        }
-        else
-        {
-            rollback_byte_order_conversion = true; // rollback byte order conversion on MWRITE_BUF_ICMD failure
-            MWRITE_BUF_ICMD(mf, mf->icmd.cmd_addr, data, write_data_size, ret = ME_ICMD_STATUS_CR_FAIL; goto cleanup;);
+        } else {
+            rollback_byte_order_conversion = true; /* rollback byte order conversion on MWRITE_BUF_ICMD failure */
+            MWRITE_BUF_ICMD(mf, mf->icmd.cmd_addr, data, write_data_size, ret = ME_ICMD_STATUS_CR_FAIL;
+                            goto cleanup;
+                            );
         }
     }
 
-    if (mf->icmd.dma_icmd)
-    {
+    if (mf->icmd.dma_icmd) {
         ret = MWRITE4_ICMD(mf, mf->icmd.ctrl_addr + EXT_MBOX_DMA_OFF, EXTRACT64(mf->icmd.dma_pa, 32, 32));
         CHECK_RC(ret);
         ret = MWRITE4_ICMD(mf, mf->icmd.ctrl_addr + EXT_MBOX_DMA_OFF + 4, EXTRACT64(mf->icmd.dma_pa, 0, 32));
@@ -772,42 +729,39 @@ static int icmd_send_command_com(mfile* mf,
     }
 
     u_int32_t reg = 0x0;
-    // check go bit down
+
+    /* check go bit down */
     ret = check_busy_bit(mf, BUSY_BITOFF, &reg);
     CHECK_RC(ret);
 
-    // set go bit + poll + returned status
+    /* set go bit + poll + returned status */
     ret = set_and_poll_on_busy_bit(mf, enhanced, BUSY_BITOFF, &reg);
     CHECK_RC_GO_TO(ret, cleanup);
 
-    // get status
+    /* get status */
     ret = translate_status(EXTRACT(reg, STATUS_BITOFF, STATUS_BITLEN));
     CHECK_RC_GO_TO(ret, cleanup);
 
     DBG_PRINTF("-D- Reading command from mailbox");
 
-    if (mf->icmd.dma_icmd)
-    {
-        if (mtcr_memaccess(mf, 0, read_data_size, data, 0, MEM_ICMD))
-        {
+    if (mf->icmd.dma_icmd) {
+        if (mtcr_memaccess(mf, 0, read_data_size, data, 0, MEM_ICMD)) {
             ret = ME_ICMD_STATUS_CR_FAIL;
             goto cleanup;
         }
-    }
-    else
-    {
-        rollback_byte_order_conversion = false; // MREAD_BUF_ICMD takes care of byte order conversion
-        MREAD_BUF_ICMD(mf, mf->icmd.cmd_addr, data, read_data_size, ret = ME_ICMD_STATUS_CR_FAIL; goto cleanup;);
+    } else {
+        rollback_byte_order_conversion = false; /* MREAD_BUF_ICMD takes care of byte order conversion */
+        MREAD_BUF_ICMD(mf, mf->icmd.cmd_addr, data, read_data_size, ret = ME_ICMD_STATUS_CR_FAIL;
+                       goto cleanup;
+                       );
     }
 
     ret = ME_OK;
 cleanup:
-    if (!enhanced)
-    {
+    if (!enhanced) {
         (void)icmd_clear_semaphore(mf);
     }
-    if (rollback_byte_order_conversion)
-    {
+    if (rollback_byte_order_conversion) {
         mtcr_fix_endianness((u_int32_t*)data, write_data_size);
     }
     return ret;
@@ -827,35 +781,35 @@ static u_int32_t set_gbox_gw_opcode_block(u_int16_t opcode, int size)
 
 static MError get_gbox_gw_start_addr(mfile* mf, u_int32_t* start_addr)
 {
-    // get gbox_gw_start_addr by reading cr-space only once
-    if (gbox_gw_start_addr == 0xffff)
-    {
-        if (MREAD4(mf, CMD_PTR_ADDR_GBOX, &gbox_gw_start_addr))
-        {
+    /* get gbox_gw_start_addr by reading cr-space only once */
+    if (gbox_gw_start_addr == 0xffff) {
+        if (MREAD4(mf, CMD_PTR_ADDR_GBOX, &gbox_gw_start_addr)) {
             return ME_ICMD_STATUS_CR_FAIL;
         }
-        // no need to /4
-        // gw_addr = gw_addr >> 2;
+        /* no need to /4 */
+        /* gw_addr = gw_addr >> 2; */
         *start_addr = gbox_gw_start_addr;
     }
     return ME_OK;
 }
 
-static int
-  icmd_send_gbox_command_com(mfile* mf, INOUT void* data, IN int write_data_size, IN int read_data_size, IN int enhanced)
+static int icmd_send_gbox_command_com(mfile     * mf,
+                                      INOUT void* data,
+                                      IN int      write_data_size,
+                                      IN int      read_data_size,
+                                      IN int      enhanced)
 {
-    int ret;
+    int       ret;
     u_int32_t data_start_off = 0x0;
-    u_int8_t buffer[GBOX_MAX_DATA_SIZE + 4] = {0};
+    u_int8_t  buffer[GBOX_MAX_DATA_SIZE + 4] = {0};
     u_int32_t reg = 0x0;
 
-    if (mf->gb_info.gb_conn_type != GEARBPX_OVER_MTUSB)
-    {
-        // wasn't supposed to get here
+    if (mf->gb_info.gb_conn_type != GEARBPX_OVER_MTUSB) {
+        /* wasn't supposed to get here */
         return ME_ERROR;
     }
 
-    // init icmd
+    /* init icmd */
     ret = icmd_open(mf);
     CHECK_RC(ret);
 
@@ -864,53 +818,55 @@ static int
 
     ret = icmd_is_cmd_ifc_ready(mf, enhanced);
     CHECK_RC(ret);
-    if (!enhanced)
-    {
+    if (!enhanced) {
         ret = icmd_take_semaphore(mf);
         CHECK_RC(ret);
     }
 
-    // check go bit down
+    /* check go bit down */
     ret = check_busy_bit(mf, GBOX_BUSY_BITOFF, &reg);
     CHECK_RC(ret);
 
-    // write to data request section
+    /* write to data request section */
     DBG_PRINTF("-D- Setting command GW");
     data_start_off = mf->gb_info.data_req_addr + GBOX_MAX_DATA_SIZE - write_data_size;
-    MWRITE_BUF_ICMD(mf, data_start_off, data, write_data_size, ret = ME_ICMD_STATUS_CR_FAIL; goto sem_cleanup;);
+    MWRITE_BUF_ICMD(mf, data_start_off, data, write_data_size, ret = ME_ICMD_STATUS_CR_FAIL;
+                    goto sem_cleanup;
+                    );
 
     int orig_reg_size = write_data_size - 4;
-    // set opcode block - size is original register size = means without register vlock ()-4 bytes
+
+    /* set opcode block - size is original register size = means without register vlock ()-4 bytes */
     reg = set_gbox_gw_opcode_block(GBOX_REG_ACCESS_CMD_OPCODE, orig_reg_size);
 
-    // set busy bit and write msg, than, poll + return status
+    /* set busy bit and write msg, than, poll + return status */
     ret = set_and_poll_on_busy_bit(mf, enhanced, GBOX_BUSY_BITOFF, &reg);
     CHECK_RC_GO_TO(ret, sem_cleanup);
 
-    // get status
+    /* get status */
     ret = translate_gbox_icmd_status(EXTRACT(reg, GBOX_STATUS_BITOFF, GBOX_STATUS_BITLEN));
     CHECK_RC_GO_TO(ret, sem_cleanup);
     ret = EXTRACT(reg, GBOX_STATUS1_BITOFF, GBOX_STATUS1_BITLEN);
 
-    // read response
+    /* read response */
     DBG_PRINTF("-D- Reading command from mailbox");
-    // no need to read size, it is the same (fw dont change this field) - uncommnet if logic will change
-    // int read_size = EXTRACT(reg, GBOX_READ_SIZE_BITOFF, GBOX_READ_SIZE_BITLEN);
-    // read_size = read_size * 4;
+    /* no need to read size, it is the same (fw dont change this field) - uncommnet if logic will change */
+    /* int read_size = EXTRACT(reg, GBOX_READ_SIZE_BITOFF, GBOX_READ_SIZE_BITLEN); */
+    /* read_size = read_size * 4; */
 
-    // reset buffer
+    /* reset buffer */
     memset(buffer, 0, GBOX_MAX_DATA_SIZE);
-    // put register status in first 4 bytes
+    /* put register status in first 4 bytes */
     memcpy(buffer, &ret, 4);
-    // get response data (into buffer+4)
+    /* get response data (into buffer+4) */
     MREAD_BUF_ICMD(mf, mf->gb_info.data_res_addr, buffer + 4, orig_reg_size, ret = ME_ICMD_STATUS_CR_FAIL;
-                   goto sem_cleanup;);
-    memcpy(data, buffer, read_data_size); // read_data_size is same as orig size + 4
+                   goto sem_cleanup;
+                   );
+    memcpy(data, buffer, read_data_size); /* read_data_size is same as orig size + 4 */
 
     ret = ME_OK;
 sem_cleanup:
-    if (!enhanced)
-    {
+    if (!enhanced) {
         (void)icmd_clear_semaphore(mf);
     }
     return ret;
@@ -924,189 +880,193 @@ int icmd_send_command(mfile* mf, IN int opcode, INOUT void* data, IN int data_si
 /*
  * icmd_send_command
  */
-int icmd_send_command_int(mfile* mf,
-                          IN int opcode,
+int icmd_send_command_int(mfile     * mf,
+                          IN int      opcode,
                           INOUT void* data,
-                          IN int write_data_size,
-                          IN int read_data_size,
-                          IN int skip_write)
+                          IN int      write_data_size,
+                          IN int      read_data_size,
+                          IN int      skip_write)
 {
-    if ((mf->gb_info.is_gb_mngr || mf->gb_info.is_gearbox) && mf->gb_info.gb_conn_type == GEARBPX_OVER_MTUSB)
-    {
+    if ((mf->gb_info.is_gb_mngr || mf->gb_info.is_gearbox) && (mf->gb_info.gb_conn_type == GEARBPX_OVER_MTUSB)) {
         return icmd_send_gbox_command_com(mf, data, write_data_size, read_data_size, 0);
-    }
-    else
-    {
+    } else {
         return icmd_send_command_com(mf, opcode, data, write_data_size, read_data_size, skip_write, 0);
     }
 }
 
-int icmd_send_command_enhanced(mfile* mf,
-                               IN int opcode,
+int icmd_send_command_enhanced(mfile     * mf,
+                               IN int      opcode,
                                INOUT void* data,
-                               IN int write_data_size,
-                               IN int read_data_size,
-                               IN int skip_write)
+                               IN int      write_data_size,
+                               IN int      read_data_size,
+                               IN int      skip_write)
 {
-    if ((mf->gb_info.is_gb_mngr || mf->gb_info.is_gearbox) && mf->gb_info.gb_conn_type == GEARBPX_OVER_MTUSB)
-    {
+    if ((mf->gb_info.is_gb_mngr || mf->gb_info.is_gearbox) && (mf->gb_info.gb_conn_type == GEARBPX_OVER_MTUSB)) {
         return icmd_send_gbox_command_com(mf, data, write_data_size, read_data_size, 1);
-    }
-    else
-    {
+    } else {
         return icmd_send_command_com(mf, opcode, data, write_data_size, read_data_size, skip_write, 1);
     }
 }
 
 static int icmd_init_cr(mfile* mf)
 {
-    int icmd_ver;
+    int       icmd_ver;
     u_int32_t hcr_address;
     u_int32_t cmd_ptr_addr;
     u_int32_t reg = 0x0;
     u_int32_t hw_id = 0x0;
+
 #ifndef __FreeBSD__
     u_int32_t dev_type = 0;
 #endif
 
-    // get device specific addresses
-    MREAD4((mf), (HW_ID_ADDR), &(hw_id));
-    switch (hw_id & 0xffff)
-    {
-        case (CIB_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CIB;
-            hcr_address = HCR_ADDR_CIB;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CIB;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    /* get device specific addresses */
+    if (read_device_id(mf, &hw_id) != 4) {
+        return ME_ICMD_NOT_SUPPORTED;
+    }
 
-        case (CX4LX_HW_ID):
-        case (CX4_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX4;
-            hcr_address = HCR_ADDR_CX4;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN;
+    mf->icmd.version_bit_offset = ICMD_VERSION_BITOFF;
+    switch (hw_id & 0xffff) {
+    case (CIB_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CIB;
+        hcr_address = HCR_ADDR_CIB;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CIB;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (CX5_HW_ID):
-        case (BF_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX5;
-            hcr_address = HCR_ADDR_CX5;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    case (CX4LX_HW_ID):
+    case (CX4_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CX4;
+        hcr_address = HCR_ADDR_CX4;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX4;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (SW_IB_HW_ID):
-        case (SW_EN_HW_ID):
-        case (SW_IB2_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_SW_IB;
-            hcr_address = HCR_ADDR_SW_IB;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
+    case (CX5_HW_ID):
+    case (BF_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CX5;
+        hcr_address = HCR_ADDR_CX5;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (QUANTUM_HW_ID):
-        case (SPECTRUM2_HW_ID):
-        case (SPECTRUM3_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
-            hcr_address = HCR_ADDR_QUANTUM;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
+    case (SW_IB_HW_ID):
+    case (SW_EN_HW_ID):
+    case (SW_IB2_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_SW_IB;
+        hcr_address = HCR_ADDR_SW_IB;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_SW_IB;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        break;
 
-        case (QUANTUM2_HW_ID):
-        case (QUANTUM3_HW_ID):
-        case (BW00_HW_ID):
-        case (SPECTRUM4_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
-            hcr_address = HCR_ADDR_QUANTUM;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM2;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
+    case (QUANTUM_HW_ID):
+    case (SPECTRUM2_HW_ID):
+    case (SPECTRUM3_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
+        hcr_address = HCR_ADDR_QUANTUM;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        break;
 
-        case (CX6_HW_ID):
-        case (CX6DX_HW_ID):
-        case (CX6LX_HW_ID):
-        case (BF2_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX5;
-            hcr_address = HCR_ADDR_CX5;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;
-            break;
+    case (QUANTUM2_HW_ID):
+    case (QUANTUM3_HW_ID):
+    case (SPECTRUM4_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
+        hcr_address = HCR_ADDR_QUANTUM;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM2;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        break;
 
-        case (CX7_HW_ID):
-        case (BF3_HW_ID):
-        case (CX8_HW_ID):
-        case (BF4_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX7;
-            hcr_address = HCR_ADDR_CX7;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX7;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX7;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
-            break;
+    case (GB100_HW_ID):
+    case (GR100_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_GPU;
+        hcr_address = HCR_ADDR_GPU;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_GPU;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_GPU;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN_GPU;
+        mf->icmd.version_bit_offset = ICMD_VERSION_BITOFF_GPU;
+        break;
 
-        case (AMOS_GBOX_HW_ID):
-            mf->icmd.ctrl_addr = GBOX_MAX_DATA_SIZE;
+    case (CX6_HW_ID):
+    case (CX6DX_HW_ID):
+    case (CX6LX_HW_ID):
+    case (BF2_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CX5;
+        hcr_address = HCR_ADDR_CX5;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;
+        break;
 
-            u_int32_t start_addr = 0x0;
-            MError rc = get_gbox_gw_start_addr(mf, &start_addr);
-            if (rc)
-            {
-                return ME_ERROR;
-            }
+    case (CX7_HW_ID):
+    case (BF3_HW_ID):
+    case (CX8_HW_ID):
+    case (BF4_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CX7;
+        hcr_address = HCR_ADDR_CX7;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX7;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX7;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
+        break;
 
-            mf->icmd.ctrl_addr += start_addr;
-            mf->icmd.cmd_addr = start_addr + GBOX_GW_OPCODE_OFFSET;
-            mf->gb_info.data_req_addr = start_addr + GBOX_GW_REQUEST_DATA_BLOCK_OFFSET;
-            mf->gb_info.data_res_addr = start_addr + GBOX_GW_RESPONSE_DATA_BLOCK_OFFSET;
+    case (AMOS_GBOX_HW_ID):
+        mf->icmd.ctrl_addr = GBOX_MAX_DATA_SIZE;
 
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_GBOX;
-            mf->icmd.static_cfg_not_done_addr = GBOX_STAT_CFG_NOT_DONE_ADDR;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;
-            mf->icmd.max_cmd_size = GBOX_MAX_DATA_SIZE;
-            mf->icmd.icmd_opened = 1;
+        u_int32_t start_addr = 0x0;
+        MError    rc = get_gbox_gw_start_addr(mf, &start_addr);
+        if (rc) {
+            return ME_ERROR;
+        }
 
-            return ME_OK;
-            break;
+        mf->icmd.ctrl_addr += start_addr;
+        mf->icmd.cmd_addr = start_addr + GBOX_GW_OPCODE_OFFSET;
+        mf->gb_info.data_req_addr = start_addr + GBOX_GW_REQUEST_DATA_BLOCK_OFFSET;
+        mf->gb_info.data_res_addr = start_addr + GBOX_GW_RESPONSE_DATA_BLOCK_OFFSET;
 
-        default:
-            return ME_ICMD_NOT_SUPPORTED;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_GBOX;
+        mf->icmd.static_cfg_not_done_addr = GBOX_STAT_CFG_NOT_DONE_ADDR;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;
+        mf->icmd.max_cmd_size = GBOX_MAX_DATA_SIZE;
+        mf->icmd.icmd_opened = 1;
+
+        return ME_OK;
+        break;
+
+    default:
+        return ME_ICMD_NOT_SUPPORTED;
     }
     mf->icmd.max_cmd_size = ICMD_MAX_CMD_SIZE;
     icmd_ver = get_version(mf, hcr_address);
-    // get command and control addresses
-    switch (icmd_ver)
-    {
-        case 1:
-            if (MREAD4(mf, cmd_ptr_addr, &reg))
-            {
-                return ME_ICMD_STATUS_CR_FAIL;
-            }
-            mf->icmd.cmd_addr = EXTRACT(reg, CMD_PTR_BITOFF, CMD_PTR_BITLEN);
-            mf->icmd.ctrl_addr = mf->icmd.cmd_addr + CTRL_OFFSET;
-            break;
-
-        case ME_ICMD_STATUS_CR_FAIL:
+    /* get command and control addresses */
+    switch (icmd_ver) {
+    case 1:
+        if (MREAD4(mf, cmd_ptr_addr, &reg)) {
             return ME_ICMD_STATUS_CR_FAIL;
+        }
+        mf->icmd.cmd_addr = EXTRACT(reg, CMD_PTR_BITOFF, mf->icmd.cmd_ptr_bitlen);
+        mf->icmd.ctrl_addr = mf->icmd.cmd_addr + CTRL_OFFSET;
+        break;
 
-        default:
-            return ME_ICMD_UNSUPPORTED_ICMD_VERSION;
+    case ME_ICMD_STATUS_CR_FAIL:
+        return ME_ICMD_STATUS_CR_FAIL;
+
+    default:
+        return ME_ICMD_UNSUPPORTED_ICMD_VERSION;
     }
-        // if IB check if we support locking via MAD
+    /* if IB check if we support locking via MAD */
 #ifndef __FreeBSD__
-    if (mget_mdevs_flags(mf, &dev_type))
-    {
+    if (mget_mdevs_flags(mf, &dev_type)) {
         dev_type = 0;
     }
-    if ((dev_type & MDEVS_IB) && (mib_semaphore_lock_is_supported(mf)))
-    {
+    if ((dev_type & MDEVS_IB) && (mib_semaphore_lock_is_supported(mf))) {
         mf->icmd.ib_semaphore_lock_supported = 1;
     }
 #endif
@@ -1118,75 +1078,76 @@ static int icmd_init_vcr_crspace_addr(mfile* mf)
 {
     u_int32_t hw_id = 0x0;
 
-    // get device specific addresses
-    MREAD4((mf), (HW_ID_ADDR), &(hw_id));
-    switch (hw_id & 0xffff)
-    {
-        case (CIB_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    /* get device specific addresses */
+    if (read_device_id(mf, &hw_id) != 4) {
+        return ME_ICMD_NOT_SUPPORTED;
+    }
+    switch (hw_id & 0xffff) {
+    case (CIB_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (CX4LX_HW_ID):
-        case (CX4_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    case (CX4LX_HW_ID):
+    case (CX4_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (CX5_HW_ID):
-        case (BF_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
+    case (CX5_HW_ID):
+    case (BF_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
+        break;
 
-        case (SW_IB_HW_ID):
-        case (SW_EN_HW_ID):
-        case (SW_IB2_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
+    case (SW_IB_HW_ID):
+    case (SW_EN_HW_ID):
+    case (SW_IB2_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        break;
 
-        case (QUANTUM_HW_ID):
-        case (SPECTRUM2_HW_ID):
-        case (SPECTRUM3_HW_ID):
-        case (QUANTUM2_HW_ID):
-        case (QUANTUM3_HW_ID):
-        case (BW00_HW_ID):
-        case (SPECTRUM4_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
+    case (QUANTUM_HW_ID):
+    case (SPECTRUM2_HW_ID):
+    case (SPECTRUM3_HW_ID):
+    case (QUANTUM2_HW_ID):
+    case (QUANTUM3_HW_ID):
+    case (GB100_HW_ID):
+    case (SPECTRUM4_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
+        break;
 
-        case (CX6_HW_ID):
-        case (CX6DX_HW_ID):
-        case (CX6LX_HW_ID):
-        case (BF2_HW_ID):
-        case (BF3_HW_ID):
-        case (CX7_HW_ID):
-        case (BF4_HW_ID):
-        case (CX8_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5; // same bit offset as CX5
-            break;
+    case (CX6_HW_ID):
+    case (CX6DX_HW_ID):
+    case (CX6LX_HW_ID):
+    case (BF2_HW_ID):
+    case (BF3_HW_ID):
+    case (CX7_HW_ID):
+    case (BF4_HW_ID):
+    case (CX8_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;     /* same bit offset as CX5 */
+        break;
 
-        case (AMOS_GBOX_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5; // same bit offset as CX5
-            break;
+    case (AMOS_GBOX_HW_ID):
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;     /* same bit offset as CX5 */
+        break;
 
-        default:
-            return ME_ICMD_NOT_SUPPORTED;
+    default:
+        return ME_ICMD_NOT_SUPPORTED;
     }
     return ME_OK;
 }
 
 static int icmd_init_vcr(mfile* mf)
 {
-    int rc = ME_OK;
+    int              rc = ME_OK;
     static u_int32_t pid = 0;
     static u_int32_t size = 0;
-    if (!pid)
-    {
+
+    if (!pid) {
         pid = getpid();
     }
 
@@ -1197,12 +1158,12 @@ static int icmd_init_vcr(mfile* mf)
 
     rc = icmd_take_semaphore_com(mf, pid);
     CHECK_RC(rc);
-    // get max command size
+    /* get max command size */
     rc = MREAD4_ICMD(mf, VCR_CMD_SIZE_ADDR, &mf->icmd.max_cmd_size);
     size = mf->icmd.max_cmd_size;
     icmd_clear_semaphore_com(mf);
     CHECK_RC(rc);
-    // adrianc: they should provide this bit as well in virtual cr-space atm get from cr-space
+    /* adrianc: they should provide this bit as well in virtual cr-space atm get from cr-space */
     rc = icmd_take_semaphore_com(mf, pid);
     CHECK_RC(rc);
     rc = icmd_init_vcr_crspace_addr(mf);
@@ -1223,24 +1184,22 @@ void icmd_get_dma_support(mfile* mf)
 {
     mf->icmd.dma_icmd = 0;
     mem_props_t mem_p;
-    if (get_mem_props(mf, MEM_ICMD, &mem_p))
-    {
+
+    if (get_mem_props(mf, MEM_ICMD, &mem_p)) {
         return;
     }
     mf->icmd.dma_pa = mem_p.dma_pa;
     mf->icmd.dma_size = mem_p.mem_size;
-    if (getenv("ENABLE_DMA_ICMD") == NULL)
-    {
+    if (getenv("ENABLE_DMA_ICMD") == NULL) {
         return;
     }
-    if (!mf->icmd.dma_pa)
-    {
+    if (!mf->icmd.dma_pa) {
         return;
     }
     u_int8_t dev_cap_data[ICMD_QUERY_CAP_CMD_SZ] = {0};
-    int rc = icmd_send_command(mf, ICMD_QUERY_CAP_CMD_ID, dev_cap_data, ICMD_QUERY_CAP_CMD_SZ, 0);
-    if (!rc)
-    {
+    int      rc = icmd_send_command(mf, ICMD_QUERY_CAP_CMD_ID, dev_cap_data, ICMD_QUERY_CAP_CMD_SZ, 0);
+
+    if (!rc) {
         mf->icmd.dma_icmd = pop_from_buff(dev_cap_data, ICMD_QUERY_CAP_EXMB_ICMD_OFF, 1);
     }
 }
@@ -1253,98 +1212,60 @@ static int is_pci_device(mfile* mf)
 
 static int is_livefish_device(mfile* mf)
 {
-    if (!mf || !mf->dinfo)
-    {
+    if (!mf || !mf->dinfo) {
         return 0;
     }
-    // Make sure to update this table both in mtcr.c & mtcr_ul_com.c !
-    static u_int32_t live_fish_ids[][2] = {{DeviceConnectX4_HwId, DeviceConnectX4_HwId},
-                                           {DeviceConnectX4LX_HwId, DeviceConnectX4LX_HwId},
-                                           {DeviceConnectX5_HwId, DeviceConnectX5_HwId},
-                                           {DeviceConnectX6_HwId, DeviceConnectX6_HwId},
-                                           {DeviceConnectX6DX_HwId, DeviceConnectX6DX_HwId},
-                                           {DeviceConnectX6LX_HwId, DeviceConnectX6LX_HwId},
-                                           {DeviceConnectX7_HwId, DeviceConnectX7_HwId},
-                                           {DeviceBlueField3_HwId, DeviceBlueField3_HwId},
-                                           {DeviceBlueField2_HwId, DeviceBlueField2_HwId},
-                                           {DeviceBlueField_HwId, DeviceBlueField_HwId},
-                                           {DeviceSwitchIB_HwId, DeviceSwitchIB_HwId},
-                                           {DeviceSpectrum_HwId, DeviceSpectrum_HwId},
-                                           {DeviceSwitchIB2_HwId, DeviceSwitchIB2_HwId},
-                                           {DeviceQuantum_HwId, DeviceQuantum_HwId},
-                                           {DeviceQuantum2_HwId, DeviceQuantum2_HwId},
-                                           {DeviceSpectrum2_HwId, DeviceSpectrum2_HwId},
-                                           {DeviceSpectrum3_HwId, DeviceSpectrum3_HwId},
-                                           {DeviceSpectrum4_HwId, DeviceSpectrum4_HwId},
-                                           {0, 0}};
-    int i = 0;
+
     unsigned int hwdevid = 0;
-    if (mf->tp == MST_SOFTWARE)
-    {
+
+    if (mf->tp == MST_SOFTWARE) {
         return 1;
     }
-    int rc = mread4(mf, 0xf0014, &hwdevid);
-    hwdevid &= 0xffff; // otherwise, BF A1 will fail in the searching (0x00010211)
-    if (rc == 4)
-    {
-        while (live_fish_ids[i][0] != 0)
-        {
-            if (live_fish_ids[i][0] == hwdevid)
-            {
-                return (mf->dinfo->pci.dev_id == live_fish_ids[i][1]);
-            }
-            i++;
-        }
+    int rc = read_device_id(mf, &hwdevid);
+
+    if (rc == 4) {
+        return ((!is_gpu_pci_device(mf->dinfo->pci.dev_id)) && (mf->dinfo->pci.dev_id == hwdevid));
     }
     return 0;
 }
-#endif
+#endif /* ifndef __FreeBSD__ */
 
 int icmd_open(mfile* mf)
 {
-    if (mf->icmd.icmd_opened)
-    {
+    if (mf->icmd.icmd_opened) {
         return ME_OK;
     }
 
 #ifndef __FreeBSD__
-    // Currently livefish check is supported for PCI devices & devices that map to CR.
-    // ICMD is not supported while in livefish (GW is locked).
-    if ((is_pci_device(mf) || (mf->flags & MDEVS_TAVOR_CR)) && (is_livefish_device(mf) || is_zombiefish_device(mf)))
-    {
+    /* Currently livefish check is supported for PCI devices & devices that map to CR. */
+    /* ICMD is not supported while in livefish (GW is locked). */
+    if ((is_pci_device(mf) || (mf->flags & MDEVS_TAVOR_CR)) && (is_livefish_device(mf) || is_zombiefish_device(mf))) {
         return ME_ICMD_NOT_SUPPORTED;
     }
 #endif
 
     mf->icmd.took_semaphore = 0;
     mf->icmd.ib_semaphore_lock_supported = 0;
-    // attempt to open via CR-Space
+    /* attempt to open via CR-Space */
 #if defined(MST_UL) && !defined(MST_UL_ICMD)
-    if (mf->vsec_supp)
-    {
+    if (mf->vsec_supp) {
         return icmd_init_vcr(mf);
     }
-    // ugly hack avoid compiler warrnings
-    if (0)
-    {
-        icmd_init_cr(mf);
+    if (is_gpu_pci_device(mf->dinfo->pci.dev_id)) {
+        return icmd_init_cr(mf);
     }
     return ME_ICMD_NOT_SUPPORTED;
 #else
     /*if (mf->gb_info.is_gearbox){
-        return icmd_init_cr(mf);
-    }*/
-    if (mf->vsec_supp)
-    {
+     *   return icmd_init_cr(mf);
+     *  }*/
+    if (mf->vsec_supp) {
         int rc = icmd_init_vcr(mf);
-        if (rc == ME_OK)
-        {
+        if (rc == ME_OK) {
             icmd_get_dma_support(mf);
         }
         return rc;
-    }
-    else
-    {
+    } else {
         return icmd_init_cr(mf);
     }
 
@@ -1356,12 +1277,9 @@ int icmd_open(mfile* mf)
  */
 void icmd_close(mfile* mf)
 {
-    if (mf)
-    {
-        if (mf->icmd.took_semaphore)
-        {
-            if (icmd_clear_semaphore(mf))
-            {
+    if (mf) {
+        if (mf->icmd.took_semaphore) {
+            if (icmd_clear_semaphore(mf)) {
                 DBG_PRINTF("Failed to clear semaphore!\n");
             }
         }

--- a/tools_layouts/adb/prm/gpu/Makefile.am
+++ b/tools_layouts/adb/prm/gpu/Makefile.am
@@ -1,4 +1,5 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#--
+# Copyright (c) 2004-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU
@@ -27,33 +28,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+#--
 
-# Makefile.am -- Process this file with automake to produce Makefile.in
-
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include/mtcr_ul -I$(top_srcdir)/common -I$(top_srcdir)/dev_mgt
-
-pkglib_LTLIBRARIES = libmtcr_ul.la
-
-libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
-			mtcr_ib_res_mgt.h mtcr_ib_res_mgt.c\
-			mtcr_tools_cif.c mtcr_tools_cif.h\
-			mtcr_ul_icmd_cif.c mtcr_icmd_cif.h\
-			mtcr_mem_ops.c mtcr_mem_ops.h\
-			mtcr_ul_com_defs.h mtcr_mf.h\
-			mtcr_ul_com.h mtcr_ul_com.c\
-			packets_common.c packets_common.h\
-			packets_layout.c packets_layout.h \
-			fwctrl.c fwctrl.h fwctrl_ioctl.h \
-			mtcr_gpu.c mtcr_gpu.h
-libmtcr_ul_la_CFLAGS = -W -Wall -g -MP -MD -fPIC -DMTCR_API="" -DMST_UL
-
-if ENABLE_INBAND
-libmtcr_ul_la_SOURCES += mtcr_ib_ofed.c
-endif
-
-libraryincludedir=$(includedir)/mstflint
-libraryinclude_HEADERS = $(top_srcdir)/include/mtcr_ul/mtcr.h  $(top_srcdir)/include/mtcr_ul/mtcr_com_defs.h  $(top_srcdir)/include/mtcr_ul/mtcr_mf.h
-
-install-exec-hook:
-	rm -f $(DESTDIR)$(pkglibdir)/libmtcr_ul.so* $(DESTDIR)$(pkglibdir)/libmtcr_ul.la
-	ln -snf mstflint/libmtcr_ul.a $(DESTDIR)$(libdir)/
+SUBDIRS = ext

--- a/tools_layouts/adb/prm/gpu/ext/Makefile.am
+++ b/tools_layouts/adb/prm/gpu/ext/Makefile.am
@@ -1,4 +1,5 @@
-# Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#--
+# Copyright (c) 2004-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU
@@ -27,33 +28,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+#--
 
-# Makefile.am -- Process this file with automake to produce Makefile.in
-
-AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include/mtcr_ul -I$(top_srcdir)/common -I$(top_srcdir)/dev_mgt
-
-pkglib_LTLIBRARIES = libmtcr_ul.la
-
-libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
-			mtcr_ib_res_mgt.h mtcr_ib_res_mgt.c\
-			mtcr_tools_cif.c mtcr_tools_cif.h\
-			mtcr_ul_icmd_cif.c mtcr_icmd_cif.h\
-			mtcr_mem_ops.c mtcr_mem_ops.h\
-			mtcr_ul_com_defs.h mtcr_mf.h\
-			mtcr_ul_com.h mtcr_ul_com.c\
-			packets_common.c packets_common.h\
-			packets_layout.c packets_layout.h \
-			fwctrl.c fwctrl.h fwctrl_ioctl.h \
-			mtcr_gpu.c mtcr_gpu.h
-libmtcr_ul_la_CFLAGS = -W -Wall -g -MP -MD -fPIC -DMTCR_API="" -DMST_UL
-
-if ENABLE_INBAND
-libmtcr_ul_la_SOURCES += mtcr_ib_ofed.c
-endif
-
-libraryincludedir=$(includedir)/mstflint
-libraryinclude_HEADERS = $(top_srcdir)/include/mtcr_ul/mtcr.h  $(top_srcdir)/include/mtcr_ul/mtcr_com_defs.h  $(top_srcdir)/include/mtcr_ul/mtcr_mf.h
-
-install-exec-hook:
-	rm -f $(DESTDIR)$(pkglibdir)/libmtcr_ul.so* $(DESTDIR)$(pkglibdir)/libmtcr_ul.la
-	ln -snf mstflint/libmtcr_ul.a $(DESTDIR)$(libdir)/
+docdir = $(pkgdatadir)/prm_dbs/gpu/ext
+dist_doc_DATA = register_access_table.adb

--- a/tools_layouts/adb/prm/gpu/ext/register_access_table.adb
+++ b/tools_layouts/adb/prm/gpu/ext/register_access_table.adb
@@ -1,0 +1,1990 @@
+<NodesDefinition>
+<config  field_mand="name, descr, size" />
+<config  field_attr="name" type="ascii" />
+<config  field_attr="descr" type="ascii" />
+<config  field_attr="size" type="hexa" />
+<config  field_attr="type" type="ascii" />
+<config  field_attr="rw" type="enum" >
+	<enum  name="OP" value="OP" />
+	<enum  name="ReadOnly" value="RO" />
+	<enum  name="ReadWrite" value="RW" />
+	<enum  name="WriteOnly" value="WO" />
+</config>
+<config  field_attr="access" type="enum" >
+	<enum  name="Index" value="INDEX" />
+	<enum  name="OP" value="OP" />
+	<enum  name="ReadOnly" value="RO" />
+	<enum  name="ReadWrite" value="RW" />
+	<enum  name="WriteOnly" value="WO" />
+</config>
+<config  field_attr="enum" type="enumval" />
+<config  big_endian_arr="1" />
+<config  field_attr="selected_by" type="ascii" used_for="node" />
+<config  field_attr="union_selector" type="ascii" used_for="node" />
+<config  field_attr="mlxconfig_desc" type="ascii" />
+<config  field_attr="mlxconfig_name" type="ascii" />
+<config  field_attr="xuefi" type="ascii" />
+<config  field_attr="supported_from_version" type="ascii" />
+<config  field_attr="dependency" type="ascii" />
+<config  field_attr="valid_bit" type="ascii" />
+<config  field_attr="tempvars" type="ascii" />
+<config  field_attr="minval" type="ascii" />
+<config  field_attr="maxval" type="ascii" />
+<config  field_attr="rule" type="ascii" />
+<config  field_attr="regex" type="ascii" />
+<config  field_attr="capability" type="ascii" />
+<config  field_attr="target" type="ascii" />
+<config  field_attr="version" type="ascii" />
+<info source_doc_name="" source_doc_version="Rev 0.10.013" />
+<node name="IB_long_portcntrs_attribute_grp_data_ext" descr="" size="0xf8.0" >
+	<field name="symbol_error_counter_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="symbol_error_counter_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="link_error_recovery_counter_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="link_error_recovery_counter_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="link_downed_counter_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="link_downed_counter_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="port_rcv_errors_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="port_rcv_errors_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="port_rcv_remote_physical_errors_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="port_rcv_remote_physical_errors_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="port_rcv_switch_relay_errors_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="port_rcv_switch_relay_errors_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="port_xmit_discards_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="port_xmit_discards_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="port_xmit_constraint_errors_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="port_xmit_constraint_errors_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="port_rcv_constraint_errors_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="port_rcv_constraint_errors_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="local_link_integrity_errors_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="local_link_integrity_errors_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="excessive_buffer_overrun_errors_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="excessive_buffer_overrun_errors_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="vl_15_dropped_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="vl_15_dropped_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="port_xmit_data_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="port_xmit_data_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="port_rcv_data_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="port_rcv_data_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="port_xmit_pkts_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="port_xmit_pkts_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="port_rcv_pkts_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="port_rcv_pkts_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="port_xmit_wait_high" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="port_xmit_wait_low" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="qp1_dropped_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="qp1_dropped_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x8C.0" size="0x4.0" />
+	<field name="port_unicast_xmit_pkts_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x90.0" size="0x4.0" />
+	<field name="port_unicast_xmit_pkts_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x94.0" size="0x4.0" />
+	<field name="port_multicast_xmit_pkts_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x98.0" size="0x4.0" />
+	<field name="port_multicast_xmit_pkts_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0x9C.0" size="0x4.0" />
+	<field name="port_unicast_rcv_pkts_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0xA0.0" size="0x4.0" />
+	<field name="port_unicast_rcv_pkts_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0xA4.0" size="0x4.0" />
+	<field name="port_multicast_rcv_pkts_high" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0xA8.0" size="0x4.0" />
+	<field name="port_multicast_rcv_pkts_low" descr="For counter description please refer to the InfiniBand specification" access="RO" offset="0xAC.0" size="0x4.0" />
+</node>
+
+<node name="IB_portcntrs_attribute_grp_data_ext" descr="" size="0xf8.0" >
+	<field name="link_downed_counter" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x0.0" size="0x0.8" />
+	<field name="link_error_recovery_counter" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="symbol_error_counter" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x0.16" size="0x0.16" />
+	<field name="port_rcv_remote_physical_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x4.0" size="0x0.16" />
+	<field name="port_rcv_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x4.16" size="0x0.16" />
+	<field name="port_xmit_discards" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="port_rcv_switch_relay_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x8.16" size="0x0.16" />
+	<field name="excessive_buffer_overrun_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0xC.0" size="0x0.4" />
+	<field name="local_link_integrity_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0xC.4" size="0x0.4" />
+	<field name="port_rcv_constraint_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0xC.16" size="0x0.8" />
+	<field name="port_xmit_constraint_errors" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0xC.24" size="0x0.8" />
+	<field name="vl_15_dropped" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x10.0" size="0x0.16" />
+	<field name="qp1_dropped" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x10.16" size="0x0.16" />
+	<field name="port_xmit_data" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="port_rcv_data" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="port_xmit_pkts" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="port_rcv_pkts" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="port_xmit_wait" descr="For counter description please refer to the InfiniBand specification\;" access="RO" offset="0x24.0" size="0x4.0" />
+</node>
+
+<node name="MLPC_ext" descr="" size="0x40.0" >
+	<field name="lp_msb" descr="port MSB\;Used to identify the L1 controller associated to the desired HW counters." access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="port\;Used to identify the L1 controller associated to the desired HW counters." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="cnt_64bit" descr="Bit mask to configure extended 64 bits long counters.\;Bit per even HW counter. When bit [i] is set, counter[2i] and counter[2i+1] will be used to form a 64-bit counter.\;The odd counter cnt_sel[2i+1], will serve as the selector to configure the 64 bit counter.\;The odd counter cnt_val[2i+1], will serve as the LSB of the counter.\;The even counter cnt_val[2i], will serve as the MSB of the counter." access="RW" offset="0x4.0" size="0x0.4" />
+	<field name="stop_at_ff" descr="When set, when one of the perf counters reaches FFs, all the counters will stop counting." access="RW" offset="0x4.29" size="0x0.1" />
+	<field name="counter_rst" descr="Force reset for all the counters" access="WO" offset="0x4.30" size="0x0.1" />
+	<field name="counter_en" descr="Enable for the HW counters" access="RW" offset="0x4.31" size="0x0.1" />
+	<field name="force_count_mask" descr="Force count bit mask, when bit[i] is set, pref_counter&lt;i&gt; will count with no consideration of any enable/reset/stop signals." access="RW" offset="0xC.0" size="0x0.8" />
+	<field name="cnt_type" descr="See Table 588, &quot;L1 Performance Counter Type,&quot; on page 875" access="RW" high_bound="7" low_bound="0" offset="0x10.28" size="0x4.0" />
+	<field name="cnt_val" descr="HW counter value.\;The counter value can be configured to an initial value before enabling the feature." access="RW" high_bound="7" low_bound="0" offset="0x20.0" size="0x20.0" />
+</node>
+
+<node name="MRFV_PVS_ext" descr="" size="0x4.0" >
+	<field name="pvs_data_index" descr="PVS Data\;Process Sigma = -4 + 0.5 * cvb_data_index\;cvb_data_index valid values 0 .. 15\;For ArcusE\;Process Sigma &lt;-&gt; DVDD (mV)\;-4.0: 856.00\;-3.5: 847.75\;-3.0: 839.50\;-2.5: 831.25\;-2.0: 823.00\;-1.5: 814.75\;-1.0: 806.50\;-0.5: 798.25\;0 (nominal): 790.00\;0.5: 781.75\;1.0: 773.50\;1.5: 765.25\;2.0: 757.00\;2.5: 748.75\;3.0: 740.50\;3.5: 732.25\;4.0: 724.00" access="RO" offset="0x0.0" size="0x0.5" />
+</node>
+
+<node name="MRFV_ULT_ext" descr="" size="0xc.0" >
+	<field name="ult_data" descr="ULT Data" access="RO" high_bound="2" low_bound="0" offset="0x0.0" size="0xc.0" />
+</node>
+
+<node name="MRFV_data_auto_ext" descr="" attr_is_union="1" size="0xc.0" >
+	<field name="MRFV_PVS_ext" descr="" subnode="MRFV_PVS_ext" offset="0x0.0" selected_by="PVS_Values" size="0x4.0" />
+	<field name="MRFV_ULT_ext" descr="" subnode="MRFV_ULT_ext" offset="0x0.0" selected_by="ULT" size="0xc.0" />
+</node>
+
+<node name="MRFV_ext" descr="" size="0x40.0" >
+	<field name="fuse_id" descr="Fuse Index\;0: PVS_Values\;1: ULT\;Other values reserved\;Reserved when fm = 1" access="INDEX" enum="PVS_Values=0x0,ULT=0x1" offset="0x0.0" size="0x0.8" />
+	<field name="fm" descr="Fuse Mismatch\;0: No fuse mismatch\;1: Fuse mismatch found\;2-3: Reserved" access="RO" offset="0x0.24" size="0x0.2" />
+	<field name="v" descr="Valid bit\;0: Fuse reading is not supported for this system\;1: Response is valid\;2-3: Reserved\;Reserved when fm = 1" access="RO" offset="0x0.30" size="0x0.2" />
+	<field name="data" descr="Data\;See Table 686, &quot;MRFV entry - PVS Layout,&quot; on page 944\;See Table 688, &quot;MRFV entry - ULT Layout,&quot; on page 945\;Reserved when fm = 1" subnode="MRFV_data_auto_ext" access="RO" offset="0x10.0" size="0xc.0" union_selector="$(parent).fuse_id" />
+</node>
+
+<node name="MSLCR_ext" descr="" size="0x110.0" >
+	<field name="cap_num_clock_gates" descr="Number of SLCGs (Secondary Level Clock Gates)\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="global" descr="Global config:\;0: Not Global\;1: Global \;When global=1 mode, then state[0] is used" access="INDEX" offset="0x4.0" size="0x0.1" />
+	<field name="slgc_base" descr="slgc base index\;Units of 1024\;e.g. when slgc_base=1 then state[3] applies to SLCG [1024+3]\;Reserved when global = 1" access="INDEX" offset="0x8.0" size="0x0.8" />
+	<field name="state" descr="State per each SLCG\;0: slcg disabled \;1: slcg enabled\;2: apply production setting (FW configuration according to production info). Note that this opcode (apply) is write only\;Note: when reading only values 0 or 1 will be returned\;States over cap_num_clock_gates are reserved (will return 0)\;Reserved when global = 1" access="RW" high_bound="1023" low_bound="0" offset="0x10.30" size="0x100.0" />
+</node>
+
+<node name="MTSR_ext" descr="" size="0x10.0" >
+	<field name="mode" descr="0: Normal\;1: Warning\;2: Critical\;3-7: Reserved" access="RO" offset="0x0.0" size="0x0.3" />
+	<field name="normal_events_cnt" descr="Num of normal thermal events triggered" access="RO" offset="0x4.0" size="0x0.8" />
+	<field name="warning_events_cnt" descr="Num of warning thermal events triggered" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="critical_events_cnt" descr="Num of critical thermal events triggered" access="RO" offset="0xC.0" size="0x0.8" />
+</node>
+
+<node name="access_reg_summary_ctrl_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="id" descr="" subnode="enum_entry" enum="MMDIO=0x9017,MGCR=0x903a,MCIA=0x9014,MCION=0x9052,PMAOS=0x5012,PMTM=0x5067,MDRCR=0x9102,MTCAP=0x9009,MTECR=0x9109,MTMP=0x900a,MTWE=0x900b,MTEWE=0x910b,MPSCR=0x910f,MTSR=0x9121,MLPC=0x9166,MSLCG=0x902c,MGIR=0x9020,MCAM=0x907f,MRFV=0x906d,MTRC_CAP=0x9040,MTRC_CONF=0x9041,MTRC_CTRL=0x9043,MTEIM=0x9118,MTIE=0x911b,MTIM=0x911c,PCAM=0x507f,PCAP=0x5001,PTYS=0x5004,PAOS=0x5006,PLTC=0x5046,PPCNT=0x5008,PUDE=0x5009,PTER=0x5055,PMLP=0x5002,PMPR=0x5013,PMMP=0x5044,PMCR=0x5045,PMPT=0x5064,PMPD=0x5065,PPSC=0x5011,PRTL=0x5014,PPLR=0x5018,PPLM=0x5023,SLTP=0x5027,SLRG=0x5028,PDDR=0x5031,PPTT=0x5036,PPRT=0x5037,PPHCR=0x503e,PPAOS=0x5040,PMTU=0x5003,PGUID=0x5066,PBSR=0x5038,PTSR=0x5400,PTSB=0x5401,PLIB=0x500a,PPSLC=0x50e2,PPSLS=0x50e3,PEVNT=0x50e6,PBWC=0x50e7,PBWR=0x50e8,PPDFD=0x50e9,MORD=0x9153,GHPKT=0x6802,GSGUID=0x6803,GTGB=0x6804,GPLID=0x6805,GMDC=0x6806,UNWKM=0x6501,UNRSA=0x6502,UNRC=0x6503,UNDRI=0x6504,UKDRI=0x6506,UNDFD=0x6505" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="access_reg_summary_ext" descr="" attr_is_union="1" size="0x110" >
+	<field name="mmdio" descr="" subnode="mmdio_ext" capability="0" offset="0x0.0" selected_by="MMDIO" size="0xc" />
+	<field name="mgcr_reg" descr="" subnode="mgcr_reg_ext" capability="0" offset="0x0.0" selected_by="MGCR" size="0x20" />
+	<field name="mcia" descr="" subnode="mcia_ext" capability="0" offset="0x0.0" selected_by="MCIA" size="0x94" />
+	<field name="mcion" descr="" subnode="mcion_ext" capability="0" offset="0x0.0" selected_by="MCION" size="0x10" />
+	<field name="pmaos_reg" descr="" subnode="pmaos_reg_ext" capability="0" offset="0x0.0" selected_by="PMAOS" size="0x10" />
+	<field name="pmtm_reg" descr="" subnode="pmtm_reg_ext" capability="0" offset="0x0.0" selected_by="PMTM" size="0x10" />
+	<field name="mdrcr" descr="" subnode="mdrcr_ext" capability="0" offset="0x0.0" selected_by="MDRCR" size="0x30" />
+	<field name="mtcap" descr="" subnode="mtcap_ext" capability="0" offset="0x0.0" selected_by="MTCAP" size="0x10" />
+	<field name="mtecr" descr="" subnode="mtecr_ext" capability="0" offset="0x0.0" selected_by="MTECR" size="0x60" />
+	<field name="mtmp" descr="" subnode="mtmp_ext" capability="0" offset="0x0.0" selected_by="MTMP" size="0x20" />
+	<field name="mtwe" descr="" subnode="mtwe_ext" capability="0" offset="0x0.0" selected_by="MTWE" size="0x10" />
+	<field name="mtewe" descr="" subnode="mtewe_ext" capability="0" offset="0x0.0" selected_by="MTEWE" size="0x5c" />
+	<field name="mpscr" descr="" subnode="mpscr_ext" capability="0" offset="0x0.0" selected_by="MPSCR" size="0x20" />
+	<field name="MTSR" descr="" subnode="MTSR_ext" capability="0" offset="0x0.0" selected_by="MTSR" size="0x10" />
+	<field name="MLPC" descr="" subnode="MLPC_ext" capability="0" offset="0x0.0" selected_by="MLPC" size="0x40" />
+	<field name="MSLCR" descr="" subnode="MSLCR_ext" capability="0" offset="0x0.0" selected_by="MSLCG" size="0x110" />
+	<field name="mgir" descr="" subnode="mgir_ext" capability="0" offset="0x0.0" selected_by="MGIR" size="0xa0" />
+	<field name="mcam_reg" descr="" subnode="mcam_reg_ext" capability="0" offset="0x0.0" selected_by="MCAM" size="0x48" />
+	<field name="MRFV" descr="" subnode="MRFV_ext" capability="0" offset="0x0.0" selected_by="MRFV" size="0x40" />
+	<field name="mtrc_cap_reg" descr="" subnode="mtrc_cap_reg_ext" capability="0" offset="0x0.0" selected_by="MTRC_CAP" size="0x84" />
+	<field name="mtrc_conf_reg" descr="" subnode="mtrc_conf_reg_ext" capability="0" offset="0x0.0" selected_by="MTRC_CONF" size="0x80" />
+	<field name="mtrc_ctrl_reg" descr="" subnode="mtrc_ctrl_reg_ext" capability="0" offset="0x0.0" selected_by="MTRC_CTRL" size="0x40" />
+	<field name="mteim_reg" descr="" subnode="mteim_reg_ext" capability="0" offset="0x0.0" selected_by="MTEIM" size="0x30" />
+	<field name="mtie" descr="" subnode="mtie_ext" capability="0" offset="0x0.0" selected_by="MTIE" size="0x30" />
+	<field name="mtim" descr="" subnode="mtim_ext" capability="0" offset="0x0.0" selected_by="MTIM" size="0x10" />
+	<field name="pcam_reg" descr="" subnode="pcam_reg_ext" capability="0" offset="0x0.0" selected_by="PCAM" size="0x50" />
+	<field name="pcap_reg" descr="" subnode="pcap_reg_ext" capability="0" offset="0x0.0" selected_by="PCAP" size="0x14" />
+	<field name="ptys_reg" descr="" subnode="ptys_reg_ext" capability="0" offset="0x0.0" selected_by="PTYS" size="0x44" />
+	<field name="paos_reg" descr="" subnode="paos_reg_ext" capability="0" offset="0x0.0" selected_by="PAOS" size="0x10" />
+	<field name="pltc_reg" descr="" subnode="pltc_reg_ext" capability="0" offset="0x0.0" selected_by="PLTC" size="0x10" />
+	<field name="ppcnt_reg" descr="" subnode="ppcnt_reg_ext" capability="0" offset="0x0.0" selected_by="PPCNT" size="0x100" />
+	<field name="pude_reg" descr="" subnode="pude_reg_ext" capability="0" offset="0x0.0" selected_by="PUDE" size="0x10" />
+	<field name="pter_reg" descr="" subnode="pter_reg_ext" capability="0" offset="0x0.0" selected_by="PTER" size="0x20" />
+	<field name="pmlp_reg" descr="" subnode="pmlp_reg_ext" capability="0" offset="0x0.0" selected_by="PMLP" size="0x40" />
+	<field name="pmpr_reg" descr="" subnode="pmpr_reg_ext" capability="0" offset="0x0.0" selected_by="PMPR" size="0x10" />
+	<field name="pmmp_reg" descr="" subnode="pmmp_reg_ext" capability="0" offset="0x0.0" selected_by="PMMP" size="0x2c" />
+	<field name="pmcr_reg" descr="" subnode="pmcr_reg_ext" capability="0" offset="0x0.0" selected_by="PMCR" size="0x20" />
+	<field name="pmpt_reg" descr="" subnode="pmpt_reg_ext" capability="0" offset="0x0.0" selected_by="PMPT" size="0x1c" />
+	<field name="pmpd_reg" descr="" subnode="pmpd_reg_ext" capability="0" offset="0x0.0" selected_by="PMPD" size="0x30" />
+	<field name="ppsc_reg" descr="" subnode="ppsc_reg_ext" capability="0" offset="0x0.0" selected_by="PPSC" size="0x30" />
+	<field name="prtl_reg" descr="" subnode="prtl_reg_ext" capability="0" offset="0x0.0" selected_by="PRTL" size="0x20" />
+	<field name="pplr_reg" descr="" subnode="pplr_reg_ext" capability="0" offset="0x0.0" selected_by="PPLR" size="0x8" />
+	<field name="pplm_reg" descr="" subnode="pplm_reg_ext" capability="0" offset="0x0.0" selected_by="PPLM" size="0x50" />
+	<field name="sltp_reg" descr="" subnode="sltp_reg_ext" capability="0" offset="0x0.0" selected_by="SLTP" size="0x4c" />
+	<field name="slrg_reg" descr="" subnode="slrg_reg_ext" capability="0" offset="0x0.0" selected_by="SLRG" size="0x28" />
+	<field name="pddr_reg" descr="" subnode="pddr_reg_ext" capability="0" offset="0x0.0" selected_by="PDDR" size="0x100" />
+	<field name="pptt_reg" descr="" subnode="pptt_reg_ext" capability="0" offset="0x0.0" selected_by="PPTT" size="0x1c" />
+	<field name="pprt_reg" descr="" subnode="pprt_reg_ext" capability="0" offset="0x0.0" selected_by="PPRT" size="0x24" />
+	<field name="pphcr" descr="" subnode="pphcr_ext" capability="0" offset="0x0.0" selected_by="PPHCR" size="0x50" />
+	<field name="ppaos_reg" descr="" subnode="ppaos_reg_ext" capability="0" offset="0x0.0" selected_by="PPAOS" size="0x10" />
+	<field name="pmtu_reg" descr="" subnode="pmtu_reg_ext" capability="0" offset="0x0.0" selected_by="PMTU" size="0x10" />
+	<field name="pguid_reg" descr="" subnode="pguid_reg_ext" capability="0" offset="0x0.0" selected_by="PGUID" size="0x60" />
+	<field name="pbsr_reg" descr="" subnode="pbsr_reg_ext" capability="0" offset="0x0.0" selected_by="PBSR" size="0x64" />
+	<field name="ptsr" descr="" subnode="ptsr_ext" capability="0" offset="0x0.0" selected_by="PTSR" size="0x20" />
+	<field name="ptsb" descr="" subnode="ptsb_ext" capability="0" offset="0x0.0" selected_by="PTSB" size="0x20" />
+	<field name="plib_reg" descr="" subnode="plib_reg_ext" capability="0" offset="0x0.0" selected_by="PLIB" size="0x10" />
+	<field name="ppslc" descr="" subnode="ppslc_ext" capability="0" offset="0x0.0" selected_by="PPSLC" size="0x34" />
+	<field name="ppsls" descr="" subnode="ppsls_ext" capability="0" offset="0x0.0" selected_by="PPSLS" size="0x8" />
+	<field name="pevnt" descr="" subnode="pevnt_ext" capability="0" offset="0x0.0" selected_by="PEVNT" size="0x8" />
+	<field name="pbwc" descr="" subnode="pbwc_ext" capability="0" offset="0x0.0" selected_by="PBWC" size="0x8" />
+	<field name="pbwr" descr="" subnode="pbwr_ext" capability="0" offset="0x0.0" selected_by="PBWR" size="0x94" />
+	<field name="ppdfd" descr="" subnode="ppdfd_ext" capability="0" offset="0x0.0" selected_by="PPDFD" size="0xc" />
+	<field name="resource_dump" descr="" subnode="resource_dump_ext" capability="0" offset="0x0.0" selected_by="MORD" size="0xc8" />
+	<field name="ghpkt" descr="" subnode="ghpkt_ext" capability="0" offset="0x0.0" selected_by="GHPKT" size="0x10" />
+	<field name="gsguid" descr="" subnode="gsguid_ext" capability="0" offset="0x0.0" selected_by="GSGUID" size="0x10" />
+	<field name="gtgb" descr="" subnode="gtgb_ext" capability="0" offset="0x0.0" selected_by="GTGB" size="0x10" />
+	<field name="gplid" descr="" subnode="gplid_ext" capability="0" offset="0x0.0" selected_by="GPLID" size="0x10" />
+	<field name="gplid2" descr="" subnode="gplid2_ext" capability="0" offset="0x0.0" selected_by="GMDC" size="0x4c" />
+	<field name="unwkm" descr="" subnode="unwkm_ext" capability="0" offset="0x0.0" selected_by="UNWKM" size="0x8c" />
+	<field name="unrsa" descr="" subnode="unrsa_ext" capability="0" offset="0x0.0" selected_by="UNRSA" size="0x18" />
+	<field name="unrc" descr="" subnode="unrc_ext" capability="0" offset="0x0.0" selected_by="UNRC" size="0x40" />
+	<field name="undri" descr="" subnode="undri_ext" capability="0" offset="0x0.0" selected_by="UNDRI" size="0x10" />
+	<field name="ukdri" descr="" subnode="ukdri_ext" capability="0" offset="0x0.0" selected_by="UKDRI" size="0x10" />
+	<field name="undfd" descr="" subnode="undfd_ext" capability="0" offset="0x0.0" selected_by="UNDFD" size="0x8" />
+</node>
+
+<node name="access_reg_summary_selector_ext" descr="" attr_is_union="1" size="0x110" >
+	<field name="access_reg_summary" descr="" subnode="access_reg_summary_ext" offset="0x0.0" size="0x110" union_selector="$(parent).ctrl.id" />
+	<field name="ctrl" descr="" subnode="access_reg_summary_ctrl_ext" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="enum_entry" descr="" size="0x4.0" >
+</node>
+
+<node name="eth_2819_cntrs_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="ether_stats_drop_events_high" descr="The total number of events in which packets were dropped by the probe due to lack of resources.\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="ether_stats_drop_events_low" descr="The total number of events in which packets were dropped by the probe due to lack of resources.\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="ether_stats_octets_high" descr="The total number of octets of data (including those in bad packets) received (excluding framing bits but including FCS octets).\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="ether_stats_octets_low" descr="The total number of octets of data (including those in bad packets) received (excluding framing bits but including FCS octets).\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="ether_stats_pkts_high" descr="The total number of packets (including bad packets, broadcast packets, and multicast packets) received.\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="ether_stats_pkts_low" descr="The total number of packets (including bad packets, broadcast packets, and multicast packets) received.\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="ether_stats_broadcast_pkts_high" descr="The total number of good packets received that were directed to the broadcast address. \;Note: This does not include multicast packets.\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="ether_stats_broadcast_pkts_low" descr="The total number of good packets received that were directed to the broadcast address. \;Note: This does not include multicast packets.\;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="ether_stats_multicast_pkts_high" descr="The total number of good packets received that were directed to a multicast MAC address. \;Note: This number does not include packets directed to the broadcast address.\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="ether_stats_multicast_pkts_low" descr="The total number of good packets received that were directed to a multicast MAC address. \;Note: This number does not include packets directed to the broadcast address.\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="ether_stats_crc_align_errors_high" descr="The total number of packets received that had a length (excluding framing bits, but including FCS octets) of between 64 and MTU octets, inclusive, but had either a bad frame check sequence (FCS) with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="ether_stats_crc_align_errors_low" descr="The total number of packets received that had a length (excluding framing bits, but including FCS octets) of between 64 and MTU octets, inclusive, but had either a bad frame check sequence (FCS) with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="ether_stats_undersize_pkts_high" descr="The total number of packets received that were less than 64 octets long (excluding framing bits, but including FCS octets) and were otherwise well formed.\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="ether_stats_undersize_pkts_low" descr="The total number of packets received that were less than 64 octets long (excluding framing bits, but including FCS octets) and were otherwise well formed.\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="ether_stats_oversize_pkts_high" descr="The total number of packets received that were longer than MTU octets (excluding framing bits, but including FCS octets) but were otherwise well formed.\;" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="ether_stats_oversize_pkts_low" descr="The total number of packets received that were longer than MTU octets (excluding framing bits, but including FCS octets) but were otherwise well formed.\;" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="ether_stats_fragments_high" descr="The total number of packets received that were less than 64 octets in length (excluding framing bits but including FCS octets) and had either a bad FCS with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="ether_stats_fragments_low" descr="The total number of packets received that were less than 64 octets in length (excluding framing bits but including FCS octets) and had either a bad FCS with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="ether_stats_jabbers_high" descr="The total number of packets received that were longer than MTU octets (excluding framing bits, but including FCS octets), and had either a bad FCS with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="ether_stats_jabbers_low" descr="The total number of packets received that were longer than MTU octets (excluding framing bits, but including FCS octets), and had either a bad FCS with an integral number of octets (FCS error) or a bad FCS with a non-integral number of octets (alignment error).\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="ether_stats_collisions_high" descr="The best estimate of the total number of collisions on this Ethernet segment.\;" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="ether_stats_collisions_low" descr="The best estimate of the total number of collisions on this Ethernet segment.\;" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="ether_stats_pkts64octets_high" descr="The total number of packets (including bad packets) received that were 64 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="ether_stats_pkts64octets_low" descr="The total number of packets (including bad packets) received that were 64 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="ether_stats_pkts65to127octets_high" descr="The total number of packets (including bad packets) received that were between 65 and 127 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="ether_stats_pkts65to127octets_low" descr="The total number of packets (including bad packets) received that were between 65 and 127 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="ether_stats_pkts128to255octets_high" descr="The total number of packets (including bad packets) received that were between 128 and 255 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="ether_stats_pkts128to255octets_low" descr="The total number of packets (including bad packets) received that were between 128 and 255 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="ether_stats_pkts256to511octets_high" descr="The total number of packets (including bad packets) received that were between 256 and 511 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="ether_stats_pkts256to511octets_low" descr="The total number of packets (including bad packets) received that were between 256 and 511 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="ether_stats_pkts512to1023octets_high" descr="The total number of packets (including bad packets) received that were between 512 and 1023 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="ether_stats_pkts512to1023octets_low" descr="The total number of packets (including bad packets) received that were between 512 and 1023 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="ether_stats_pkts1024to1518octets_high" descr="The total number of packets (including bad packets) received that were between 1024 and 1518 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="ether_stats_pkts1024to1518octets_low" descr="The total number of packets (including bad packets) received that were between 1024 and 1518 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="ether_stats_pkts1519to2047octets_high" descr="The total number of packets (including bad packets) received that were between 1519 and 2047 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="ether_stats_pkts1519to2047octets_low" descr="The total number of packets (including bad packets) received that were between 1519 and 2047 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x8C.0" size="0x4.0" />
+	<field name="ether_stats_pkts2048to4095octets_high" descr="The total number of packets (including bad packets) received that were between 2048 and 4095 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x90.0" size="0x4.0" />
+	<field name="ether_stats_pkts2048to4095octets_low" descr="The total number of packets (including bad packets) received that were between 2048 and 4095 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x94.0" size="0x4.0" />
+	<field name="ether_stats_pkts4096to8191octets_high" descr="The total number of packets (including bad packets) received that were between 4096 and 8191 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x98.0" size="0x4.0" />
+	<field name="ether_stats_pkts4096to8191octets_low" descr="The total number of packets (including bad packets) received that were between 4096 and 8191 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x9C.0" size="0x4.0" />
+	<field name="ether_stats_pkts8192to10239octets_high" descr="The total number of packets (including bad packets) received that were between 8192 and 10239 octets in length (excluding framing bits but including FCS octets).\;" access="RO" offset="0xA0.0" size="0x4.0" />
+	<field name="ether_stats_pkts8192to10239octets_low" descr="The total number of packets (including bad packets) received that were between 8192 and 10239 octets in length (excluding framing bits but including FCS octets).\;" access="RO" offset="0xA4.0" size="0x4.0" />
+</node>
+
+<node name="eth_2863_cntrs_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="if_in_octets_high" descr="The total number of octets received, including framing characters. Including MAC control frames.\;\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="if_in_octets_low" descr="The total number of octets received, including framing characters. Including MAC control frames.\;\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="if_in_ucast_pkts_high" descr="The number of packets successfully received, which were not addressed to a multicast or broadcast MAC address.\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="if_in_ucast_pkts_low" descr="The number of packets successfully received, which were not addressed to a multicast or broadcast MAC address.\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="if_in_discards_high" descr="The number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;\;\;\;\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="if_in_discards_low" descr="The number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;\;\;\;\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="if_in_errors_high" descr="The number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol. \;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="if_in_errors_low" descr="The number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol. \;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="if_in_unknown_protos_high" descr="The number of packets received via the interface which were discarded because of an unknown or unsupported protocol.\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="if_in_unknown_protos_low" descr="The number of packets received via the interface which were discarded because of an unknown or unsupported protocol.\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="if_out_octets_high" descr="The total number of octets transmitted out of the interface, including framing characters.\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="if_out_octets_low" descr="The total number of octets transmitted out of the interface, including framing characters.\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="if_out_ucast_pkts_high" descr="The total number of packets that higher-level protocols requested be transmitted and were not addressed to a multicast or broadcast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="if_out_ucast_pkts_low" descr="The total number of packets that higher-level protocols requested be transmitted and were not addressed to a multicast or broadcast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="if_out_discards_high" descr="The number of outbound packets which were chosen to be discarded, even though no errors had been detected to prevent their being transmitted. \;" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="if_out_discards_low" descr="The number of outbound packets which were chosen to be discarded, even though no errors had been detected to prevent their being transmitted. \;" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="if_out_errors_high" descr="The number of outbound packets that could not be transmitted because of errors.\;" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="if_out_errors_low" descr="The number of outbound packets that could not be transmitted because of errors.\;" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="if_in_multicast_pkts_high" descr="The number of packets successfully received, which were addressed to a multicast MAC address.\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="if_in_multicast_pkts_low" descr="The number of packets successfully received, which were addressed to a multicast MAC address.\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="if_in_broadcast_pkts_high" descr="The number of packets successfully received, which were addressed to a broadcast MAC address.\;" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="if_in_broadcast_pkts_low" descr="The number of packets successfully received, which were addressed to a broadcast MAC address.\;" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="if_out_multicast_pkts_high" descr="The total number of packets that higher-level protocols requested be transmitted, and which were addressed to a multicast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="if_out_multicast_pkts_low" descr="The total number of packets that higher-level protocols requested be transmitted, and which were addressed to a multicast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="if_out_broadcast_pkts_high" descr="The total number of packets that higher-level protocols requested be transmitted, and which were addressed to a broadcast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="if_out_broadcast_pkts_low" descr="The total number of packets that higher-level protocols requested be transmitted, and which were addressed to a broadcast MAC address, including those that were discarded or not sent.\;" access="RO" offset="0x64.0" size="0x4.0" />
+</node>
+
+<node name="eth_3635_cntrs_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="dot3stats_alignment_errors_high" descr="A count of frames received that are not an integral number of octets in length and do not pass the FCS check.\;" access="RW" offset="0x0.0" size="0x4.0" />
+	<field name="dot3stats_alignment_errors_low" descr="A count of frames received that are not an integral number of octets in length and do not pass the FCS check.\;" access="RW" offset="0x4.0" size="0x4.0" />
+	<field name="dot3stats_fcs_errors_high" descr="A count of frames received that are an integral number of octets in length but do not pass the FCS check. This count does not include frames received with frame-too-long or frame-too-short errors.\;" access="RW" offset="0x8.0" size="0x4.0" />
+	<field name="dot3stats_fcs_errors_low" descr="A count of frames received that are an integral number of octets in length but do not pass the FCS check. This count does not include frames received with frame-too-long or frame-too-short errors.\;" access="RW" offset="0xC.0" size="0x4.0" />
+	<field name="dot3stats_single_collision_frames_high" descr="A count of frames that are involved in a single collision, and are subsequently transmitted successfully.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x10.0" size="0x4.0" />
+	<field name="dot3stats_single_collision_frames_low" descr="A count of frames that are involved in a single collision, and are subsequently transmitted successfully.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x14.0" size="0x4.0" />
+	<field name="dot3stats_multiple_collision_frames_high" descr="A count of frames that are involved in more than one collision and are subsequently transmitted successfully. \;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x18.0" size="0x4.0" />
+	<field name="dot3stats_multiple_collision_frames_low" descr="A count of frames that are involved in more than one collision and are subsequently transmitted successfully. \;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x1C.0" size="0x4.0" />
+	<field name="dot3stats_sqe_test_errors_high" descr="A count of times that the SQE TEST ERROR is received on a particular interface.\;This counter does not increment on interfaces operating at speeds greater than 10 Mb/s, or on interfaces operating in full-duplex mode. \;" access="RW" offset="0x20.0" size="0x4.0" />
+	<field name="dot3stats_sqe_test_errors_low" descr="A count of times that the SQE TEST ERROR is received on a particular interface.\;This counter does not increment on interfaces operating at speeds greater than 10 Mb/s, or on interfaces operating in full-duplex mode. \;" access="RW" offset="0x24.0" size="0x4.0" />
+	<field name="dot3stats_deferred_transmissions_high" descr="A count of frames for which the first transmission attempt on a particular interface is delayed because the medium is busy. \;This counter does not increment when the interface is operating in full-duplex mode. \;" access="RW" offset="0x28.0" size="0x4.0" />
+	<field name="dot3stats_deferred_transmissions_low" descr="A count of frames for which the first transmission attempt on a particular interface is delayed because the medium is busy. \;This counter does not increment when the interface is operating in full-duplex mode. \;" access="RW" offset="0x2C.0" size="0x4.0" />
+	<field name="dot3stats_late_collisions_high" descr="The number of times that a collision is detected on a particular interface later than one slotTime into the transmission of a packet.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x30.0" size="0x4.0" />
+	<field name="dot3stats_late_collisions_low" descr="The number of times that a collision is detected on a particular interface later than one slotTime into the transmission of a packet.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x34.0" size="0x4.0" />
+	<field name="dot3stats_excessive_collisions_high" descr="A count of frames for which transmission on a particular interface fails due to excessive collisions.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x38.0" size="0x4.0" />
+	<field name="dot3stats_excessive_collisions_low" descr="A count of frames for which transmission on a particular interface fails due to excessive collisions.\;This counter does not increment when the interface is operating in full-duplex mode.\;" access="RW" offset="0x3C.0" size="0x4.0" />
+	<field name="dot3stats_internal_mac_transmit_errors_high" descr="A count of frames for which transmission failed and were discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;" access="RW" offset="0x40.0" size="0x4.0" />
+	<field name="dot3stats_internal_mac_transmit_errors_low" descr="A count of frames for which transmission failed and were discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;" access="RW" offset="0x44.0" size="0x4.0" />
+	<field name="dot3stats_carrier_sense_errors_high" descr="The number of times that the carrier sense condition was lost or never asserted when attempting to transmit a frame on a particular interface. \;This counter does not increment when the interface is operating in full-duplex mode. \;" access="RW" offset="0x48.0" size="0x4.0" />
+	<field name="dot3stats_carrier_sense_errors_low" descr="The number of times that the carrier sense condition was lost or never asserted when attempting to transmit a frame on a particular interface. \;This counter does not increment when the interface is operating in full-duplex mode. \;" access="RW" offset="0x4C.0" size="0x4.0" />
+	<field name="dot3stats_frame_too_longs_high" descr="A count of frames received that exceed the maximum permitted frame size.\;" access="RW" offset="0x50.0" size="0x4.0" />
+	<field name="dot3stats_frame_too_longs_low" descr="A count of frames received that exceed the maximum permitted frame size.\;" access="RW" offset="0x54.0" size="0x4.0" />
+	<field name="dot3stats_internal_mac_receive_errors_high" descr="A count of frames for which reception failed and were discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;" access="RW" offset="0x58.0" size="0x4.0" />
+	<field name="dot3stats_internal_mac_receive_errors_low" descr="A count of frames for which reception failed and were discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;" access="RW" offset="0x5C.0" size="0x4.0" />
+	<field name="dot3stats_symbol_errors_high" descr="The number of times the receiving media is non-idle (a carrier event) for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate &quot;Receive Error&quot;.\;\;" access="RW" offset="0x60.0" size="0x4.0" />
+	<field name="dot3stats_symbol_errors_low" descr="The number of times the receiving media is non-idle (a carrier event) for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate &quot;Receive Error&quot;.\;\;" access="RW" offset="0x64.0" size="0x4.0" />
+	<field name="dot3control_in_unknown_opcodes_high" descr="A count of MAC Control frames received that contain an opcode that is not supported.\;" access="RW" offset="0x68.0" size="0x4.0" />
+	<field name="dot3control_in_unknown_opcodes_low" descr="A count of MAC Control frames received that contain an opcode that is not supported.\;" access="RW" offset="0x6C.0" size="0x4.0" />
+	<field name="dot3in_pause_frames_high" descr="A count of MAC Control frames received with an opcode indicating the PAUSE operation.\;\;" access="RW" offset="0x70.0" size="0x4.0" />
+	<field name="dot3in_pause_frames_low" descr="A count of MAC Control frames received with an opcode indicating the PAUSE operation.\;\;" access="RW" offset="0x74.0" size="0x4.0" />
+	<field name="dot3out_pause_frames_high" descr="A count of MAC Control frames transmitted with an opcode indicating the PAUSE operation.\;\;" access="RW" offset="0x78.0" size="0x4.0" />
+	<field name="dot3out_pause_frames_low" descr="A count of MAC Control frames transmitted with an opcode indicating the PAUSE operation.\;\;" access="RW" offset="0x7C.0" size="0x4.0" />
+</node>
+
+<node name="eth_802_3_cntrs_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="a_frames_transmitted_ok_high" descr="A count of frames that are successfully transmitted. \;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="a_frames_transmitted_ok_low" descr="A count of frames that are successfully transmitted. \;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="a_frames_received_ok_high" descr="A count of frames that are successfully received. This does not include frames received with frame-too-long, frame check sequence (FCS), length or alignment errors, or frames lost due to other MAC errors.\;\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="a_frames_received_ok_low" descr="A count of frames that are successfully received. This does not include frames received with frame-too-long, frame check sequence (FCS), length or alignment errors, or frames lost due to other MAC errors.\;\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="a_frame_check_sequence_errors_high" descr="A count of receive frames that are an integral number of octets in length and do not pass the FCS check. This does not include frames received with frame-too-long, or frame-too-short (frame fragment) errors.\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="a_frame_check_sequence_errors_low" descr="A count of receive frames that are an integral number of octets in length and do not pass the FCS check. This does not include frames received with frame-too-long, or frame-too-short (frame fragment) errors.\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="a_alignment_errors_high" descr="A count of frames that are not an integral number of octets in length and do not pass the FCS check.\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="a_alignment_errors_low" descr="A count of frames that are not an integral number of octets in length and do not pass the FCS check.\;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="a_octets_transmitted_ok_high" descr="A count of data and padding octets of frames that are successfully transmitted.\;\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="a_octets_transmitted_ok_low" descr="A count of data and padding octets of frames that are successfully transmitted.\;\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="a_octets_received_ok_high" descr="A count of data and padding octets in frames that are successfully received. This does not include octets in frames received with frame-too-long, FCS, length or alignment errors, or frames lost due to other MAC errors.\;\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="a_octets_received_ok_low" descr="A count of data and padding octets in frames that are successfully received. This does not include octets in frames received with frame-too-long, FCS, length or alignment errors, or frames lost due to other MAC errors.\;\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="a_multicast_frames_xmitted_ok_high" descr="A count of frames that are successfully transmitted to a group destination address other than broadcast.\;\; \;\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="a_multicast_frames_xmitted_ok_low" descr="A count of frames that are successfully transmitted to a group destination address other than broadcast.\;\; \;\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="a_broadcast_frames_xmitted_ok_high" descr="A count of the frames that were successfully transmitted to the broadcast address. Frames transmitted to multicast addresses are not broadcast frames and are excluded.\;\;" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="a_broadcast_frames_xmitted_ok_low" descr="A count of the frames that were successfully transmitted to the broadcast address. Frames transmitted to multicast addresses are not broadcast frames and are excluded.\;\;" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="a_multicast_frames_received_ok_high" descr="A count of frames that are successfully received and directed to an active nonbroadcast group address. This does not include frames received with frame-too-long, FCS, length or alignment errors, or frames lost due to internal MAC sublayer error. \;  \;\;\;" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="a_multicast_frames_received_ok_low" descr="A count of frames that are successfully received and directed to an active nonbroadcast group address. This does not include frames received with frame-too-long, FCS, length or alignment errors, or frames lost due to internal MAC sublayer error. \;  \;\;\;" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="a_broadcast_frames_received_ok_high" descr="A count of the frames that were successfully transmitted to the broadcast address. Frames transmitted to multicast addresses are not broadcast frames and are excluded. \;\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="a_broadcast_frames_received_ok_low" descr="A count of the frames that were successfully transmitted to the broadcast address. Frames transmitted to multicast addresses are not broadcast frames and are excluded. \;\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="a_in_range_length_errors_high" descr="A count of frames with a length/type field value between the minimum unpadded MAC client data size and the maximum allowed MAC client data size, inclusive, that does not match the number of MAC client data octets received. The counter also increments for frames whose length/type field value is less than the minimum allowed unpadded MAC client data size and the number of MAC client data octets received is greater than the minimum unpadded MAC client data size.\;" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="a_in_range_length_errors_low" descr="A count of frames with a length/type field value between the minimum unpadded MAC client data size and the maximum allowed MAC client data size, inclusive, that does not match the number of MAC client data octets received. The counter also increments for frames whose length/type field value is less than the minimum allowed unpadded MAC client data size and the number of MAC client data octets received is greater than the minimum unpadded MAC client data size.\;" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="a_out_of_range_length_field_high" descr="A count of frames with a length field value greater than the maximum allowed LLC data size. \;" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="a_out_of_range_length_field_low" descr="A count of frames with a length field value greater than the maximum allowed LLC data size. \;" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="a_frame_too_long_errors_high" descr="A count of frames received that exceed the maximum permitted frame size by IEEE 802.3 (MTU size).\;" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="a_frame_too_long_errors_low" descr="A count of frames received that exceed the maximum permitted frame size by IEEE 802.3 (MTU size).\;" access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="a_symbol_error_during_carrier_high" descr="For full duplex operation at 1000 Mb/s, it is a count of the number of times the receiving media is non-idle (a carrier event) for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate &quot;Data reception error&quot;.\;For operation at 10 Gb/s, 40 Gb/s, and 100 Gb/s, it is a count of the number of times the receiving media is non-idle for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate\;Error.\;\;" access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="a_symbol_error_during_carrier_low" descr="For full duplex operation at 1000 Mb/s, it is a count of the number of times the receiving media is non-idle (a carrier event) for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate &quot;Data reception error&quot;.\;For operation at 10 Gb/s, 40 Gb/s, and 100 Gb/s, it is a count of the number of times the receiving media is non-idle for a period of time equal to or greater than minFrameSize, and during which there was at least one occurrence of an event that causes the PHY to indicate\;Error.\;\;" access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="a_mac_control_frames_transmitted_high" descr="A count of MAC Control frames passed to the MAC sublayer for transmission.\;\;" access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="a_mac_control_frames_transmitted_low" descr="A count of MAC Control frames passed to the MAC sublayer for transmission.\;\;" access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="a_mac_control_frames_received_high" descr="A count of MAC Control frames passed by the MAC sublayer to the MAC Control sublayer.\;\;" access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="a_mac_control_frames_received_low" descr="A count of MAC Control frames passed by the MAC sublayer to the MAC Control sublayer.\;\;" access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="a_unsupported_opcodes_received_high" descr="A count of MAC Control frames received that contain an opcode that is not supported by the device.\;\;" access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="a_unsupported_opcodes_received_low" descr="A count of MAC Control frames received that contain an opcode that is not supported by the device.\;\;" access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="a_pause_mac_ctrl_frames_received_high" descr="A count of MAC PAUSE frames passed by the MAC sublayer to the MAC Control sublayer.\;\;" access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="a_pause_mac_ctrl_frames_received_low" descr="A count of MAC PAUSE frames passed by the MAC sublayer to the MAC Control sublayer.\;\;" access="RO" offset="0x8C.0" size="0x4.0" />
+	<field name="a_pause_mac_ctrl_frames_transmitted_high" descr="A count of PAUSE frames passed to the MAC sublayer for transmission.\;\;" access="RO" offset="0x90.0" size="0x4.0" />
+	<field name="a_pause_mac_ctrl_frames_transmitted_low" descr="A count of PAUSE frames passed to the MAC sublayer for transmission.\;\;" access="RO" offset="0x94.0" size="0x4.0" />
+</node>
+
+<node name="eth_discard_cntrs_grp_ext" descr="" size="0xf8.0" >
+	<field name="ingress_general_high" descr="Ingress general \;\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="ingress_general_low" descr="Ingress general \;\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="ingress_policy_engine_high" descr="Ingress policy engine discards" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="ingress_policy_engine_low" descr="Ingress policy engine discards" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="ingress_vlan_membership_high" descr="Ingress VLAN membership filter discards" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="ingress_vlan_membership_low" descr="Ingress VLAN membership filter discards" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="ingress_tag_frame_type_high" descr="Ingress VLAN tag allowance (tagged, untagged and prio-tagged) filter discards" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="ingress_tag_frame_type_low" descr="Ingress VLAN tag allowance (tagged, untagged and prio-tagged) filter discards" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="egress_vlan_membership_high" descr="Egress VLAN membership filter discards" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="egress_vlan_membership_low" descr="Egress VLAN membership filter discards" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="loopback_filter_high" descr="Loop-back filter discards" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="loopback_filter_low" descr="Loop-back filter discards" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="egress_general_high" descr="Egress general discards\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="egress_general_low" descr="Egress general discards\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="egress_hoq_high" descr="Head-of-Queue time-out discards" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="egress_hoq_low" descr="Head-of-Queue time-out discards" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="port_isolation_high" descr="Port isolation filter discards\;[IInternal] Not supported due to HW bug." access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="port_isolation_low" descr="Port isolation filter discards\;[IInternal] Not supported due to HW bug." access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="egress_policy_engine_high" descr="Egress policy engine discards" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="egress_policy_engine_low" descr="Egress policy engine discards" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="ingress_tx_link_down_high" descr="Per ingress port count dropped packets due to egress link down" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="ingress_tx_link_down_low" descr="Per ingress port count dropped packets due to egress link down" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="egress_stp_filter_high" descr="Egress spanning tree filter" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="egress_stp_filter_low" descr="Egress spanning tree filter" access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="egress_hoq_stall_high" descr="Number of sequential packets dropped, due to Head-Of-Queue Lifetime Limit, that causes the port to enter the Stall state \;\;Reserved for Switches" access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="egress_hoq_stall_low" descr="Number of sequential packets dropped, due to Head-Of-Queue Lifetime Limit, that causes the port to enter the Stall state \;\;Reserved for Switches" access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="egress_sll_high" descr="Number of packets dropped, because the Switch Lifetime Limit was exceeded. \;\;Applies for switches only. Reserved for HCAs" access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="egress_sll_low" descr="Number of packets dropped, because the Switch Lifetime Limit was exceeded. \;\;Applies for switches only. Reserved for HCAs" access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="ingress_discard_all_high" descr="Number of packets dropped for of any reason.\; Note: see description in the description area for limitations of this counter.\;Applies for switches only. Reserved for HCAs\;\;Note: deprecated for all Ethernet devices" access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="ingress_discard_all_low" descr="Number of packets dropped for of any reason.\; Note: see description in the description area for limitations of this counter.\;Applies for switches only. Reserved for HCAs\;\;Note: deprecated for all Ethernet devices" access="RO" offset="0x7C.0" size="0x4.0" />
+</node>
+
+<node name="eth_extended_cntrs_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="port_transmit_wait_high" descr="The time (in 4ns resolution) during which the port selected had data to transmit but no data was sent.\;time = port_transmit_wait*4 [ns]\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="port_transmit_wait_low" descr="The time (in 4ns resolution) during which the port selected had data to transmit but no data was sent.\;time = port_transmit_wait*4 [ns]\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="ecn_marked_high" descr="A count of packets marked as ECN or potentially marked as ECN.\;ECN Counting enable/disable is configurable. \;Valid only for Spectrum family.\;\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="ecn_marked_low" descr="A count of packets marked as ECN or potentially marked as ECN.\;ECN Counting enable/disable is configurable. \;Valid only for Spectrum family.\;\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="no_buffer_discard_mc_high" descr="The number of multicast packets dropped due to lack of egress buffer resources.\;Valid only for Spectrum.\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="no_buffer_discard_mc_low" descr="The number of multicast packets dropped due to lack of egress buffer resources.\;Valid only for Spectrum.\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="rx_ebp_high" descr="The number of received EBP packets.\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="rx_ebp_low" descr="The number of received EBP packets.\;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="tx_ebp_high" descr="The number of transmitted EBP packets.\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="tx_ebp_low" descr="The number of transmitted EBP packets.\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="rx_buffer_almost_full_high" descr="The number of events where the port rx buffer has passed a fullness threshold \;\;Reserved for Switches." access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="rx_buffer_almost_full_low" descr="The number of events where the port rx buffer has passed a fullness threshold \;\;Reserved for Switches." access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="rx_buffer_full_high" descr="The number of events where the port rx buffer has reached 100% fullness \;\;Reserved for Switches." access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="rx_buffer_full_low" descr="The number of events where the port rx buffer has reached 100% fullness \;\;Reserved for Switches." access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="rx_icrc_encapsulated_high" descr="The number of roce packets with ICRC error\;\;Reserved for Switches." access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="rx_icrc_encapsulated_low" descr="The number of roce packets with ICRC error\;\;Reserved for Switches." access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="tx_stats_pkts64octets_high" descr="The total number of packets (including bad packets) transmitted that were 64 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="tx_stats_pkts64octets_low" descr="The total number of packets (including bad packets) transmitted that were 64 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="tx_stats_pkts65to127octets_high" descr="The total number of packets (including bad packets) transmitted that were between 65 and 127 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="tx_stats_pkts65to127octets_low" descr="The total number of packets (including bad packets) transmitted that were between 65 and 127 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="tx_stats_pkts128to255octets_high" descr="The total number of packets (including bad packets) transmitted that were between 128 and 255 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="tx_stats_pkts128to255octets_low" descr="The total number of packets (including bad packets) transmitted that were between 128 and 255 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="tx_stats_pkts256to511octets_high" descr="The total number of packets (including bad packets) transmitted that were between 256 and 511 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="tx_stats_pkts256to511octets_low" descr="The total number of packets (including bad packets) transmitted that were between 256 and 511 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="tx_stats_pkts512to1023octets_high" descr="The total number of packets (including bad packets) transmitted that were between 512 and 1023 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="tx_stats_pkts512to1023octets_low" descr="The total number of packets (including bad packets) transmitted that were between 512 and 1023 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="tx_stats_pkts1024to1518octets_high" descr="The total number of packets (including bad packets) transmitted that were between 1024 and 1518 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="tx_stats_pkts1024to1518octets_low" descr="The total number of packets (including bad packets) transmitted that were between 1024 and 1518 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="tx_stats_pkts1519to2047octets_high" descr="The total number of packets (including bad packets) transmitted that were between 1519 and 2047 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="tx_stats_pkts1519to2047octets_low" descr="The total number of packets (including bad packets) transmitted that were between 1519 and 2047 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="tx_stats_pkts2048to4095octets_high" descr="The total number of packets (including bad packets) transmitted that were between 2048 and 4095 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="tx_stats_pkts2048to4095octets_low" descr="The total number of packets (including bad packets) transmitted that were between 2048 and 4095 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x8C.0" size="0x4.0" />
+	<field name="tx_stats_pkts4096to8191octets_high" descr="The total number of packets (including bad packets) transmitted that were between 4096 and 8191 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x90.0" size="0x4.0" />
+	<field name="tx_stats_pkts4096to8191octets_low" descr="The total number of packets (including bad packets) transmitted that were between 4096 and 8191 octets in length (excluding framing bits but including FCS octets)." access="RO" offset="0x94.0" size="0x4.0" />
+	<field name="tx_stats_pkts8192to10239octets_high" descr="The total number of packets (including bad packets) transmitted that were between 8192 and 10239 octets in length (excluding framing bits but including FCS octets).transmitted\;" access="RO" offset="0x98.0" size="0x4.0" />
+	<field name="tx_stats_pkts8192to10239octets_low" descr="The total number of packets (including bad packets) transmitted that were between 8192 and 10239 octets in length (excluding framing bits but including FCS octets).transmitted\;" access="RO" offset="0x9C.0" size="0x4.0" />
+	<field name="ece_marked_high" descr="A count of packets marked as ECE or potentially marked as ECE." access="RO" offset="0xA0.0" size="0x4.0" />
+	<field name="ece_marked_low" descr="A count of packets marked as ECE or potentially marked as ECE." access="RO" offset="0xA4.0" size="0x4.0" />
+	<field name="tx_int_cksm_err_high" descr="Counter is incremented upon packet payload internal checksum error" access="RO" offset="0xA8.0" size="0x4.0" />
+	<field name="tx_int_cksm_err_low" descr="Counter is incremented upon packet payload internal checksum error" access="RO" offset="0xAC.0" size="0x4.0" />
+</node>
+
+<node name="eth_per_prio_grp_data_layout_ext" descr="" size="0xf8.0" >
+	<field name="rx_octets_high" descr="The total number of octets received, including framing characters.\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="rx_octets_low" descr="The total number of octets received, including framing characters.\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="rx_frames_high" descr="The total number of packets received for this priority (not including pause frames).\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="rx_frames_low" descr="The total number of packets received for this priority (not including pause frames).\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="tx_octets_high" descr="The total number of octets transmitted, including framing characters.\;\;\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="tx_octets_low" descr="The total number of octets transmitted, including framing characters.\;\;\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="tx_frames_high" descr="The total number of packets transmitted.\;\;\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="tx_frames_low" descr="The total number of packets transmitted.\;\;\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="rx_pause_high" descr="The total number of PAUSE frames received from the far-end port.\;" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="rx_pause_low" descr="The total number of PAUSE frames received from the far-end port.\;" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="rx_pause_duration_high" descr="The total time in microseconds that transmission of packets to the far-end port have been paused.\;Note that if pause is global then tclass &quot;0&quot; will increment\;\;" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="rx_pause_duration_low" descr="The total time in microseconds that transmission of packets to the far-end port have been paused.\;Note that if pause is global then tclass &quot;0&quot; will increment\;\;" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="tx_pause_high" descr="The total number of PAUSE or PFC frames sent to the far-end port.\;\;\;" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="tx_pause_low" descr="The total number of PAUSE or PFC frames sent to the far-end port.\;\;\;" access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="tx_pause_duration_high" descr="The total time in microseconds that the far-end port have been requested to pause.\;\;" access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="tx_pause_duration_low" descr="The total time in microseconds that the far-end port have been requested to pause.\;\;" access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="rx_pause_transition_high" descr="Counts the number of transitions from Xoff to Xon.\;\;" access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="rx_pause_transition_low" descr="Counts the number of transitions from Xoff to Xon.\;\;" access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="rx_discards_high" descr="The number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;\;\;\;" access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="rx_discards_low" descr="The number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.\;\;\;\;" access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="device_stall_minor_watermark_cnt_high" descr="The number of times the device detected a stalled state for a period longer than device_stall_minor_watermark\;The counter is presented in priority 0, but is a sum of all events on all priorities (including global pause)." access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="device_stall_minor_watermark_cnt_low" descr="The number of times the device detected a stalled state for a period longer than device_stall_minor_watermark\;The counter is presented in priority 0, but is a sum of all events on all priorities (including global pause)." access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="device_stall_critical_watermark_cnt_high" descr="The number of times the device detected a stalled state for a period longer than device_stall_critical_watermark\;The counter is presented in priority 0, but is a sum of all events on all priorities (including global pause).\;" access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="device_stall_critical_watermark_cnt_low" descr="The number of times the device detected a stalled state for a period longer than device_stall_critical_watermark\;The counter is presented in priority 0, but is a sum of all events on all priorities (including global pause).\;" access="RO" offset="0x8C.0" size="0x4.0" />
+</node>
+
+<node name="eth_per_traffic_class_cong_layout_ext" descr="" size="0xf8.0" >
+	<field name="wred_discard_high" descr="The number of packet that are dropped by the Weighted Random Early Detection (WRED) function.\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="wred_discard_low" descr="The number of packet that are dropped by the Weighted Random Early Detection (WRED) function.\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="ecn_marked_tc_high" descr="A count of packets marked as ECN or potentially marked as ECN.\;ECN Counting enable/disable is configurable. \;\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="ecn_marked_tc_low" descr="A count of packets marked as ECN or potentially marked as ECN.\;ECN Counting enable/disable is configurable. \;\;" access="RO" offset="0xC.0" size="0x4.0" />
+</node>
+
+<node name="eth_per_traffic_class_layout_ext" descr="" size="0xf8.0" >
+	<field name="transmit_queue_high" descr="Contains the transmit queue depth in bytes on traffic class selected by traffic_class of the port selected by local_port.\;\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="transmit_queue_low" descr="Contains the transmit queue depth in bytes on traffic class selected by traffic_class of the port selected by local_port.\;\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="no_buffer_discard_uc_high" descr="The number of unicast packets dropped due to lack of shared buffer resources.\;Valid only for Spectrum.\;Valid for HCA when ppcnt_no_buffer_uc is set in PCAM." access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="no_buffer_discard_uc_low" descr="The number of unicast packets dropped due to lack of shared buffer resources.\;Valid only for Spectrum.\;Valid for HCA when ppcnt_no_buffer_uc is set in PCAM." access="RO" offset="0xC.0" size="0x4.0" />
+</node>
+
+<node name="ghpkt_ext" descr="" size="0x10.0" >
+	<field name="trap_id" descr="Trap IDs\;See Section 1203, &quot;GPUNet Trap IDs&quot;, on page 1152" access="INDEX" offset="0x0.0" size="0x0.10" />
+	<field name="action" descr="Action to perform on trap_id\;0: NOP \;1: TRAP" access="RW" enum="NOP=0x0,TRAP=0x1" offset="0x0.20" size="0x0.4" />
+</node>
+
+<node name="gplid2_ext" descr="" size="0x4c.0" >
+	<field name="mnoc_port" descr="Local Port" access="INDEX" offset="0x0.0" size="0x0.4" />
+	<field name="clr" descr="" access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="cnt_mnoc_send_lfm" descr="The number of LFM packets were sent from the NETIR to the MSE" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="cnt_mnoc_recieve_lfm" descr="The number of LFM packets were received to the NETIR from the MSE" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="cnt_mnoc_send_prm" descr="The number of PRM packets were sent from the NETIR to the MSE" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="cnt_mnoc_recieve_prm" descr="The number of PRM packets were received to the NETIR from the MSE" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="cnt_mnoc_send_event" descr="The number of events packets were sent from the NETIR to the MSE" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="cnt_mnoc_send_ack" descr="The number of MNOC ACK packets were sent from the NETIR to the MSE" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="cnt_mnoc_recieve_ack" descr="The number of MNOC ACK packets were received to the NETIR from the MSE" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="cnt_mnoc_drop_due_credits" descr="The number of packets were dropped because not enough credits" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="cnt_mnoc_status_failure" descr="The number of packets were received to the NETIR from the MSE and and sent back to the MSE with MNOC status error" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_mem_read" descr="The number of errors received during sending a message through the mnoc because err_mem_read" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_client" descr="The number of errors received during sending a message through the mnoc because err_mem_read&quot; /&gt;\;&lt;field name=&quot;cnt_mnoc_err_client&quot;              offset=&quot;0x70.0&quot;     size=&quot;0x4.0&quot;      descr=&quot;The number of errors received during sending a message through the mnoc because err_client" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_no_rx_buffer" descr="The number of errors received during sending a message through the mnoc because err_no_rx_buffer" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_retry_expiry" descr="The number of errors received during sending a message through the mnoc because err_retry_expiry" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_msg_assembly" descr="The number of errors received during receiving a message through the mnoc because err_msg_assembly" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_mem_write" descr="The number of errors received during receiving a message through the mnoc because err_mem_write" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="cnt_mnoc_err_not_enough_buffer" descr="The number of errors received during receiving a message through the mnoc because err_not_enough_buffer" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="cnt_mnoc_drop_due_wrong_port" descr="The number of packets were dropped due to wrong port" access="RO" offset="0x48.0" size="0x4.0" />
+</node>
+
+<node name="gplid_ext" descr="" size="0x10.0" >
+	<field name="local_port" descr="Local Port" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="lid" descr="The Port LID configured to the GPU Port. \;[Internal] Notice: the port LID has 20 bits for future compatibility, but only the 16 LSBs are being used." access="RO" offset="0x4.0" size="0x0.20" />
+</node>
+
+<node name="gsguid_ext" descr="" size="0x10.0" >
+	<field name="system_guid_h" descr="The system GUID of the device." access="RW" offset="0x8.0" size="0x4.0" />
+	<field name="system_guid_l" descr="The system GUID of the device." access="RW" offset="0xC.0" size="0x4.0" />
+</node>
+
+<node name="gtgb_ext" descr="" size="0x10.0" >
+	<field name="local_port" descr="Local Port" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="buffer_size" descr="FIFO buffer size in 8B units for each VC within the port." access="RO" offset="0x4.0" size="0x0.8" />
+</node>
+
+<node name="lane_2_module_mapping_ext" descr="" size="0x4.0" >
+	<field name="module" descr="Module number" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA \;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="RW" offset="0x0.8" size="0x0.4" />
+	<field name="tx_lane" descr="TX lane. \;When m_lane_m field is set, this field is ignored (Reserved). \;When rxtx field is cleared, this field is used for RX as well." access="RW" offset="0x0.16" size="0x0.4" />
+	<field name="rx_lane" descr="RX lane.\;When m_lane_m field is set, this field is ignored (Reserved). \;When rxtx field is cleared, this field is ignored and RX lane is equal to TX lane." access="RW" offset="0x0.24" size="0x0.4" />
+</node>
+
+<node name="mcam_reg_ext" descr="" size="0x48.0" >
+	<field name="access_reg_group" descr="Access Register ID groups \;0: First_128_REG_ID - Register IDs 0x9001 - 0x907F)\;1: Register_IDs_0x9080 - 0x90FF (bit 0 in mng_access_reg_cap_mask represent register ID 0x9080 while bit 127 represents register ID 0x90FF).\;2: Register_IDs_0x9100 - 0x917F (bit 0 in mng_access_reg_cap_mask represent register ID 0x9100 while bit 127 represents register ID 0x917F).\;3: Register_IDs_0x9180 - 0x91FF (bit 0 in mng_access_reg_cap_mask represent register ID 0x9180 while bit 127 represents register ID 0x91FF)." access="INDEX" enum="First_128_REG_ID=0x0,Register_IDs_0x9080=0x1,Register_IDs_0x9100=0x2,Register_IDs_0x9180=0x3" offset="0x0.0" size="0x0.8" />
+	<field name="feature_group" descr="Feature list mask index: \;0: enhanced_features" access="INDEX" enum="enhanced_features=0x0" offset="0x0.16" size="0x0.8" />
+	<field name="mng_access_reg_cap_mask" descr="Supported management&apos;s access register bitmask. Based on access_reg_group index. \;When bit is set, the register is supported in the device. \;For example:\;Bit 1: MFCR_0x9001\;Bit 2: MFSC_0x9002\;Bit 3: MFSM_0x9003\;Bit 4: MFSL_0x9004\;Bit 58: MGCR_0x903A\;Bit 73: MPPF_0x9049\;Bit 127: MCAP_0x907F" access="RO" enum="MFCR_0x9001=0x2,MFSC_0x9002=0x4,MFSM_0x9003=0x8,MFSL_0x9004=0x10,MGCR_0x903A=0x4000000,MPPF_0x9049=0x200,MCAP_0x907F=0x80000000" high_bound="3" low_bound="0" offset="0x8.0" size="0x10.0" />
+	<field name="mng_feature_cap_mask" descr="Supported port&apos;s enhanced features.Based on feature_group index.\;When bit is set, The feature is supported in the device: \;Bit 0: MPCNT counter group- PCIE performance counters supported\;Bit 1: mtpps_fs - If set, field_select field in MTPPS register is supported.\;Bit 2: mtpps_enhanced_out_periodic_adjustment - If set, enhanced_out_periodic_adjustment field in MTPPS register is supported.\;Bit 3: tx_lossy_overflow_oper - If set, tx_overflow_buffer_pkt counter in MPCNT register is supported.\;Bit 4: pcie_outbound_stalled - if set, outbound_stalled_reads, outbound_stalled_writes, outbound_stalled_reads_events and outbound_stalled_writes_events counters in MPCNT are supported.\;Bit 5: Management pass through is supported\;Bit 6: sensor_map - If set, sensor_map is supported in MTCAP register.\;Bit 7: if set, module_status bit 8 (Module Low Power) in MCION register is supported. \;Bit 8: beacon_capability_disable - If set, beacon feature, as appears in MLCR register, in not supported by the device. \;Bit 9: dynamic_tx_overflow - If set, tx_overflow_sense field is supported in MPEGC register. \;Bit 10: mark_tx_action_cqe is supported if set to &apos;1&apos;.\;Bit 11: mark_tx_action_cnp is supported if set to &apos;1&apos;.\;Bit 12: dev_info is supported in  register is set to &apos;1&apos;.\;Bit 13: sensor_count field is 12bit size in MTMP and MTBR\;Bit 14: cs_tokens_supported is supported \;Bit 15: debug_fw_tokens_supported\;Bit 16: long_keys is supported \;Bit 17: pwr_status and pci_power are supported in MPEIN\;Bit 18: If set, accessing through device_type and device_index is supported in MCC, MCQI and MCQS\;Bit 19: pcie_sync_for_fw_update_supported is set to &apos;1&apos;\;Bit 20: ptpCyc2Realtime_modify - If set, the cycle to realtime translation offload is supported\;Bit 21: If set to &apos;1&apos;, reset_state in MFRL is supported\;Bit 22: If set to &apos;1&apos;, link_peer_max_speed is supported in MPEIN Register\;Bit 23: If set to &apos;1&apos;, slot_index field is supported in: MCIA, MCAS, MCION, MQSP, MTCAP, MTECR, MTMP, MTEWE, MTBR, MVCAP, MVCR, MGPIR, MDDT, MDCR.\;Bit 24: If set, transceiver burn flow is supported in MCC, MCQI and MCQS.\;Bit 26: If set, progress field is supported in MCQS\;Bit 28: If set, number_of_slots field is supported in MGPIR.\;Bit 29: If set, virtual hot plug / unplug is supported in MPEGC.\;Bit 30: If set, my_pf_number is supported in MPPF.\;Bit 31: If set, sdee is supported in MTMP\;Bit 34: If set, MCIA supports 32 D-words. Otherwise, 12 D-words.\;Bit 35: If set, MGIR.hw_info.technology is supported. \;Bit 37: If set, lp_msb is supported for MLCR, MPIR Bit 39: If set, MRCS and RMDT tokens are supported in MCQS\;Bit 40: If set, &apos;encryption&apos; field in MGIR is supported\;Bit 43: If set, MFCR supports tacho_active_msb field\;Bit 44: If set, FORE supports fan_under_limit_msb and fan_over_limit_msb fields\;Bit 45: If set, MFRL.pci_rescan_required is supported\;Bit 46: time_adjust_range_extended - if set, the MTUTC.time_adjustment range is extended to -200,000 to +200,000\;Bit 47: If set, MTUTC.freq_adj_units=1 is supported\;Bit 48: If set, MRSR.command=6 is supported\;Bit 49: If set, MCQS.identifier support CRCS and CRDT tokens\;Bit 51: If set, MTUTC.freq_adj_units=2 is supported\;\;Bit 53: If set, Mlx mlxfwreset with downstream port is supported by FW [Internal]: NIC only, FW rejects reset till user committed that traffic is disabled\;\;Bit 59: If set, MCC.component_specific_error_code is valid for LinkX devices" access="RO" high_bound="3" low_bound="0" offset="0x28.0" size="0x10.0" />
+</node>
+
+<node name="mcia_ext" descr="" size="0x94.0" >
+	<field name="status" descr="Module Status\;0: SUCCESS\;1: NO_EEPROM_MODULE. No response from module&apos;s EEPROM.\;2: MODULE_NOT_SUPPORTED. Module type not supported by the device. 3: MODULE_NOT_CONNECTED. No module present indication. \;4: MODULE_TYPE_INVALID - module is not supported by INI. \;\;9: I2C_ERROR. Error occurred while trying to access the module&apos;s EEPROM using I2C.\;16: MODULE_DISABLED - module is disabled \;" access="RO" offset="0x0.0" size="0x0.8" />
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x0.12" size="0x0.4" />
+	<field name="module" descr="Module number\;\;" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="pnv" descr="[DWIP]:\;Page Number Valid\;0: write page number\;1: don&apos;t write page number\;Valid only if module is in SW control" access="OP" offset="0x0.29" size="0x0.1" />
+	<field name="l" descr="Lock Page bit. \;When bit is set, FW can access the last accessed page.\;After boot and ISSU, default value is 0.\;\;" access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="device_address" descr="Device address" access="INDEX" offset="0x4.0" size="0x0.16" />
+	<field name="page_number" descr="Page number\;Reserved when MCIA.l = 1 or when MCIA.pnv = 0" access="INDEX" offset="0x4.16" size="0x0.8" />
+	<field name="i2c_device_address" descr="I2C device address\;" access="INDEX" offset="0x4.24" size="0x0.8" />
+	<field name="size" descr="Number of bytes to read/write (up to 128 bytes)" access="INDEX" offset="0x8.0" size="0x0.16" />
+	<field name="bank_number" descr="Bank number" access="INDEX" offset="0x8.16" size="0x0.8" />
+	<field name="passwd_length" descr="0: password length is 4B (password_msb is reserved)\;1: password length is 8B (password_msb is used)" access="OP" offset="0x8.28" size="0x0.1" />
+	<field name="password" descr="The password that is written to the module password field.\;This field is reserved when passwd_cap is not set to 1. \;Reserved when module is in SW control." access="OP" offset="0xC.0" size="0x4.0" />
+	<field name="dword" descr="Bytes to read/write\;Note: some FW versions support only 12*4B\;See MCAM bit34" access="RW" high_bound="31" low_bound="0" offset="0x10.0" size="0x80.0" />
+	<field name="password_msb" descr="password msb\;Supported only when MCAM bit34 is set\;Supported only when passwd_cap is set\;Reserved when passwd_length = 0" access="RW" offset="0x90.0" size="0x4.0" />
+</node>
+
+<node name="mcion_ext" descr="" size="0x10.0" >
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x0.12" size="0x0.4" />
+	<field name="module" descr="Module number\;\;" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="module_status_bits" descr="Module IO status, as defined by SFF and CMIS:\;Bit 0: Present\;Bit 1: RX_LOS\;Bit 2: TX_Fault\;Bit 6: LPMode\;[DWIP] Bit 7: Interrupt (IntL)\;Bit 8: Low Power Mode Status \;[DWIP] Bit 9: Power Good\;If bit 0 (Present) is clear, all other bits are reserved." access="RO" offset="0x4.0" size="0x0.16" />
+	<field name="module_inputs" descr="[DWIP][SwitchOnly]\;Module inputs: \;Bit 0: ResetL - low polarity\;Bit 1: LPMode\;Bit 2: Power Enable\;Reserved when module is controlled by FW" access="RW" offset="0xC.0" size="0x0.4" />
+	<field name="module_status_bits_valid" descr="[DWIP][SwitchOnly]\;Module Inputs Valid Bitmask\;Bitmask which mentions the validity of module_inputs fields.\;For each bit, 0 means valid, 1 means not valid.\;For example:\;Bit 0: if set, present bit value is ignored. If cleared, value is valid.\;Bit 1: if set, rx loss value is ignored. when cleared, value is valid and so on for all bits mentioned in module_inputs.\;Reserved when module is controlled by FW" access="RO" offset="0xC.16" size="0x0.16" />
+</node>
+
+<node name="mdrcr_ext" descr="" size="0x30.0" >
+	<field name="device_type" descr="Peripheral device type\;1: Gearbox\;" access="INDEX" offset="0x0.0" size="0x0.8" />
+	<field name="device_index" descr="Device number \;For gearboxes, the index represents the gearbox die." access="INDEX" offset="0x4.0" size="0x0.12" />
+	<field name="all" descr="All devices are selected and device_index is ignored\;When set to &apos;1&apos;, the rst_status should represent the worst case of any of the devices." access="INDEX" offset="0x4.31" size="0x0.1" />
+	<field name="rst_op" descr="Reset Operation.\;0: Query of the reset status which is displayed through rst_status.\;1: Full Reset of the selected device(s).\;2-8: Reserved." access="RW" offset="0xC.0" size="0x0.3" />
+	<field name="rst_status" descr="Reset status.\;0: Reset completed successfully. 1: Reset operation has not finished yet." access="RO" offset="0xC.16" size="0x0.4" />
+</node>
+
+<node name="mgcr_reg_ext" descr="" size="0x20.0" >
+	<field name="segment" descr="The GPIO segment which the command&apos;s parameters apply" access="INDEX" offset="0x0.0" size="0x0.8" />
+	<field name="segments_count" descr="Ceiling function of total number of GPIOs / 32 in the system." access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="GPIO_data_in" descr="Input value of accessible GPIO[i] signals.\;When GPIO_access_en[i] = 0, GPIO_data_in[i] always returns 0" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="GPIO_data_out" descr="Output value of accessible GPIO signals.\;When GPIO_access_en[i] = 0, GPIO_data_out[i] always returns 0" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="GPIO_set" descr="These 2 fields are used together to control GPIO signals in the following manner:\;GPIO_set[i]=0, GPIO_clear[i]=0 : GPIO_data_out[i] = No Change\;GPIO_set[i]=0, GPIO_clear[i]=1 : GPIO_data_out[i] = 0\;GPIO_set[i]=1, GPIO_clear[i]=0 : GPIO_data_out[i] = 1\;GPIO_set[i]=1, GPIO_clear[i]=1 : GPIO_data_out[i] = not(GPIO_data_out[i])\;Ignored for non-controllable GPIO signals." access="WO" offset="0xC.0" size="0x4.0" />
+	<field name="GPIO_clear" descr="These 2 fields are used together to control GPIO signals in the following manner:\;GPIO_set[i]=0, GPIO_clear[i]=0 : GPIO_data_out[i] = No Change\;GPIO_set[i]=0, GPIO_clear[i]=1 : GPIO_data_out[i] = 0\;GPIO_set[i]=1, GPIO_clear[i]=0 : GPIO_data_out[i] = 1\;GPIO_set[i]=1, GPIO_clear[i]=1 : GPIO_data_out[i] = not(GPIO_data_out[i])\;Ignored for non-controllable GPIO signals." access="WO" offset="0x10.0" size="0x4.0" />
+	<field name="GPIO_access_en" descr="Access allowance to the corresponding GPIO signal.\;0: GPIO[i] is not observable / controllable by the host SW.\;1: GPIO[i] is observable / controllable by the host SW." access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="direction" descr="0: GPIO[i] is an input only signal\;1: GPIO[i] is an output signal. Data out can be updates by the host SW and data in can be queried by the host SW.\;For non-accessible GPIOs, the corresponding value is 0." access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="drive_type" descr="0: GPIO[i] is an open drain output. The device can only drive the GPIO[i] output pin low when GPIO_data_out[i] is 0. When GPIO_data_out[i] is 1, GPIO[i] is in HighZ. \;1: GPIO[i] is a full-drive output pin\;When GPIO_access_en[i] =0, direction[i] and drive_type[i] are always read as 0." access="RO" offset="0x1C.0" size="0x4.0" />
+</node>
+
+<node name="mgir_dev_info_ext" descr="" size="0x1c.0" >
+	<field name="dev_branch_tag" descr="The format of the string represented by ASCII." access="RO" high_bound="27" low_bound="0" offset="0x0.24" size="0x1c.0" />
+</node>
+
+<node name="mgir_ext" descr="" size="0xa0.0" >
+	<field name="hw_info" descr="Hardware Information, see Table 647, &quot;Hardware Info Layout,&quot; on page 917" subnode="mgir_hardware_info_ext" access="RW" offset="0x0.0" size="0x20.0" />
+	<field name="fw_info" descr="Firmware Information, see Table 650, &quot;Firmware Info Layout,&quot; on page 921" subnode="mgir_fw_info_ext" access="RW" offset="0x20.0" size="0x40.0" />
+	<field name="sw_info" descr="Software Information, see Table 652, &quot;Software Info Layout,&quot; on page 924\;This field indicates the oldest software version compatible with the current firmware" subnode="mgir_sw_info_ext" access="RW" offset="0x60.0" size="0x20.0" />
+	<field name="dev_info" descr="Development Information, see Table 656, &quot;Development Info Layout,&quot; on page 928" subnode="mgir_dev_info_ext" access="RW" offset="0x80.0" size="0x1c.0" />
+</node>
+
+<node name="mgir_fw_info_ext" descr="" size="0x40.0" >
+	<field name="sub_minor" descr="Sub-minor firmware version number.\;Deprecated and returns &apos;0&apos;. \;Refer to extended_sub_minor." access="RO" offset="0x0.0" size="0x0.8" />
+	<field name="minor" descr="Minor firmware version number.\;Deprecated and returns &apos;0&apos;. \;Refer to extended_minor." access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="major" descr="Major firmware version number.\;Deprecated and returns &apos;0&apos;. \;Refer to extended_major." access="RO" offset="0x0.16" size="0x0.8" />
+	<field name="secured" descr="When set, the device is running firmware with secure-firmware updates capabilities." access="RO" offset="0x0.24" size="0x0.1" />
+	<field name="signed_fw" descr="When set the device is running a signed FW binaries." access="RO" offset="0x0.25" size="0x0.1" />
+	<field name="debug" descr="When set, the device is running a debug firmware. &apos;debug&apos; binary can only be installed on specific devices (identified by their &apos;Factory base MAC&apos;), which currently run a specific firmware version. These restrictions are expressed by a signed &apos;debug&apos; token that must be loaded to the device before installing the debug binary." access="RO" offset="0x0.26" size="0x0.1" />
+	<field name="dev" descr="*NOTE* this field has diff meaning for Switch vs. NIC \;\;\;\;\;" access="RO" offset="0x0.27" size="0x0.1" />
+	<field name="string_tlv" descr="When set, string-TLV is supported.\;For Retimer - always return 0 (not supported)." access="RO" offset="0x0.28" size="0x0.1" />
+	<field name="dev_sc" descr="*NOTE* for NICs same as dev field\;Development-secure:\;The device is running:\;0: a regular-secure firmware version\;1: a development-secure firmware version" access="RO" offset="0x0.30" size="0x0.1" />
+	<field name="build_id" descr="Firmware Build ID. Optional. ." access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="year" descr="Firmware installation date. \;\;For example: 3 May 2004 will be coded as Month= 0x05, Day= 0x03, and Year= 0x04" access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="day" descr="Firmware installation date. \;\;For example: 3 May 2004 will be coded as Month= 0x05, Day= 0x03, and Year= 0x04" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="month" descr="Firmware installation date. \;\;For example: 3 May 2004 will be coded as Month= 0x05, Day= 0x03, and Year= 0x04" access="RO" offset="0x8.24" size="0x0.8" />
+	<field name="hour" descr="Firmware installation hour.\;For example 17:43 will be coded as 0x1743" access="RO" offset="0xC.0" size="0x0.16" />
+	<field name="psid" descr="FW PSID" access="RO" high_bound="15" low_bound="0" offset="0x10.24" size="0x10.0" />
+	<field name="ini_file_version" descr="User-configured version number of the current INI file." access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="extended_major" descr="FW version&apos;s Major field in extended (32b) format." access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="extended_minor" descr="FW version&apos;s Minor field in extended (32b) format." access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="extended_sub_minor" descr="FW version&apos;s SubMinor field in extended (32b) format." access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="isfu_major" descr="incremented by one when version is not ISSUable" access="RO" offset="0x30.0" size="0x0.16" />
+	<field name="disabled_tiles_bitmap" descr="Bitmap representing the disabled tiles in the ASIC. Tile &apos;0&apos; is represented by the msb bit. \;0: tile is enabled\;1: tile is disabled\;\;The total number of tiles can be derived through MGPIR register." access="RO" offset="0x30.16" size="0x0.16" />
+	<field name="life_cycle" descr="0: Production\;1: GA Secured\;2: GA Non-Secured\;3: RMA" access="RO" offset="0x34.0" size="0x0.2" />
+	<field name="sec_boot" descr="0: Disable\;1: Enable" access="RO" offset="0x34.2" size="0x0.1" />
+	<field name="encryption" descr="0: Disable\;1: Enable" access="RO" offset="0x34.3" size="0x0.1" />
+	<field name="issu_able" descr="[DWIP]\;ISSU-able:\;0: not ISSUable\;1: ISSUable\;Supported from Quantum-3 and on\;Supported for Retimers\;Based on FW decisions: fuse, INI, NV and version on flash vs. running version" access="RO" offset="0x34.13" size="0x0.1" />
+</node>
+
+<node name="mgir_hardware_info_ext" descr="" size="0x20.0" >
+	<field name="device_id" descr="PCI device ID." access="RO" offset="0x0.0" size="0x0.16" />
+	<field name="device_hw_revision" descr="See Table 649, &quot;Device HW Revision Descriptions,&quot; on page 919" access="RO" offset="0x0.16" size="0x0.16" />
+	<field name="pvs" descr="Process Voltage Scaling\;Supported nominal V_CORE voltage (in 50mV units) for the device." access="RO" offset="0x4.0" size="0x0.5" />
+	<field name="technology" descr="Process technology\;0: N/A\;1: 40nm\;2: 28nm\;3: 16nm\;4: 7nm\;5: 5nm\;6-31: Reserved" access="RO" offset="0x4.11" size="0x0.5" />
+	<field name="num_ports" descr="Number of physical port the device supports.\;For Retimer: returns the number of data path \;" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="ib_mad_gen" descr="[DWIP]\;IB MAD Protocol. Based on value from ConfigProfile\;0: IBg1\;1: IBg2\;2-7: Reserved" access="RO" offset="0x4.28" size="0x0.3" />
+	<field name="hw_dev_id" descr="The PCI device-ID of the NIC/HCA in recovery (Livefish) mode." access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="chassis_slot_index" descr="[DWIP]\;Slot index\;Info provided from the chassis EEPROM (FRU) if exists." access="RO" offset="0xC.0" size="0x0.8" />
+	<field name="chassis_module_id" descr="[DWIP]\;Chassis Module Id\;Info provided from the chassis EEPROM (FRU) if exists." access="RO" offset="0xC.16" size="0x0.8" />
+	<field name="cfiv" descr="[DWIP]\;Chassis FRU Info Valid bit\;chassis_module_id and chassis_slot_index are valid" access="RO" offset="0xC.31" size="0x0.1" />
+	<field name="manufacturing_base_mac_47_32" descr="MSB of the &quot;base&quot; MAC address of the NIC that was allocate during manufacturing. The NIC derives the MAC addresses for the different PCI PFs from this MAC address. This parameter can be used as a canonical unique identifier of the NIC.\;manufacturing_base_mac of value 0 means field is not supported." access="RO" offset="0x10.0" size="0x0.16" />
+	<field name="ga" descr="[DWIP]\;Geographical Address\;0: ASIC 0\;1: ASIC 1\;2: ASIC 2\;3: ASIC 3\;Valid for multi ASIC platforms only" access="RO" offset="0x10.16" size="0x0.6" />
+	<field name="chip_type" descr="[DWIP]\;Chip Type\;0: Real chip\;1: Emulation\;2: ChipSim\;3: SimX \;Supported from Quantum-3 and ArcusE" access="RO" offset="0x10.24" size="0x0.4" />
+	<field name="manufacturing_base_mac_31_0" descr="LSB of the &quot;base&quot; MAC address of the NIC that was allocate during manufacturing. The NIC derives the MAC addresses for the different PCI PFs from this MAC address. This parameter can be used as a canonical unique identifier of the NIC.\;manufacturing_base_mac of value 0 means field is not supported." access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="uptime" descr="Time (in secs.) since last reset0" access="RO" offset="0x1C.0" size="0x4.0" />
+</node>
+
+<node name="mgir_sw_info_ext" descr="" size="0x20.0" >
+	<field name="sub_minor" descr="Sub-minor Driver version number.\;" access="RO" offset="0x0.0" size="0x0.8" />
+	<field name="minor" descr="Minor Driver version number.\;" access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="major" descr="Major Driver version number.\;" access="RO" offset="0x0.16" size="0x0.8" />
+	<field name="rom3_type" descr="ROM 3 type:\;0x0: none\;0x1: Flexboot\;0x2: UEFI\;0x3: UEFI-CLP\;0x4: NVME\;0x5: FCODE\;0x6: UEFI Virtio net\;0x7: UEFI Virtio blk\;0x8: PXE Virtio net\;0x9-0xF: Reserved" access="RO" offset="0x4.0" size="0x0.4" />
+	<field name="rom3_arch" descr="Arch type of ROM 3:\;0x0: unspecified\;0x1: AMD64 - x86 64bit architecture\;0x2: AARCH64 - ARM Architecture 64 bits\;0x3: AMD64_AARCH64 - ROM code supporting both AMD64 and AARCH64 architectures\;0x4: IA32 - Intel Architecture 32 bits" access="RO" offset="0x4.4" size="0x0.4" />
+	<field name="rom2_type" descr="ROM 2type:\;0x0: none\;0x1: Flexboot\;0x2: UEFI\;0x3: UEFI-CLP\;0x4: NVME\;0x5: FCODE\;0x6: UEFI Virtio net\;0x7: UEFI Virtio blk\;0x8: PXE Virtio net\;0x9-0xF: Reserved" access="RO" offset="0x4.8" size="0x0.4" />
+	<field name="rom2_arch" descr="Arch type of ROM 2:\;0x0: unspecified\;0x1: AMD64 - x86 64bit architecture\;0x2: AARCH64 - ARM Architecture 64 bits\;0x3: AMD64_AARCH64 - ROM code supporting both AMD64 and AARCH64 architectures\;0x4: IA32 - Intel Architecture 32 bits" access="RO" offset="0x4.12" size="0x0.4" />
+	<field name="rom1_type" descr="ROM 1type:\;0x0: none\;0x1: Flexboot\;0x2: UEFI\;0x3: UEFI-CLP\;0x4: NVME\;0x5: FCODE\;0x6: UEFI Virtio net\;0x7: UEFI Virtio blk\;0x8: PXE Virtio net\;0x9-0xF: Reserved" access="RO" offset="0x4.16" size="0x0.4" />
+	<field name="rom1_arch" descr="Arch type of ROM 1:\;0x0: unspecified\;0x1: AMD64 - x86 64bit architecture\;0x2: AARCH64 - ARM Architecture 64 bits\;0x3: AMD64_AARCH64 - ROM code supporting both AMD64 and AARCH64 architectures\;0x4: IA32 - Intel Architecture 32 bits" access="RO" offset="0x4.20" size="0x0.4" />
+	<field name="rom0_type" descr="ROM 0 type:\;0x0: none\;0x1: Flexboot\;0x2: UEFI\;0x3: UEFI-CLP\;0x4: NVME\;0x5: FCODE\;0x6: UEFI Virtio net\;0x7: UEFI Virtio blk\;0x8: PXE Virtio net\;0x9-0xF: Reserved" access="RO" offset="0x4.24" size="0x0.4" />
+	<field name="rom0_arch" descr="Arch type of ROM 0:\;0x0: unspecified\;0x1: AMD64 - x86 64bit architecture\;0x2: AARCH64 - ARM Architecture 64 bits\;0x3: AMD64_AARCH64 - ROM code supporting both AMD64 and AARCH64 architectures\;0x4: IA32 - Intel Architecture 32 bits" access="RO" offset="0x4.28" size="0x0.4" />
+	<field name="rom0_version" descr="ROM 0 version." subnode="rom_version_ext" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="rom1_version" descr="ROM 1 version." subnode="rom_version_ext" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="rom2_version" descr="ROM 2version." subnode="rom_version_ext" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="rom3_version" descr="ROM 3 version." subnode="rom_version_ext" access="RO" offset="0x14.0" size="0x4.0" />
+</node>
+
+<node name="mmdio_ext" descr="" size="0xc.0" >
+	<field name="operation" descr="0 - NOP\;1 - Address (reserved for Clause 22)\;2 - Read\;3 - Write\;4 - Post Read Increment Address (reserved for Clause 22)\;6 - Address + Read - Generates Address cycle and then Read cycle in Clause 45 (reserved for Clause 22)\;7 - Address + Write - Generates Address cycle and then Write cycle in Clause 45 (reserved for Clause 22)" access="WO" offset="0x0.0" size="0x0.3" />
+	<field name="clause" descr="MDIO Definition:\;0 - Clause 22\;1 - Clause 45" access="WO" offset="0x0.8" size="0x0.2" />
+	<field name="mdio_index" descr="Selection of the MDIO interface" access="INDEX" offset="0x0.16" size="0x0.4" />
+	<field name="reg_adr" descr="Reg Address (Clause 22) / Dev Type (Clause 45)" access="RW" offset="0x4.0" size="0x0.5" />
+	<field name="phy_adr" descr="PHY Address (PHYAD)" access="RW" offset="0x4.8" size="0x0.5" />
+	<field name="data" descr="Data (Clause 22) / Address/Data (Clause 45)" access="RW" offset="0x8.0" size="0x0.16" />
+	<field name="address" descr="Address (Clause 45)\;This field is only valid for Address + Read and Address + Write operations, providing the address. For other Clause 45 operations the data field provides the address when appropriate." access="RW" offset="0x8.16" size="0x0.16" />
+</node>
+
+<node name="module_latched_flag_info_ext" descr="" size="0xf8.0" >
+	<field name="rx_los_cap" descr="when set, indicates modules supports rx los indication" access="RO" offset="0x0.0" size="0x0.1" />
+	<field name="dp_fw_fault" descr="Valid for CMIS based modules only\;Latched modules Datapath fw fault flag" access="RO" offset="0x0.22" size="0x0.1" />
+	<field name="mod_fw_fault" descr="Valid for CMIS based modules only\;Latched module fw fault flag" access="RO" offset="0x0.23" size="0x0.1" />
+	<field name="vcc_flags" descr="Latched VCC flags of module\;Bit 0: high_vcc_alarm\;Bit 1: low_vcc_alarm\;Bit 2: high_vcc_warning\;Bit 3: low_vcc_warning" access="RO" enum="high_vcc_alarm=0x1,low_vcc_alarm=0x2,high_vcc_warning=0x4,low_vcc_warning=0x8" offset="0x0.24" size="0x0.4" />
+	<field name="temp_flags" descr="Latched temperature flags of module\;Bit 0: high_temp_alarm\;Bit 1: low_temp_alarm\;Bit 2: high_temp_warning\;Bit 3: low_temp_warning" access="RO" enum="high_temp_alarm=0x1,low_temp_alarm=0x2,high_temp_warning=0x4,low_temp_warning=0x8" offset="0x0.28" size="0x0.4" />
+	<field name="tx_ad_eq_fault" descr="Reserved for SFP\;Bitmask for latched Tx adaptive equalization fault flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x4.0" size="0x0.8" />
+	<field name="tx_cdr_lol" descr="Bitmask for latched Tx cdr loss of lock flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x4.8" size="0x0.8" />
+	<field name="tx_los" descr="Reserved for SFP\;Bitmask for latched Tx loss of signal flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="tx_fault" descr="Bitmask for latched Tx fault flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x4.24" size="0x0.8" />
+	<field name="tx_power_lo_war" descr="Bitmask for latched Tx power low warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="tx_power_hi_war" descr="Bitmask for latched Tx power high warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x8.8" size="0x0.8" />
+	<field name="tx_power_lo_al" descr="Bitmask for latched Tx power low alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="tx_power_hi_al" descr="Bitmask for latched Tx power high alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x8.24" size="0x0.8" />
+	<field name="tx_bias_lo_war" descr="Bitmask for latched Tx bias low warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0xC.0" size="0x0.8" />
+	<field name="tx_bias_hi_war" descr="Bitmask for latched Tx bias high warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0xC.8" size="0x0.8" />
+	<field name="tx_bias_lo_al" descr="Bitmask for latched Tx bias low alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0xC.16" size="0x0.8" />
+	<field name="tx_bias_hi_al" descr="Bitmask for latched Tx bias high alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0xC.24" size="0x0.8" />
+	<field name="rx_cdr_lol" descr="Bitmask for latched Rx cdr loss of lock flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x10.16" size="0x0.8" />
+	<field name="rx_los" descr="Bitmask for latched Rx loss of signal flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x10.24" size="0x0.8" />
+	<field name="rx_power_lo_war" descr="Bitmask for latched Rx power low warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x14.0" size="0x0.8" />
+	<field name="rx_power_hi_war" descr="Bitmask for latched Rx power high warning flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x14.8" size="0x0.8" />
+	<field name="rx_power_lo_al" descr="Bitmask for latched Rx power low alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x14.16" size="0x0.8" />
+	<field name="rx_power_hi_al" descr="Bitmask for latched Rx power high alarm flag per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x14.24" size="0x0.8" />
+	<field name="rx_output_valid_change" descr="Bitmask for latched rx output valid change per lane.\;Bit 0 - lane 0 ... Bit 7 - lane 7" access="RO" offset="0x18.0" size="0x0.8" />
+</node>
+
+<node name="mpscr_ext" descr="" size="0x20.0" >
+	<field name="warning_inactive_time" descr="Thermal Throttling (FW mode) warning inactive time\;Each unit is equivalent to 100uSec\;Reserved for Switch.\;" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="warning_active_time" descr="Thermal Throttling (FW mode) warning active time\;Each unit is equivalent to 100uSec\;Reserved for Switch.\;" access="RW" offset="0x4.16" size="0x0.8" />
+	<field name="critical_inactive_time" descr="Thermal Throttling (FW mode) critical inactive time\;Each unit is equivalent to 100uSec\;Reserved for Switch.\;" access="RW" offset="0x8.0" size="0x0.8" />
+	<field name="critical_active_time" descr="Thermal Throttling (FW mode) critical active time\;Each unit is equivalent to 100uSec\;Reserved for Switch.\;" access="RW" offset="0x8.16" size="0x0.8" />
+	<field name="cc" descr="Clear Counters\;0: Don&apos;t clear MTSR counters\;1: Clear MTSR counters\;Reserved for Switch." access="OP" offset="0x10.0" size="0x0.1" />
+	<field name="queue_depth_th" descr="[DWIP][SwitchOnly]:\;Queue Depth Threshold\;Defines the threshold that above it we move to L1 Idle (not in desire).\;Relevant for normal queues only (high-priority queues are considered empty only if the queue has no PCB line usage at all).\;For Quantum-3: Units of 64Bytes\;\;Relevant for switches only. Unit are line of PCB" access="RW" offset="0x14.0" size="0x0.16" />
+</node>
+
+<node name="mtcap_ext" descr="" size="0x10.0" >
+	<field name="sensor_count" descr="Number of ASIC+platform sensors supported by the device \;This includes the ASIC and the ambient sensors. Module sensors are not included.\;This actually is equal to sum of all &apos;1&apos; in sensor_map\;Range 1..64\;\;Known sensors:\;0: current asic temp, FW exposes current max(all diode temp sensors)\;1..63: ambient, supported only for unmanaged switch, defined by ini\;64..127: modules (not exposed by this field)" access="RO" offset="0x0.0" size="0x0.7" />
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x0.16" size="0x0.4" />
+	<field name="internal_sensor_count" descr="Number of sensors supported by the device that are on the ASIC.\;Exposes how many ASIC diodes exist. \;The FW exposes all of them as sensor[0]" access="RO" offset="0x4.0" size="0x0.7" />
+	<field name="sensor_map" descr="Mapping of system sensors supported by the device. Only ASIC and ambient sensors are supported. Each bit represents a sensor.\;Per bit:\;0: Not_connected_or_not_supported\;1: Supports_temperature_measurements" subnode="uint64" access="RO" offset="0x8.0" size="0x8.0" />
+</node>
+
+<node name="mtecr_ext" descr="" size="0x60.0" >
+	<field name="sensor_count" descr="Number of sensors supported by the ASIC+platform\;This includes the ASIC, ambient sensors, module sensors, Gearboxes etc. \;This actually is equal to sum of all &apos;1&apos; in sensor_map\;\;Known sensors:\;0: current asic temp, FW exposes current max(all diode temp sensors)\;1..62: ambient, supported only for unmanaged switch, defined by ini\;64..255: modules\;256..288: Gearbox\;289..704: reserved for future" access="RO" offset="0x0.0" size="0x0.12" />
+	<field name="last_sensor" descr="Last sensor index that is available in the system to read from.\;e.g. when 32modules: 64+32-1 = 95" access="RO" offset="0x0.16" size="0x0.12" />
+	<field name="internal_sensor_count" descr="Number of sensors supported by the device that are on the ASIC. \;Exposes how many ASIC diodes exist. \;The FW exposes all of them as sensor[0]" access="RO" offset="0x4.0" size="0x0.7" />
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x4.28" size="0x0.4" />
+	<field name="sensor_map" descr="Mapping of system sensors supported by the device. Each bit represents a sensor.\;This field is size variable based on the last_sensor field and in granularity of 32bits.\;Per bit:\;0: Not connected or not supported\;1: Supports temperature measurements\;\;In case of last_sensor = 704 (22*32):\;sensor_warning[0] bit31 is sensor_warning[703]\;sensor_warning[0] bit0 is sensor_warning[703-31]\;sensor_warning[21] bit31 is sensor_warning[31]\;sensor_warning[21] bit0 is sensor_warning[0]\;\;In case if last_sensor = 259 (22*32):\;Note: roundup(259,32)=288\;sensor_warning[0] bit31 is sensor_warning[287]\;sensor_warning[0] bit0 is sensor_warning[287-31=256]\;sensor_warning[8] bit31 is sensor_warning[31]\;sensor_warning[8] bit0 is sensor_warning[0]\;sensor_warning[9..21] are not used\;\;64-192 of sensor_index are mapped to the modules sequentially (module 0 is mapped to sensor_index 64, module 1 to sensor_index 65 and so on)." access="RO" high_bound="21" low_bound="0" offset="0x8.0" size="0x58.0" />
+</node>
+
+<node name="mteim_reg_ext" descr="" size="0x30.0" >
+	<field name="cap_core_tile" descr="Number of processors per tile ASIC." access="RO" offset="0x0.0" size="0x0.8" />
+	<field name="cap_core_main" descr="Number of processors in the main ASIC." access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="cap_core_dpa" descr="Number of processors in the DPA unit." access="RO" offset="0x0.16" size="0x0.8" />
+	<field name="cap_num_of_tile" descr="Number of tiles per device. For devices without tiles (only main ASIC), this field should be &apos;0&apos;." access="RO" offset="0x0.24" size="0x0.8" />
+	<field name="type_core_tile" descr="Processor type.\;0: N/A\;1: IRISC\;2: RISC5\;Else: Reserved" access="RO" offset="0x4.0" size="0x0.4" />
+	<field name="type_core_main" descr="Processor type.\;0: N/A\;1: IRISC\;2: RISC5\;Else: Reserved" access="RO" offset="0x4.4" size="0x0.4" />
+	<field name="type_core_dpa" descr="Processor type.\;0: N/A\;1: IRISC\;2: RISC5\;Else: Reserved" access="RO" offset="0x4.8" size="0x0.4" />
+	<field name="is_phy_uc_supported" descr="Indicates wether Phy_UC tracers mapping are supported by the device FW. \;When set, The event_id of the Phy UC of the instance will be calculated by first_tile/main _core _event_id[i] + cap_core_tile/main.\;When clear the Phy UC will be ignored." access="RO" offset="0x4.30" size="0x0.1" />
+	<field name="is_dwsn_msb_supported" descr="When set to &apos;1&apos;, the device supports dwsn_msb bit within the FW trace layout." access="RO" offset="0x4.31" size="0x0.1" />
+	<field name="first_dpa_core_event_id" descr="The mapping for the rest of the DPA ASIC processors are sequential and the mapping is defined as:\;processor[x]=first_dpacore_event_id+x" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="first_main_core_event_id" descr="The mapping for the rest of the main ASIC processors are sequential and the mapping is defined as:\;processor[x]=first_main_core_event_id+x" access="RO" offset="0x8.24" size="0x0.8" />
+	<field name="first_tile_core_event_id" descr="The mapping for the rest of the tile[y] ASIC processors are sequential and the mapping is defined as:\;processor[x]=first_tile_core_event_id[y]+x" access="RO" high_bound="7" low_bound="0" offset="0xC.24" size="0x8.0" />
+</node>
+
+<node name="mtewe_ext" descr="" size="0x5c.0" >
+	<field name="sensor_count" descr="Number of sensors supported by the device\;This includes the ASIC, ambient sensors, Gearboxes etc." access="RO" offset="0x0.0" size="0x0.12" />
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x0.12" size="0x0.4" />
+	<field name="last_sensor" descr="Last sensor index that is available in the system to read from." access="RO" offset="0x0.16" size="0x0.12" />
+	<field name="sensor_warning" descr="Bit vector indicating which of the sensor reading is above threshold.\;This field is size dependent and based on last_sensor field and in granularity of 32bits.\;\;In case of last_sensor = 704 (22*32):\;sensor_warning[0] bit31 is sensor_warning[703]\;sensor_warning[0] bit0 is sensor_warning[703-31]\;sensor_warning[21] bit31 is sensor_warning[31]\;sensor_warning[21] bit0 is sensor_warning[0]\;\;In case if last_sensor = 259 (22*32):\;Note: roundup(259,32)=288\;sensor_warning[0] bit31 is sensor_warning[287]\;sensor_warning[0] bit0 is sensor_warning[287-31=256]\;sensor_warning[8] bit31 is sensor_warning[31]\;sensor_warning[8] bit0 is sensor_warning[0]\;sensor_warning[9..21] are not used" access="RO" high_bound="21" low_bound="0" offset="0x4.0" size="0x58.0" />
+</node>
+
+<node name="mtie_ext" descr="" size="0x30.0" >
+	<field name="enable_all" descr="Enable/Disable all FW tracer initiator and ignore mask.\;Starts from bit 0.\;0: Use bit mask\;1: Enable all\;2: Disable all" access="OP" offset="0x0.0" size="0x0.2" />
+	<field name="log_delay" descr="Adding delay to log events in usecs\;" access="RW" offset="0x4.0" size="0x0.16" />
+	<field name="source_id_bitmask" descr="Bit mask of all the possible tracer initiators.\;Reserved when enable_all != 0.\;The mapping of source id to HW unit is unique per device and can be fetched from FW code.\;" access="RW" high_bound="7" low_bound="0" offset="0x10.0" size="0x20.0" />
+</node>
+
+<node name="mtim_ext" descr="" size="0x10.0" >
+	<field name="log_level" descr="The verbosity of the log. \;0: LOG_DEBUG\;1: LOG_INFO\;2: LOG_WARNING\;3: LOG_ERROR\;\;The lower value reflects higher verbosity than higher value.\;e.g: LOG_INFO contains LOG_WARNING and LOG_ERROR" access="RW" offset="0x0.0" size="0x0.4" />
+	<field name="log_bit_mask" descr="Bit mask of the different FW units that can be activated for the FW log.\;The mapping of source id to FW unit is unique per device and can be fetched from FW code.\;" access="RW" offset="0x4.0" size="0x4.0" />
+</node>
+
+<node name="mtmp_ext" descr="" size="0x20.0" >
+	<field name="sensor_index" descr="Sensors index\;0: current asic temp, FW exposes current max(all diode temp sensors)\;1..62: ambient, supported only for unmanaged switch, defined by ini\;64..255: modules 256..288: Gearbox\;289..704: reserved for future" access="INDEX" offset="0x0.0" size="0x0.12" />
+	<field name="slot_index" descr="Slot index\;0: Main board" access="INDEX" offset="0x0.16" size="0x0.4" />
+	<field name="temperature" descr="Temperature reading from the sensor. \;Units of 0.125 Celsius degrees.\;For negative values 2&apos;s complement is used (for example: -3.25 Celsius will read as 0xFFE6)" access="RO" offset="0x4.0" size="0x0.16" />
+	<field name="max_temperature" descr="The highest measured temperature from the sensor.\;Reserved when mte = 0\;Cleared by mtr = 1\;Valid only when i = 0\;" access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="sdme" descr="Shut Down Events Modify Set Enable:\;0: all fields are set\;1: only sdee field is set, all other fields reserved" access="OP" offset="0x8.28" size="0x0.1" />
+	<field name="weme" descr="Warning Events Modify Set Enable:\;0: all fields are set\;1: only tee field is set, all other fields reserved" access="OP" offset="0x8.29" size="0x0.1" />
+	<field name="mtr" descr="Max Temperature Reset:\;0: do not modify the value of the max temperature register\;1: clear the value of the max temperature register" access="OP" offset="0x8.30" size="0x0.1" />
+	<field name="mte" descr="Max Temperature Enable:\;0: disable measuring the max temperature on a sensor\;1: enables measuring the max temperature on a sensor" access="RW" offset="0x8.31" size="0x0.1" />
+	<field name="temperature_threshold_hi" descr="temperature_threshold_hi refers to the high threshold of Warning Event. \;If the sensor temperature measurement is above the threshold (and events are enabled), an event will be generated.\;threshold_hi and threshold_lo implements hysteresis mechanism of the threshold preventing toggling of the indication.\;Note that temperature_threshold_hi must be equal or lower than the system requirement.\;System requirement for module is the module warning temperature.\;System requirement for board/silicon sensors is according to product information parameters\;Note that the temperature threshold can be used to generate an event message or an interrupt using GPIO" access="RW" offset="0xC.0" size="0x0.16" />
+	<field name="sdee" descr="Temperature Shut Down Event Enable (MTSDE Register)\;0: do_not_generate_event\;1: generate_event\;2: generate_single_event\;\;Supported in downstream devices (devices on slots)." access="RW" offset="0xC.28" size="0x0.2" />
+	<field name="tee" descr="Temperature Warning Event Enable (MTEWE Register)\;0: do_not_generate_event\;1: generate_event\;2: generate_single_event\;\;" access="RW" enum="do_not_generate_event=0x0,generate_event=0x1,generate_single_event=0x2" offset="0xC.30" size="0x0.2" />
+	<field name="temperature_threshold_lo" descr="temperature_threshold_lo refers to the low threshold of Warning Event. \;The offset threshold_lo implements the lower threshold for the hysteresis mechanism of over temperature alert. Once alert is set, if the temperature goes below this threshold, the alert is cleared.\;Note that temperature_threshold_lo must be at least 5 degrees lower than temperature_threshold_hi" access="RW" offset="0x10.0" size="0x0.16" />
+	<field name="sensor_name_hi" descr="Sensor Name\;8 character long sensor name\;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="sensor_name_lo" descr="Sensor Name\;8 character long sensor name\;" access="RO" offset="0x1C.0" size="0x4.0" />
+</node>
+
+<node name="mtrc_cap_reg_ext" descr="" size="0x84.0" >
+	<field name="num_string_db" descr="Number of different string sections building the database" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="trc_ver" descr="Indicates the version of the tracing mechanism.\;0x0: VER_0\;0x1: VER_1\;Other values are reserved.\;Reserved in Switch" access="RO" offset="0x0.24" size="0x0.2" />
+	<field name="trace_to_memory" descr="When set the device supports logging traces to memory\;0: FIFO Mode\;1: Host Memory Mode" access="RO" offset="0x0.30" size="0x0.1" />
+	<field name="trace_owner" descr="Write 0x1 to register for tracer ownership, write 0x0 to de-register.\;Read value 0x1 indicates tracer ownership is granted.\;Reserved in Switch\;" access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="num_string_trace" descr="The number of consecutive event_id that should be interpreted as a string trace" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="first_string_trace" descr="The lowest event_id that should be interpreted as a string trace" access="RO" offset="0x4.24" size="0x0.8" />
+	<field name="log_max_trace_buffer_size" descr="Log 2 of the maximal size of the trace buffer given in units of 4KB" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="tracer_capabilities" descr="Tracer suppported capbailities bitmask:\;0: FIFO.\;1: MEM mode.\;else, reserved." access="RO" offset="0x8.30" size="0x0.2" />
+	<field name="string_db_param" descr="String DB section parameters." subnode="string_db_parameters_ext" access="RO" high_bound="7" low_bound="0" offset="0x10.0" size="0x40.0" />
+</node>
+
+<node name="mtrc_conf_reg_ext" descr="" size="0x80.0" >
+	<field name="trace_mode" descr="Tracing mode\;0x0: FIFO\;0x1: TRACE_TO_MEMORY\;Other values are reserved." access="RW" offset="0x0.0" size="0x0.4" />
+	<field name="log_trace_buffer_size" descr="Log 2 of the Size of the trace buffer, given in units of 4KB.\;Value should not exceed log_max_trace_buffer_size.\;Valid only for trace_mode TRACE_TO_MEMORY.\;Modifying this parameter after the tracer was active may cause loss of sync regarding the location of the next trace." access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="trace_mkey" descr="MKey registered for the trace buffer access.\;Valid only for trace_mode TRACE_TO_MEMORY.\;Modifying this parameter after the tracer was active may cause loss of sync regarding the location of the next trace.\;Reserved for Switches." access="RW" offset="0x8.0" size="0x4.0" />
+</node>
+
+<node name="mtrc_ctrl_reg_ext" descr="" size="0x40.0" >
+	<field name="modify_field_select" descr="Field select indicated which writable fields to modify\;bit 0: trace_status\;Other bits are reserved." access="WO" offset="0x0.0" size="0x0.16" />
+	<field name="arm_event" descr="When set, an event will be generated if new Tracer events were logged since last event.\;Reserved in Switches." access="WO" offset="0x0.27" size="0x0.1" />
+	<field name="trace_status" descr="Current status of the tracer\;0x0: DISABLED - logging traces is stopped\;0x1: ACTIVE - logging traces is active" access="RW" offset="0x0.30" size="0x0.2" />
+	<field name="current_timestamp_52_32" descr="MSB of the current timesatmp counter" access="RO" offset="0x8.0" size="0x0.21" />
+	<field name="current_timestamp_31_0" descr="LSB of the current timesatmp counter" access="RO" offset="0xC.0" size="0x4.0" />
+</node>
+
+<node name="mtwe_ext" descr="" size="0x10.0" >
+	<field name="sensor_warning" descr="Bit vector indicating which of the sensor reading is above threshold.\;Address 00h bit31 is sensor_warning[127]\;Address 0Ch bit0 is sensor_warning[0]" access="RO" high_bound="3" low_bound="0" offset="0x0.0" size="0x10.0" />
+</node>
+
+<node name="paos_reg_ext" descr="" size="0x10.0" >
+	<field name="oper_status" descr="Port operational state:\;1: up\;2: down\;4: down_by_port_failure - (transitioned by the hardware)\;  \;" access="RO" enum="up=0x1,down=0x2,down_by_port_failure=0x4" offset="0x0.0" size="0x0.4" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="admin_status" descr="Port administrative state (the desired state of the interface):\;1: up\;2: down_by_configuration\;4: disabled_by_system - this mode cannot be set by the software, only by the hardware.\;6: sleep - can be configured only if sleep_cap is set. Note that a sleep setting will cause the port to transition immediately into sleep state regardless of previous admin_status.\;\;\;" access="RW" enum="up=0x1,down_by_configuration=0x2,disabled_by_system=0x4,sleep=0x6" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="swid" descr="For HCA: must always be 0.\;Switch partition ID with which to associate the port.\;Switch partitions are numbered from 0 to 7 inclusively.\;The swid field is only valid when the local_port is the router port. In this case, the swid indicates which of the router ports to configure/query." access="INDEX" offset="0x0.24" size="0x0.8" />
+	<field name="e" descr="Event generation on operational state change (oper_status):\;0: Do_not_generate_event\;1: Generate_Event \;2: Generate_Single_Event\;\;Not Supported for HCA." access="RW" enum="Do_not_generate_event=0x0,Generate_Event=0x1,Generate_Single_Event=0x2" offset="0x4.0" size="0x0.2" />
+	<field name="physical_state_status" descr="IB Port Physical link state:\;0: N/A\;1: Sleep\;2: Polling\;3: Disabled\;4: PortConfigurationTraining\;5: LinkUp\;6-15: reserved\;Note that physical state of 1,2,3,4 will all be reflected as oper_status = down.\;[internal] Note: Supported from XDR devices onwards\;LinkUp for Ethernet link refers to PhyUp state where local side is ready, but not necessarily that peer side is also ready." access="RO" enum="N_A=0x0,Sleep=0x1,Polling=0x2,Disabled=0x3,PortConfigurationTraining=0x4,LinkUp=0x5" offset="0x4.4" size="0x0.4" />
+	<field name="fd" descr="Force down.\;Supported only when indicated in PCAM\;Can be set only with admin_status = 2 (&apos;down_by_configuration&apos;), will force link to be down. \;" access="RW" offset="0x4.8" size="0x0.1" />
+	<field name="sleep_cap" descr="Sleep capability:\;0: Sleep state is not supported\;1: Sleep state supported" access="RO" offset="0x4.9" size="0x0.1" />
+	<field name="ps_e" descr="Event generation for physical state.\;On set operation, will be ignored if ee_ps is not set.\;When bit is set, will generate an event for transition into state.\;Bit 0: Sleep\;Bit 2: Disabled\;Bit 3: PortConfigurationTraining\;Not Supported for HCA." access="RW" enum="Sleep=0x1,Disabled=0x4,PortConfigurationTraining=0x8" offset="0x4.12" size="0x0.4" />
+	<field name="logical_state_status" descr="IB or NVLink Port Logical link state:\;0: N/A\;1: Down\;2: Init\;3: Arm\;4: Active" access="RO" enum="N_A=0x0,Down=0x1,Init=0x2,Arm=0x3,Active=0x4" offset="0x4.16" size="0x0.3" />
+	<field name="ls_e" descr="event generation mask for logical state.\;On set operation, will be ignored when ee_ls is not set.\;When bit is set, will generate event for transition into state.\;Bit 0: Down\;Bit 1: Init\;Bit 2: Arm\;Bit 3: Active\;Not Supported for HCA." access="RW" enum="Down=0x1,Init=0x2,Arm=0x4,Active=0x8" offset="0x4.20" size="0x0.4" />
+	<field name="ee_ps" descr="Event update enable for physical state. If this bit is set, event generation will be updated based on the ps_e field. Only relevant on Set operations.\;Not Supported for HCA." access="WO" offset="0x4.28" size="0x0.1" />
+	<field name="ee_ls" descr="Event update enable for logical state. If this bit is set, event generation will be updated based on the ls_e field. Only relevant on Set operations.\;Not Supported for HCA." access="WO" offset="0x4.29" size="0x0.1" />
+	<field name="ee" descr="Event update enable. If this bit is set, event generation will be updated based on the e field. Only relevant on Set operations.\;Not Supported for HCA." access="WO" offset="0x4.30" size="0x0.1" />
+	<field name="ase" descr="Admin state update enable. If this bit is set, admin state will be updated based on admin_state field. Only relevant on Set() operations." access="WO" offset="0x4.31" size="0x0.1" />
+</node>
+
+<node name="pbsr_reg_ext" descr="" size="0x64.0" >
+	<field name="buffer_type" descr="Valid only for 8x port setting (see PMLP): \;1: Main buffer\;2: Secondary buffer" access="INDEX" offset="0x0.0" size="0x0.2" />
+	<field name="lp_msb" descr="Local port[9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="clear_wm_buff_mask" descr="Each bit represents a stat_buffer\;per bit:\;0: do not clear watermark\;1: clear watermark\;Reserved when clear_wm = 1" access="OP" offset="0x4.0" size="0x0.10" />
+	<field name="used_shared_headroom_buffer" descr="Number of currently used shared headroom buffer cells." access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="clear_wm" descr="Clear watermarks for all PGs" access="OP" offset="0x8.31" size="0x0.1" />
+	<field name="stat_buffer" descr="status per-buffer parameters. i=0..9\;" subnode="stat_bufferx_reg_ext" access="RO" high_bound="9" low_bound="0" offset="0xC.0" size="0x50.0" />
+	<field name="stat_shared_headroom_pool" descr="status of shared headroom pool parameters. Using the same layout as in stat_BufferX, for details see Table 1918, &quot;stat_bufferX Register Layout,&quot; on page 2239.\;Not supported in SwitchX and SwitchX-2\;Not supported in HCA (See PCAM shp_pbmc_pbsr_support bit). \;Not supported in GPUNet" subnode="stat_bufferx_reg_ext" access="RO" offset="0x5C.0" size="0x8.0" />
+</node>
+
+<node name="pbwc_ext" descr="" size="0x8.0" >
+	<field name="log_time_interval" descr="Log time interval.\;This field determine the time between measurements T:\;T = (2^log_time_interval) * 64uSec\;Range is dependent on the port&apos;s rate:\;800Gbps: 0..10\;400Gbps: 0..10\;200Gbps: 0..11\;100Gbps: 0..12\;50Gbps: 0..13\;25Gbps: 0..14\;10Gbps: 0..15\;Default is 7, means that T = (2^7) * 64uSec = 8mSec\;" access="RW" offset="0x0.0" size="0x0.4" />
+	<field name="alpha_factor" descr="Alpha for the exponential moving average formula.\;Alpha = 1/(2^alpha_factor)\;Range 0..7\;\;Default is 2" access="RW" offset="0x4.0" size="0x0.3" />
+</node>
+
+<node name="pbwr_ext" descr="" size="0x94.0" >
+	<field name="local_port_bitmap" descr="Local port\;Each bit represents a local port. Refer to Section 9.3, &quot;Port Numbering&quot;, on page 1606 for port numbering scheme.\;Ports order in the bitmask is from bottom to top. e.g for setting local port 1, bit 1 in the last DWORD (offset 0x7Ch) should be set.\;CPU port is not supported.\;Router port is not supported" access="INDEX" high_bound="31" low_bound="0" offset="0x0.0" size="0x80.0" />
+	<field name="num_rec" descr="Number of records.\;Range 0..1024.\;Range 1025..2047 is reserved." access="OP" offset="0x80.0" size="0x0.11" />
+	<field name="dir" descr="Direction:\;0: ingress\;1: egress" access="OP" enum="ingress=0x0,egress=0x1" offset="0x80.31" size="0x0.1" />
+	<field name="bw_record" descr="BW of the corresponding local port. Valid only if the corresponding bit at local_port_bitmap is set (1).\;The units of the BW are determined by Table 2034, &quot;PBWC - Port BW Configuration Register Layout,&quot; on page 2366.\;\;" access="RO" high_bound="VARIABLE" low_bound="0" offset="0x90.0" size="0x4.0" />
+</node>
+
+<node name="pcam_reg_ext" descr="" size="0x50.0" >
+	<field name="access_reg_group" descr="Access Register ID groups\;0: RegID_0x5000_to_0x507F\;1: RegID_0x5080_to_50FF\;Values 2-255 are Reserved" access="INDEX" offset="0x0.0" size="0x0.8" />
+	<field name="pl_op" descr="Reserved for non-planarized port.\;Features and access regs will be presented according to:\;0: aggregated_port_access\;1: plane_port_access" access="OP" enum="aggregated_port_access=0x0,plane_port_access=0x1" offset="0x0.8" size="0x0.1" />
+	<field name="feature_group" descr="Feature list mask index: \;0: enhanced_features \;Values 1 - 255 are Reserved" access="INDEX" enum="enhanced_features=0x0" offset="0x0.16" size="0x0.8" />
+	<field name="port_access_reg_cap_mask" descr="Supported port&apos;s access register bitmaks. Based on access_reg_group index.\;When bit is set , The register is supported in the device. \;When access_reg_group == 0 :\;Bit_0: 0x5000 \;Bit_1: 0x5001 (PCAP)\;Bit_2: 0x5002 (PMLP)\;Bit_3: 0x5003 (PMTU)\;Bit_4: 0x5004 (PTYS)\;.\;.\;Bit_127: 0x507F (PCAM)\;" access="RO" high_bound="3" low_bound="0" offset="0x8.0" size="0x10.0" />
+	<field name="feature_cap_mask" descr="Supported port&apos;s enhanced features. Based on feature_group index.\;When bit is set, The feature is supported in the device: \;Bit 0: PPCNT_counter_group_Phy_statistical_counter_group \;Bit 1 - PPCNT_counter_group_Discard_counter_group\;Bit 9: PFCC - support of stall mask and global rx,tx mask. \;Bit 10: PMCR - support of tx_disable override.\;Bit 11: PPCNT_counter_group - IB Extended port counter group\;Bit 12: PPCNT_Extended_Ethernet_group - tx packet size histograms\;Bit 13: PTYS_extended_Ethernet_support\;Bit 14: PMAOS_reset_toggle_support\;Bit 15: Set_Module_low_power_supported \;Bit 16: Module_power_optimization_is_supported_in_PPSC\;Bit 17: Support_of_IB_force_state_machine_in_PTYS - (an_disable)\;Bit 18: PPCNT_Extended_Ethernet_group_icrc_counter\;Bit 19: cm2_en_is_supported_in_PCAP\;Bit 20: time_tolink_up_is_supported_in_PDDR\;Bit 21: gearbox_die_num_field_is_supported_in_PMDR\;Bit 22: force_entropy_entropy_calc_entropy_gre_calc - and capability bits are supported in PCMR\;Bit 23: FEC_override_support_for_50G_per_lane_is_supported_in_PPLM\;Bit 25: PTYS_allow_both_extended_and_legacy_protocol_masks\;Bit 26: PPCNT_eth_per_tc_cong_group_supported\;Bit 27: pnat_sup_host - the device supports pnat = 2 (host) when set to &apos;1&apos;\;Bit 28: ppcnt_no_buffer_discard_uc - this counter is supported in PPCNT when set to &apos;1&apos;\;Bit 29: pbmc_port_shared_buffer - supported in PBMC.\;Bit 30: PLR_max_retry_window_support - PPCNT group 0x22 max retry per window\;Bit 32: PDDR_ext_eth_proto_support\;Bit 41: PMAOS - support of &quot;opertional_notifcation&quot; field\;Bit 42: PRBS_polarity_support - support of polarity bits in PPTT and PPRT\;Bit 43: PDDR_register_is_supported\;Bit 44: pfcc_buffer_onwership - PFCC buffer ownership is supported.\;Bit 45: force_down - supported in PAOS reg.\;Bit 46: pmlp_lane_mapping_off - Support of m_lane_m field in PMLP.\;Bit 51: ppcnt_symobl_ber\;Bit 52: shp_pbmc_pbsr_support\;Bit 54: ppcnt_effective_error_counter\;Bit 55: FEC_override_support_for_100G_per_lane_is_supported_in_PPLM\;Bit 57: PMECR_option_to_not_generate_events_upon_PMLP_set\;Bit 64: Local_port_MSB - bits [9:8] supported\;Bit 65: PDDR_moule_latched_info_page_supported\;Bit 66: PDDR_module_info_ext_supported\;Bit 70: SLTP_tx_policy_supported\;Bit 71: pmcr_capability_bits_supported\;Bit 72: pmtu_max_admin_mtu_supported\;Bit 73: PPCNT_grp_profile_supported\;Bit 77: PPCNT.physical_layer_counters_RS_FEC_8_lanes_supported\;Bit 85: PPCNT.counters_cap\;Bit 86: SLTP.lane_broadcast_supported\;Bit 87: PMMP.apply_im_supported\;Other bits are reserved" access="RO" enum="PPCNT_counter_group_Phy_statistical_counter_group=0x1,PFCC=0x200,PMCR=0x400,PPCNT_counter_group=0x800,PPCNT_Extended_Ethernet_group=0x1000,PTYS_extended_Ethernet_support=0x2000,PMAOS_reset_toggle_support=0x4000,Set_Module_low_power_supported=0x8000,Module_power_optimization_is_supported_in_PPSC=0x10000,Support_of_IB_force_state_machine_in_PTYS=0x20000,PPCNT_Extended_Ethernet_group_icrc_counter=0x40000,cm2_en_is_supported_in_PCAP=0x80000,time_tolink_up_is_supported_in_PDDR=0x100000,gearbox_die_num_field_is_supported_in_PMDR=0x200000,force_entropy_entropy_calc_entropy_gre_calc=0x400000,FEC_override_support_for_50G_per_lane_is_supported_in_PPLM=0x800000,PTYS_allow_both_extended_and_legacy_protocol_masks=0x2000000,PPCNT_eth_per_tc_cong_group_supported=0x4000000,pnat_sup_host=0x8000000,ppcnt_no_buffer_discard_uc=0x10000000,pbmc_port_shared_buffer=0x20000000,PLR_max_retry_window_support=0x40000000,PDDR_ext_eth_proto_support=0x1,PMAOS=0x200,PRBS_polarity_support=0x400,PDDR_register_is_supported=0x800,pfcc_buffer_onwership=0x1000,force_down=0x2000,pmlp_lane_mapping_off=0x4000,ppcnt_symobl_ber=0x80000,shp_pbmc_pbsr_support=0x100000,ppcnt_effective_error_counter=0x400000,FEC_override_support_for_100G_per_lane_is_supported_in_PPLM=0x800000,PMECR_option_to_not_generate_events_upon_PMLP_set=0x2000000,Local_port_MSB=0x1,PDDR_moule_latched_info_page_supported=0x2,PDDR_module_info_ext_supported=0x4,SLTP_tx_policy_supported=0x40,pmcr_capability_bits_supported=0x80,pmtu_max_admin_mtu_supported=0x100,PPCNT_grp_profile_supported=0x200,PPCNT_physical_layer_counters_RS_FEC_8_lanes_supported=0x2000,PPCNT_counters_cap=0x200000,SLTP_lane_broadcast_supported=0x400000,PMMP_apply_im_supported=0x800000" high_bound="3" low_bound="0" offset="0x28.0" size="0x10.0" />
+</node>
+
+<node name="pcap_reg_ext" descr="" size="0x14.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="cm2_en" descr="port_capability_mask[95:80] is supported if set to &apos;1&apos;." access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="port_capability_mask" descr="Sets the PortInfoCapabilityMask:\;Specifies the supported capabilities of this node. A bit set to 1 for affirmation of supported capability.\;port_capability_mask[127:96] is mapped to CapabilityMask in PortInfo MAD.\;port_capability_mask[95:80] is mapped to CapabilityMask2 in PortInfo MAD.\;\;\;" access="RW" high_bound="3" low_bound="0" offset="0x4.0" size="0x10.0" />
+</node>
+
+<node name="pddr_c2p_link_enabed_eth_ext" descr="" size="0x4.0" >
+	<field name="core_to_phy_link_eth_enabled" descr="Ethernet protocols admin state: see PTYS.ext_eth_proto_admin" access="RO" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_c2p_link_enabed_ib_ext" descr="" size="0x4.0" >
+	<field name="core_to_phy_link_proto_enabled" descr="ib link enabled speed:\;Bit 0: SDR\;Bit 1: DDR\;Bit 2: QDR\;Bit 3: FDR10\;Bit 4: FDR\;Bit 5: EDR\;Bit 6: HDR\;Bit 7: NDR\;Bit 8: XDR" access="RO" enum="SDR=0x1,DDR=0x2,QDR=0x4,FDR10=0x8,FDR=0x10,EDR=0x20,HDR=0x40,NDR=0x80,XDR=0x100" offset="0x0.0" size="0x0.16" />
+	<field name="core_to_phy_link_width_enabled" descr="ib link enabled width:\;Bit 0: 1x\;Bit 1: 2x\;Bit 2: 4x\;\;Other - reserved" access="RO" offset="0x0.16" size="0x0.16" />
+</node>
+
+<node name="pddr_cable_cap_eth_ext" descr="" size="0x4.0" >
+	<field name="cable_ext_eth_proto_cap" descr="Cable Ethernet protocols cap. If PTYS.ext_eth_proto_cap filed is supported, use for opcode definition PTYS.ext_eth_proto_capIf PTYS.ext_eth_proto_capability mask is empty, use For opcode definition PTYS.eth_proto_cap." access="RO" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_cable_cap_ib_ext" descr="" size="0x4.0" >
+	<field name="cable_link_speed_cap" descr="Cable support IB speed:\;Bit 0: SDR\;Bit 1: DDR\;Bit 2: QDR\;Bit 3: FDR10\;Bit 4: FDR\;Bit 5: EDR\;Bit 6: HDR\;Bit 7: NDR\;Bit 8: XDR" access="RO" enum="SDR=0x1,DDR=0x2,QDR=0x4,FDR10=0x8,FDR=0x10,EDR=0x20,HDR=0x40,NDR=0x80,XDR=0x100" offset="0x0.0" size="0x0.16" />
+	<field name="cable_link_width_cap" descr="Cable support IB width:\;Bit 0: 1x\;Bit 1: 2x\;Bit 2: 4x\;\;Other - reserved" access="RO" offset="0x0.16" size="0x0.16" />
+</node>
+
+<node name="pddr_link_active_eth_ext" descr="" size="0x4.0" >
+	<field name="link_eth_active" descr="Ethernet protocols active : see PTYS.ext_eth_proto_oper" access="RO" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_link_active_ib_ext" descr="" size="0x4.0" >
+	<field name="link_speed_active" descr="ib link active speed:\;Bit 0: SDR\;Bit 1: DDR\;Bit 2: QDR\;Bit 3: FDR10\;Bit 4: FDR\;Bit 5: EDR\;Bit 6: HDR\;Bit 7: NDR\;Bit 8: XDR" access="RO" enum="SDR=0x1,DDR=0x2,QDR=0x4,FDR10=0x8,FDR=0x10,EDR=0x20,HDR=0x40,NDR=0x80,XDR=0x100" offset="0x0.0" size="0x0.16" />
+	<field name="link_width_active" descr="ib link active width:\;Bit 0: 1x\;Bit 1: 2x\;Bit 2: 4x\;\;Other - reserved" access="RO" offset="0x0.16" size="0x0.16" />
+</node>
+
+<node name="pddr_link_down_info_page_ext" descr="" size="0xf4.0" >
+	<field name="down_blame" descr="Which receiver caused last link down: \;0: Unknown\;1: Local_phy\;2: Remote_phy" access="RO" enum="Unknown=0x0,Local_phy=0x1,Remote_phy=0x2" offset="0x0.0" size="0x0.4" />
+	<field name="local_reason_opcode" descr="Opcde of link down reason: \;0: No_link_down_indication\;1: Unknown_reason\;2: Hi_SER_or_Hi_BER\;3: Block_Lock_loss\;4: Alignment_loss\;5: FEC_sync_loss\;6: PLL_lock_loss\;7: FIFO_overflow\;8: false_SKIP_condition\;9: Minor_Error_threshold_exceeded\;10: Physical_layer_retransmission_timeout\;11: Heartbeat_errors\;12: Link_Layer_credit_monitoring_watchdog\;13: Link_Layer_integrity_threshold_exceeded\;14: Link_Layer_buffer_overrun\;15: Down_by_outband_command_with_healthy_link\;16: Down_by_outband_command_for_link_with_hi_ber\;17: Down_by_inband_command_with_healthy_link\;18: Down_by_inband_command_for_link_with_hi_ber\;19: Down_by_verification_GW\;20: Received_Remote_Fault \;21: Received_TS1\;22: Down_by_management_command\;23: Cable_was_unplugged\;24: Cable_access_issue \;25: Thermal_shutdown \;26: Current_issue \;27: Power_budget\;28: Fast_recovery_raw_ber\;29: Fast_recovery_effective_ber\;30: Fast_recovery_symbol_ber\;31: Fast_recovery_credit_watchdog\;32: Timeout" access="RO" enum="No_link_down_indication=0x0,Unknown_reason=0x1,Hi_SER_or_Hi_BER=0x2,Block_Lock_loss=0x3,Alignment_loss=0x4,FEC_sync_loss=0x5,PLL_lock_loss=0x6,FIFO_overflow=0x7,false_SKIP_condition=0x8,Minor_Error_threshold_exceeded=0x9,Physical_layer_retransmission_timeout=0xa,Heartbeat_errors=0xb,Link_Layer_credit_monitoring_watchdog=0xc,Link_Layer_integrity_threshold_exceeded=0xd,Link_Layer_buffer_overrun=0xe,Down_by_outband_command_with_healthy_link=0xf,Down_by_outband_command_for_link_with_hi_ber=0x10,Down_by_inband_command_with_healthy_link=0x11,Down_by_inband_command_for_link_with_hi_ber=0x12,Down_by_verification_GW=0x13,Received_Remote_Fault=0x14,Received_TS1=0x15,Down_by_management_command=0x16,Cable_was_unplugged=0x17,Cable_access_issue=0x18,Thermal_shutdown=0x19,Current_issue=0x1a,Power_budget=0x1b,Fast_recovery_raw_ber=0x1c,Fast_recovery_effective_ber=0x1d,Fast_recovery_symbol_ber=0x1e,Fast_recovery_credit_watchdog=0x1f,Timeout=0x20" offset="0x4.0" size="0x0.8" />
+	<field name="remote_reason_opcode" descr="see local_reason_opcode" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="e2e_reason_opcode" descr="see local_reason_opcode for local reason opcode\;for remote reason opcode: local_reason_opcode+100" access="RO" offset="0xC.0" size="0x0.8" />
+	<field name="ts1_opcode" descr="TS1 opcode describes the reason the peer requested to ramp down the link:\;0x8: TS1.Sleep\;0x9: TS1.Disable\;0xA: TS1.PortLock\;0xB: TS1.Thermal\;0xC: TS1.Clean \;0xD  : TS1.Force\;0xE: TS1.reset_req\;\;Note: This field is valid in case the local_reason_opcode = 21:Received_TS1." access="RO" offset="0xC.12" size="0x0.4" />
+</node>
+
+<node name="pddr_module_info_ext" descr="" size="0xd8.0" >
+	<field name="ethernet_compliance_code" descr="QSFP:\;Ethernet Compliance Codes bit mask (10/40G/100G)\;Byte131 per SFF-8636 \;Bit 7 - Extended Specification Compliance valid\;Bit 6 - 10GBASE-LRM\;Bit 5 - 10GBASE-LR\;Bit 4 - 10GBASE-SR\;Bit 3 - 40GBASE-CR4\;Bit 2 - 40GBASE-SR4\;Bit 1 - 40GBASE-LR4\;Bit 0 - 40G Active Cable (XLPPI)\;\;SFP : \;10G Ethernet Compliance Codes\;Byte3 per SFF-8472:\;Bit 7 - 10G Base-ER \;Bit 6 - 10G Base-LRM \;Bit 5 - 10G Base-LR \;Bit 4 - 10G Base-SR\;\;CMIS based (QSFP-DD/ SFP-DD / OSFP)\;Byte 87 - Module Media Interface" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="ext_ethernet_compliance_code" descr="Extended Specification Compliance Codes \;for SFP:\;byte 36 per SFF-8472\;\;for QSFP:\;byte192 per SFF-8636 (QSFP28) \;\;for CMIS (SFP-DD / QSFP-DD/ OSFP):\;Byte 86 - Host Electrical Interface" access="RW" offset="0x0.8" size="0x0.8" />
+	<field name="cable_breakout" descr="Reserved for SFP. \;\;For QSFP:\;Byte113 per SFF-8636\;\;For CMIS based modules:\;\;XX naming is according to cable_identifier name\;For example: if cable_identifier = ,6 XX string is QSFP-DD\;\;0 - Unspecified\;1 - XX to XX\;2 - XX to 2xQSFP or 2xXX (depopulated / 4 lanes)\;3 - XX to 4xDSFP or 4xQSFP (depopulated / 2 lanes)\;4 - XX to 8xSFP\;5 - XX (depopulated / 4 lanes) to QSFP or XX (depopulated / 4 lanes)\;6 - XX (depopulated / 4 lanes) to 2xXX(depopulated / 2 lanes) or 2xSFP-DD\;7 - XX (depopulated / 4 lanes) to 4xSFP\;8 - XX(/ 2 lane module) to XX\;9 - XX(/ 2 lane module) to 2xSFP" access="RW" offset="0x0.16" size="0x0.8" />
+	<field name="cable_technology" descr="QSFP: \;Byte 147 per SFF-8636.\;\;SFP:\;SFP+ Cable Technology: \;byte8 per SFF-8472:\;Bit 3 - Active Cable\;Bit 2 - Passive Cable\;\;CMIS based (QSFP-DD / OSFP/ SFP-DD):\;Byte 212" access="RW" offset="0x0.24" size="0x0.8" />
+	<field name="cable_power_class" descr="Module maximum power consumption for SFP/QSFP:\;0: Power_Class_0 - (1.0 W max)\;1: Power_Class_1 - (1.5 W max)\;2: Power_Class_2 - (2.0 W max)\;3: Power_Class_3 - (2.5 W max)\;4: Power_Class_4 - (3.5 W max)\;5: Power_Class_5 - (4.0 W max)\;6: Power_Class_6 - (4.5 W max)\;7: Power_Class_7 - (5.0 W max)\;8: Power_Class_8 - (power from max_power field)\;\;Module maximum power consumption for SFP-DD:\;0: Power_Class_0 - (0.5 W max)\;1: Power_Class_1 - (1.0 W max)\;2: Power_Class_2 - (1.5 W max)\;3: Power_Class_3 - (2.0 W max)\;4: Power_Class_4 - (3.5 W max)\;5: Power_Class_5 - (5.0 W max)\;6: reserved\;7: reserved\;8: Power_Class_8 - (power from max_power field)\;\;Module maximum power consumption for QSFP-DD/OSFP:\;1 - Power_Class_1 - (1.5 W max)\;2 - Power_Class_2 - (3.5 W max)\;3 - Power_Class_3 - (7.0 W max)\;4 - Power_Class_4 - (8.0 W max)\;5 - Power_Class_5 - (10 W max)\;6 - Power_Class_6 - (12 W max)\;7 - Power_Class_7 - (14 W max)\;8 - Power_Class_8 - (power from max_power field)" access="RO" offset="0x4.0" size="0x0.8" />
+	<field name="cable_identifier" descr="0: QSFP28\;1: QSFP_Plus\;2: SFP28_or_SFP_Plus\;3: QSA - (QSFP-&gt;SFP)\;4: Backplane\;5: SFP_DD\;6: QSFP_DD\;7: QSFP_CMIS\;8: OSFP\;9: C2C\;10: DSFP\;11: QSFP_Split_Cable\;\;identifiers that are CMIS compliant are: 5,6,7,8,10" access="RO" offset="0x4.8" size="0x0.8" />
+	<field name="cable_length" descr="Cable length in 1m units.\;\;For CMIS modules:\;bits 6:7 represent cable_length_multiplier for calculating cable length\;00 - 0.1 multiplier (0.1 to 6.3m)\;01- 1 multiplier (1 to 63m)\;10 - 10 multiplier (10 to 630m)\;11 - 100 multiplier (100 to 6300m)\;\;bits 0:5 represent cable_length_value for calculating cable length.\;length is calculated with cable_length_value * cable_length_multiplier" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="cable_vendor" descr="Cable vendor:\;0: Other\;1: Mellanox\;2: Known_OUI\;3: NVIDIA\;" access="RO" enum="Other=0x0,Mellanox=0x1,Known_OUI=0x2,NVIDIA=0x3" offset="0x4.24" size="0x0.4" />
+	<field name="cable_type" descr="Cable/module type:\;0: Unidentified\;1: Active_cable - (active copper / optics)\;2: Optical_Module - (separated)\;3: Passive_copper_cable\;4: Cable_unplugged\;5: Twisted_pair\;" access="RO" enum="Unidentified=0x0,Active_cable=0x1,Optical_Module=0x2,Passive_copper_cable=0x3,Cable_unplugged=0x4,Twisted_pair=0x5" offset="0x4.28" size="0x0.4" />
+	<field name="cable_tx_equalization" descr="\;" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="cable_rx_emphasis" descr="\;For CMIS (QSFP-DD/ SFP-DD/ OSFP) field will represent Rx pre-emphasis." access="RO" offset="0x8.8" size="0x0.8" />
+	<field name="cable_rx_amp" descr="Reserved for SFP\;" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="max_power" descr="Reserved for SFP, QSFP\;Byte 201 for CMIS (QSFP-DD/ SFP-DD/ OSFP)\;Other Cable ignore field." access="RO" offset="0x8.24" size="0x0.8" />
+	<field name="cable_attenuation_5g" descr="Reserved for SFP" access="RO" offset="0xC.0" size="0x0.8" />
+	<field name="cable_attenuation_7g" descr="Reserved for SFP" access="RO" offset="0xC.8" size="0x0.8" />
+	<field name="cable_attenuation_12g" descr="Reserved for SFP" access="RO" offset="0xC.16" size="0x0.8" />
+	<field name="cable_attenuation_25g" descr="Valid only for CMIS (QSFP-DD/ SFP-DD/ OSFP)\;Other Cable ignore field." access="RO" offset="0xC.24" size="0x0.8" />
+	<field name="tx_cdr_state" descr="Reserved for SFP\;\;Bit 0 - TX CDR on/off on channel 0 \;Bit 1 - TX CDR on/off on channel 1 \;Bit 2 - TX CDR on/off on channel 2 \;Bit 3 - TX CDR on/off on channel 3 \;Bit 4 - TX CDR on/off on channel 4 \;Bit 5 - TX CDR on/off on channel 5 \;Bit 6 - TX CDR on/off on channel 6 \;Bit 7 - TX CDR on/off on channel 7 \;\;CDR on - when bit is set.\;CDR off - when bit is clear.\;" access="RO" offset="0x10.0" size="0x0.8" />
+	<field name="rx_cdr_state" descr="Reserved for SFP\;\;Bit 0 - RX CDR on/off on channel 0 \;Bit 1 - RX CDR on/off on channel 1 \;Bit 2 - RX CDR on/off on channel 2 \;Bit 3 - RX CDR on/off on channel 3\;Bit 4 - RX CDR on/off on channel 4 \;Bit 5 - RX CDR on/off on channel 5 \;Bit 6 - RX CDR on/off on channel 6 \;Bit 7 - RX CDR on/off on channel 7 \;\;CDR on - when bit is set.\;CDR off - when bit is clear.\;" access="RO" offset="0x10.8" size="0x0.8" />
+	<field name="tx_cdr_cap" descr="0 - No CDR\;1 - Build-in CDR with on/off control \;2 - Build-in CDR without on/off control" access="RO" offset="0x10.16" size="0x0.4" />
+	<field name="rx_cdr_cap" descr="0 - No CDR\;1 - Build-in CDR with on/off control \;2 - Build-in CDR without on/off control" access="RO" offset="0x10.20" size="0x0.4" />
+	<field name="cable_rx_post_emphasis" descr="Valid only for CMIS (QSFP-DD/ SFP-DD/ OSFP)\;Rx post-emphasis." access="RO" offset="0x10.24" size="0x0.8" />
+	<field name="vendor_name" descr="ASCII Vendor name left-aligned and padded on the right with\;ASCII spaces (20h)" access="RO" high_bound="3" low_bound="0" offset="0x14.0" size="0x10.0" />
+	<field name="vendor_pn" descr="Vendor Part Number left-aligned and padded on the right with ASCII spaces (20h)" access="RO" high_bound="3" low_bound="0" offset="0x24.0" size="0x10.0" />
+	<field name="vendor_rev" descr="ASCII Vendor revision aligned to right padded with 0h on the left" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="fw_version" descr="If information is not available by the module: set to 0" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="vendor_sn" descr="Vendor Serial Number" access="RO" high_bound="3" low_bound="0" offset="0x3C.0" size="0x10.0" />
+	<field name="voltage" descr="Internally measured supply voltage in 100uV" access="RO" offset="0x4C.00" size="0x0.16" />
+	<field name="temperature" descr="module temperature in 1/256 C" access="RO" offset="0x4C.16" size="0x0.16" />
+	<field name="rx_power_lane1" descr="RX measured power channel 1.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x50.0" size="0x0.16" />
+	<field name="rx_power_lane0" descr="RX measured power channel 0.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x50.16" size="0x0.16" />
+	<field name="rx_power_lane3" descr="RX measured power channel 3.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x54.0" size="0x0.16" />
+	<field name="rx_power_lane2" descr="RX measured power channel 2.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x54.16" size="0x0.16" />
+	<field name="rx_power_lane5" descr="RX measured power channel 5.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x58.0" size="0x0.16" />
+	<field name="rx_power_lane4" descr="RX measured power channel 4.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x58.16" size="0x0.16" />
+	<field name="rx_power_lane7" descr="RX measured power channel 7.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x5C.0" size="0x0.16" />
+	<field name="rx_power_lane6" descr="RX measured power channel 6.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x5C.16" size="0x0.16" />
+	<field name="tx_power_lane1" descr="TX measured power channel 1.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x60.0" size="0x0.16" />
+	<field name="tx_power_lane0" descr="TX measured power channel 0.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x60.16" size="0x0.16" />
+	<field name="tx_power_lane3" descr="TX measured power channel 3.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x64.0" size="0x0.16" />
+	<field name="tx_power_lane2" descr="TX measured power channel 2.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x64.16" size="0x0.16" />
+	<field name="tx_power_lane5" descr="TX measured power channel 5.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x68.0" size="0x0.16" />
+	<field name="tx_power_lane4" descr="TX measured power channel 4.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x68.16" size="0x0.16" />
+	<field name="tx_power_lane7" descr="TX measured power channel 7.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x6C.0" size="0x0.16" />
+	<field name="tx_power_lane6" descr="TX measured power channel 6.\;measured in dBm/uW according to module_info_ext value" access="RO" offset="0x6C.16" size="0x0.16" />
+	<field name="tx_bias_lane1" descr="TX measured bias current on channel 1 in 2uA" access="RO" offset="0x70.0" size="0x0.16" />
+	<field name="tx_bias_lane0" descr="TX measured bias current on channel 0 in 2uA" access="RO" offset="0x70.16" size="0x0.16" />
+	<field name="tx_bias_lane3" descr="TX measured bias current on channel 3 in 2uA" access="RO" offset="0x74.0" size="0x0.16" />
+	<field name="tx_bias_lane2" descr="TX measured bias current on channel 2 in 2uA" access="RO" offset="0x74.16" size="0x0.16" />
+	<field name="tx_bias_lane5" descr="TX measured bias current on channel 5 in 2uA" access="RO" offset="0x78.0" size="0x0.16" />
+	<field name="tx_bias_lane4" descr="TX measured bias current on channel 4 in 2uA" access="RO" offset="0x78.16" size="0x0.16" />
+	<field name="tx_bias_lane7" descr="TX measured bias current on channel 7 in 2uA" access="RO" offset="0x7C.0" size="0x0.16" />
+	<field name="tx_bias_lane6" descr="TX measured bias current on channel 6 in 2uA" access="RO" offset="0x7C.16" size="0x0.16" />
+	<field name="temperature_low_th" descr="Alarm low temperature threshold in 1/256 C" access="RO" offset="0x80.0" size="0x0.16" />
+	<field name="temperature_high_th" descr="Alarm high temperature threshold in 1/256 C" access="RO" offset="0x80.16" size="0x0.16" />
+	<field name="voltage_low_th" descr="Alarm low Voltage threshold in 100uV" access="RO" offset="0x84.0" size="0x0.16" />
+	<field name="voltage_high_th" descr="Alarm high Voltage threshold in 100uV" access="RO" offset="0x84.16" size="0x0.16" />
+	<field name="rx_power_low_th" descr="Alarm low RX Power threshold in dBm. \;Taking only from channel 0." access="RO" offset="0x88.0" size="0x0.16" />
+	<field name="rx_power_high_th" descr="Alarm high RX Power threshold in dBm. \;Taking only from channel 0." access="RO" offset="0x88.16" size="0x0.16" />
+	<field name="tx_power_low_th" descr="Alarm low TX Power threshold in dBm. \;Taking only from channel 0." access="RO" offset="0x8C.0" size="0x0.16" />
+	<field name="tx_power_high_th" descr="Alarm high TX Power threshold in dBm. \;Taking only from channel 0." access="RO" offset="0x8C.16" size="0x0.16" />
+	<field name="tx_bias_low_th" descr="Alarm low TX Bias current threshold in 2 uA." access="RO" offset="0x90.0" size="0x0.16" />
+	<field name="tx_bias_high_th" descr="Alarm high TX Bias current threshold in 2 uA." access="RO" offset="0x90.16" size="0x0.16" />
+	<field name="wavelength" descr="Nominal laser wavelength in nm" access="RO" offset="0x94.0" size="0x0.16" />
+	<field name="smf_length" descr="SMF link length\;SFP per byte 14,15.\;QSFP per byte 142\;for CMIS based modules, per byte 132\;\;bit 9:8 - 00 length base in 1 km units\;bit 9:8 - 01 length base in 100m units\;bits 7:0 - length base" access="RO" offset="0x94.16" size="0x0.10" />
+	<field name="rx_output_valid_cap" descr="when set, indicates rx_output_valid is supported by the module" access="RW" offset="0x94.26" size="0x0.1" />
+	<field name="did_cap" descr="set in case of Linear Direct Drive module" access="RO" offset="0x94.27" size="0x0.1" />
+	<field name="rx_power_type" descr="rx power measurement type\;0: OMA\;1: Average_power" access="RO" enum="OMA=0x0,Average_power=0x1" offset="0x94.28" size="0x0.1" />
+	<field name="module_st" descr="Valid for CMIS modules only.\;Module state:\;0: reserved\;1: LowPwr_state\;2: PwrUp_state\;3: Ready_state\;4: PwrDn_state\;5: Fault_state" access="RO" enum="reserved=0x0,LowPwr_state=0x1,PwrUp_state=0x2,Ready_state=0x3,PwrDn_state=0x4,Fault_state=0x5" offset="0x94.29" size="0x0.3" />
+	<field name="ib_compliance_code" descr="Byte 164 of SFF-8636\;For CMIS modules IB Protocols." access="RO" offset="0x98.0" size="0x0.8" />
+	<field name="active_set_media_compliance_code" descr="Valid for CMIS modules only.\;According to current Active set, value of Module Media Interface byte" access="RO" offset="0x98.16" size="0x0.8" />
+	<field name="active_set_host_compliance_code" descr="Valid for CMIS modules only.\;According to current Active set, value of Host Electrical Interface byte" access="RO" offset="0x98.24" size="0x0.8" />
+	<field name="ib_width" descr="Bitmask of width of IB Protocols" access="RO" offset="0x9C.0" size="0x0.6" />
+	<field name="monitor_cap_mask" descr="monitoring capabilities mask\;Bit 0 - temperature monitoring implemented\;Bit 1 - voltage monitoring implemented\;Bit 2 - tx power monitoring implemented\;Bit 3 - rx power monitoring implemented\;Bit 4 - tx bias monitoring implemented" access="RO" offset="0x9C.8" size="0x0.8" />
+	<field name="nbr100" descr="Nominal bit rate in units of 100Mb/s" access="RO" offset="0x9C.16" size="0x0.8" />
+	<field name="nbr250" descr="Nominal bit rate in units of 250Mb/s" access="RO" offset="0x9C.24" size="0x0.8" />
+	<field name="dp_st_lane7" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.0" size="0x0.4" />
+	<field name="dp_st_lane6" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.4" size="0x0.4" />
+	<field name="dp_st_lane5" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.8" size="0x0.4" />
+	<field name="dp_st_lane4" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.12" size="0x0.4" />
+	<field name="dp_st_lane3" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.16" size="0x0.4" />
+	<field name="dp_st_lane2" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.20" size="0x0.4" />
+	<field name="dp_st_lane1" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" offset="0xA0.24" size="0x0.4" />
+	<field name="dp_st_lane0" descr="DataPath state for lane&lt;i&gt;\;1: DPDeactivated\;2: DPInit\;3: DPDeinit\;4: DPActivated\;5: DPTxTurnOn\;6: DPTxTurnOff\;7: DPInitialized" access="RO" enum="DPDeactivated=0x1,DPInit=0x2,DPDeinit=0x3,DPActivated=0x4,DPTxTurnOn=0x5,DPTxTurnOff=0x6,DPInitialized=0x7" offset="0xA0.28" size="0x0.4" />
+	<field name="length_om5" descr="OM5 fiber length supported in units of 2m" access="RO" offset="0xA4.0" size="0x0.8" />
+	<field name="length_om4" descr="OM4 fiber length supported in units of 2m\;SFP in units of 10m" access="RO" offset="0xA4.8" size="0x0.8" />
+	<field name="length_om3" descr="OM3 fiber length supported in units of 2m\;SFP in units of 10m" access="RO" offset="0xA4.16" size="0x0.8" />
+	<field name="length_om2" descr="OM2 fiber length supported in units of 1m\;SFP in units of 10m" access="RO" offset="0xA4.24" size="0x0.8" />
+	<field name="memory_map_rev" descr="memory map revision" access="RO" offset="0xA8.0" size="0x0.8" />
+	<field name="wavelength_tolerance" descr="16-bit integer value for the laser wavelength tolerance in nm divided by 200 (units of 0.005nm)." access="RO" offset="0xA8.8" size="0x0.16" />
+	<field name="length_om1" descr="OM1 fiber length supported in units of 10m" access="RO" offset="0xA8.24" size="0x0.8" />
+	<field name="memory_map_compliance" descr="memory map compliance in ASCII.\;SFF-8472 / SFF-8636/ CMIS" access="RO" offset="0xAC.0" size="0x4.0" />
+	<field name="date_code" descr="ASCII code for vendor&apos;s date code.\;63:48- 2 digit for date code year, 00 = year 2000\;47:32 - 2 digit for date code month.\;31:16 - 2 digit for day of the month code.\;15:0 - 2 digit LOT code." subnode="uint64" access="RO" offset="0xB0.0" size="0x8.0" />
+	<field name="vendor_oui" descr="vendor oui" access="RO" offset="0xB8.0" size="0x0.24" />
+	<field name="connector_type" descr="connector type based on SFF-8024" access="RO" offset="0xB8.24" size="0x0.8" />
+	<field name="rx_output_valid" descr="Rx output status indication per lane" access="RO" offset="0xBC.0" size="0x0.8" />
+	<field name="cable_attenuation_53g" descr="cable attenuation at 53GHz" access="RO" offset="0xBC.8" size="0x0.8" />
+	<field name="tx_input_freq_sync" descr="Defines which Tx input lanes must be frequency synchronous.\;0: Tx_input_lanes_1_8\;1: Tx_input_lanes_1_4_and_5-8\;2: Tx_input_lanes_1_2_and_3_4_and_5_6_and_7_8\;3: Lanes_may_be_asynchronous_in_frequency" access="RO" enum="Tx_input_lanes_1_8=0x0,Tx_input_lanes_1_4_and_5=0x1,Tx_input_lanes_1_2_and_3_4_and_5_6_and_7_8=0x2,Lanes_may_be_asynchronous_in_frequency=0x3" offset="0xBC.16" size="0x0.2" />
+	<field name="error_code" descr="Relevant for CMIS modules only\;Error Code response for ConrolSet configuration of DataPath.\;0x0: ConfigUndefined\;0x1: ConfigSuccess\;0x2: ConfigRejected\;0x3: ConfigRejectedInvalidAppSel\;0x4: ConfigRejectedInvalidDataPath\;0x5: ConfigRejectedInvalidSI\;0x6: ConfigRejectedLanesInUse\;0x7: ConfigRejectedPartialDataPath\;0xC: ConfigInProgress" access="RO" enum="ConfigUndefined=0x0,ConfigSuccess=0x1,ConfigRejected=0x2,ConfigRejectedInvalidAppSel=0x3,ConfigRejectedInvalidDataPath=0x4,ConfigRejectedInvalidSI=0x5,ConfigRejectedLanesInUse=0x6,ConfigRejectedPartialDataPath=0x7,ConfigInProgress=0xc" offset="0xC0.0" size="0x0.4" />
+	<field name="max_fiber_length" descr="Maximum length of allowed fiber in meters" access="RO" offset="0xC0.16" size="0x0.16" />
+</node>
+
+<node name="pddr_monitor_opcode_ext" descr="" size="0x4.0" >
+	<field name="monitor_opcode" descr="Status opcode: \;\;PHY FW indication (0 - 1023):\;0 - No issue observed\;1 - Port is close by command (see PAOS).\;2,3,4,38,39 - AN failure \;5,6,7,8 - Link training failure. \;9,10,11,12,13 - Logical mismatch between link partners\;14 - Remote fault received\;15,42,17,48,49,52, - Bad signal integrity \;16,24-32 - Cable compliance code mismatch (protocol mismatch between cable and port) \;23,22,19,18,50,55- Internal error\;34,35 - Speed degradation\;56 - module_lanes_frequency_not_synced\;57 - signal not detected\;60 - no partner detected for long time\;128 - Troubleshooting in process\;1023- Info not available\;\;MNG FW issues (1024 - 2047):\;1024 - Cable is unplugged\;1025 - Long Range for non Mellanox cable/module .\;1026 - Bus stuck (I2C Data or clock shorted) \;1027 - Bad/unsupported EEPROM \;1028 - Part number list\;1029 - Unsupported cable.\;1030 - Module temperature shutdown\;1031 - Shorted cable\;1032 - Power budget exceeded\;1033 - Management forced down the port\;1034 - Module is disabled by command\;1036 - Module&apos;s PMD type is not enabled (see PMTPS).\;1040 - pcie system power slot Exceeded\;1042 - Module state machine fault\;1043,1044,1045,1046 - Module&apos;s stamping speed degeneration\;1047, 1048 - Modules DataPath FSM fault\;1050 - Module Boot Error\;Core/Driver (2048 - 3071):" access="RW" offset="0x0.0" size="0x0.16" />
+</node>
+
+<node name="pddr_operation_info_page_cable_proto_cap_auto_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="pddr_cable_cap_ib_ext" descr="" subnode="pddr_cable_cap_ib_ext" offset="0x0.0" size="0x4.0" />
+	<field name="pddr_cable_cap_eth_ext" descr="" subnode="pddr_cable_cap_eth_ext" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_operation_info_page_core_to_phy_link_enabled_auto_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="pddr_c2p_link_enabed_ib_ext" descr="" subnode="pddr_c2p_link_enabed_ib_ext" offset="0x0.0" size="0x4.0" />
+	<field name="pddr_c2p_link_enabed_eth_ext" descr="" subnode="pddr_c2p_link_enabed_eth_ext" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_operation_info_page_ext" descr="" size="0xf8.0" >
+	<field name="neg_mode_active" descr="0: protocol_was_not_negotiated - (force mode)\;1: MLPN_rev0_negotiated\;2: CL73_Ethernet_negotiated\;3: Protocol_according_to_Parallel_detect - (remote port in force mode)\;4: Standard_IB_negotiated \;\;8: NLPN_rev2_negotiated\;9: HS_NLPN_rev2_negotiated_" access="RO" enum="protocol_was_not_negotiated=0x0,MLPN_rev0_negotiated=0x1,CL73_Ethernet_negotiated=0x2,Protocol_according_to_Parallel_detect=0x3,Standard_IB_negotiated=0x4,NLPN_rev2_negotiated=0x8,HS_NLPN_rev2_negotiated_=0x9" offset="0x0.16" size="0x0.4" />
+	<field name="proto_active" descr="Active protocol:\;Bit 0: InfiniBand\;Bit 2: Ethernet" access="RO" enum="InfiniBand=0x1,Ethernet=0x4" offset="0x0.20" size="0x0.4" />
+	<field name="ib_phy_fsm_state" descr="FW IB state machine:\;0x0: IB_AN_FSM_DISABLED\;0x1: IB_AN_FSM_INITIALY\;0x2: IB_AN_FSM_RCVR_CFG\;0x3: IB_AN_FSM_CFG_TEST\;0x4: IB_AN_FSM_WAIT_RMT_TEST\;0x5: IB_AN_FSM_WAIT_CFG_ENHANCED\;0x6: IB_AN_FSM_CFG_IDLE\;0x7: IB_AN_FSM_LINK_UP\;0x8: IB_AN_FSM_POLLING" access="RO" enum="IB_AN_FSM_DISABLED=0x0,IB_AN_FSM_INITIALY=0x1,IB_AN_FSM_RCVR_CFG=0x2,IB_AN_FSM_CFG_TEST=0x3,IB_AN_FSM_WAIT_RMT_TEST=0x4,IB_AN_FSM_WAIT_CFG_ENHANCED=0x5,IB_AN_FSM_CFG_IDLE=0x6,IB_AN_FSM_LINK_UP=0x7,IB_AN_FSM_POLLING=0x8" offset="0x4.8" size="0x0.8" />
+	<field name="eth_an_fsm_state" descr="Ethernet (CL73) Auto-negotiation FSM state:\;0x0: ETH_AN_FSM_ENABLE\;0x1: ETH_AN_FSM_XMIT_DISABLE\;0x2: ETH_AN_FSM_ABILITY_DETECT\;0x3: ETH_AN_FSM_ACK_DETECT\;0x4: ETH_AN_FSM_COMPLETE_ACK\;0x5: ETH_AN_FSM_AN_GOOD_CHECK\;0x6: ETH_AN_FSM_AN_GOOD\;0x7: ETH_AN_FSM_NEXT_PAGE_WAIT" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="phy_mngr_fsm_state" descr="FW Phy Manager FSM state:\;0: Disabled \;1: Open_port\;2: Polling\;3: Active\;4: Close_port\;5: Phy_up\;6: Sleep\;7: Rx_disable\;8: Signal_detect\;9: Receiver_detect\;10: Sync_peer\;11: Negotiation\;12: Training\;13: SubFSM_active" access="RO" enum="Disabled=0x0,Open_port=0x1,Polling=0x2,Active=0x3,Close_port=0x4,Phy_up=0x5,Sleep=0x6,Rx_disable=0x7,Signal_detect=0x8,Receiver_detect=0x9,Sync_peer=0xa,Negotiation=0xb,Training=0xc,SubFSM_active=0xd" offset="0x4.24" size="0x0.8" />
+	<field name="phy_manager_link_enabled" descr="For IB: Table 1648, &quot;PDDR - Phy manager link enabled IB layout,&quot; on page 1917\;For Ethernet: Table 1650, &quot;PDDR - Phy manager link enabled Eth layout,&quot; on page 1917\;" subnode="pddr_operation_info_page_phy_manager_link_enabled_auto_ext" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="core_to_phy_link_enabled" descr="For IB: Table 1652, &quot;PDDR - core2phy link enabled IB layout,&quot; on page 1918\;For Ethernet: Table 1654, &quot;PDDR - Core2Phy link enabled Eth layout,&quot; on page 1918" subnode="pddr_operation_info_page_core_to_phy_link_enabled_auto_ext" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="cable_proto_cap" descr="For IB: Table 1656, &quot;PDDR - cable cap IB layout,&quot; on page 1919\;For Ethernet: Table 1658, &quot;PDDR - cable cap Eth layout,&quot; on page 1920\;" subnode="pddr_operation_info_page_cable_proto_cap_auto_ext" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="link_active" descr="For IB: Table 1660, &quot;PDDR - Link Active IB layout,&quot; on page 1921\;For Ethernet: Table 1662, &quot;PDDR - Link Active Eth layout,&quot; on page 1921" subnode="pddr_operation_info_page_link_active_auto_ext" access="RO" offset="0x14.0" size="0x4.0" union_selector="$(parent).proto_active" />
+	<field name="loopback_mode" descr="0: No_loopback_active\;1: Phy_remote_loopback \;2: Phy_local_loopback -When set the port&apos;s egress traffic is looped back to the receiver and the port transmitter is disabled. \;4: External_local_loopback -Enables the port&apos;s transmitter to link with the port&apos;s receiver using an external loopback connector." access="RO" enum="No_loopback_active=0x0,Phy_remote_loopback=0x1,Phy_local_loopback=0x2,External_local_loopback=0x4" offset="0x18.0" size="0x0.12" />
+	<field name="fec_mode_request" descr="FEC mode request\;See fec_mode_active\;for supported retransmission mode see PPLM.fec_mode_capability" access="RO" offset="0x1C.0" size="0x0.16" />
+	<field name="fec_mode_active" descr="FEC mode active\;0: No_FEC\;1: Firecode_FEC\;2: Standard_RS_FEC - RS(528,514)\;3: Standard_LL_RS_FEC - RS(271,257)\;6: Interleaved_Standard_RS-FEC - (544,514)\;7: Standard_RS-FEC - (544,514)\;9: Ethernet_Consortium_LL_50G_RS_FEC- (272,257+1)\;10: Interleaved_Ethernet_Consortium_LL_50G_RS_FEC - (272,257+1)\;For supported retransmission mode see PPLM.fec_mode_capability" access="RO" enum="No_FEC=0x0,Firecode_FEC=0x1,Standard_RS_FEC=0x2,Standard_LL_RS_FEC=0x3,Interleaved_Standard_RS=0x6,Standard_RS=0x7,Ethernet_Consortium_LL_50G_RS_FEC=0x9,Interleaved_Ethernet_Consortium_LL_50G_RS_FEC=0xa" offset="0x1C.16" size="0x0.16" />
+	<field name="eth_100g_fec_support" descr="FEC 100G (25Gb/s per lane) supported FEC include override masking , should reflect current phy configuration after link is up\;\;Bit 0 - No FEC\;Bit 2 - Standard RS-FEC - RS(528,514)\;" access="RO" offset="0x20.0" size="0x0.4" />
+	<field name="eth_25g_50g_fec_support" descr="FEC 25G/50G (25Gb/s per lane) supported FEC include override masking , should reflect current phy configuration after link is up\;Bit 0 - No FEC\;Bit 1 - Firecode FEC\;Bit 2 - Standard RS-FEC - RS(528,514)\;" access="RO" offset="0x20.4" size="0x0.4" />
+</node>
+
+<node name="pddr_operation_info_page_link_active_auto_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="pddr_link_active_ib_ext" descr="" subnode="pddr_link_active_ib_ext" offset="0x0.0" selected_by="InfiniBand" size="0x4.0" />
+	<field name="pddr_link_active_eth_ext" descr="" subnode="pddr_link_active_eth_ext" offset="0x0.0" selected_by="Ethernet" size="0x4.0" />
+</node>
+
+<node name="pddr_operation_info_page_phy_manager_link_enabled_auto_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="pddr_phy_manager_link_enabed_ib_ext" descr="" subnode="pddr_phy_manager_link_enabed_ib_ext" offset="0x0.0" size="0x4.0" />
+	<field name="pddr_phy_manager_link_enabed_eth_ext" descr="" subnode="pddr_phy_manager_link_enabed_eth_ext" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_phy_manager_link_enabed_eth_ext" descr="" size="0x4.0" >
+	<field name="phy_manager_link_eth_enabled" descr="Ethernet protocols admin state: see PTYS.ext_eth_proto_admin" access="RO" offset="0x0.0" size="0x4.0" />
+</node>
+
+<node name="pddr_phy_manager_link_enabed_ib_ext" descr="" size="0x4.0" >
+	<field name="phy_manager_link_proto_enabled" descr="ib link enabled speed:\;Bit 0 - SDR\;Bit 1 - DDR\;Bit 2 - QDR\;Bit 3 - FDR10\;Bit 4 - FDR\;Bit 5 - EDR\;Bit 6 - HDR\;Bit 7 - NDR\;Bit 8 - XDR" access="RO" offset="0x0.0" size="0x0.16" />
+	<field name="phy_manager_link_width_enabled" descr="ib link enabled width:\;Bit 0 - 1x\;Bit 1 - 2x\;Bit 2 - 4x\;Other - reserved" access="RO" offset="0x0.16" size="0x0.16" />
+</node>
+
+<node name="pddr_reg_ext" descr="" size="0x100.0" >
+	<field name="port_type" descr="Supported only when indicated by PCAM \;0: Network_port\;1: Near_End_Port - (For Retimer/Gearbox - Host side)\;2: Internal_IC_LR_Port \;3: Far_End_Port - (For Retimer/Gearbox - Line side)\;Other values are reserved." access="INDEX" enum="Network_port=0x0,Near_End_Port=0x1,Internal_IC_LR_Port=0x2,Far_End_Port=0x3" offset="0x0.4" size="0x0.4" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0: Local_port_number\;1: IB_port_number\;" access="INDEX" enum="Local_port_number=0x0,IB_port_number=0x1" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="page_select" descr="page select index:\;0: Operational_info_page\;1: Troubleshooting_info_page\;3: Module_info_page\;6: link_down_info\;9: Module_latched_flag_info_page" access="INDEX" enum="Operational_info_page=0x0,Troubleshooting_info_page=0x1,Module_info_page=0x3,link_down_info=0x6,Module_latched_flag_info_page=0x9" offset="0x4.0" size="0x0.8" />
+	<field name="module_info_ext" descr="Module info extended configurations.\;resolution for rx_power, rx_power_high_th, rx_power_low_th tx_power, tx_power_high_th, tx_power_low_th in module info page\;0: dbm\;1: uW" access="OP" enum="dbm=0x0,uW=0x1" offset="0x4.29" size="0x0.2" />
+	<field name="page_data" descr="Table 1646, &quot;Operation Info Page Layout,&quot; on page 1908\;Table 1682, &quot;Troubleshooting info Page layout,&quot; on page 1957\;Table 1680, &quot;Module Info Page Layout,&quot; on page 1945\;Table 1676, &quot;Link Down Info Page layout,&quot; on page 1940\;Table 1694, &quot;Module Latched Flag Info Page Layout,&quot; on page 1974\;" subnode="pddr_reg_page_data_auto_ext" access="RO" offset="0x8.0" size="0xf8.0" union_selector="$(parent).page_select" />
+</node>
+
+<node name="pddr_reg_page_data_auto_ext" descr="" attr_is_union="1" size="0xf8.0" >
+	<field name="pddr_operation_info_page_ext" descr="" subnode="pddr_operation_info_page_ext" offset="0x0.0" selected_by="Operational_info_page" size="0xf8.0" />
+	<field name="pddr_troubleshooting_page_ext" descr="" subnode="pddr_troubleshooting_page_ext" offset="0x0.0" selected_by="Troubleshooting_info_page" size="0xf8.0" />
+	<field name="pddr_module_info_ext" descr="" subnode="pddr_module_info_ext" offset="0x0.0" selected_by="Module_info_page" size="0xd8.0" />
+	<field name="pddr_link_down_info_page_ext" descr="" subnode="pddr_link_down_info_page_ext" offset="0x0.0" selected_by="link_down_info" size="0xf4.0" />
+	<field name="module_latched_flag_info_ext" descr="" subnode="module_latched_flag_info_ext" offset="0x0.0" selected_by="Module_latched_flag_info_page" size="0xf8.0" />
+</node>
+
+<node name="pddr_troubleshooting_page_ext" descr="" size="0xf8.0" >
+	<field name="group_opcode" descr="0: Monitor_opcodes" access="INDEX" enum="Monitor_opcodes=0x0" offset="0x0.0" size="0x0.16" />
+	<field name="status_opcode" descr="Status opcode described in:\;Table 1684, &quot;PDDR - Monitor opcodes layout,&quot; on page 1958" subnode="pddr_troubleshooting_page_status_opcode_auto_ext" access="RO" offset="0x4.0" size="0x4.0" union_selector="$(parent).group_opcode" />
+	<field name="status_message" descr="ASCII code message\;All Messages are terminated by a Null character &apos;\0&apos;" access="RO" high_bound="58" low_bound="0" offset="0xC.0" size="0xec.0" />
+</node>
+
+<node name="pddr_troubleshooting_page_status_opcode_auto_ext" descr="" attr_is_union="1" size="0x4.0" >
+	<field name="pddr_monitor_opcode_ext" descr="" subnode="pddr_monitor_opcode_ext" offset="0x0.0" selected_by="Monitor_opcodes" size="0x4.0" />
+</node>
+
+<node name="pevnt_ext" descr="" size="0x8.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="rx_cont" descr="The local_port RX is contained.\;RX containd - When a packet had a corruption, and is discarded. the port which detect the error &apos;contains&apos; it by stopping the traffic." access="RO" offset="0x4.0" size="0x0.1" />
+	<field name="tx_cont" descr="The local_port TX is contained.\;TX containd - When a packet had a corruption, and is discarded. the port which detect the error &apos;contains&apos; it by stopping the traffic." access="RO" offset="0x4.1" size="0x0.1" />
+</node>
+
+<node name="pguid_reg_ext" descr="" size="0x60.0" >
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0 - Local port number\;1 - IB port number" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="local_port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="sys_guid" descr="System GUID" access="RO" high_bound="3" low_bound="0" offset="0x4.0" size="0x10.0" />
+	<field name="node_guid" descr="Node GUID" access="RO" high_bound="3" low_bound="0" offset="0x14.0" size="0x10.0" />
+	<field name="port_guid" descr="Port GUID" access="RO" high_bound="3" low_bound="0" offset="0x24.0" size="0x10.0" />
+	<field name="allocated_guid" descr="Allocated GUID" access="RO" high_bound="3" low_bound="0" offset="0x34.0" size="0x10.0" />
+</node>
+
+<node name="phys_layer_cntrs_ext" descr="" size="0xf8.0" >
+	<field name="time_since_last_clear_high" descr="The time passed since the last counters clear event in msec." access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="time_since_last_clear_low" descr="The time passed since the last counters clear event in msec." access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="symbol_errors_high" descr="Perf.PortCounters(SymbolErrorCounter) = Perf.PortCounters(UnknownSymbol)" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="symbol_errors_low" descr="Perf.PortCounters(SymbolErrorCounter) = Perf.PortCounters(UnknownSymbol)" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="sync_headers_errors_high" descr="Perf.PortExtendedSpeedsCounters(SynchHeaderErrorCounter)" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="sync_headers_errors_low" descr="Perf.PortExtendedSpeedsCounters(SynchHeaderErrorCounter)" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane0_high" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane0Counter) / BIP error counter, lane 0\;In PRBS test mode, indicates the number of PRBS errors\;on lane 0" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane0_low" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane0Counter) / BIP error counter, lane 0\;In PRBS test mode, indicates the number of PRBS errors\;on lane 0" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane1_high" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane1Counter) / BIP error counter, lane 1\;In PRBS test mode, indicates the number of PRBS errors\;on lane 1" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane1_low" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane1Counter) / BIP error counter, lane 1\;In PRBS test mode, indicates the number of PRBS errors\;on lane 1" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane2_high" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane2Counter) / BIP error counter, lane 2\;In PRBS test mode, indicates the number of PRBS errors\;on lane 2" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane2_low" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane2Counter) / BIP error counter, lane 2\;In PRBS test mode, indicates the number of PRBS errors\;on lane 2" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane3_high" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane3Counter) / BIP error counter, lane 3\;In PRBS test mode, indicates the number of PRBS errors\;on lane 3" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="edpl_bip_errors_lane3_low" descr="Perf.PortExtendedSpeedsCounters(ErrorDetectionPerLane3Counter) / BIP error counter, lane 3\;In PRBS test mode, indicates the number of PRBS errors\;on lane 3" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane0_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane0)" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane0_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane0)" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane1_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane1)" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane1_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane1)" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane2_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane2)" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane2_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane2)" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane3_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane3)" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="fc_fec_corrected_blocks_lane3_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane3)" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane0_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane0)" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane0_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane0)" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane1_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane1)" access="RO" offset="0x60.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane1_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane1)" access="RO" offset="0x64.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane2_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane2)" access="RO" offset="0x68.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane2_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane2)" access="RO" offset="0x6C.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane3_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane3)" access="RO" offset="0x70.0" size="0x4.0" />
+	<field name="fc_fec_uncorrectable_blocks_lane3_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrectableBlockCounterLane3)" access="RO" offset="0x74.0" size="0x4.0" />
+	<field name="rs_fec_corrected_blocks_high" descr="Perf.PortExtendedSpeedsCounters(FECCorrecableBlockCounter)" access="RO" offset="0x78.0" size="0x4.0" />
+	<field name="rs_fec_corrected_blocks_low" descr="Perf.PortExtendedSpeedsCounters(FECCorrecableBlockCounter)" access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="rs_fec_uncorrectable_blocks_high" descr="Perf.PortExtendedSpeedsCounters(FEUncorrecableBlockCounter)" access="RO" offset="0x80.0" size="0x4.0" />
+	<field name="rs_fec_uncorrectable_blocks_low" descr="Perf.PortExtendedSpeedsCounters(FEUncorrecableBlockCounter)" access="RO" offset="0x84.0" size="0x4.0" />
+	<field name="rs_fec_no_errors_blocks_high" descr="The number of RS-FEC blocks received that had no errors.\;Note: Total rs_fec blocks received = rs_fec_corrected_blocks + rs_fec_uncorrectable_blocks + rs_fec_no_errors_blocks" access="RO" offset="0x88.0" size="0x4.0" />
+	<field name="rs_fec_no_errors_blocks_low" descr="The number of RS-FEC blocks received that had no errors.\;Note: Total rs_fec blocks received = rs_fec_corrected_blocks + rs_fec_uncorrectable_blocks + rs_fec_no_errors_blocks" access="RO" offset="0x8C.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_total_high" descr="Perf.PortExtendedSpeedCounters(PortFECCorrectedSymbolCounter)" access="RO" offset="0x98.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_total_low" descr="Perf.PortExtendedSpeedCounters(PortFECCorrectedSymbolCounter)" access="RO" offset="0x9C.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane0_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane0)" access="RO" offset="0xA0.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane0_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane0)" access="RO" offset="0xA4.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane1_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane1)" access="RO" offset="0xA8.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane1_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane1)" access="RO" offset="0xAC.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane2_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane2)" access="RO" offset="0xB0.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane2_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane2)" access="RO" offset="0xB4.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane3_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane3)" access="RO" offset="0xB8.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane3_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane3)" access="RO" offset="0xBC.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane4_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane4)" access="RO" offset="0xC8.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane4_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane4)" access="RO" offset="0xCC.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane5_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane5)" access="RO" offset="0xD0.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane5_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane5)" access="RO" offset="0xD4.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane6_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane6)" access="RO" offset="0xD8.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane6_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane6)" access="RO" offset="0xDC.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane7_high" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane7)" access="RO" offset="0xE0.0" size="0x4.0" />
+	<field name="rs_fec_corrected_symbols_lane7_low" descr="Perf.PortExtendedSpeedCounters(FECCorrectedSymbolCounterLane7)" access="RO" offset="0xE4.0" size="0x4.0" />
+</node>
+
+<node name="phys_layer_stat_cntrs_ext" descr="" size="0xf8.0" >
+	<field name="time_since_last_clear_high" descr="The time passed since the last counters clear event in msec.\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="time_since_last_clear_low" descr="The time passed since the last counters clear event in msec.\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="phy_received_bits_high" descr="This counter provides information on the total amount of traffic (bits) received.\;" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="phy_received_bits_low" descr="This counter provides information on the total amount of traffic (bits) received.\;" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="phy_symbol_errors_high" descr="This counter provides information on error bits that were not corrected by phy correction mechanisms. (FEC + PLR)\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="phy_symbol_errors_low" descr="This counter provides information on error bits that were not corrected by phy correction mechanisms. (FEC + PLR)\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="phy_corrected_bits_high" descr="Corrected bits by FEC engine. \;" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="phy_corrected_bits_low" descr="Corrected bits by FEC engine. \;" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane0_high" descr="This counter provides information on error bits that were identified on lane 0. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 0\;\;\;" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane0_low" descr="This counter provides information on error bits that were identified on lane 0. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 0\;\;\;" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane1_high" descr="This counter provides information on error bits that were identified on lane 1. \;When FEC is enabled this induction corresponds to corrected errors\;In PRBS test mode, indicates the number of PRBS errors\;on lane 1\;\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane1_low" descr="This counter provides information on error bits that were identified on lane 1. \;When FEC is enabled this induction corresponds to corrected errors\;In PRBS test mode, indicates the number of PRBS errors\;on lane 1\;\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane2_high" descr="This counter provides information on error bits that were identified on lane 2. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 2\;\;\;\;" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane2_low" descr="This counter provides information on error bits that were identified on lane 2. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 2\;\;\;\;" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane3_high" descr="This counter provides information on error bits that were identified on lane 3. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 3\;\;" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane3_low" descr="This counter provides information on error bits that were identified on lane 3. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 3\;\;" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane4_high" descr="This counter provides information on error bits that were identified on lane 4. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 4\;\;\;" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane4_low" descr="This counter provides information on error bits that were identified on lane 4. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 4\;\;\;" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane5_high" descr="This counter provides information on error bits that were identified on lane 5. \;When FEC is enabled this induction corresponds to corrected errors\;In PRBS test mode, indicates the number of PRBS errors\;on lane 5\;\;" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane5_low" descr="This counter provides information on error bits that were identified on lane 5. \;When FEC is enabled this induction corresponds to corrected errors\;In PRBS test mode, indicates the number of PRBS errors\;on lane 5\;\;" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane6_high" descr="This counter provides information on error bits that were identified on lane 6. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 6" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane6_low" descr="This counter provides information on error bits that were identified on lane 6. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 6" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane7_high" descr="This counter provides information on error bits that were identified on lane 7. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 7" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="phy_raw_errors_lane7_low" descr="This counter provides information on error bits that were identified on lane 7. \;When FEC is enabled this induction corresponds to corrected errors.\;In PRBS test mode, indicates the number of PRBS errors\;on lane 7" access="RO" offset="0x5C.0" size="0x4.0" />
+	<field name="raw_ber_coef" descr="Raw_BER = raw_ber_coef  *10^(-raw_ber_magnitude)\;" access="RO" offset="0x60.0" size="0x0.4" />
+	<field name="raw_ber_magnitude" descr="Raw_BER = raw_ber_coef  *10^(-raw_ber_magnitude)\;" access="RO" offset="0x60.8" size="0x0.8" />
+	<field name="fc_zero_hist" descr="Valid for links with RS FEC histograms only.\;First histogram bin with value of 0 while all higher bins are only with 0 value as well.\;0 - No histogram active / N/A value" access="RO" offset="0x60.16" size="0x0.4" />
+	<field name="effective_ber_coef" descr="effective_fec_BER = effective_fec_ber_coef *10^(-effective_fec_ber_magnitude)\;" access="RO" offset="0x64.0" size="0x0.4" />
+	<field name="effective_ber_magnitude" descr="effective_fec_BER = effective_fec_ber_coef *10^(-effective_fec_ber_magnitude)\;" access="RO" offset="0x64.8" size="0x0.8" />
+	<field name="symbol_ber_coef" descr="Symbol_BER = symbol_ber_coef*10^(-symbol_ber_magnitude)" access="RO" offset="0x68.0" size="0x0.4" />
+	<field name="symbol_ber_magnitude" descr="Symbol_BER = symbol_ber_coef*10^(-symbol_ber_magnitude)" access="RO" offset="0x68.8" size="0x0.8" />
+	<field name="phy_effective_errors_high" descr="This counter provides information on error bits that were not corrected by FEC correction algorithm or that FEC is not active.\;" access="RO" offset="0x7C.0" size="0x4.0" />
+	<field name="phy_effective_errors_low" descr="This counter provides information on error bits that were not corrected by FEC correction algorithm or that FEC is not active.\;" access="RO" offset="0x80.0" size="0x4.0" />
+</node>
+
+<node name="plib_reg_ext" descr="" size="0x10.0" >
+	<field name="ib_port" descr="In IB port: InfiniBand port remapping for local_port\;In Ethernet port: Label port remapping for local_port\;Note: ib_port number can only be updated when a port admin state is DISABLED." access="RW" offset="0x0.0" size="0x0.10" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="split_num" descr="Valid only for Ethernet Switches. \;Label split mapping for local_port" access="RW" offset="0x4.0" size="0x0.4" />
+</node>
+
+<node name="pltc_reg_ext" descr="" size="0x10.0" >
+	<field name="lane_mask" descr="for set operation, lane bitmask\;for query operation, one-hot key" access="INDEX" offset="0x0.0" size="0x0.8" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0: Local_port_number\;1: IB_port_number" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="precoding_cap_mask" descr="0x0 - no tx precoding available / no override capabilty\;\;Bit 0- tx precoding override possible via local_tx_precoding_admin field\;Bit 1- rx precoding override possible via local_rx_precoding_admin field" access="RO" offset="0x4.0" size="0x0.4" />
+	<field name="local_tx_precoding_admin" descr="0 - auto\;1 - force Tx precoding\;2 - force Tx without precoding" access="RW" offset="0x8.0" size="0x0.2" />
+	<field name="local_rx_precoding_admin" descr="Rx configuration override for 100g Pam4 per lane protocols.\;0 - auto\;1 - Rx precoding enabled. \;if negotiated, request Tx precoding from peer.\;2 - Rx precoding disabled. \;if negotiated, request no Tx precoding from peer\;" access="RW" offset="0x8.16" size="0x0.2" />
+	<field name="local_tx_precoding_oper" descr="0 - unknown / no active link\;1 - Tx precoding enabled.\;2 - Tx precoding disabled." access="RO" offset="0xC.0" size="0x0.2" />
+	<field name="local_rx_precoding_oper" descr="Rx precoding operational mode\;0 - unknown / no active link\;1 - Rx precoding enabled. \;2 - Rx precoding disabled." access="RO" offset="0xC.16" size="0x0.2" />
+</node>
+
+<node name="pmaos_reg_ext" descr="" size="0x10.0" >
+	<field name="oper_status" descr="Module state (reserved while admin_status is disabled):\;0: initializing\;1: plugged_enabled\;2: unplugged\;3: module_plugged_with_error - (details in error_type).\;5: unknown" access="RO" enum="initializing=0x0,plugged_enabled=0x1,unplugged=0x2,module_plugged_with_error=0x3,unknown=0x5" offset="0x0.0" size="0x0.4" />
+	<field name="admin_status" descr="Module administrative state (the desired state of the module):\;1: enabled\;2: disabled_by_configuration\;3: enabled_once - if the module is active and then unplugged, or module experienced an error event, the operational status should go to &quot;disabled&quot; and can only be enabled upon explicit enable command.\;\;Note - To disable a module, all ports associated with the port must be disabled first.\;" access="RW" enum="enabled=0x1,disabled_by_configuration=0x2,enabled_once=0x3" offset="0x0.8" size="0x0.4" />
+	<field name="module" descr="Module number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA\;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="rst" descr="Module Reset toggle\;NOTE: setting reset while module is plugged-in will result in transition of oper_status to initialization." access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="e" descr="Event Generation on operational state change:\;0: Do_not_generate_event\;1: Generate_Event\;2: Generate_Single_Event" access="RW" enum="Do_not_generate_event=0x0,Generate_Event=0x1,Generate_Single_Event=0x2" offset="0x4.0" size="0x0.2" />
+	<field name="error_type" descr="Module error details:\;0x0: Power_Budget_Exceeded\;0x1: Long_Range_for_non_MLNX_cable_or_module\;0x2: Bus_stuck - (I2C Data or clock shorted)\;0x3: bad_or_unsupported_EEPROM\;0x4: Enforce_part_number_list\;0x5: unsupported_cable\;0x6: High_Temperature\;0x7: bad_cable - (Module/Cable is shorted)\;0x8: PMD_type_is_not_enabled - (see PMTPS)\;0xc: pcie_system_power_slot_Exceeded\;\;[DWIP] 0xf: Boot_error\;[DWIP] 0x10: Recovery_error\;[DWIP] 0x11: Submodule_failure\;Valid only when oper_status = 4&apos;b0011" access="RO" enum="Power_Budget_Exceeded=0x0,Long_Range_for_non_MLNX_cable_or_module=0x1,Bus_stuck=0x2,bad_or_unsupported_EEPROM=0x3,Enforce_part_number_list=0x4,unsupported_cable=0x5,High_Temperature=0x6,bad_cable=0x7,PMD_type_is_not_enabled=0x8,pcie_system_power_slot_Exceeded=0xc" offset="0x4.8" size="0x0.5" />
+	<field name="operational_notification" descr="This notification can occur only if module passed initialization process\;0x0: No notifications.\;0x1: Speed degradation - the module is not enabled in its full speed due to incompatible transceiver/cable \;Valid only when oper_status = 4&apos;b0001." access="RO" offset="0x4.16" size="0x0.4" />
+	<field name="rev_incompatible" descr="When in multi ASIC module sharing systems,\;This flag will be asserted in case primary and secondary FW versions are not compatible." access="RO" offset="0x4.28" size="0x0.1" />
+	<field name="secondary" descr="Indicates whether the ASIC serves as a the modules secondary (=1) or primary (=0) device." access="RO" offset="0x4.29" size="0x0.1" />
+	<field name="ee" descr="Event update enable. If this bit is set, event generation will be updated based on the e field. Only relevant on Set operations." access="WO" offset="0x4.30" size="0x0.1" />
+	<field name="ase" descr="Admin state update enable. If this bit is set, admin state will be updated based on admin_state field. Only relevant on Set() operations." access="WO" offset="0x4.31" size="0x0.1" />
+</node>
+
+<node name="pmcr_reg_ext" descr="" size="0x20.0" >
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="error_code_response" descr="Valid for CMIS modules.\;error code response on override values.\;0x0: ConfigUndefined\;0x1: ConfigSuccess\;0x2: ConfigRejected\;0x3: ConfigRejectedInvalidAppSel\;0x4: ConfigRejectedInvalidDataPath\;0x5: ConfigRejectedInvalidSI\;0x6: ConfigRejectedLanesInUse\;0x7: ConfigRejectedPartialDataPath\;0xC: ConfigInProgress" access="RO" enum="ConfigUndefined=0x0,ConfigSuccess=0x1,ConfigRejected=0x2,ConfigRejectedInvalidAppSel=0x3,ConfigRejectedInvalidDataPath=0x4,ConfigRejectedInvalidSI=0x5,ConfigRejectedLanesInUse=0x6,ConfigRejectedPartialDataPath=0x7,ConfigInProgress=0xc" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="cs_sel" descr="Valid only for CMIS (QSFP-DD / SFP-DD / OSFP) compliant modules.\;If Control Set 1 not implemented or non CMIS module ignore field.\;0 - Auto (default)\;1 - Use Control Set 0\;2 - Use Control Set 1" access="INDEX" offset="0x0.24" size="0x0.2" />
+	<field name="cdr_override_cntl" descr="Module CDR override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0x4.0" size="0x0.2" />
+	<field name="cdr_override_cap" descr="Module TX and RX override control capability.\;Bit 0 - RX CDR control is possible\;Bit 0 - TX CDR control is possible" access="RO" offset="0x4.2" size="0x0.2" />
+	<field name="cdr_override_value" descr="Valid only in case CDR is configured to override mode by cdr_override_cntl: \;0 - RX OFF, TX OFF\;1 - RX ON , TX OFF\;2 - RX OFF, TX ON\;3 - RX ON, TX ON" access="RW" offset="0x4.8" size="0x0.4" />
+	<field name="tx_disable_override_cntl" descr="In HCA, valid based on PCAM feature capabilities. \;Module TX_DISABLE override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0x4.16" size="0x0.2" />
+	<field name="tx_disable_override_value" descr="Valid only in case TX_DISABLE is configured to override mode by tx_disable_override_cntl: \;0 - TX_DISABLE is low (i.e. TX is enabled)\;1 - TX_DISABLE is high (i.e. TX is disabled)" access="RW" offset="0x4.24" size="0x0.2" />
+	<field name="rx_amp_override_cntl" descr="Module RX amplitude override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0x8.0" size="0x0.2" />
+	<field name="rx_amp_override_cap" descr="Module rx_amp override control capability." access="RO" offset="0x8.2" size="0x0.1" />
+	<field name="rx_amp_override_value" descr="Valid only in case RX amplitude is configured to override mode by rx_amp_override_cntl" access="RW" offset="0x8.8" size="0x0.4" />
+	<field name="rx_amp_override_value_cap" descr="Module rx_amp bitmask of allowed values." access="RO" offset="0x8.12" size="0x0.4" />
+	<field name="rx_los_override_cntl" descr="Valid only in case RX _LOS is configured to override mode by rx_los_override_admin" access="RW" offset="0x8.16" size="0x0.2" />
+	<field name="rx_los_override_cap" descr="Module RX_LOS override control capability." access="RO" offset="0x8.18" size="0x0.1" />
+	<field name="rx_los_override_admin" descr="Module RX _LOS override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0x8.24" size="0x0.2" />
+	<field name="rx_emp_override_cntl" descr="Module RX emphasis override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0xC.0" size="0x0.2" />
+	<field name="rx_emp_override_cap" descr="Module rx_emp override control capability." access="RO" offset="0xC.2" size="0x0.1" />
+	<field name="rx_emp_override_value" descr="For CMIS modules, pre emphasis equalization value.\;For SFF modules, emphasis equalization value.\;Valid only in case RX emphasis is configured to override mode by rx_emp_override_cntl" access="RW" offset="0xC.8" size="0x0.4" />
+	<field name="rx_emp_override_value_cap" descr="Module rx_emp max allowed values." access="RO" offset="0xC.12" size="0x0.4" />
+	<field name="rx_post_emp_override_cntl" descr="Module RX emphasis override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0xC.16" size="0x0.2" />
+	<field name="rx_post_emp_override_cap" descr="Module rx_post_emp override control capability." access="RO" offset="0xC.18" size="0x0.1" />
+	<field name="rx_post_emp_override_value" descr="Valid for CMIS modules only.\;Post emphasis equalization value.\;Valid only in case RX emphasis is configured to override mode by rx_post_emp_override_cntl" access="RW" offset="0xC.24" size="0x0.4" />
+	<field name="rx_post_emp_override_value_cap" descr="Module rx_post_emp max allowed values." access="RO" offset="0xC.28" size="0x0.4" />
+	<field name="tx_equ_override_cntl" descr="Module TX equalization override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - Override" access="RW" offset="0x10.0" size="0x0.2" />
+	<field name="tx_equ_override_cap" descr="Module TX equalization override control capability." access="RO" offset="0x10.2" size="0x0.1" />
+	<field name="tx_equ_override_value" descr="Valid only in case TX equalization is configured to override mode by tx_equ_override_cntl." access="RW" offset="0x10.8" size="0x0.4" />
+	<field name="tx_equ_override_value_cap" descr="Module tx_eq max allowed values." access="RO" offset="0x10.12" size="0x0.4" />
+	<field name="tx_adaptive_override_value" descr="0 - disable adaptive Tx Equailization\;1 - enable adaptive Tx equalization\;Valid only in case TX equalization is configured to override mode by tx_adaptive_override_cntrl." access="RW" offset="0x10.17" size="0x0.1" />
+	<field name="tx_adaptive_override_cntrl" descr="Module adaptive tuning flow override control:\;0 - Auto (default)\;1 - Keep the module configuration\;2 - override" access="RW" offset="0x10.24" size="0x0.2" />
+	<field name="tx_adaptive_override_cap" descr="Module TX adaptive tuning flow override control capability." access="RO" offset="0x10.26" size="0x0.1" />
+	<field name="ap_sel_override_cntrl" descr="Module Application select override control:\;0 - Auto (default)\;1 - Use Module&apos;s Default application value\;2 - Override" access="RW" offset="0x18.0" size="0x0.2" />
+	<field name="ap_sel_override_value" descr="Application Select from the applications list advertised by the module. Up to 15 applications available.\;\;Values range from 1 to 15.\;\;Note: application can be set with default SI values defined by the module or SI defined by the host" access="RW" offset="0x18.8" size="0x0.4" />
+</node>
+
+<node name="pmlp_reg_ext" descr="" size="0x40.0" >
+	<field name="width" descr="0: unmap_local_port\;1: x1 - lane 0 is used\;2: x2 - lanes 0,1 are used\;4: x4 - lanes 0,1,2 and 3 are used\;8: x8 - lanes 0-7 are used\;\;Other - reserved" access="RW" enum="unmap_local_port=0x0,x1=0x1,x2=0x2,x4=0x4,x8=0x8" offset="0x0.0" size="0x0.8" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="m_lane_m" descr="Module lane mapping: \;0 - Local to Module mapping include module lanes mapping\;1 - Local to Module mapping only, without lane mapping\;\;When this operational is set (&apos;1&apos;), the following fields are ignored in SET command and should return the value &quot;0&quot; in GET commands: \;PMLP.rxtx\;PMLP.lane&lt;i&gt;_module_mapping.tx_lane\;PMLP.lane&lt;i&gt;_module_mapping.rx_lane" access="OP" offset="0x0.28" size="0x0.1" />
+	<field name="rxtx" descr="Use different configuration for RX and TX.\;If this bit is cleared, the TX value is used for both RX and TX. When set, the RX configuration is taken from the separate field. This is to enable backward compatible implementation." access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="lane_module_mapping" descr="Module SerDes for lane &lt;i&gt;\;Up to 8 SerDeses in a module can be mapped to a local port." subnode="lane_2_module_mapping_ext" access="RW" high_bound="7" low_bound="0" offset="0x4.0" size="0x20.0" />
+</node>
+
+<node name="pmmp_cmis_protocol_override_layout_ext" descr="" size="0xc.0" >
+	<field name="host_electrical_compliance" descr="Host Electrical compliance code per CMIS byte 86 based on SFF-8024 table 4-5\;0 - unspecified\;1- 1000BASE - CX\;2 - XAUI\;3 - XFI\;4 - SFI\;5 - 25GAUI C2M\;6 - XLAUI C2M\;7 - XLPPI\;8 - LAUI-2 C2M\;9 - 50GAUI-2 C2M\;10 - 50GAUI-1 C2M\;11 - CAUI-4 C2M\;13 - 100GAUI-2 C2M\;15 - 200GAUI-4 C2M\;17 - 400GAUI-8 C2M\;20 - 25GBASE-CR CA-L\;21 - 25GBASE-CR CA-S\;22 - 25GBASE-CR CA-N\;23 - 40GBASE-CR4\;24 - 50GBASE-CR\;26 - 100GBASE-CR4\;27 - 100GBASE-CR2\;28 - 200GBASE-CR4\;29 - 400GBASE-CR8\;\;65 - CAUI-4 C2M no FEC\;66 - CAUI-4 C2M RS FEC\;67 - 50GBASE-CR2 RS FEC\;68 - 50GBASE-CR2 FC FEC\;69 - 50GBASE-CR2 no FEC" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="cable_breakout" descr="bits 7-0 as per byte 210 in CMIS, Near-End implementation\;Bit 0 - Channel 1 implementation \;Bit 1 - Channel 2 implementation\;Bit 2 - Channel 3 implementation\;Bit 3 - Channel 4 implementation\;Bit 4- Channel 5 implementation \;Bit 5- Channel 6 implementation\;Bit 6- Channel 7 implementation\;Bit 7- Channel 8 implementation\;\;for each channel:\;0 - Channel implemented \;1 - Channel not - implemented\;\;bit 12-8 as per byte 211 4-0 in CMIS, Far-End implementation\;" access="RW" offset="0x0.8" size="0x0.13" />
+	<field name="media_type_encoding" descr="Byte 85 in CMIS. Media type encoding override\;0: undefined\;1: Optical_MMF\;2: Optical_SMF\;3: Passive_copper\;4: Active_cables\;5: BASE_T" access="RW" offset="0x0.21" size="0x0.4" />
+	<field name="media_compliance" descr="Module media interface compliance for CMIS, per byte 87.\;Values taken according to module_media_type from SFF-8024:\;\;If MMF - SFF-8024 table 4-6, MM media interface codes\;If SMF - SFF-8024 table 4-7, SM media interface code\;\;If Active cable- SFF-8024 table 4-9 Active cable assembly code:\;0 -unspecified\;1 - Active cable assembly with BER &lt; 1e-12\;2 - Active cable assembly with BER &lt; 5e-5\;3 - Active cable assembly with BER &lt; 2.6e-4\;4 - Active cable assembly with BER &lt; 1e-6" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="module_media_type" descr="Module media type encoding, per byte 85 of CMIS:\;0 - undefined\;1 - MMF\;2 - SMF\;3 - passive Copper\;4 - Active cables\;5 - Base-T" access="RW" offset="0x4.8" size="0x0.8" />
+	<field name="dp_tx_off_maxDuration" descr="Data path turn off maximum duration. coded according to table 8-29 of CMIS 4.0." access="RW" offset="0x4.16" size="0x0.4" />
+	<field name="dp_tx_on_maxDuration" descr="Data path turn on maximum duration. coded according to table 8-29 of CMIS 4.0." access="RW" offset="0x4.20" size="0x0.4" />
+	<field name="dp_init_maxDuration" descr="Data path init maximum duration. coded according to table 8-29 of CMIS 4.0." access="RW" offset="0x4.28" size="0x0.4" />
+	<field name="cmis_override_mask" descr="bitmask of override from CMIS protocol bytes page.\;Relevant only when Bit 9 is set in eeprom_override field.\;inverse polarity.\;0 - override\;1 - don&apos;t override\;\;Bit 0 - cable_breakout\;Bit 1 -host_electrical_compliance\;Bit 2 - module_media_type\;Bit 3 - media_compliance\;Bit 4 - mod_pwrup_maxDuration\;Bit 5 - dp_init_maxDuration\;Bit 6 - dp_tx_on_maxDuration\;Bit 7 - dp_tx_off_maxDuration\;Bit 9 - media_type_encoding" access="RW" offset="0x8.0" size="0x0.16" />
+</node>
+
+<node name="pmmp_qsfp_protocol_override_layout_ext" descr="" size="0xc.0" >
+	<field name="ethernet_compliance_code" descr="Ethernet Compliance Codes bit mask (10/40G/100G)\;Override byte131 per SFF-8636:\;Bit 7 - Extended Specification Compliance valid\;Bit 6 - 10GBASE-LRM\;Bit 5 - 10GBASE-LR\;Bit 4 - 10GBASE-SR\;Bit 3 - 40GBASE-CR4\;Bit 2 - 40GBASE-SR4\;Bit 1 - 40GBASE-LR4\;Bit 0 - 40G Active Cable (XLPPI)" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="cable_breakout" descr="Override of byte113 per SFF-8636:\;Bit 6-4 (Far End):\;0 - Far end is unspecified\;1 - Cable with single far end with 4 channels implemented, or separable module with 4-channel connector\;2 - Cable with single far end with 2 channels implemented, or separable module with 2-channel connector\;3 - Cable with single far end with 1 channel implemented, or separable module with 1-channel connector\;4 - 4 far ends with 1 channel implemented in each (i.e. 4x1 break out)\;5 - 2 far ends with 2 channels implemented in each (i.e. 2x2 break out)\;6 - 2 far ends with 1 channel implemented in each (i.e. 2x1 break out)\;\;Bit 3-0 (Near End)\;Bit 0 - Channel 1 implementation \;Bit 1 - Channel 2 implementation\;Bit 2 - Channel 3 implementation\;Bit 3 - Channel 4 implementation\;\;for each channel:\;0 - Channel implemented \;1 - Channel not - implemented\;" access="RW" offset="0x0.8" size="0x0.8" />
+	<field name="giga_ethernet_compliance_code" descr="Gigabit Ethernet Compliance Codes \;Override byte134 per SFF-8636:\;Bit 3 - 1000BASE-T\;Bit 2 - 1000BASE-CX\;Bit 1 - 1000BASE-LX\;Bit 0 - 1000BASE-SX" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="ext_ethernet_compliance_code" descr="Extended Specification Compliance Codes \;Override byte192 per SFF-8636:\;0 - Unspecified\;1 - 100G AOC (Active Optical Cable) or 25GAUI C2M AOC with FEC\;2 - 100GBASE-SR4 or 25GBASE-SR\;3 - 100GBASE-LR4 or 25GBASE-LR\;4 - 100GBASE-ER4 or 25GBASE-ER\;5 - 100GBASE-SR10\;6 - 100G CWDM4\;7 - 100G PSM4 Parallel SMF\;8 - 100G ACC (Active Copper Cable) or 25GAUI C2M ACC. with FEC\;11 - 100GBASE-CR4 or 25GBASE-CR CA-L\;12 - 25GBASE-CR CA-S\;13 - 25GBASE-CR CA-N\;16 - 40GBASE-ER4\;17 - 4 x 10GBASE-SR\;18 - 40G PSM4 Parallel SMF\;19 - G959.1 profile P1I1-2D1 (10709 MBd, 2km, 1310nm SM)\;20 - G959.1 profile P1S1-2D2 (10709 MBd, 40km, 1550nm SM)\;21 - G959.1 profile P1L1-2D2 (10709 MBd, 80km, 1550nm SM)\;22 - 10GBASE-T with SFI electrical interface\;23 - 100G CLR4\;24 - 100G AOC or 25GAUI C2M AOC. No FEC\;25 - 100G ACC or 25GAUI C2M ACC. No FEC" access="RW" offset="0x4.8" size="0x0.8" />
+</node>
+
+<node name="pmmp_reg_ext" descr="" size="0x2c.0" >
+	<field name="sticky" descr="When set will keep eeprom_override values after plug out event" access="RW" offset="0x0.0" size="0x0.1" />
+	<field name="apply_im" descr="When set, override will be configured immediately without PMAOS toggle requirement if supported.\;for list supported overrides see eeprom_override description.\;supported if PCAM.bit 87 set" access="WO" offset="0x0.1" size="0x0.1" />
+	<field name="module" descr="Module number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA\;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="eeprom_override" descr="Override/ignore EEPROM advertisement properties bitmask: \;Bit 0: Override_cable_protocols_and_technology_for_QSFP\;Bit 1: Override_cable_protocols_and_technology_for_SFP\;Bit 2: Ignore_Power_Class - set high power\;Bit 3: Override_Cable_Length \;Bit 4: Override_Attenuation\;Bit 8: Set_Module_to_Low_Power\;Bit 9: Override_cable_protocols_and_technology_for_CMIS - based modules QSFP-DD/ OSFP/ DSFP/ SFP-DD\;Bit 11: Override_module_type\;\;Supported overrides with apply_im is Bit 8.\;rest of overrides will be applied only after PMAOS toggle." access="RW" enum="Override_cable_protocols_and_technology_for_QSFP=0x1,Override_cable_protocols_and_technology_for_SFP=0x2,Ignore_Power_Class=0x4,Override_Cable_Length=0x8,Override_Attenuation=0x10,Set_Module_to_Low_Power=0x100,Override_cable_protocols_and_technology_for_CMIS=0x200,Override_module_type=0x800" offset="0x4.0" size="0x0.16" />
+	<field name="eeprom_override_mask" descr="Write Mask bit (negative polarity):\;0 - allow write\;1 - ignore write\;On write commands, indicates which of the bits from eeprom_override field are updated.\;Reserved on read operations." access="WO" offset="0x4.16" size="0x0.16" />
+	<field name="qsfp_cable_protocol_technology" descr="Protocol technology override for QSFP cable or CMIS based cable (QSFP-DD/OSFP)\;Valid only when the protocols and technology for QSFP is overridden as indicated by eeprom_override\;Table 1512, &quot;PMMP - QSFP Protocol Bytes Override Layout,&quot; on page 1768\;Table 1516, &quot;PMMP - CMIS Protocol Bytes Override Layout,&quot; on page 1772" subnode="pmmp_reg_qsfp_cable_protocol_technology_auto_ext" access="RW" offset="0x8.0" size="0xc.0" union_selector="$(parent).eeprom_override" />
+	<field name="sfp_cable_protocol_technology" descr="Valid only when the protocols and technology is overridden as indicated by eeprom_override\;Table 1514, &quot;PMMP - SFP Protocol Bytes Override Layout,&quot; on page 1771" access="RW" high_bound="2" low_bound="0" offset="0x14.0" size="0xc.0" />
+	<field name="cable_length" descr="Length of cable assembly, units of 1 m for non CMIS cables.\;\;for CMIS cables, represents cable length field:\;bits 6:7 represent cable_length_multiplier for calculating cable length\;00 - 0.1 multiplier (0.1 to 6.3m)\;01- 1 multiplier (1 to 63m)\;10 - 10 multiplier (10 to 630m)\;11 - 100 multiplier (100 to 6300m)\;\;Valid only when the cable length is overridden as indicated by eeprom_override." access="RW" offset="0x20.0" size="0x0.8" />
+	<field name="module_type" descr="0: passive_copper_cable\;1: active_copper_cable\;2: Liner_far_end_equlized_copper\;3: Linear_full_equlized_copper\;4: Linear_optical_module - Direct Drive\;5: active_optical_module\;6: on_board_retimer_over_transceiver" access="RW" offset="0x20.8" size="0x0.4" />
+	<field name="attenuation_5g" descr="Valid only when the attenuation is overridden as indicated by eeprom_override.\;Attenuation - total channel attenuation @ 5GHz in db." access="RW" offset="0x24.0" size="0x0.8" />
+	<field name="attenuation_7g" descr="Valid only when the attenuation is overridden as indicated by eeprom_override.\;Attenuation - total channel attenuation @ 7GHz in db." access="RW" offset="0x24.8" size="0x0.8" />
+	<field name="attenuation_12g" descr="Valid only when the attenuation is overridden as indicated by eeprom_override.\;Attenuation - total channel attenuation @ 12GHz in db." access="RW" offset="0x24.16" size="0x0.8" />
+	<field name="attenuation_25g" descr="Valid only when the attenuation is overridden as indicated by eeprom_override.\;Attenuation - total channel attenuation @ 25GHz in db." access="RW" offset="0x24.24" size="0x0.8" />
+	<field name="attenuation_53g" descr="Valid only when the attenuation is overridden as indicated by eeprom_override.\;Attenuation - total channel attenuation @ 53GHz in db." access="RW" offset="0x28.8" size="0x0.8" />
+</node>
+
+<node name="pmmp_reg_qsfp_cable_protocol_technology_auto_ext" descr="" attr_is_union="1" size="0xc.0" >
+	<field name="pmmp_qsfp_protocol_override_layout_ext" descr="" subnode="pmmp_qsfp_protocol_override_layout_ext" offset="0x0.0" selected_by="Override_cable_protocols_and_technology_for_QSFP" size="0xc.0" />
+	<field name="pmmp_cmis_protocol_override_layout_ext" descr="" subnode="pmmp_cmis_protocol_override_layout_ext" offset="0x0.0" selected_by="Override_cable_protocols_and_technology_for_CMIS" size="0xc.0" />
+</node>
+
+<node name="pmpd_reg_ext" descr="" size="0x30.0" >
+	<field name="status" descr="0 - Diagnostic data not supported\;1 - Normal mission mode. \;2 - PRBS checker is not locked. \;3 - PRBS checker is locked." access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="cl" descr="clear counters" access="OP" offset="0x0.4" size="0x0.1" />
+	<field name="lane" descr="Module lane number" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="host_media" descr="Host or Media lanes\;0 - Media lanes\;1 - Host lanes" access="INDEX" offset="0x0.12" size="0x0.1" />
+	<field name="module" descr="module to access" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA\;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="errors_cap" descr="Bits Errors count capability" access="RO" offset="0x0.29" size="0x0.1" />
+	<field name="ber_cap" descr="BER measure capability" access="RO" offset="0x0.30" size="0x0.1" />
+	<field name="snr_cap" descr="SNR measure capability" access="RO" offset="0x0.31" size="0x0.1" />
+	<field name="prbs_bits_high" descr="This counter provides information on the total amount of prbs traffic (bits) received on module&apos;s side." access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="prbs_bits_low" descr="This counter provides information on the total amount of prbs traffic (bits) received on module&apos;s side." access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="prbs_errors_high" descr="This counter provides information on the total amount of prbs errors detected on module&apos;s side." access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="prbs_errors_low" descr="This counter provides information on the total amount of prbs errors detected on module&apos;s side." access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="measured_snr" descr="SNR in dB\;0 - not supported." access="RO" offset="0x14.16" size="0x0.16" />
+	<field name="ber_coef" descr="BER = raw_ber_coef*10^(-raw_ber_magnitude)" access="RO" offset="0x18.0" size="0x0.4" />
+	<field name="ber_magnitude" descr="BER = raw_ber_coef*10^(-raw_ber_magnitude)" access="RO" offset="0x18.8" size="0x0.8" />
+</node>
+
+<node name="pmpr_reg_ext" descr="" size="0x10.0" >
+	<field name="module" descr="Module number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA \;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="attenuation_5g" descr="Attenuation - total channel attenuation @ 5GHz in db." access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="attenuation_7g" descr="Attenuation - total channel attenuation @ 7GHz in db. \;A 0 value implies that attenuation_5g is used also for 7GHz" access="RW" offset="0x8.0" size="0x0.8" />
+	<field name="attenuation_53g" descr="Attenuation - total channel attenuation @ 53GHz in db.\;A 0 value implies that attenuation_5g is used also for 25GHz" access="RW" offset="0x8.16" size="0x0.8" />
+	<field name="attenuation_12g" descr="Attenuation - total channel attenuation @ 12GHz in db.\;A 0 value implies that attenuation_5g is used also for 12GHz" access="RW" offset="0xC.0" size="0x0.8" />
+	<field name="attenuation_25g" descr="Attenuation - total channel attenuation @ 25GHz in db.\;A 0 value implies that attenuation_5g is used also for 25GHz" access="RW" offset="0xC.16" size="0x0.8" />
+</node>
+
+<node name="pmpt_reg_ext" descr="" size="0x1c.0" >
+	<field name="status" descr="0 - Normal mission mode. \;1 - Module is not connected OR module doesn&apos;t support PRBS and diagnostics data\;2 - unsupported configuration setting\;3 - PRBS Generator only\;4 - PRBS Checker only \;5 - PRBS traffic both Checker and Generator\;Note: For lock status on PRBS data see PMPD.status" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="lane_mask" descr="Reserved when (le=0 or ls = 0)\;Logical lane number mask.\;For Get operation One-Hot key (Only one bit set)" access="INDEX" offset="0x0.4" size="0x0.8" />
+	<field name="host_media" descr="Host or Media lanes\;0 - Media lanes\;1 - Host lanes" access="INDEX" offset="0x0.12" size="0x0.1" />
+	<field name="invt_cap" descr="PRBS inversion is supported" access="RO" offset="0x0.13" size="0x0.1" />
+	<field name="swap_cap" descr="PAM4 MSB&lt;-&gt; LSB swapping is supported by the module" access="RO" offset="0x0.14" size="0x0.1" />
+	<field name="module" descr="module index" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA\;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="le" descr="Per Lane configuration enable (can be set only if ls = 1):\;0 - No per lane configuration\;1 - Per lane configurations\;When le is cleared, lane index is reserved and all PMPT configurations are taking place on all lanes.\;When le is set, configurations are taking place per lane based on lane index\;Affects lane indexing for set operations only, ignored for get operations" access="OP" offset="0x0.29" size="0x0.1" />
+	<field name="ls" descr="Per Lane configuration support/capability: \;0 - No support of per lane configuration\;1 - Support of per lane configuration" access="RO" offset="0x0.30" size="0x0.1" />
+	<field name="e" descr="Enable PRBS test mode bit:\;0 - PRBS is disabled.\;1 - PRBS is enabled." access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="prbs_modes_cap" descr="Supported module&apos;s PRBS capability (bitmask)\;Bit 0 - PRBS31 (x^31 + x^28 + 1)\;Bit 1 - PRBS23 (x^23 + x^18 + 1)\;Bit 5 - PRBS7 (x^7 + x^6 + 1)\;Bit 6 - PRBS11 (x^11 + x^9 + 1)\;Bit 11 - PRBS9 (x^9 + x^5 + 1)\;Bit 17 - PRBS13 (x^13 + x^12 + x^2+ x + 1)\;Bit 21 - SSPR\;Bit 22 - SSPRQ" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="modulation" descr="Reserved for speeds below 53.125Gb/s (lane_rate_admin &lt; 7):\;0 - NRZ test pattern\;1 - PAM4 encoding" access="INDEX" offset="0x8.0" size="0x0.4" />
+	<field name="ch_ge" descr="0 - Access is for both Checker and Generator (Can be used for Set operations only)\;1 - Access is for Generator\;2 - Access if for Checker\;Note: Checker and Generator must be in same rate" access="INDEX" offset="0x8.4" size="0x0.2" />
+	<field name="invt_admin" descr="PRBS inversion enable bit, see ivnt_cap:\;0 - NO PRBS inversion\;1 - PRBS inversion" access="RW" offset="0x8.8" size="0x0.1" />
+	<field name="swap_admin" descr="PAM4 MSB&lt;-&gt; LSB swapping enable bit, see swap_cap. \;0 - NO MSB&lt;-&gt; LSB swapping \;1 - MSB &lt;-&gt; LSB swapping" access="RW" offset="0x8.9" size="0x0.1" />
+	<field name="prbs_mode_admin" descr="See prbs_mode_cap: \;0x0 - PRBS31 (x^31 + x^28 + 1)\;0x1 - PRBS23 (x^23 + x^18 + 1)\;0x5 - PRBS7 (x^7 + x^6 + 1)\;0x6 - PRBS11 (x^11 + x^9 + 1)\;0xB - PRBS9 (x^9 + x^5 + 1)\;0x11 - PRBS13 (x^13 + x^12 + x^2+ x + 1)\;0x15 - SSPR\;0x16 - SSPRQ" access="RW" offset="0x8.24" size="0x0.8" />
+	<field name="lane_rate_cap" descr="Per lane rate capability (bitmask)\;Bit 0 - 1GE (1.25 Gb/s)\;Bit 1 - SDR (2.5 Gb/s) \;Bit 2 - Reserved\;Bit 3- 10GE/40GE (10.3125 Gb/s) \;Bit 4- FDR (14.0625 Gb/s) \;Bit 5- EDR / 25GE / 50GE / 100GE (25.78125 Gb/s) \;Bit 6- Reserved \;Bit 7- HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s) \;Bit 8- NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;Bit 9 - XDR (106.25 Gbd / 212.5Gb/s)" access="RO" offset="0xC.16" size="0x0.16" />
+	<field name="lane_rate_admin" descr="Lane rate be used in PRBS, see lane_rate_cap:\;0 - Non selected. \;1 - 1GE (1.25 Gb/s)\;2 - SDR (2.5 Gb/s) \;8 - 10GE/40GE (10.3125 Gb/s) \;16 - FDR (14.0625 Gb/s) \;32 - EDR / 25GE / 50GE / 100GE (25.78125 Gb/s) \;128 - HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s) \;256 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;512 - XDR (106.25 Gbd / 212.5Gb/s)\;" access="RW" offset="0x10.16" size="0x0.16" />
+</node>
+
+<node name="pmtm_reg_ext" descr="" size="0x10.0" >
+	<field name="module" descr="module number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="slot_index" descr="Reserved for HCA\;Slot_index \;Slot_index = 0 represent the onboard (motherboard). \;In case of non modular system only slot_index = 0 is available." access="INDEX" offset="0x0.24" size="0x0.4" />
+	<field name="module_type" descr="module_type: \;0: Backplane_with_4_lanes\;1: QSFP\;2: SFP\;3: No_Cage\;4: Backplane_with_single_lane\;8: Backplane_with_two_lanes\;10: Chip2Chip4x\;11: Chip2Chip2x \;12: Chip2Chip1x\;14: QSFP_DD \;15: OSFP\;16: SFP_DD\;17: DSFP \;18: Chip2Chip8x\;19: Twisted_Pair\;20: Backplane_with_8_lanes" access="RW" enum="Backplane_with_4_lanes=0x0,QSFP=0x1,SFP=0x2,No_Cage=0x3,Backplane_with_single_lane=0x4,Backplane_with_two_lanes=0x8,Chip2Chip4x=0xa,Chip2Chip2x=0xb,Chip2Chip1x=0xc,QSFP_DD=0xe,OSFP=0xf,SFP_DD=0x10,DSFP=0x11,Chip2Chip8x=0x12,Twisted_Pair=0x13,Backplane_with_8_lanes=0x14" offset="0x4.0" size="0x0.5" />
+	<field name="module_width" descr="Number of module&apos;s electrical lanes\;\;NOTE: For SET command, this value should match the module type width in module_type field" access="RW" offset="0x4.8" size="0x0.5" />
+</node>
+
+<node name="pmtu_reg_ext" descr="" size="0x10.0" >
+	<field name="itre" descr="Ingress Truncation enable, the admin_mtu is used as truncation:\;0: disable\;1: enable\;Reserved when NICs (NICs use only &apos;0&apos;)\;Reserved when SwitchX/-2 and IB Switches (use only &apos;0&apos;)\;Reserved when i_e = 0 or 2\;Reserved when GPUNet" access="RW" offset="0x0.0" size="0x0.1" />
+	<field name="i_e" descr="Ingress/Egress:\;0: applies for both ingress and for egress, read from egress\;1: applies only for ingress\;2: applies only for egress\;Reserved when NICs (NICs use only &apos;0&apos;)\;Reserved when SwitchX/-2 and IB Switches (use only &apos;0&apos;)\;Reserved when GPUNet" access="INDEX" offset="0x0.4" size="0x0.2" />
+	<field name="lp_msb" descr="Local port[9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number\;Not including CPU port" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="protocol" descr="[DWIP]:\;The protocol which the MTU is applied to. \;0: All protocols that are supported by the device. On get, it will return the value for IBg1\;1: IB (gen 1) \;2: NVLink\;3: IBg2\;4-15: Reserved\;Reserved when Eth switches\;Reserved when NIC\;Note: for GB100 IBg2 is not PoR, Nov 2023" access="INDEX" offset="0x0.28" size="0x0.4" />
+	<field name="max_mtu" descr="Maximum MTU supported on the port (Read Only).\;MTU depends on the port type. When port type (Eth/IB/FC) is configured, the relevant MTU is reported. When the port type is not configured, the minimum between the max_mtu for the different types (Eth/IB/FC) is reported.\;Informative:- For GPUNet: IB is used for MADs, thus max MTU is 768B\;- NVLink max MTU is 320B" access="RO" offset="0x4.16" size="0x0.16" />
+	<field name="admin_mtu" descr="Administratively configured MTU on the port. Must be smaller or equal to max_mtu.\;When IB: configuration is allowed only when port state is down.\;When itre=1 then must be at least 128B and granularity is 8B" access="RW" offset="0x8.16" size="0x0.16" />
+	<field name="oper_mtu" descr="Operational MTU. This is the actual MTU configured on the ports. Packets exceeding this size will be dropped.\;Note: For NICs and for IB the actual operational MTU is reported which may be smaller than admin_mtu.\;For NICs: when PCAM.max_admin_mtu capability is set then oper_mtu will be the max of all admin_mtu" access="RO" offset="0xC.16" size="0x0.16" />
+</node>
+
+<node name="ppaos_reg_ext" descr="" size="0x10.0" >
+	<field name="phy_test_mode_status" descr="Port extended down status:\;0: regular_operation - (port down/up according to PAOS) \;1: phy_test_mode\;phy test mode can be valid only when PAOS.admin_status=2 and PAOS.oper_status=2 (i.e port is down)." access="RO" enum="regular_operation=0x0,phy_test_mode=0x1" offset="0x0.0" size="0x0.4" />
+	<field name="port_type" descr="For HCA supported only when indicated by PCAM \;0 - Network Port\;1 - Near-End Port (For Retimer/Gearbox - Host side)\;2 - Internal IC LR Port \;3 - Far-End Port (For Retimer/Gearbox - Line side)\;Other values are reserved." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="phy_test_mode_admin" descr="Port extended administrative down status:\;0: regular_operation (port down/up according to PAOS) \;1: phy_test_mode \;\;The phy test mode (1) can be set only when PAOS.admin_status=2 (i.e port configuration is down)." access="RW" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="swid" descr="For HCA: must always be 0.\;Switch partition ID with which to associate the port.\;Switch partitions are numbered from 0 to 7 inclusively.\;The swid field is only valid when the local_port is the router port. In this case, the swid indicates which of the router ports to configure/query." access="INDEX" offset="0x0.24" size="0x0.8" />
+	<field name="phy_status" descr="rx phy status:\;0: rx_phy_down\;1: rx_phy_up\;2: rx_phy_down_by_command\;\;Note: The phy up indication is according to protocol (up == align_status=true)\;i.g. In PRBS test mode phy up is when PRB is lock (up== prbs lock)" access="RO" offset="0x4.0" size="0x0.4" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x4.4" size="0x0.4" />
+	<field name="phy_status_admin" descr="rx phy port admin. Controls phy entities operational port status.\;valid for port_type &lt;&gt; &apos;0&apos;.\;to operate link status for port_type &apos;0&apos; use PAOS.admin_status.\;0: rx_phy_down\;1: rx_phy_up\;" access="RW" offset="0x4.8" size="0x0.4" />
+	<field name="dc_cpl_port" descr="When set, indicates that ports trace is DC coupled.\;Enabling test mode in case of DC coupled port is allowed only when setting dc_cpl_allow and printing warning to user as specified in the description." access="RO" offset="0x4.28" size="0x0.1" />
+	<field name="dc_cpl_allow" descr="Relevant only for DC couple ports, Ignored otherwise.\;Field must be set when entering test mode, otherwise command is ignored.\;When entering test mode in DC couple system the following message must be presented to user:\;&quot;Warning: DC couple system must be powered on both sides of the physical link prior to enabling test mode. System may be harmed and product lifetime may be shortened if not ensured.&quot;" access="WO" offset="0x4.29" size="0x0.1" />
+</node>
+
+<node name="ppcnt_infiniband_general_counter_ext" descr="" size="0xf8.0" >
+	<field name="rq_general_error_high" descr="The total number of packets that were dropped since it contained errors. Reasons for this include:\;1. dropped due to MPR mismatch.\;Supported only when indicated by PCAM.\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="rq_general_error_low" descr="The total number of packets that were dropped since it contained errors. Reasons for this include:\;1. dropped due to MPR mismatch.\;Supported only when indicated by PCAM.\;" access="RO" offset="0x14.0" size="0x4.0" />
+</node>
+
+<node name="ppcnt_infiniband_packets_counter_ext" descr="" size="0xf8.0" >
+	<field name="time_since_last_clear_high" descr="The time passed since the last counters clear event in msec." access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="time_since_last_clear_low" descr="The time passed since the last counters clear event in msec." access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="port_unicast_xmit_pkts_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="port_unicast_xmit_pkts_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="port_unicast_rcv_pkts_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="port_unicast_rcv_pkts_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="sync_header_error_counter_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="sync_header_error_counter_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="port_local_physical_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="port_local_physical_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="port_malformed_packet_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="port_malformed_packet_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="port_buffer_overrun_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="port_buffer_overrun_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="port_dlid_mapping_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="port_dlid_mapping_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="port_vl_mapping_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="port_vl_mapping_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x44.0" size="0x4.0" />
+	<field name="port_looping_errors_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x48.0" size="0x4.0" />
+	<field name="port_looping_errors_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x4C.0" size="0x4.0" />
+	<field name="port_inactive_discards_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x50.0" size="0x4.0" />
+	<field name="port_inactive_discards_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x54.0" size="0x4.0" />
+	<field name="port_neighbor_mtu_discards_high" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x58.0" size="0x4.0" />
+	<field name="port_neighbor_mtu_discards_low" descr="For counter description please refer to the InfiniBand  Specification" access="RO" offset="0x5C.0" size="0x4.0" />
+</node>
+
+<node name="ppcnt_plr_counters_ext" descr="" size="0xf8.0" >
+	<field name="plr_rcv_codes_high" descr="Number of received PLR codewords\;\;" access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="plr_rcv_codes_low" descr="Number of received PLR codewords\;\;" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="plr_rcv_code_err_high" descr="The total number of rejected codewords received" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="plr_rcv_code_err_low" descr="The total number of rejected codewords received" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="plr_rcv_uncorrectable_code_high" descr="The number of uncorrectable codewords received\;" access="RO" offset="0x10.0" size="0x4.0" />
+	<field name="plr_rcv_uncorrectable_code_low" descr="The number of uncorrectable codewords received\;" access="RO" offset="0x14.0" size="0x4.0" />
+	<field name="plr_xmit_codes_high" descr="Number of transmitted PLR codewords" access="RO" offset="0x18.0" size="0x4.0" />
+	<field name="plr_xmit_codes_low" descr="Number of transmitted PLR codewords" access="RO" offset="0x1C.0" size="0x4.0" />
+	<field name="plr_xmit_retry_codes_high" descr="The total number of codewords retransmitted." access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="plr_xmit_retry_codes_low" descr="The total number of codewords retransmitted." access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="plr_xmit_retry_events_high" descr="The total number of retransmitted event. \;\;" access="RO" offset="0x28.0" size="0x4.0" />
+	<field name="plr_xmit_retry_events_low" descr="The total number of retransmitted event. \;\;" access="RO" offset="0x2C.0" size="0x4.0" />
+	<field name="plr_sync_events_high" descr="The number of sync events" access="RO" offset="0x30.0" size="0x4.0" />
+	<field name="plr_sync_events_low" descr="The number of sync events" access="RO" offset="0x34.0" size="0x4.0" />
+	<field name="plr_codes_loss_high" descr="Recieved bandwidth loss due to codes retransmission. calculated in resolution of \;(plr_rcv_code_err / plr_rcv_codes) * 10^10\;\;BW Loss % = (plr_codes_loss / 10^10 ) *100" access="RO" offset="0x38.0" size="0x4.0" />
+	<field name="plr_codes_loss_low" descr="Recieved bandwidth loss due to codes retransmission. calculated in resolution of \;(plr_rcv_code_err / plr_rcv_codes) * 10^10\;\;BW Loss % = (plr_codes_loss / 10^10 ) *100" access="RO" offset="0x3C.0" size="0x4.0" />
+	<field name="plr_xmit_retry_events_within_t_sec_max_high" descr="The maximum number of retransmitted events in t sec window\;" access="RO" offset="0x40.0" size="0x4.0" />
+	<field name="plr_xmit_retry_events_within_t_sec_max_low" descr="The maximum number of retransmitted events in t sec window\;" access="RO" offset="0x44.0" size="0x4.0" />
+</node>
+
+<node name="ppcnt_reg_counter_set_auto_ext" descr="" attr_is_union="1" size="0xf8.0" >
+	<field name="eth_802_3_cntrs_grp_data_layout_ext" descr="" subnode="eth_802_3_cntrs_grp_data_layout_ext" offset="0x0.0" selected_by="IEEE_802_3_Counters" size="0xf8.0" />
+	<field name="eth_2863_cntrs_grp_data_layout_ext" descr="" subnode="eth_2863_cntrs_grp_data_layout_ext" offset="0x0.0" selected_by="RFC_2863_Counters" size="0xf8.0" />
+	<field name="eth_2819_cntrs_grp_data_layout_ext" descr="" subnode="eth_2819_cntrs_grp_data_layout_ext" offset="0x0.0" selected_by="RFC_2819_Counters" size="0xf8.0" />
+	<field name="eth_3635_cntrs_grp_data_layout_ext" descr="" subnode="eth_3635_cntrs_grp_data_layout_ext" offset="0x0.0" selected_by="RFC_3635_Counters" size="0xf8.0" />
+	<field name="eth_extended_cntrs_grp_data_layout_ext" descr="" subnode="eth_extended_cntrs_grp_data_layout_ext" offset="0x0.0" selected_by="Ethernet_Extended_Counters" size="0xf8.0" />
+	<field name="eth_discard_cntrs_grp_ext" descr="" subnode="eth_discard_cntrs_grp_ext" offset="0x0.0" selected_by="Ethernet_Discard_Counters" size="0xf8.0" />
+	<field name="eth_per_prio_grp_data_layout_ext" descr="" subnode="eth_per_prio_grp_data_layout_ext" offset="0x0.0" selected_by="Per_Priority_Counters" size="0xf8.0" />
+	<field name="eth_per_traffic_class_layout_ext" descr="" subnode="eth_per_traffic_class_layout_ext" offset="0x0.0" selected_by="Per_Traffic_Class_Counters" size="0xf8.0" />
+	<field name="phys_layer_cntrs_ext" descr="" subnode="phys_layer_cntrs_ext" offset="0x0.0" selected_by="Physical_Layer_Counters" size="0xf8.0" />
+	<field name="eth_per_traffic_class_cong_layout_ext" descr="" subnode="eth_per_traffic_class_cong_layout_ext" offset="0x0.0" selected_by="Per_Traffic_Class_Congestion_Counters" size="0xf8.0" />
+	<field name="phys_layer_stat_cntrs_ext" descr="" subnode="phys_layer_stat_cntrs_ext" offset="0x0.0" selected_by="Physical_Layer_Statistical_Counters" size="0xf8.0" />
+	<field name="IB_portcntrs_attribute_grp_data_ext" descr="" subnode="IB_portcntrs_attribute_grp_data_ext" offset="0x0.0" selected_by="InfiniBand_Port_Counters" size="0xf8.0" />
+	<field name="IB_long_portcntrs_attribute_grp_data_ext" descr="" subnode="IB_long_portcntrs_attribute_grp_data_ext" offset="0x0.0" selected_by="InfiniBand_Extended_Port_Counters" size="0xf8.0" />
+	<field name="ppcnt_plr_counters_ext" descr="" subnode="ppcnt_plr_counters_ext" offset="0x0.0" selected_by="PLR_counters_group" size="0xf8.0" />
+	<field name="ppcnt_rs_fec_histograms_counters_ext" descr="" subnode="ppcnt_rs_fec_histograms_counters_ext" offset="0x0.0" selected_by="RS_FEC_Histogram_group" size="0xf8.0" />
+	<field name="ppcnt_infiniband_packets_counter_ext" descr="" subnode="ppcnt_infiniband_packets_counter_ext" offset="0x0.0" selected_by="InfiniBand_pkts_counters" size="0xf8.0" />
+	<field name="ppcnt_infiniband_general_counter_ext" descr="" subnode="ppcnt_infiniband_general_counter_ext" offset="0x0.0" selected_by="InfiniBand_General_Counters" size="0xf8.0" />
+</node>
+
+<node name="ppcnt_reg_ext" descr="" size="0x100.0" >
+	<field name="grp" descr="Performance counter group.\;Group 63 indicates all groups (include all per priority/TC/Receive Buffer counters). Only valid on Set() operation with clr bit set.\;0x0: IEEE_802_3_Counters\;0x1: RFC_2863_Counters\;0x2: RFC_2819_Counters\;0x3: RFC_3635_Counters\;0x5: Ethernet_Extended_Counters\;0x6: Ethernet_Discard_Counters \;0x10: Per_Priority_Counters - \;0x11: Per_Traffic_Class_Counters - \;0x12: Physical_Layer_Counters\;0x13: Per_Traffic_Class_Congestion_Counters\;0x16: Physical_Layer_Statistical_Counters\;0x20: InfiniBand_Port_Counters\;0x21: InfiniBand_Extended_Port_Counters\;0x22: PLR_counters_group\;0x23: RS_FEC_Histogram_group\;0x25: InfiniBand_pkts_counters\;0x26: InfiniBand_General_Counters\;0x27: L1_General_Counters" access="INDEX" enum="IEEE_802_3_Counters=0x0,RFC_2863_Counters=0x1,RFC_2819_Counters=0x2,RFC_3635_Counters=0x3,Ethernet_Extended_Counters=0x5,Ethernet_Discard_Counters=0x6,Per_Priority_Counters=0x10,Per_Traffic_Class_Counters=0x11,Physical_Layer_Counters=0x12,Per_Traffic_Class_Congestion_Counters=0x13,Physical_Layer_Statistical_Counters=0x16,InfiniBand_Port_Counters=0x20,InfiniBand_Extended_Port_Counters=0x21,PLR_counters_group=0x22,RS_FEC_Histogram_group=0x23,InfiniBand_pkts_counters=0x25,InfiniBand_General_Counters=0x26" offset="0x0.0" size="0x0.6" />
+	<field name="port_type" descr="Supported only when indicated by PCAM on FPGA based NICs:\;0 - Network Port\;1 - Near-End Port (For Retimer/Gearbox - Host side)\;2 - Internal IC LR Port \;3 - Far-End Port (For Retimer/Gearbox - Line side)" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type:\;0: Local_port_number\;1: IB_port_number\;2: host_port_number\;\;Note - pnat=2 is supported for &quot;Per Traffic Class Congestion Counters&quot; and &quot;Per Traffic Class Counters&quot; groups." access="INDEX" enum="Local_port_number=0x0,IB_port_number=0x1,host_port_number=0x2" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number. \;Note:\;when lp_gl = 0, 255 indicates all ports on the device, and is only allowed for Set() operation.\;when lp_gl = 1, the index is a global port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="swid" descr="For HCA: must be always 0.\;Switch partition ID to associate port with.\;Switch partitions are numbered from 0 to 7 inclusively.\;Switch partition 254 indicates stacking ports.\;Switch partition 255 indicates all switch partitions.\;Only valid on Set() operation with local_port=255." access="INDEX" offset="0x0.24" size="0x0.8" />
+	<field name="prio_tc" descr="Priority index for per priority counter sets, valid values: 0-7\;For Spectrum-2 and on at tx side range can be 0 .. cap_max_tclass_data-1, see QGCR.tx_cnt_tclass\;\;Traffic class index for per traffic class counter set, valid values: \;For Switches, valid values: 0 .. cap_max_tclass_data-1 \;\;For HCA, valid values: 0.. HCA_CAP.max_tc\;\;Otherwise must be 0.\;" access="INDEX" offset="0x4.0" size="0x0.5" />
+	<field name="grp_profile" descr="Supported only when indicated by PCAM: PPCNT_grp_profile_supported (bit 73).\;The group profile index. Relevant only if the clr bit is set.\;0: Will reset the counter value for all counters in the counter group.\;Else: Will point to the corresponding bit-map profile in the PPCGP register. The bit map will return the specific counters that will be reset in the group.\;\;NOTE: The grp_profile index is not supported for the following counters groups:\;1. 0x12: Physical_Layer_Counters2. 0x16: Physical_Layer_Statistical_Counters3. 0x22: PLR_counters_group" access="INDEX" offset="0x4.5" size="0x0.3" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x4.8" size="0x0.4" />
+	<field name="counters_cap" descr="counters_cap is supported if PCAM.feature_cap_mask bit 85 is set.\;When set, each counter in the group will show in bit 0 if the counter is supported.\;&apos;0&apos; - not supported\;&apos;1&apos; - supported\;Note: To know which PPCNT groups are supported per device, listed in table TBD or PCAM fields with PPCNT can be queried." access="OP" offset="0x4.29" size="0x0.1" />
+	<field name="lp_gl" descr="Local Port global variable\;0: local_port port 255 = all ports of the device.\;1: local_port index indicates Local port number." access="OP" offset="0x4.30" size="0x0.1" />
+	<field name="clr" descr="Clear counters. Setting the clr bit will reset the counter value for all counters in the counter group. This bit can be set for both Set() and Get() operation.\;\;NOTE: Clearing a certain group&apos;s counters can influence another group&apos;s counters value." access="OP" offset="0x4.31" size="0x0.1" />
+	<field name="counter_set" descr="Counter set as described in\;Table 1424, &quot;Ethernet IEEE 802.3 Counters Group Data Layout,&quot; on page 1664\;Table 1426, &quot;Ethernet RFC 2863 Counter Group Data Layout,&quot; on page 1669\;Table 1428, &quot;Ethernet RFC 2819 Counter Group Data Layout,&quot; on page 1673\;Table 1430, &quot;Ethernet RFC 3635 Counter Group Data Layout,&quot; on page 1678\;Table 1432, &quot;Ethernet Extended Counter Group Data Layout,&quot; on page 1682\;Table 1435, &quot;Ethernet Discard Counter Group Fields,&quot; on page 1687\;Table 1436, &quot;Ethernet Per Priority Group Data Layout,&quot; on page 1690\;Table 1440, &quot;Ethernet Per Traffic Class Group data layout,&quot; on page 1698\;Table 1452, &quot;Physical Layer Counters Data Layout,&quot; on page 1708\;Table 1442, &quot;Ethernet Per Traffic Class Congestion Group data layout,&quot; on page 1699\;Table 1456, &quot;Physical Layer Statistical Counters Data Layout,&quot; on page 1716\;Table 1448, &quot;InfiniBand PortCounters Attribute Group Data Layout,&quot; on page 1702\;Table 1450, &quot;InfiniBand Extended PortCounters Attribute Group Data Layout,&quot; on page 1704\;Table 1458, &quot;PLR Counters Data Layout,&quot; on page 1722 \;Table 1460, &quot;RS-Histograms Data Layout,&quot; on page 1724\;Table 1462, &quot;InfiniBand Packets Counters Data Layout,&quot; on page 1725\;Table 1464, &quot;InfiniBand General Counters Data Layout,&quot; on page 1727" subnode="ppcnt_reg_counter_set_auto_ext" access="RO" offset="0x8.0" size="0xf8.0" union_selector="$(parent).grp" />
+</node>
+
+<node name="ppcnt_rs_fec_histograms_counters_ext" descr="" size="0xf8.0" >
+	<field name="hist" descr="Value of RS-hist" subnode="uint64" access="RO" high_bound="17" low_bound="0" offset="0x0.0" size="0x90.0" />
+</node>
+
+<node name="ppdfd_ext" descr="" size="0xc.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="ntimes" descr="Number of times to transmit the error\;Note that by HW the event is triggered 1 time. So FW will trigger the event again and again as fast as possible (roughly every 1uSec)" access="WO" offset="0x4.0" size="0x0.16" />
+	<field name="poison_en" descr="Poison will set a Phy EBP signal (different type than stomp). \;Reserved when stomp_en = 1" access="WO" offset="0x8.0" size="0x0.1" />
+	<field name="stomp_en" descr="Stomp will set a Phy EBP signal" access="WO" offset="0x8.1" size="0x0.1" />
+</node>
+
+<node name="pphcr_bin_range_ext" descr="" size="0x4.0" >
+	<field name="low_val" descr="low range of bin&apos;s measurement" access="RW" offset="0x0.0" size="0x0.4" />
+	<field name="high_val" descr="high range of bin&apos;s measurement" access="RW" offset="0x0.16" size="0x0.4" />
+</node>
+
+<node name="pphcr_ext" descr="" size="0x50.0" >
+	<field name="we" descr="Support of histogram bins configuration. \;In case this bit is cleared, the port doesn&apos;t support configuration of the histogram bins, for the specific hist_type." access="RO" offset="0x0.0" size="0x0.1" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="port_type" descr="0 - Network Port\;1 - Near-End Port (For Retimer/Gearbox - Host side)\;3 - Far-End Port (For Retimer/Gearbox - Line side)\;Other values are reserved." access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type:\;0: Local_port_number\;1: IB_port_number" access="INDEX" enum="Local_port_number=0x0,IB_port_number=0x1" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="local_port or DataPath number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="active_hist_type" descr="0 - Invalid (Link down / unsupported) \;1 - KP4 RS-FEC (544,514) errors \;2 - LL RS-FEC (271,257) / (272,257+1) errors\;3 - KR4 RS-FEC (528,514) errors\;4 - PRBS errors" access="RO" offset="0x0.28" size="0x0.4" />
+	<field name="hist_type" descr="0: According to active link" access="INDEX" offset="0x4.0" size="0x0.4" />
+	<field name="num_of_bins" descr="Available number of bins \;" access="RO" offset="0x4.16" size="0x0.8" />
+	<field name="hist_min_measurement" descr="Lowest measurement/low limit of the histogram \;Example:\;In case of hist_type = 1, represent KP4 RS FEC symbol errors(= 0)\;In case of hist_type = 2, represent LL RS FEC symbol errors ( = 0)\;" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="hist_max_measurement" descr="Highest measurement/high limit of the histogram:\;Example:\;In case of hist_type = 1, represent KP4 RS FEC symbol errors ( = 15)\;In case of hist_type = 2, represent LL RS FEC symbol errors ( = 7)" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="bin_range_write_mask" descr="Valid only if we (write enable) = 1 \;Ignored on GET \;Write mask for the bin_range array. \;If bit X is set, bin_range [X] write should be execute\;Else if bit X is clear, ignored value in written to bin_range [X]" access="WO" offset="0xC.0" size="0x0.16" />
+	<field name="bin_range" descr="Write to bin_range[x] is applicable only if we = 1 &amp; the corresponding bits in bin_range_write_mask is set.\;Mapping of measurement units to a bin.\;See Table 1728, &quot;PPHCR - Port Phy Bin Range Histogram Configuration Layout,&quot; on page 2028" subnode="pphcr_bin_range_ext" access="RW" high_bound="15" low_bound="0" offset="0x10.0" size="0x40.0" />
+</node>
+
+<node name="pplm_reg_ext" descr="" size="0x50.0" >
+	<field name="test_mode" descr="0: Mission_mode_configuration_and_capabilities\;1: Test_mode_configuration_and_capabilities" access="INDEX" enum="Mission_mode_configuration_and_capabilities=0x0,Test_mode_configuration_and_capabilities=0x1" offset="0x0.1" size="0x0.1" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="port_type" descr="Supported only when indicated by PCAM \;0: Network_Port\;1: Near_End_Port - For Gearbox - Host side\;2: Internal_IC_Port \;3: Far_End_Port - For Gearbox - Line side\;\;Other values are reserved.\;\;Using port_type &apos;0&apos; will override all different parts of the link structure.\;Using port_type &apos;1&apos; will configure also port_type &apos;2&apos; accordingly and vise versa." access="INDEX" enum="Network_Port=0x0,Near_End_Port=0x1,Internal_IC_Port=0x2,Far_End_Port=0x3" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. \;0: Local_port_number\;1: IB_port_number" access="INDEX" enum="Local_port_number=0x0,IB_port_number=0x1" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="fec_mode_active" descr="Active FEC (bitmask)\;For each enum, a short prefix for tools is presented in the row below.\;0: No_FEC \;1: Firecode_FEC\;FC_FEC\;2: Standard_RS_FEC - RS(528,514)\;KR4_FEC\;3: Standard_LL_RS_FEC - RS(271,257)\;LL_FEC\;5: reserved - [Internal]\;6: Interleaved_Standard_RS-FEC - (544,514)\;Int_KP4_FEC\;7: Standard_RS-FEC - (544,514)\;KP4_FEC\;9: Ethernet_Consortium_LL_50G_RS_FEC- (272,257+1)\;ELL_FEC\;10: Interleaved_Ethernet_Consortium_LL_50G_RS_FEC - (272,257+1)\;Int_ELL_FEC\;12: RS-FEC - (544,514) + PLR\;13: LL-FEC - (271,257) + PLR\;14: Ethernet_Consortium_LL_50G_RS_FEC_PLR - (272,257+1) [Internal] \;15: Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_PLR - (272,257+1) [Internal]\;" access="RO" enum="No_FEC=0x0,Firecode_FEC=0x1,Standard_RS_FEC=0x2,Standard_LL_RS_FEC=0x3,Interleaved_Standard_RS=0x6,Standard_RS=0x7,Ethernet_Consortium_LL_50G_RS_FEC=0x9,Interleaved_Ethernet_Consortium_LL_50G_RS_FEC=0xa" offset="0xC.0" size="0x0.24" />
+	<field name="fec_override_cap_10g_40g" descr="10GE/40GE Ethernet FEC override capability bitmask:\;Bit 0: No-FEC\;Bit 1: Firecode_FEC\;Bit 2: Reserved2\;Bit 3: Reserved3\;\;" access="RO" enum="No=0x1,Firecode_FEC=0x2,Reserved2=0x4,Reserved3=0x8" offset="0x10.0" size="0x0.4" />
+	<field name="fec_override_cap_25g" descr="25GE Ethernet FEC override capability bitmask:\;Bit 0: No-FEC\;Bit 1: Firecode_FEC\;Bit 2: RS-FEC\;Bit 3: Reserved" access="RO" enum="No=0x1,Firecode_FEC=0x2,RS=0x4,Reserved=0x8" offset="0x10.4" size="0x0.4" />
+	<field name="fec_override_cap_50g" descr="50GE (2 lanes) Ethernet FEC override capability bitmask:\;Bit 0: No-FEC\;Bit 1: Firecode_FEC\;Bit 2: RS-FEC\;Bit 3: Reserved" access="RO" enum="No=0x1,Firecode_FEC=0x2,RS=0x4,Reserved=0x8" offset="0x10.8" size="0x0.4" />
+	<field name="fec_override_cap_100g" descr="100GE (4 lanes) Ethernet FEC override capability bitmask:\;Bit 0: No-FEC\;Bit 1: Reserved1\;Bit 2: RS-FEC - (528,514)\;Bit 3: Reserved3" access="RO" enum="No=0x1,Reserved1=0x2,RS=0x4,Reserved3=0x8" offset="0x10.12" size="0x0.4" />
+	<field name="fec_override_cap_56g" descr="56GE Ethernet FEC override capability bitmask:\;Bit 0: No-FEC\;Bit 1: Firecode_FEC\;Bit 2: Reserved2\;Bit 3: Reserved3" access="RO" enum="No=0x1,Firecode_FEC=0x2,Reserved2=0x4,Reserved3=0x8" offset="0x10.16" size="0x0.4" />
+	<field name="rs_fec_correction_bypass_cap" descr="RS-FEC correction bypass override capability:\;0: NO_correction_bypass\;1: RS-FEC_correction_bypass" access="RO" enum="NO_correction_bypass=0x0,RS=0x1" offset="0x10.28" size="0x0.4" />
+	<field name="fec_override_admin_10g_40g" descr="10GE/40GE Ethernet FEC override admin, see 10g_40g_fec_override_cap.\;(one-hot setting): \;0: auto_mode - no override\;Bit 0: No_FEC\;Bit 1: Firecode_FEC\;\;" access="RW" enum="No_FEC=0x1,Firecode_FEC=0x2" offset="0x14.0" size="0x0.4" />
+	<field name="fec_override_admin_25g" descr="25GE Ethernet FEC override admin, see 25g_fec_override_cap. (one-hot setting): \;0: auto_mode - no override\;Bit 0: No_FEC\;Bit 1: Firecode_FEC\;Bit 2: RS-FEC\;\;Note - 25g_fec_override_admin and 50g_fec_override_admin must be set with the same value." access="RW" enum="No_FEC=0x1,Firecode_FEC=0x2,RS=0x4" offset="0x14.4" size="0x0.4" />
+	<field name="fec_override_admin_50g" descr="50GE Ethernet FEC override admin, see 50g_fec_override_cap. (one-hot setting): \;0: auto_mode - no override\;Bit 0: No_FEC\;Bit 1: Firecode_FEC\;Bit 2: RS-FEC\;\;Note - 25g_fec_override_admin and 50g_fec_override_admin must be set with the same value." access="RW" enum="No_FEC=0x1,Firecode_FEC=0x2,RS=0x4" offset="0x14.8" size="0x0.4" />
+	<field name="fec_override_admin_100g" descr="100GE Ethernet FEC override admin, see 100g_fec_override_cap. (one-hot setting): \;0: auto_mode - no override\;Bit 0: No_FEC\;Bit 2: RS-FEC" access="RW" enum="No_FEC=0x1,RS=0x4" offset="0x14.12" size="0x0.4" />
+	<field name="fec_override_admin_56g" descr="56GE Ethernet FEC override admin, see 56g_fec_override_cap. (one-hot setting): \;0: auto_mode - no override\;Bit 0: No_FEC\;Bit 1: Firecode_FEC" access="RW" enum="No_FEC=0x1,Firecode_FEC=0x2" offset="0x14.16" size="0x0.4" />
+	<field name="rs_fec_correction_bypass_admin" descr="RS-FEC correction bypass override admin: (one-hot setting): \;0: auto_mode - no override \;1: NO_correction_bypass\;2: RS-FEC_correction_bypass" access="RW" enum="auto_mode=0x0,NO_correction_bypass=0x1,RS=0x2" offset="0x14.28" size="0x0.4" />
+	<field name="fec_override_cap_200g_4x" descr="200GE FEC override capability bitmask:\;Bit 8: Zero_Latency_FEC\;Bit 9: Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1\;Others bits reserved" access="RO" enum="Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1=0x200" offset="0x18.0" size="0x0.16" />
+	<field name="fec_override_cap_400g_8x" descr="400GE FEC override capability bitmask:\;Bit 8: Zero_Latency_FEC\;Bit 9: Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1\;All others are reserved" access="RO" enum="Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1=0x200" offset="0x18.16" size="0x0.16" />
+	<field name="fec_override_cap_50g_1x" descr="50GE single lane override capability bitmask:\;Bit 8: Zero_Latency_FEC\;Bit 9: Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1\;All others are reserved" access="RO" enum="Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1=0x200" offset="0x1C.0" size="0x0.16" />
+	<field name="fec_override_cap_100g_2x" descr="100GE over 2 lanes, FEC override capability bitmask:\;Bit 8: Zero_Latency_FEC\;Bit 9: Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1\;All others are reserved" access="RO" enum="Fifty50G_Ethernet_Consortium_LL_RS_FEC_272_257plus1=0x200" offset="0x1C.16" size="0x0.16" />
+	<field name="fec_override_admin_200g_4x" descr="200GE FEC override admin bitmask (one-hot setting) \;0: Auto_mode\;Bit 7: RS_FEC_544_514 - (544,514)\;Bit 9: RS_FEC_272_257_plus_1 - (272,257+1)" access="RW" enum="RS_FEC_544_514=0x80,RS_FEC_272_257_plus_1=0x200" offset="0x20.0" size="0x0.16" />
+	<field name="fec_override_admin_400g_8x" descr="400GE FEC override admin bitmast (one-hot setting): \;0: Auto_mode\;Bit7: RS_FEC_544_514\;Bit 9: RS_FEC_272_257_plus_1 - (272,257+1)" access="RW" enum="RS_FEC_544_514=0x80,RS_FEC_272_257_plus_1=0x200" offset="0x20.16" size="0x0.16" />
+	<field name="fec_override_admin_50g_1x" descr="50GE, 1lanes FEC override admin bitmask (one-hot setting)\;0: Auto_mode\;Bit 7: RS_FEC_544_514 - (544,514)\;Bit 9: RS_FEC_272_257_plus_1 - (272,257+1)" access="RW" enum="RS_FEC_544_514=0x80,RS_FEC_272_257_plus_1=0x200" offset="0x24.0" size="0x0.16" />
+	<field name="fec_override_admin_100g_2x" descr="100GE, 2 lanes FEC override admin bitmask (one-hot setting):\;0: Auto_mode\;Bit 7: RS_FEC_544_514 - (544,514)\;Bit 9: RS_FEC_272_257_plus_1 - (272,257+1)" access="RW" enum="RS_FEC_544_514=0x80,RS_FEC_272_257_plus_1=0x200" offset="0x24.16" size="0x0.16" />
+	<field name="fec_override_cap_400g_4x" descr="400GE, 4 lanes FEC override capability bitmask:\;Bit 7: RS_FEC_544_514 - (544,514)\;Bit 9: Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1 - (272,257+1)\;Other bits Reserved" access="RO" enum="RS_FEC_544_514=0x80,Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1=0x200" offset="0x28.0" size="0x0.16" />
+	<field name="fec_override_cap_800g_8x" descr="800GE, 8 lanes FEC override capability bitmask:\;Bit 7: RS_FEC_544_514 - RS-FEC (544,514)\;Bit 8: Reserved\;Bit 9: Ethernet_Consortium_LL_50G_RS_FEC- (272,257+1)\;Other bits Reserved" access="RO" enum="RS_FEC_544_514=0x80,Reserved=0x100,Ethernet_Consortium_LL_50G_RS_FEC=0x200" offset="0x28.16" size="0x0.16" />
+	<field name="fec_override_cap_100g_1x" descr="100GE, 1 lane FEC override capability bitmask:\;Bit 6: Interleaved_RS_FEC_544_514\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_Low_Latency_RS_FEC_272_257_plus_1\;Bit 10: Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1\;Other bits reserved" access="RO" enum="Interleaved_RS_FEC_544_514=0x40,RS_FEC_544_514=0x80,Ethernet_Consortium_Low_Latency_RS_FEC_272_257_plus_1=0x200,Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1=0x400" offset="0x2C.0" size="0x0.16" />
+	<field name="fec_override_cap_200g_2x" descr="200GE, 2 lanes FEC override capability bitmask:\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1\;Other bits Reserved" access="RO" enum="RS_FEC_544_514=0x80,Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1=0x200" offset="0x2C.16" size="0x0.16" />
+	<field name="fec_override_admin_400g_4x" descr="400GE, 4 lanes FEC override admin bitmask (one-hot setting):\;Bit 0: Auto_mode\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_Low_Latency_RS_FEC_272_257plus_1\;Other bits Reserved" access="RW" enum="Auto_mode=0x1,RS_FEC_544_514=0x80,Ethernet_Consortium_Low_Latency_RS_FEC_272_257plus_1=0x200" offset="0x44.0" size="0x0.16" />
+	<field name="fec_override_admin_800g_8x" descr="800GE, 8 lanes FEC override admin bitmask (one-hot setting):\;Bit 0: Auto_mode\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_Low_Latency_RS_FEC_272_257plus_1\;Other bits Reserved" access="RW" enum="Auto_mode=0x1,RS_FEC_544_514=0x80,Ethernet_Consortium_Low_Latency_RS_FEC_272_257plus_1=0x200" offset="0x44.16" size="0x0.16" />
+	<field name="fec_override_admin_100g_1x" descr="100GE, 1 lane FEC override admin bitmask (one-hot setting):\;Bit 0: Auto_mode\;Bit 6: Interleaved_RS_FEC_544_514\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_50G_Low_Latency_RS_FEC_272_257_plus_1\;Bit 10: Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1\;Other bits Reserved" access="RW" enum="Auto_mode=0x1,Interleaved_RS_FEC_544_514=0x40,RS_FEC_544_514=0x80,Ethernet_Consortium_50G_Low_Latency_RS_FEC_272_257_plus_1=0x200,Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_272_257_plus_1=0x400" offset="0x48.0" size="0x0.16" />
+	<field name="fec_override_admin_200g_2x" descr="200GE, 2 lanes FEC override admin bitmask (one-hot setting):\;Bit 0: Auto_mode\;Bit 7: RS_FEC_544_514\;Bit 9: Ethernet_Consortium_Low_Latency_RS_FEC_272_257_plus_1\;Other bits Reserved" access="RW" enum="Auto_mode=0x1,RS_FEC_544_514=0x80,Ethernet_Consortium_Low_Latency_RS_FEC_272_257_plus_1=0x200" offset="0x48.16" size="0x0.16" />
+</node>
+
+<node name="pplr_reg_ext" descr="" size="0x8.0" >
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.0" size="0x0.4" />
+	<field name="port_type" descr="For HCA supported only when indicated by PCAM \;0: Network_Port\;1: Near-End_Port- (For Retimer/Gearbox - Host side)\;2: Internal_IC_LR_Port \;3: Far-End_Port - (For Retimer/Gearbox - Line side)\;Other values are reserved." access="INDEX" enum="Network_Port=0x0,Near=0x1,Internal_IC_LR_Port=0x2,Far=0x3" offset="0x0.4" size="0x0.4" />
+	<field name="op_mod" descr="operational mode for link configurations for phy_ local_loopback mode.\;0 - link will operate in optimal latency performance mode\;1 - link will operate in same configurations as operational port.\;\;Note: for FEC override via PPLM register, chosen FEC will be according to the PPLM configuration that was set and this bit will be ignored for FEC purposes" access="OP" offset="0x0.8" size="0x0.1" />
+	<field name="apply_im" descr="Apply immediate: When set, the enabled/disabled loopback will be set immediately even if link is active.\;Note: Currently supported only for Bit 7: LL_local_loopback. in other loopbacks will be ignored" access="OP" offset="0x0.9" size="0x0.1" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="lb_en" descr="Loopback enable - One-hot key.\;Bit 0: Phy_remote_loopback\;Bit 1: Phy_local_loopback\;Bit 2: External_local_loopback\;Bit 7: LL_local_loopback\;\;\;" access="RW" enum="Phy_remote_loopback=0x1,Phy_local_loopback=0x2,External_local_loopback=0x4,LL_local_loopback=0x80" offset="0x4.0" size="0x0.12" />
+	<field name="lb_cap" descr="Loopback capability - bitmask\;Bit 0: Phy_remote_loopback\;Bit 1: Phy_local_loopback - When set the port&apos;s egress traffic is looped back to the receiver and the port transmitter is disabled.\;Bit 2: External_local_loopback - Enables the port&apos;s transmitter to link with the port&apos;s receiver using an external loopback connector.\;Bit 4: Near_end_digital_loopback - [Internal]\;Bit 7: LL_local_loopback - When set the port&apos;s egress Link layer traffic is looped back to the receiver. Physical port in this loopback mode is down.\;\;Note - Phy remote loopback can be supported only for lane rate higher than 25Gbuad in the 16nm devices.\;\;" access="RO" enum="Phy_remote_loopback=0x1,Phy_local_loopback=0x2,External_local_loopback=0x4,LL_local_loopback=0x80" offset="0x4.16" size="0x0.12" />
+</node>
+
+<node name="pprt_reg_ext" descr="" size="0x24.0" >
+	<field name="le" descr="Per Lane configuration enable (can be set only if ls = 1):\;0 - No per lane configuration\;1 - Per lane configurations\;When le is cleared, lane index is reserved and all PPRT configurations are taking place on all lanes.\;When le is set, configurations are taking place per lane based on lane index\;Affects lane indexing for set operations only, ignored for get operations." access="OP" offset="0x0.0" size="0x0.1" />
+	<field name="ls" descr="Per Lane configuration support: \;0 - No support of per lane configuration\;1 - Support of per lane configuration" access="RO" offset="0x0.1" size="0x0.1" />
+	<field name="port_type" descr="Supported only when indicated by PCAM \;0 - Network Port\;1 - Near-End Port (For Retimer/Gearbox - Host side)\;2 - Internal IC LR Port \;3 - Far-End Port (For Retimer/Gearbox - Line side)\;Other values are reserved.\;" access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="lane" descr="Reserved when (le=0 or ls = 0)\;Logical lane number" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0 - Local port number\;1 - IB port number" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="local_port" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="sw_c" descr="PRBS MSB &lt;-&gt;LSB Swap for PAM4 symbols support\;if this bit is cleared - bit 25 (&apos;s&apos;) is ignored" access="RO" offset="0x0.24" size="0x0.1" />
+	<field name="sw" descr="PRBS MSB &lt;-&gt;LSB Swap for PAM4 symbols\;0 - No Swap.\;1 - Swap MSB &lt;-&gt; LSB." access="RW" offset="0x0.25" size="0x0.1" />
+	<field name="dm_ig" descr="disable mask ignore\;If set to 1, the port&quot;s and the cable&quot;s capabilities won&quot;t affect tuning" access="OP" offset="0x0.26" size="0x0.1" />
+	<field name="p_c" descr="PRBS RX polarity support indication\;if this bit is cleared - bit 28 (&apos;p&apos;) is ignored" access="RO" offset="0x0.27" size="0x0.1" />
+	<field name="p" descr="PRBS RX polarity - NOT gate in PRBS (not Physical lane Polarity)\;\;0 - No polarity inversion.\;1 - PRBS RX polarity inversion." access="RW" offset="0x0.28" size="0x0.1" />
+	<field name="tun_ovr" descr="" access="OP" offset="0x0.29" size="0x0.1" />
+	<field name="s" descr="start tuning:\;1 - start RX_tuning based on PRBS pattern \;Note: assuming peer transmitting PRBS. \;cannot be set when prbs_rx_tuning_status = 1 (during tuning)" access="OP" offset="0x0.30" size="0x0.1" />
+	<field name="e" descr="Enable PRBS test mode bit:\;0 - PRBS RX is disabled.\;1 - PRBS RX is enabled." access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="prbs_modes_cap" descr="PRBS capability (bitmask)\;Bit 0 - PRBS31 (x^31 + x^28 + 1)\;Bit 1 - PRBS23A (x^23 + x^18 + 1)\;Bit 2 - PRBS23B (x^23 + x^18 + x^12+ x^6 + 1)\;Bit 3 - PRBS23C (x^23 + x^22 + x^19+ x^18 + 1)\;Bit 4 - PRBS23D (x^23 + x^19 + x^18+ x^11 + 1)\;Bit 5 - PRBS7 (x^7 + x^6 + 1)\;Bit 6 - PRBS11 (x^11 + x^9 + 1)\;Bit 7 - PRBS11A (x^11 + x^10 + x^6+ x^5 + 1)\;Bit 8 - PRBS11B (x^11 + x^9 + x^6+ x^5 + 1)\;Bit 9 - PRBS11C (x^11 + x^8 + x^6+ x^4 + 1)\;Bit 10 - PRBS11D (x^11 + x^7 + x^6+ x^4 + 1)\;Bit 11 - PRBS9 (x^9 + x^5 + 1)\;Bit 12 - IDLE using scramble58 (x^58+ x^39 + 1)\;Bit 13 - Square_wave : Non error based tune\;Bit 17 - PRBS13A (x^13 + x^12 + x^2+ x + 1)\;Bit 18 - PRBS13B (x^13 + x^7 + x^3+ x^2 + 1)\;Bit 19 - PRBS13C (x^13 + x^8 + x^4+ x^2 + 1)\;Bit 20 - PRBS13D (x^13 + x^9 + x^5+ x^2 + 1)\;Bit 21- SSPR\;Bit 22- SSPRQ\;Bit 23- LT frames (KR-startup frames)\;Bit 24 - PRBS15 - x^15 + x^14 + 1\;Bit 25 - PRBS28 - x^28 + x^25 + 1\;Bit 26 - Square wave3 (3ones, 3zeros)\;Bit 27 - Square wave13 (13ones, 13zeros)\;Bit 28 - Square wave30 (30ones, 30zeros)" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="modulation" descr="Reserved for speeds below 53.125Gb/s (lane_rate_admin &lt; 13):\;0 - NRZ test pattern\;1 - PAM4 encoding [interlnal] with gray no precoding\;2 - PAM4 with precoding [internal] with gray\;3 - PAM4 without gray no precoding\;" access="RW" offset="0x8.0" size="0x0.4" />
+	<field name="prbs_mode_admin" descr="See prbs_mode_cap: \;0x0 - PRBS31 (x^31 + x^28 + 1)\;0x1 - PRBS23A (x^23 + x^18 + 1)\;0x2 - PRBS23B (x^23 + x^18 + x^12+ x^6 + 1)\;0x3 - PRBS23C (x^23 + x^22 + x^19+ x^18 + 1)\;0x4 - PRBS23D (x^23 + x^19 + x^18+ x^11 + 1)\;0x5 - PRBS7 (x^7 + x^6 + 1)\;0x6 - PRBS11 (x^11 + x^9 + 1)\;0x7 - PRBS11A (x^11 + x^10 + x^6+ x^5 + 1)\;0x8 - PRBS11B (x^11 + x^9 + x^6+ x^5 + 1)\;0x9 - PRBS11C (x^11 + x^8 + x^6+ x^4 + 1)\;0xA - PRBS11D (x^11 + x^7 + x^6+ x^4 + 1)\;0xB - PRBS9 (x^9 + x^5 + 1)\;0xC - IDLEs using scramble58 (x^58+ x^39 + 1)\;0xD - Square_wave : Non error based tune \;0x11 - PRBS13A (x^13 + x^12 + x^2+ x + 1)\;0x12 - PRBS13B (x^13 + x^7 + x^3+ x^2 + 1)\;0x13 - PRBS13C (x^13 + x^8 + x^4+ x^2 + 1)\;0x14 - PRBS13D (x^13 + x^9 + x^5+ x^2 + 1)\;0x15 - SSPR\;0x16 - SSPRQ\;0x17 - LT frames (KR-startup frames)\;0x18 - PRBS15 - x^15 + x^14 + 1\;0x19 - PRBS28 - x^28 + x^25 + 1\;0x1A - Square wave3 (3ones, 3zeros)\;0x1B - Square wave13 (13ones, 13zeros)\;0x1C - Square wave30 (30ones, 30zeros)" access="RW" offset="0x8.24" size="0x0.8" />
+	<field name="lane_rate_cap" descr="Per lane rate capability (bitmask)\;Bit 0 - 1GE (1.25 Gb/s)\;Bit 1 - SDR (2.5 Gb/s) \;Bit 2 - XAUI/2.5GE (3.125 Gb/s)\;Bit 3- DDR (5 Gb/s) \;Bit 4- QDR (10 Gb/s) \;Bit 5- FDR10 / 10GE/40GE (10.3125 Gb/s) \;Bit 6- FDR (14.0625 Gb/s) \;Bit 7- EDR / 25GE / 50GE / 100GE (25.78125 Gb/s) \;Bit 8 - 50GE-KR4 (12.89 Gb/s) \;Bit 9 - HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s) \;Bit 10 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;Bit 11 - XDR (106.25Gbd / 212.5Gb/s)" access="RO" offset="0xC.16" size="0x0.16" />
+	<field name="lane_rate_oper" descr="Lane rate to be used in PRBS, see lane_rate_cap:\;0 - SDR (2.5 Gb/s)\;1 - DDR (5 Gb/s) \;2 - QDR (10 Gb/s)\;3 - FDR10 / 10GE/4 0GE (10.3125 Gb/s)\;4 - FDR (14.0625 Gb/s) \;5 - EDR / 25GE / 50GE / 100GE (25.78125 Gb/s)\;6 - HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s\;7 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s) \;8 - XDR (106.25Gbd / 212.5Gb/s)\;9 - reserved\;10 - 1GE (1.25 Gb/s)\;11 - XAUI/2.5GE (3.125 Gb/s)\;12 - 50GE-KR4 (12.89 Gb/s) \;\;Note: All lanes must be set to the same rate" access="RW" offset="0x10.16" size="0x0.16" />
+	<field name="prbs_lock_status_ext" descr="PRBS lock on PRBS pattern status for lanes 7-4: \;0 - Not locked\;1 - Locked\;\;Note: Once exiting prbs test mode the prbs_rx_tuning_status will return to 0 (Not locked)" access="RO" offset="0x14.20" size="0x0.4" />
+	<field name="prbs_lock_status" descr="PRBS lock on PRBS pattern status for lanes 3-0: \;0 - Not locked\;1 - Locked\;\;Note: Once exiting prbs test mode the prbs_rx_tuning_status will return to 0 (Not locked)" access="RO" offset="0x14.24" size="0x0.4" />
+	<field name="prbs_rx_tuning_status" descr="Tuning status: \;0 - PRBS mode tuning was not performed.\;1 - Performing PRBS mode tuning.\;2 - PRBS mode tuning completed.\;3 - Signal Detect in progress\;\;Note: Once exiting prbs test mode the prbs_rx_tuning_status will return to 0." access="RO" offset="0x14.28" size="0x0.4" />
+</node>
+
+<node name="ppsc_reg_ext" descr="" size="0x30.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="mod_pwr_opt" descr="See PCAM.feature_cap_mask bit 16 for support indication: \;Transceiver power optimization:\;0 - Disable\;1 - Enable" access="RW" offset="0x4.0" size="0x0.1" />
+	<field name="wrps_admin" descr="Width reduction power save admin state:\;0000: Disable Width Reduction - Force link to full width (Default)\;0001: Force Width Reduction - Force link to single lane\;0010: Auto - Automatic Width Reduction (based on traffic)." access="RW" offset="0x10.0" size="0x0.4" />
+	<field name="wrps_status" descr="Link actual width:\;0000: Full width\;0001: Single lane\;1111: In transition" access="RO" offset="0x14.0" size="0x0.4" />
+	<field name="down_threshold" descr="Link width down threshold, Values: 1%-100%\;The BW (In percent) before the link width is moved to single lane" access="RW" offset="0x18.0" size="0x0.8" />
+	<field name="up_threshold" descr="Link width up threshold, Values: 1-5 (default 3)\;how aggressive/smoothed in response to high BW.\;1 - means aggressive response to every BW increase\;5 - means smoothened response to every BW increase" access="RW" offset="0x18.16" size="0x0.8" />
+	<field name="down_th_vld" descr="Valid bit to update the down threshold\;if &apos;1&apos; update down_threshold" access="WO" offset="0x18.30" size="0x0.1" />
+	<field name="up_th_vld" descr="Valid bit to update the up threshold\;if &apos;1&apos; update up_threshold" access="WO" offset="0x18.31" size="0x0.1" />
+	<field name="srps_admin" descr="Speed reduction power save admin state:\;0000: Disable Speed Reduction - force link to full speed (Default)\;0001: Force Speed Reduction - force link to low speed" access="RW" offset="0x20.0" size="0x0.4" />
+</node>
+
+<node name="ppslc_ext" descr="" size="0x34.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="l1_req_en" descr="Enable L1 Request\;0: L1 Request is disabled on this port\;1: L1 Request is enabled on this port\;" access="RW" offset="0x4.0" size="0x0.1" />
+	<field name="l1_fw_req_en" descr="Enable L1 FW Request\;0: Only L1 HW mode is supported (thermal throttling is disabled) \;1: support thermal throttling on this port \;Reserved for Switch." access="RW" offset="0x8.0" size="0x0.1" />
+	<field name="l1_cap_adv" descr="L1 Capability Advertisement\;0: Port doesn&apos;t support L1\;1: Port supports L1 advertisement" access="RW" offset="0x8.4" size="0x0.1" />
+	<field name="l1_fw_cap_adv" descr="L1 FW Capability Advertisement\;0: Port doesn&apos;t support L1 FW\;1: Port supports L1 FW advertisement\;Reserved for Switch." access="RW" offset="0x8.8" size="0x0.1" />
+	<field name="ignore_pred_pm" descr="[DWIP] [SwitchOnly]:\;Ignore Predictor Post Mistake\;If the predictor decision is to move to L1 idle, but no traffic arrives, we will ignore the predictor until traffic arrives again\;0: don&apos;t ignore predictor\;1: ignore predictor" access="RW" offset="0xC.30" size="0x0.1" />
+	<field name="pred_algo_en" descr="[DWIP] [SwitchOnly]:\;Predictive Algo Enable\;0: Predictive Algo&apos; is disabled\;1: Predictive Algo&apos; is enabled\;\;Relevant for Switch Only" access="RW" offset="0xC.31" size="0x0.1" />
+	<field name="hp_queues_bitmap" descr="High Priority Queues Bitmap\;for each queue, \;0: Normal queue\;1: High priority queue\;\;Note: High priority queues can move to L1 active only when queue is fully empty. Normal queues can move to L1 active as long as the number of bytes within the queue is lower than MPSCR.queue_depth_th\;\;bits 17-31 are reserved" access="RW" offset="0x10.0" size="0x4.0" />
+	<field name="l1_hw_active_time" descr="[DWIP]\;units of 50 usec minimum value of 50 usec\;" access="RW" offset="0x18.0" size="0x0.10" />
+	<field name="l1_hw_inactive_time" descr="[DWIP]\;units of 50 usec. minimum value of 50 usec\;" access="RW" offset="0x1C.0" size="0x0.10" />
+	<field name="qem" descr="Queue Desire (state) Exit Mode upon traffic arrival\;0: Move to L1 Idle immediately \;1: Wait for desire window completion before moving to L1 idle\;2: Ignore traffic arrival \;\;Note: \;For GB100, only index 0-7 are valid. \;For QM-3 only index 0-16 are valid." access="RW" high_bound="19" low_bound="0" offset="0x20.24" size="0x14.0" />
+</node>
+
+<node name="ppsls_ext" descr="" size="0x8.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="l1_fw_mode_cap" descr="0: Port doesn&apos;t support L1 fw mode\;1: Port supports L1 fw mode\;" access="RO" offset="0x4.16" size="0x0.1" />
+	<field name="l1_cap" descr="0: Port doesn&apos;t support L1\;1: Port supports L1 \;" access="RO" offset="0x4.18" size="0x0.1" />
+	<field name="fw_mode_remote" descr="FW mode remote indication\;0: N/A\;1: L1 fw mode remote capability is set \;2: L1 fw mode remote request is set \;3: L1 fw mode remote request and capability are set \;Valid only is l1_neg_status = 1 \;Reserved when link is down" access="RO" offset="0x4.27" size="0x0.2" />
+	<field name="fw_mode_act" descr="Actual Mode \;0: HW mode\;1: FW mode\;Valid only is l1_neg_status = 1 \;Reserved when link is down\;Reserved for Switch." access="RO" offset="0x4.29" size="0x0.1" />
+	<field name="fw_mode_neg_status" descr="FW mode negotiation status\;0: L1 fw mode negotiation failed\;1: L1 fw mode negotiation succeeded \;Valid only if l1_neg_status = 1 \;Reserved when link is down" access="RO" offset="0x4.30" size="0x0.1" />
+	<field name="l1_neg_status" descr="L1 negotiation status\;0: L1 negotiation failed (L1 is not supported by both sides)\;1: L1 negotiation succeeded (supported on both sides)\;Reserved when link is down" access="RO" offset="0x4.31" size="0x0.1" />
+</node>
+
+<node name="pptt_reg_ext" descr="" size="0x1c.0" >
+	<field name="le" descr="Per Lane configuration enable (can be set only if ls = 1):\;0 - No per lane configuration\;1 - Per lane configurations\;When le is cleared, lane index is reserved and all PPTT configurations are taking place on all lanes.\;When le is set, configurations are taking place per lane based on lane index\;Affects lane indexing for set operations only, ignored for get operations" access="OP" offset="0x0.0" size="0x0.1" />
+	<field name="ls" descr="Per Lane configuration support/capability: \;0 - No support of per lane configuration\;1 - Support of per lane configuration" access="RO" offset="0x0.1" size="0x0.1" />
+	<field name="port_type" descr="For HCA supported only when indicated by PCAM \;0 - Network Port\;1 - Near-End Port (For Retimer/Gearbox - Host side)\;2 - Internal IC LR Port \;3 - Far-End Port (For Retimer/Gearbox - Line side)\;Other values are reserved.\;Note: PRBS can be enabled only for two entities that directly connected to each other.\;For non MCM and no Retimer/Gearbox only 0 allowed.\;For non MCM and with Retimer/Gearbox 2-1 or 3 or 0.\;For MCM without Retimer/Gearbox 4-5 or 2 or 0.\;For MCM with Retimer/Gearbox 4-5 or 2-1 or 3 or 0.\;all the port will be in test mode when PRBS is enabled." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="lane" descr="Reserved when (le=0 or ls = 0)\;Logical lane number" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0 - Local port number\;1 - IB port number" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="local_port" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="sw_c" descr="PRBS MSB &lt;-&gt;LSB Swap for PAM4 symbols support\;if this bit is cleared - bit 25 (&apos;s&apos;) is ignored" access="RO" offset="0x0.24" size="0x0.1" />
+	<field name="sw" descr="PRBS MSB &lt;-&gt;LSB Swap for PAM4 symbols\;0 - No Swap.\;1 - Swap MSB &lt;-&gt; LSB." access="RW" offset="0x0.25" size="0x0.1" />
+	<field name="dm_ig" descr="disable mask ignore\;If set to 1, the port&quot;s and the cable&quot;s capabilities won&quot;t affect tuning" access="OP" offset="0x0.26" size="0x0.1" />
+	<field name="p_c" descr="PRBS TX polarity support indication.\;if this bit is cleared - bit 28 (&apos;p&apos;) is been ignored" access="RO" offset="0x0.27" size="0x0.1" />
+	<field name="p" descr="PRBS TX polarity - NOT gate in PRBS (not Physical lane Polarity)\;0 - No polarity inversion.\;1 - PRBS TX polarity inversion." access="RW" offset="0x0.28" size="0x0.1" />
+	<field name="e" descr="Enable PRBS test mode bit:\;0 - PRBS TX is disabled.\;1 - PRBS TX is enabled." access="RW" offset="0x0.31" size="0x0.1" />
+	<field name="prbs_modes_cap" descr="PRBS capability (bitmask)\;Bit 0 - PRBS31 (x^31 + x^28 + 1)\;Bit 1 - PRBS23A (x^23 + x^18 + 1)\;Bit 2 - PRBS23B (x^23 + x^18 + x^12+ x^6 + 1)\;Bit 3 - PRBS23C (x^23 + x^22 + x^19+ x^18 + 1)\;Bit 4 - PRBS23D (x^23 + x^19 + x^18+ x^11 + 1)\;Bit 5 - PRBS7 (x^7 + x^6 + 1)\;Bit 6 - PRBS11 (x^11 + x^9 + 1)\;Bit 7 - PRBS11A (x^11 + x^10 + x^6+ x^5 + 1)\;Bit 8 - PRBS11B (x^11 + x^9 + x^6+ x^5 + 1)\;Bit 9 - PRBS11C (x^11 + x^8 + x^6+ x^4 + 1)\;Bit 10 - PRBS11D (x^11 + x^7 + x^6+ x^4 + 1)\;Bit 11 - PRBS9 (x^9 + x^5 + 1)\;Bit 12 - IDLE using scramble58 (x^58+ x^39 + 1)\;Bit 13 - Square_wave8 (8 ones , 8 zeros)\;Bit 14 - Square_wave4 (4 ones , 4zeros)\;Bit 15 - Square_wave2 (2 ones , 2zeros)\;Bit 16 - Square_wave1 (one , zero)\;Bit 17 - PRBS13A (x^13 + x^12 + x^2+ x + 1)\;Bit 18 - PRBS13B (x^13 + x^7 + x^3+ x^2 + 1)\;Bit 19 - PRBS13C (x^13 + x^8 + x^4+ x^2 + 1)\;Bit 20 - PRBS13D (x^13 + x^9 + x^5+ x^2 + 1)\;Bit 21- SSPR\;Bit 22- SSPRQ\;Bit 23- LT frames (KR-startup frames)\;Bit 24 - PRBS15 - x^15 + x^14 + 1\;Bit 25 - PRBS28 - x^28 + x^25 + 1\;Bit 26 - Square wave3 (3ones, 3zeros)\;Bit 27 - Square wave13 (13ones, 13zeros)\;Bit 28 - Square wave30 (30ones, 30zeros)\;Bit 29 - PRBS58 (x^58+ x^39 + 1)" access="RO" offset="0x4.0" size="0x4.0" />
+	<field name="modulation" descr="Reserved for speeds below 53.125Gb/s (lane_rate_admin &lt; 13):\;0 - NRZ test pattern\;1 - PAM4 encoding [interlnal] with gray no precoding\;2 - PAM4 with precoding [internal] with gray\;3 - PAM4 without gray no precoding\;" access="RW" offset="0x8.0" size="0x0.4" />
+	<field name="prbs_mode_admin" descr="See prbs_mode_cap: \;0x0 - PRBS31 (x^31 + x^28 + 1)\;0x1 - PRBS23A (x^23 + x^18 + 1)\;0x2 - PRBS23B (x^23 + x^18 + x^12+ x^6 + 1)\;0x3 - PRBS23C (x^23 + x^22 + x^19+ x^18 + 1)\;0x4 - PRBS23D (x^23 + x^19 + x^18+ x^11 + 1)\;0x5 - PRBS7 (x^7 + x^6 + 1)\;0x6 - PRBS11 (x^11 + x^9 + 1)\;0x7 - PRBS11A (x^11 + x^10 + x^6+ x^5 + 1)\;0x8 - PRBS11B (x^11 + x^9 + x^6+ x^5 + 1)\;0x9 - PRBS11C (x^11 + x^8 + x^6+ x^4 + 1)\;0xA - PRBS11D (x^11 + x^7 + x^6+ x^4 + 1)\;0xB - PRBS9 (x^9 + x^5 + 1)\;0xC - IDLEs using scramble58 (x^58+ x^39 + 1)\;0xD - Square_wave8 (8 ones , 8 zeros)\;0xE - Square_wave4 (4 ones , 4zeros)\;0xF - Square_wave2 (2 ones , 2zeros)\;0x10 - Square_wave1 (one , zero)\;0x11 - PRBS13A (x^13 + x^12 + x^2+ x + 1)\;0x12 - PRBS13B (x^13 + x^7 + x^3+ x^2 + 1)\;0x13 - PRBS13C (x^13 + x^8 + x^4+ x^2 + 1)\;0x14 - PRBS13D (x^13 + x^9 + x^5+ x^2 + 1)\;0x15 - SSPR\;0x16 - SSPRQ\;0x17 - LT frames (KR-startup frames)\;0x18 - PRBS15 - x^15 + x^14 + 1\;0x19 - PRBS28 - x^28 + x^25 + 1\;0x1A - Square wave3 (3ones, 3zeros)\;0x1B - Square wave13 (13ones, 13zeros)\;0x1C - Square wave30 (30ones, 30zeros)\;0x1D - PRBS58 (x^58+ x^39 + 1)" access="RW" offset="0x8.24" size="0x0.8" />
+	<field name="prbs_fec_cap" descr="When set, PRBS over FEC is supported.\;Note: Feature is enabled on all lanes of port" access="RO" offset="0xC.0" size="0x0.1" />
+	<field name="lane_rate_cap" descr="Per lane rate capability (bitmask)\;Bit 0 - 1GE (1.25 Gb/s)\;Bit 1 - SDR (2.5 Gb/s) \;Bit 2 - XAUI/2.5GE (3.125 Gb/s)\;Bit 3- DDR (5 Gb/s) \;Bit 4- QDR (10 Gb/s) \;Bit 5- FDR10 / 10GE/40GE (10.3125 Gb/s) \;Bit 6- FDR (14.0625 Gb/s) \;Bit 7- EDR / 25GE / 50GE / 100GE (25.78125 Gb/s) \;Bit 8 - 50GE-KR4 (12.89 Gb/s) \;Bit 9 - HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s) \;Bit 10 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;Bit 11 - XDR (106.25Gbd / 212.5Gb/s)\;" access="RO" offset="0xC.16" size="0x0.16" />
+	<field name="prbs_fec_admin" descr="When set, PRBS over FEC is enabled for port.\;For FEC configuration, set PPLM.test_mode" access="RW" offset="0x10.0" size="0x0.1" />
+	<field name="lane_rate_admin" descr="Lane rate be used in PRBS, see lane_rate_cap:\;0 - SDR (2.5 Gb/s)\;1 - DDR (5 Gb/s) \;2 - QDR (10 Gb/s)\;3 - FDR10 / 10GE/40GE (10.3125 Gb/s)\;4 - FDR (14.0625 Gb/s) \;5 - EDR / 25GE / 50GE / 100GE (25.78125 Gb/s)\;6 - HDR /50GE / 100GE / 200GE / 400GE (26.5625Gbd / 53.125Gb/s)\;7 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;8 - XDR (106.25Gbd / 212.5Gb/s)\;9 - reserved\;10 - 1GE (1.25 Gb/s)\;11 - XAUI/2.5GE (3.125 Gb/s)\;12 - 50GE-KR4 (12.89 Gb/s)\;\;Note: All lanes must be set to the same rate" access="RW" offset="0x10.16" size="0x0.16" />
+</node>
+
+<node name="prtl_reg_ext" descr="" size="0x20.0" >
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0: Local_port_number\;1: IB_port_number\;3: Out_of_band" access="INDEX" enum="Local_port_number=0x0,IB_port_number=0x1,Out_of_band=0x3" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number [7:0]" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="rtt_support" descr="Support of RTT measurement" access="RO" offset="0x0.31" size="0x0.1" />
+	<field name="latency_accuracy" descr="Latency measurement accuracy (i,e. max error size). \;accuracy is relative to specific device implementation. \;This field returns the accuracy in nsec resolution. \;" access="RO" offset="0x4.0" size="0x0.8" />
+	<field name="latency_res" descr="Latency resolution in nsec of round_trip_latency \;" access="RO" offset="0x4.16" size="0x0.4" />
+	<field name="local_phy_latency" descr="Shall be 0 if not implemented (rtt_support = 0). \;This value represents the intra-ASIC pipeline latency of the physical layer. It is an unsigned 16-bit integer in nsec." access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="local_mod_dp_latency" descr="Shall be 0 if not implemented (rtt_support = 0), if the module is not plugged in or if the information is not available on the plugged module. \;This value represents the module&apos;s Datapath pipeline latency.It It is an unsigned 16-bit integer in nsec." access="RO" offset="0xC.0" size="0x0.16" />
+	<field name="round_trip_latency" descr="Shall be 0 if not implemented (rtt_support = 0). \;This value represents a measurement of the round-trip latency of the link attached to this port. \;It is an unsigned 24-bit integer counting latency_res nsec. \;intervals. \;This value might not be accurate to better than +/- latency_accuracy nsec. \;A value of 0 is valid when implemented, and indicates a latency of up to latency_accuracy nsec. \;round_trip_latency is reset to 0xFFFFFF whenever this port transitions to PAOS.Oper_status = Down." access="RO" offset="0x10.0" size="0x0.24" />
+</node>
+
+<node name="pter_phy_page_reg_ext" descr="" size="0x1c.0" >
+	<field name="error_type_admin" descr="Error Type to generate\;0 - No Error\;---- Physical Errors ----\;1 - Raw BER\;2 - Effective BER\;16 - PCS link fault" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="error_type_cap" descr="Error injection capabilities \;Bit 0 - Raw BER\;Bit 1 - Effective BER\;\;Bit 4 - PCS link fault" access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="error_type_oper" descr="Error injection opertional status\;0x0 - No error injection\;0x1 - Performing error injection" access="RO" offset="0x0.24" size="0x0.4" />
+	<field name="ber_exp" descr="BER for injection.\;BER = ber_mantissa * 10^(-ber_exp)" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="ber_mantissa" descr="BER for injection.\;BER = ber_mantissa * 10^(-ber_exp)" access="RW" offset="0x4.8" size="0x0.4" />
+	<field name="error_injection_time" descr="Duration in 10 msec the port will generate errors.\;Reading this field will return the time left for errors to inject in msec\;\;\;0x0000 indicates no generation of errors.\;When set to 0xFFFF - No decremental operation, meaning the errors will be injected continuously without stop condition." access="RW" offset="0x4.12" size="0x0.16" />
+</node>
+
+<node name="pter_port_page_reg_ext" descr="" size="0x1c.0" >
+	<field name="error_type_admin" descr="Error Type to generate\;0 - No Error\;---- Port Errors ----\;1 - Corrupt data packet ICRC\;2 - Corrupt data packet VCRC\;4- Corrupt credit packet LPCRC" access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="error_type_cap" descr="Error injection capabilities \;Bit 0- Corrupt data packet ICRC\;Bit 1- Corrupt data packet VCRC\;Bit 2- Corrupt credit packet LPCRC\;" access="RO" offset="0x0.8" size="0x0.8" />
+	<field name="error_count" descr="Error Count\;Number of times the port will generate the configured error.\;0 indicates not to generate error.\;Reading error_count will return the number of left errors to inject. When 0, all requested errors has been injected." access="RW" offset="0x4.12" size="0x0.5" />
+</node>
+
+<node name="pter_reg_ext" descr="" size="0x20.0" >
+	<field name="status" descr="Error injection status: \;0x0 -Good status\;0x2 - No available sources for Error injection\;0x3 - Error injection configuration when port is in non operational state (port is neither in UP or TEST MODE)\;0x4 - out of range BER setting" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0 - Local port number\;1 - IB port number\;" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="error_page" descr="Error_page selection: \;0: Injection_of_Phy_Errors\;1: Injection_of_Port_Errors" access="INDEX" enum="Injection_of_Phy_Errors=0x0,Injection_of_Port_Errors=0x1" offset="0x0.24" size="0x0.4" />
+	<field name="page_data" descr="error injection page data: \;Table 1484, &quot;PTER- Port Transmit Errors Register Phy Level Layout,&quot; on page 1750\;Table 1486, &quot;PTER- Port Transmit Errors Register Port Level Fields,&quot; on page 1752" subnode="pter_reg_page_data_auto_ext" access="RW" offset="0x4.0" size="0x1c.0" union_selector="$(parent).error_page" />
+</node>
+
+<node name="pter_reg_page_data_auto_ext" descr="" attr_is_union="1" size="0x1c.0" >
+	<field name="pter_phy_page_reg_ext" descr="" subnode="pter_phy_page_reg_ext" offset="0x0.0" selected_by="Injection_of_Phy_Errors" size="0x1c.0" />
+	<field name="pter_port_page_reg_ext" descr="" subnode="pter_port_page_reg_ext" offset="0x0.0" selected_by="Injection_of_Port_Errors" size="0x1c.0" />
+</node>
+
+<node name="ptsb_ext" descr="" size="0x20.0" >
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="sl" descr="SL\;For GB100: allowed 0..3\;Reserved when type = 0" access="INDEX" offset="0x4.0" size="0x0.4" />
+	<field name="vc" descr="VC (Virtual Channel)\;For GB100: allowed 0,1\;Reserved when type = 1" access="INDEX" offset="0x4.4" size="0x0.4" />
+	<field name="pipe" descr="Pipe\;For GB100: allowed 0,1\;Reserved when type = 1" access="INDEX" offset="0x4.8" size="0x0.4" />
+	<field name="type" descr="Type:\;0: NVLink\;1: IB" access="INDEX" offset="0x4.12" size="0x0.4" />
+	<field name="burst_send" descr="Burst send:\;Send up to burst_send consecutive packets.\;Value of 0 is not supported.\;FW will send 1 packet after each other, typically time of 100&apos;s of nSec between every 2 packets.\;Note that this &quot;allows sending&quot;. If there are no packets or no credits then the packets will not be transmitted but the counter will be incremented" access="OP" offset="0x8.0" size="0x0.10" />
+</node>
+
+<node name="ptsr_ext" descr="" size="0x20.0" >
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="ts" descr="Tx suspend:\;0: Tx enabled (default)\;1: Tx disabled" access="RW" offset="0x4.0" size="0x0.1" />
+</node>
+
+<node name="ptys_reg_ext" descr="" size="0x44.0" >
+	<field name="proto_mask" descr="Protocol Mask. Indicates which of the protocol data is valid\;Bit 0: InfiniBand\;Bit 2: Ethernet" access="INDEX" enum="InfiniBand=0x1,Ethernet=0x4" offset="0x0.0" size="0x0.3" />
+	<field name="transmit_allowed" descr="Valid only when port is mapped to SW controlled module, otherwise ignored. module control can be queried via MMCR register.\;\;0: transmit_not_allowed - Transmitter is not allowed to transmit signal on output\;1: transmit_allowed - Transmitter is allowed to transmit signal on output. for enabling transmitter, PAOS.admin_status must be up as well." access="RW" enum="transmit_not_allowed=0x0,transmit_allowed=0x1" offset="0x0.3" size="0x0.1" />
+	<field name="plane_ind" descr="Reserved for non-planarized port.\;Plane port index of the aggregated port. A value of 0 refers to the aggregated port only." access="INDEX" offset="0x0.4" size="0x0.4" />
+	<field name="port_type" descr="Supported only when indicated by PCAM \;0: Network_Port\;1: Near-End_Port - (For Gearbox - Host side)\;2: Internal_IC_Port \;3: Far-End_Port - (For Gearbox - Line side)\;\;Other values are reserved." access="INDEX" enum="Network_Port=0x0,Near=0x1,Internal_IC_Port=0x2,Far=0x3" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="tx_ready_e" descr="Valid only when ee_tx_ready is set, otherwise field is ignored.\;0: do_not_generate_event\;Bit 0: generate_tx_ready_event - When set, PTSE register will generate event when Transmitter is generating valid signal on the line\;Bit 1: generate_tx_not_ready_event - when set, PTSE will generate event when the transmitter stopped transmitting after Tx_ready was set.\;Note: if both tx_not_ready and tx_ready are set, one toggle event may be received instead of 2 consecutive events of not ready --&gt; ready." access="RW" offset="0x0.26" size="0x0.2" />
+	<field name="ee_tx_ready" descr="Event Enable for tx_ready_e.\;when bit is not set, tx_teady_e write value will be ignored" access="WO" offset="0x0.28" size="0x0.1" />
+	<field name="an_disable_cap" descr="Auto Negotiation disable capability:\;0 - Device does not support AN disable\;1 - Device Supports  AN disable" access="RO" offset="0x0.29" size="0x0.1" />
+	<field name="an_disable_admin" descr="Auto Negotiation disable:\;0 - Normal operation \;1 - Disable AN.\;Note: In Ethernet port, when Disabling AN, the &quot;eth_proto_admin&quot; bit mask must comply to single speed rate set.\;In IB port, when Disabling AN, the &quot;ib_proto_admin&quot; bit mask must comply to single speed rate set.\;It&apos;s recommended to validate the FEC override bits in PPLM when operating with AN. \;\;" access="RW" offset="0x0.30" size="0x0.1" />
+	<field name="reserved_high" descr="" access="RO" offset="0x0.31" size="0x0.1" />
+	<field name="data_rate_oper" descr="Port data rate in resolution of 100 Mb/s (data_rate_oper * 100 Mb/s)\;Value 0x0 indicates this field is not supported.\;" access="RO" offset="0x4.0" size="0x0.16" />
+	<field name="max_port_rate" descr="Port maxium data rate in resolution of 1 Gb/s (data_rate_oper * 1 Gb/s)\;Value 0x0 indicates this field is not supported.\;\;" access="RO" offset="0x4.16" size="0x0.12" />
+	<field name="an_status" descr="Auto Negotiation status: \;0: Status_is_unavailable\;1: AN_completed_successfully \;2: AN_performed_but_failed\;3: AN_was_not_performed_link_is_up \;4: AN_was_not_performed_link_is_down" access="RO" enum="Status_is_unavailable=0x0,AN_completed_successfully=0x1,AN_performed_but_failed=0x2,AN_was_not_performed_link_is_up=0x3,AN_was_not_performed_link_is_down=0x4" offset="0x4.28" size="0x0.4" />
+	<field name="ext_eth_proto_capability" descr="For HCA: See also PCAM.feature_cap_mask bit 13 for Extended Ethernet protocol support.\;Extended Ethernet port speed/protocols supported (bitmask):\;Bit 0: SGMII_100M\;Bit 1: 1000BASE-X / SGMII\;Bit 3: 5GBASE-R\;Bit 4: XFI / XAUI-1 // 10G\;Bit 5: XLAUI-4/XLPPI-4 // 40G \;Bit 6: 25GAUI-1/ 25GBASE-CR / KR \;Bit 7: 50GAUI-2 / LAUI-2/ 50GBASE-CR2/KR2 \;Bit 8: 50GAUI-1 /50GBASE-CR / KR\;Bit 9: CAUI-4 / 100GBASE-CR4 / KR4\;Bit 10: 100GAUI-2 / 100GBASE-CR2 / KR2 \;Bit 11: 100GAUI-1 / 100GBASE-CR / KR\;Bit 12: 200GAUI-4 / 200GBASE-CR4/KR4\;Bit 13: 200GAUI-2 / 200GBASE-CR2/KR2\;Bit 14: Reserved [internal] Placeholder for 200GAUI-1\;Bit 15: 400GAUI-8/ 400GBASE-CR8\;Bit 16: 400GAUI-4/ 400GBASE-CR4\;Bit 17: Reserved [internal] Placeholder for 400GAUI-2\;Bit 18: Reserved [internal] Placeholder for 400GAUI-1\;Bit 19: 800GAUI-8 / 800GBASE-CR8 / KR8\;Bit 31: SGMII_10M\;Other - Reserved" access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="eth_proto_capability" descr="Ethernet port speed/protocols supported (bitmask)\;Bit 31 - 50GBase-KR2\;Bit 30 - 50GBase-CR2\;Bit 29 - 25GBase-SR\;Bit 28 - 25GBase-KR\;Bit 27 - 25GBase-CR\;Bit 26 - 10GBase-T \;Bit 25 - 1000Base-T\;Bit 24 - 100Base-TX\;Bit 23 - 100GBase LR4/ER4\;Bit 22 - 100GBase KR4\;Bit 21 - 100GBase SR4\;Bit 20 - 100GBase CR4\;Bit 18 - 50GBase-SR2\;Bit 16 - 40GBase LR4/ER4\;Bit 15 - 40GBase SR4\;Bit 14 - 10GBase ER/LR\;Bit 13 - 10GBase SR\;Bit 12 - 10GBase CR\;Bit 10 - 10Base-T\;Bit 9 - SGMII_100Base\;Bit 7 - 40GBase KR4\;Bit 6 - 40GBase CR4\;Bit 4 - 10GBase KR\;Bit 3 - 10GBase KX4\;Bit 2 - 10GBase-CX4\;Bit 1 - 1000Base KX\;Bit 0 - SGMII" access="RO" offset="0xC.0" size="0x4.0" />
+	<field name="ib_proto_capability" descr="InfiniBand port speed supported (bitmask)\;Bit 0: SDR\;Bit 1: DDR\;Bit 2: QDR\;Bit 3: FDR10\;Bit 4: FDR\;Bit 5: EDR\;Bit 6: HDR\;Bit 7: NDR\;Bit 8: XDR" access="RO" enum="SDR=0x1,DDR=0x2,QDR=0x4,FDR10=0x8,FDR=0x10,EDR=0x20,HDR=0x40,NDR=0x80,XDR=0x100" offset="0x10.0" size="0x0.16" />
+	<field name="ib_link_width_capability" descr="ib_link_width &lt;= ib_proto_capability\;Bit 0 - 1x\;Bit 1 - 2x\;Bit 2 - 4x\;" access="RO" offset="0x10.16" size="0x0.16" />
+	<field name="ext_eth_proto_admin" descr="Ethernet port extended speed/protocols bitmask\;NOTE: This field and &quot;eth_proto_admin&quot; are mutual exclusive, meaning that only one of the field can be set on write command." access="RW" offset="0x14.0" size="0x4.0" />
+	<field name="eth_proto_admin" descr="Ethernet port speed/protocols bitmask" access="RW" offset="0x18.0" size="0x4.0" />
+	<field name="ib_proto_admin" descr="InfiniBand port speed bitmask" access="RW" offset="0x1C.0" size="0x0.16" />
+	<field name="ib_link_width_admin" descr="InfiniBand port link width bitmask\;" access="RW" offset="0x1C.16" size="0x0.16" />
+	<field name="ext_eth_proto_oper" descr="Ethernet port extended speed/protocols bitmask" access="RO" offset="0x20.0" size="0x4.0" />
+	<field name="eth_proto_oper" descr="Ethernet port speed/protocols bitmask" access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="ib_proto_oper" descr="InfiniBand port speed bitmask" access="RO" offset="0x28.0" size="0x0.16" />
+	<field name="ib_link_width_oper" descr="InfiniBand port link width bitmask\;" access="RO" offset="0x28.16" size="0x0.16" />
+	<field name="connector_type" descr="Connector type indication\;0: No_connector_or_unknown \;1: PORT_NONE - None\;2: PORT_TP - Twisted Pair\;3: PORT_AUI - AUI\;4: PORT_BNC - BNC\;5: PORT_MII - MII\;6: PORT_FIBRE - FIBRE\;7: PORT_DA - Direct Attach Copper\;8: PORT_OTHER - Other" access="RO" enum="No_connector_or_unknown=0x0,PORT_NONE=0x1,PORT_TP=0x2,PORT_AUI=0x3,PORT_BNC=0x4,PORT_MII=0x5,PORT_FIBRE=0x6,PORT_DA=0x7,PORT_OTHER=0x8" offset="0x2C.0" size="0x0.4" />
+	<field name="lane_rate_oper" descr="For active link, Indicates the lane data rate passed per physical lane including the overhead due to FEC.\;resolution of 10 Mb/s (lane_rate_oper * 10Mb/s)." access="RO" offset="0x2C.4" size="0x0.20" />
+	<field name="xdr_2x_slow_active" descr="When set and link active, indicates link speed is xdr_2x slow." access="RO" offset="0x2C.24" size="0x0.1" />
+	<field name="xdr_2x_slow_admin" descr="When set, along with ib protocol xdr_2x, XDR_2x slow will be allowed instead of xdr_2x.\;Note: in GB100, set by default only with ini and cannot be changed." access="RW" offset="0x2C.25" size="0x0.1" />
+	<field name="force_lt_frames_admin" descr="Ethernet Force mode options when AN disable is set.\;0 - auto, keep normal operation\;1 - Do Force LT (KR Startup) flow\;2 - Do not do LT (KR Startup) flow\;\;Note: Ignored when an_disable_admin is not set\;In Ethernet port, when setting force LT flow, the &quot;eth_proto_ext_admin&quot; bit mask must comply to single speed rate set." access="RW" offset="0x2C.28" size="0x0.2" />
+	<field name="force_lt_frames_cap" descr="0 - device does not support Force LT (KR Startup) flow\;1 - device supports Force LT (KR Startup) flow\;\;Note: Ignored when an_disable_admin is not set" access="RO" offset="0x2C.30" size="0x0.1" />
+	<field name="xdr_2x_slow_cap" descr="capability for XDR_2x slow is support (200G)" access="RO" offset="0x2C.31" size="0x0.1" />
+</node>
+
+<node name="pude_reg_ext" descr="" size="0x10.0" >
+	<field name="oper_status" descr="Port operational state:\;0001 - up\;0010 - down\;0100 - down by port failure (transitioned by the hardware)\;" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="admin_status" descr="Port administrative state (the desired state of the interface):\;0001 - up\;0010 - down by configuration\;0011 - up once - if the port goes up and then down, the operational status should go to &quot;down by port failure&quot; and can only go back up upon explicit command\;0100 - disabled by system \;0110 - sleep" access="RO" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="swid" descr="For HCA: must  always be 0.\;Switch partition ID with which to associate the port.\;Switch partitions are numbered from 0 to 7 inclusively.\;Switch partition 254 indicates stacking ports.\;Switch partition 255 indicates all switch partitions.\;Note: While external ports uses unique local port numbers (and thus swid is redundant), router ports use the same local port number where swid is the only indication for the relevant port." access="INDEX" offset="0x0.24" size="0x0.8" />
+	<field name="physical_state_status" descr="IB Port Physical link state:\;0: N/A\;1: Sleep\;2: Polling\;3: Disabled\;4: PortConfigurationTraining\;5: LinkUp\;\;6-15: reserved\;[internal] Note: Supported from XDR devices onwards" access="RO" enum="N_A=0x0,Sleep=0x1,Polling=0x2,Disabled=0x3,PortConfigurationTraining=0x4,LinkUp=0x5" offset="0x4.4" size="0x0.4" />
+	<field name="logical_state_status" descr="IB or NVLink Port Logical link state:\;0: N/A\;1: Down\;2: Init\;3: Arm\;4: Active" access="RO" offset="0x4.16" size="0x0.3" />
+</node>
+
+<node name="resource_dump_ext" descr="" size="0xc8.0" >
+	<field name="segment_type" descr="See Resource Dump section in the Adapters PRM." access="INDEX" offset="0x0.0" size="0x0.16" />
+	<field name="seq_num" descr="Sequence number. 0 on first call of dump and incremented on each more dump." access="INDEX" offset="0x0.16" size="0x0.4" />
+	<field name="vhca_id_valid" descr="If set, then vhca_id field is valid. Otherwise dump resources on my vhca_id.\;Not supported in Switch." access="WO" offset="0x0.29" size="0x0.1" />
+	<field name="inline_dump" descr="If set, data is dumped in the register in inline_data field. otherwise dump to mkey.\;Supports only inline dump = 1" access="OP" offset="0x0.30" size="0x0.1" />
+	<field name="more_dump" descr="If set, the device has additional information that has not been dumped yet." access="RO" offset="0x0.31" size="0x0.1" />
+	<field name="vhca_id" descr="vhca_id where the resource is allocated.\;Not supported in Switch." access="WO" offset="0x4.0" size="0x0.16" />
+	<field name="index1" descr="First object index to be dumped when supported by the object.\;SW shall read this field upon command done and shall provide it on the next call in case dump_more==1." access="INDEX" offset="0x8.0" size="0x4.0" />
+	<field name="index2" descr="Second object index to be dumped when supported by the object.\;SW shall read this field upon command done and shall provide it on the next call in case dump_more==1." access="INDEX" offset="0xC.0" size="0x4.0" />
+	<field name="num_of_obj2" descr="The amount of objects to dump starting for index 2.\;SW shall read this field upon command done and shall provide it on the next call in case dump_more==1. \;Range is 0..0xfff0. When the segment&apos;s num_of_obj2_supports_all is set, the special value of 0xffff represents &quot;all&quot;. When the segment&apos;s num_of_objx_supports_active is set, the special value of 0xfffe represents &quot;active&quot;. The  value of 0x0 and 0x1 are allowed even if the supported_num_of_obj2 is &quot;0&quot;." access="INDEX" offset="0x10.0" size="0x0.16" />
+	<field name="num_of_obj1" descr="The amount of objects to dump starting for index 1\;SW shall read this field upon command done and shall provide it on the next call in case dump_more==1. \;Range is 0..0xfff0. When the segment&apos;s num_of_obj1_supports_all is set, the special value of 0xffff represents &quot;all&quot;. When the segment&apos;s num_of_objx_supports_active is set, the special value of 0xfffe represents &quot;active&quot;. The  value of 0x0 and 0x1 are allowed even if the supported_num_of_obj1 is &quot;0&quot;." access="INDEX" offset="0x10.16" size="0x0.16" />
+	<field name="device_opaque" descr="An opaque provided by the device. SW shall read the device_opaque upon command done and shall provide it on the next call in case dump_more==1. On first call, device_opaque shall be 0.\;" subnode="uint64" access="INDEX" offset="0x18.0" size="0x8.0" />
+	<field name="mkey" descr="Memory key to dump to. \;Valid when inline_dump==0.\;Not supported in Switch." access="WO" offset="0x20.0" size="0x4.0" />
+	<field name="size" descr="In write, the size of maximum allocated buffer that the device can use.\;In read, the actual written size.\;In granularity of Bytes.\;Not supported in Switch." access="RO" offset="0x24.0" size="0x4.0" />
+	<field name="address" descr="VA address (absolute address) of memory where to start dumping. \;Valid when inline_dump==0.\;Not supported in Switch." subnode="uint64" access="WO" offset="0x28.0" size="0x8.0" />
+	<field name="inline_data" descr="Data that is dumped in case of inline mode.\;Valid when inline_dump==1." access="RO" high_bound="37" low_bound="0" offset="0x30.0" size="0x98.0" />
+</node>
+
+<node name="rom_version_ext" descr="" size="0x4.0" >
+	<field name="build" descr="Build version" access="RO" offset="0x0.0" size="0x0.16" />
+	<field name="minor" descr="Minor version" access="RO" offset="0x0.16" size="0x0.8" />
+	<field name="major" descr="Major version" access="RO" offset="0x0.24" size="0x0.8" />
+</node>
+
+<node name="slrg_16nm_ext" descr="" size="0x24.0" >
+	<field name="grade_lane_speed" descr="The lane speed on which the grade was measured:\;0 - SDR / PCIe Gen 1\;1 - DDR / PCIe Gen 2\;2 - QDR / PCIe Gen 3\;3 - FDR10 (10GE / 40GE)\;4 - FDR (56GE) / PCIe Gen 4\;5 - EDR (25GE / 50GE / 100GE) / PCIe Gen 5\;6 - HDR (50GE / 200GE / 400GE)\;7- 9 - reserved\;10 - 1GE\;11 - 2.5GE (XAUI)\;12 - 50GE-KR4\;13 - 15 - reserved" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="grade" descr="The grade that the lane received based on a specific configuration.\;" access="RO" offset="0x4.0" size="0x0.24" />
+	<field name="grade_version" descr="" access="RO" offset="0x4.24" size="0x0.8" />
+	<field name="height_eo_neg_up" descr="Voltage offset from eye center to the negative side of the upper eye. Only applicable for PAM4 signal." access="RO" offset="0x8.0" size="0x0.16" />
+	<field name="height_eo_pos_up" descr="Voltage offset from eye center to the positive side of the upper eye.\;Only applicable for PAM4 signal." access="RO" offset="0x8.16" size="0x0.16" />
+	<field name="height_eo_pos_mid" descr="Voltage offset from eye center to the positive side of the middle eye." access="RO" offset="0xC.0" size="0x0.16" />
+	<field name="phase_eo_neg_up" descr="The offset from the eye center to the negative (left) side of the upper eye. Only applicable for PAM4 signal." access="RO" offset="0xC.16" size="0x0.8" />
+	<field name="phase_eo_pos_up" descr="The offset from the eye center to the positive (right) side of the upper eye. Only applicable for PAM4 signal." access="RO" offset="0xC.24" size="0x0.8" />
+	<field name="phase_eo_neg_mid" descr="The offset from the eye center to the negative (left) side of the middle eye." access="RO" offset="0x10.0" size="0x0.8" />
+	<field name="phase_eo_pos_mid" descr="The offset from the eye center to the positive (right) side of the middle eye." access="RO" offset="0x10.8" size="0x0.8" />
+	<field name="height_eo_neg_mid" descr="Voltage offset from eye center to the negative side of the middle eye." access="RO" offset="0x10.16" size="0x0.16" />
+	<field name="height_eo_neg_low" descr="Voltage offset from eye center to the negative side of the lower eye. Only applicable for PAM4 signal." access="RO" offset="0x14.0" size="0x0.16" />
+	<field name="height_eo_pos_low" descr="Voltage offset from eye center to the positive side of the lower eye. Only applicable for PAM4 signal." access="RO" offset="0x14.16" size="0x0.16" />
+	<field name="phase_eo_neg_low" descr="The offset from the eye center to the negative (left) side of the lower eye. Only applicable for PAM4 signal." access="RO" offset="0x18.16" size="0x0.8" />
+	<field name="phase_eo_pos_low" descr="The offset from the eye center to the positive (right) side of the lower eye. Only applicable for PAM4 signal." access="RO" offset="0x18.24" size="0x0.8" />
+	<field name="up_eye_grade" descr="upper eye grade" access="RO" offset="0x1C.0" size="0x0.16" />
+	<field name="mid_eye_grade" descr="middle eye grade" access="RO" offset="0x1C.16" size="0x0.16" />
+	<field name="dn_eye_grade" descr="lower eye grade" access="RO" offset="0x20.0" size="0x0.16" />
+</node>
+
+<node name="slrg_40nm_28nm_ext" descr="" size="0x24.0" >
+	<field name="grade_lane_speed" descr="The lane speed on which the grade was measured:\;0 - SDR\;1 - DDR\;2 - QDR\;3 - FDR10 (10GE / 40GE)\;4 - FDR (56GE)\;5 - EDR (25GE / 50GE / 100GE)\;6 - 9 - reserved\;10 - 1GE\;11 - 2.5GE (XAUI)\;12 - 50GE-KR4\;13 - 15 - reserved" access="RO" offset="0x0.0" size="0x0.4" />
+	<field name="grade" descr="" access="RO" offset="0x4.0" size="0x0.24" />
+	<field name="grade_version" descr="" access="RO" offset="0x4.24" size="0x0.8" />
+	<field name="height_eo_neg" descr="Voltage offset from eye center to the negative side." access="RO" offset="0x14.0" size="0x0.16" />
+	<field name="height_eo_pos" descr="Voltage offset from eye center to the positive side." access="RO" offset="0x14.16" size="0x0.16" />
+	<field name="phase_eo_neg" descr="The offset from the eye center to the negative side." access="RO" offset="0x1C.0" size="0x0.8" />
+	<field name="phase_eo_pos" descr="The offset from the eye center to the positive side." access="RO" offset="0x1C.16" size="0x0.8" />
+</node>
+
+<node name="slrg_7nm_ext" descr="" size="0x18.0" >
+	<field name="fom_measurment" descr="Bitmask for measurement activation\;Bit 0 - Upper eye\;Bit 1 - Middle eye\;Bit 2 - Lower eye\;Bit 3- Composite eye\;Note: NRZ only Bit 3 is valid" access="OP" offset="0x0.0" size="0x0.4" />
+	<field name="initial_fom" descr="measured EOM status after FEQ.\;valid only when SLRG.status is &apos;1&apos;" access="RO" offset="0x4.0" size="0x0.8" />
+	<field name="fom_mode" descr="fom mode:\;FOM eye mode to search\;0x0: FOM_MODE_EYEC\;0x1: FOM_MODE_EYEO\;0x2: FOM_MODE_EYEM\;0x3: FOM_MODE_BER\;0x4:FOM_MODE_EYEC_VN\;0x5:FOM_MODE_EYEC_VP\;0x6:FOM_MODE_EYEM_VN\;0x7:FOM_MODE_EYEM_VP\;\;" access="RW" enum="FOM_MODE_EYEC=0x0,FOM_MODE_EYEO=0x1,FOM_MODE_EYEM=0x2,FOM_MODE_BER=0x3,FOM_MODE_EYEC_VN=0x4,FOM_MODE_EYEC_VP=0x5,FOM_MODE_EYEM_VN=0x6,FOM_MODE_EYEM_VP=0x7" offset="0x4.16" size="0x0.3" />
+	<field name="lower_eye" descr="last measured EOM-FOM status of lower eye.\;valid only if fom_measurment bit &apos;2&apos; is set" access="RO" offset="0x8.0" size="0x0.8" />
+	<field name="mid_eye" descr="last measured EOM-FOM status of middle eye.\;valid only if fom_measurment bit &apos;1&apos; is set" access="RO" offset="0x8.8" size="0x0.8" />
+	<field name="upper_eye" descr="last measured EOM-FOM status of upper eye.\;valid only if fom_measurment bit &apos;0&apos; is set" access="RO" offset="0x8.16" size="0x0.8" />
+	<field name="last_fom" descr="last measured EOM-FOM status of composite eye.\;valid only if fom_measurment bit &apos;3&apos; is set" access="RO" offset="0x8.24" size="0x0.8" />
+</node>
+
+<node name="slrg_reg_ext" descr="" size="0x28.0" >
+	<field name="port_type" descr="For HCA supported only when indicated by PCAM \;0: Network_Port\;1: NearEnd_Port - (For Retimer/Gearbox - Host side)\;2: Internal_IC_LR_Port \;3: FarEnd_Port - (For Retimer/Gearbox - Line side)\;\;" access="INDEX" enum="Network_Port=0x0,NearEnd_Port=0x1,Internal_IC_LR_Port=0x2,FarEnd_Port=0x3" offset="0x0.4" size="0x0.4" />
+	<field name="lane" descr="Logical lane number" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.12" size="0x0.2" />
+	<field name="pnat" descr="Port number access type. \;0 - Local port number\;1 - IB port number\;" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="version" descr="0: prod_40nm\;1: prod_28nm\;3: prod_16nm\;4: prod_7nm\;5: prod_5nm" access="RO" enum="prod_40nm=0x0,prod_28nm=0x1,prod_16nm=0x3,prod_7nm=0x4,prod_5nm=0x5" offset="0x0.24" size="0x0.4" />
+	<field name="status" descr="0 - Invalid\;1 - Valid\;" access="RO" offset="0x0.28" size="0x0.4" />
+	<field name="page_data" descr="Table 1594, &quot;SLRG - Serdes Lane Receive Grade Register Layout for 40nm and 28nm,&quot; on page 1871\;Table 1596, &quot;SLRG - Serdes Lane Receive Grade Register Layout for 16nm,&quot; on page 1872\;Table 1598, &quot;SLRG - Serdes Lane Receive Grade Register Layout for 7nm and 5nm,&quot; on page 1874" subnode="slrg_reg_page_data_auto_ext" access="RO" condition="$(parent).version" offset="0x4.0" size="0x24.0" />
+</node>
+
+<node name="slrg_reg_page_data_auto_ext" descr="" attr_is_union="1" is_conditional="1" size="0x24.0" >
+	<field name="slrg_40nm_28nm_ext" descr="" subnode="slrg_40nm_28nm_ext" condition="($(parent).port_type == Network_Port AND ($(parent).version == prod_40nm | $(parent).version == prod_28nm)" offset="0x0.0" size="0x24.0" />
+	<field name="slrg_16nm_ext" descr="" subnode="slrg_16nm_ext" condition="($(parent).port_type == Network_Port AND ($(parent).version == prod_16nm)" offset="0x0.0" size="0x24.0" />
+	<field name="slrg_7nm_ext" descr="" subnode="slrg_7nm_ext" condition="($(parent).port_type == Network_Port) AND (($(parent).version == prod_7nm) || ($(parent).version == prod_5nm))" offset="0x0.0" size="0x18.0" />
+</node>
+
+<node name="sltp_16nm_ext" descr="" size="0x48.0" >
+	<field name="post_tap" descr="Value of each tap is between -96 to 96\;\;NOTE: The total sum of all absolute taps values should be 96 or smaller.\;" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="main_tap" descr="Value of each tap is between -96 to 96\;\;NOTE: The total sum of all absolute taps values should be 96 or smaller.\;" access="RW" offset="0x4.8" size="0x0.8" />
+	<field name="pre_tap" descr="Value of each tap is between -96 to 96\;\;NOTE: The total sum of all absolute taps values should be 96 or smaller.\;" access="RW" offset="0x4.16" size="0x0.8" />
+	<field name="pre_2_tap" descr="Value of each tap is between -96 to 96\;\;NOTE: The total sum of all absolute taps values should be 96 or smaller.\;" access="RW" offset="0x4.24" size="0x0.8" />
+	<field name="ob_alev_out" descr="Output common mode. Values can be set in the range of (0-30)" access="RW" offset="0x8.0" size="0x0.5" />
+	<field name="ob_amp" descr="Output amplitude. Values can be set in the range of (10-100)." access="RW" offset="0x8.8" size="0x0.7" />
+	<field name="ob_m2lp" descr="MSB to LSB proportion. \;Values can be set between -10 to 50. \;\;MSB emphasis achieved when value is between -10 to -1 \;LSB emphasis achieved when value is between 1 to 50. \;When set to 0 - equal proportion." access="RW" offset="0x8.25" size="0x0.7" />
+	<field name="ob_bad_stat" descr="Bitmask for bad &apos;set&apos; status:\;0: configuration_warning - taps values can&apos;t be set to serdes due to internal limitations. Actual TX configuration is modify internally with the same sum of taps weight.\;11: Illegal_ob_combination - ob_m2lp, ob_amp and ob_alev is in legal range each, but the total combination can&apos;t be set to serdes due to internal limitations, the Set command is ignored.\;12: Illegal_ob_m2lp\;13: Illegal_ob_amp\;14: Illegal_ob_alev_out\;15: Illegal_taps\;\;Bit 12-0 - Reserved /Unknown" access="RO" enum="configuration_warning=0x0,Illegal_ob_combination=0xb,Illegal_ob_m2lp=0xc,Illegal_ob_amp=0xd,Illegal_ob_alev_out=0xe,Illegal_taps=0xf" offset="0xC.16" size="0x0.16" />
+	<field name="regp_bfm1n" descr="Values can be set in the range of (0-200)." access="RW" offset="0x10.0" size="0x0.8" />
+	<field name="regn_bfm1p" descr="Values can be set in the range of (0-200)." access="RW" offset="0x10.8" size="0x0.8" />
+	<field name="obnlev" descr="Values can be set in the range of (0-200)." access="RW" offset="0x10.16" size="0x0.8" />
+	<field name="obplev" descr="Values can be set in the range of (0-200)." access="RW" offset="0x10.24" size="0x0.8" />
+</node>
+
+<node name="sltp_28nm_40nm_ext" descr="" size="0x48.0" >
+	<field name="ob_tap2" descr="\;" access="RW" offset="0x4.0" size="0x0.8" />
+	<field name="ob_tap1" descr="\;" access="RW" offset="0x4.8" size="0x0.8" />
+	<field name="ob_tap0" descr="\;" access="RW" offset="0x4.16" size="0x0.8" />
+	<field name="polarity" descr="Tx lane polarity" access="RW" offset="0x4.24" size="0x0.1" />
+	<field name="ob_bias" descr="" access="RW" offset="0x8.0" size="0x0.8" />
+	<field name="ob_reg" descr="(ref_txcml100_reg)" access="RW" offset="0x8.8" size="0x0.8" />
+	<field name="ob_preemp_mode" descr="Concatenation of taps polarity + preemp_sel" access="RW" offset="0x8.16" size="0x0.4" />
+	<field name="ob_leva" descr="" access="RW" offset="0x8.20" size="0x0.4" />
+	<field name="ob_bad_stat" descr="Bitmask for bad SET status:\;Bit 0 - Illegal ob_bais value\;Bit 1 - Illegal ob taps polarity (distance between taps)" access="RO" offset="0xC.29" size="0x0.2" />
+	<field name="ob_norm" descr="OB Normalization status:\;0 - No Normalization was done\;1 - Normalization performed" access="RO" offset="0xC.31" size="0x0.1" />
+</node>
+
+<node name="sltp_7nm_ext" descr="" size="0x48.0" >
+	<field name="fir_pre2" descr="Signed value for TX FIR taps.\;tap scaling = fir_tap/63.\;for 100G per lane 5 taps, \;for 50G per lane 4 taps are used (no pre3),\;or 25G per lane 3 taps are used (no pre3,pre2)\;Valid values for taps:\;fir_main [34,63]\;fir_pre1 [-23,0]\;fir_pre2 [0,8]\;fir_pre3 [-5,0]\;fir_post1 [-21,0]\;\;Need to guarantee that the sum of the coefficient magnitude equals sum |c(i)| &lt;= 63.\;NRZ speeds must guarantee sum|c(i)| = 63\;Note: Configured taps may get effective value of +/-1 from the value that has been set." access="RW" offset="0x0.0" size="0x0.8" />
+	<field name="fir_pre3" descr="Signed value for TX FIR taps.\;tap scaling = fir_tap/63.\;for 100G per lane 5 taps, \;for 50G per lane 4 taps are used (no pre3),\;or 25G per lane 3 taps are used (no pre3,pre2)\;Valid values for taps:\;fir_main [34,63]\;fir_pre1 [-23,0]\;fir_pre2 [0,8]\;fir_pre3 [-5,0]\;fir_post1 [-21,0]\;\;Need to guarantee that the sum of the coefficient magnitude equals sum |c(i)| &lt;= 63.\;NRZ speeds must guarantee sum|c(i)| = 63\;Note: Configured taps may get effective value of +/-1 from the value that has been set." access="RW" offset="0x0.8" size="0x0.8" />
+	<field name="ob_bad_stat" descr="Bitmask for bad &apos;set&apos; status:\;Bit 0: pre3_is_out_of_range\;Bit 1: pre2_is_out_of_range\;Bit 2: pre1_is_out_of_range\;Bit 3: main_tap_is_out_of_range\;Bit 4: post1_is_out_of_range\;Bit 5: sum_of_taps_is_out_of_range\;Bit 6: taps_not_alinged_with_speed" access="RO" enum="pre3_is_out_of_range=0x1,pre2_is_out_of_range=0x2,pre1_is_out_of_range=0x4,main_tap_is_out_of_range=0x8,post1_is_out_of_range=0x10,sum_of_taps_is_out_of_range=0x20,taps_not_alinged_with_speed=0x40" offset="0x0.16" size="0x0.8" />
+	<field name="drv_amp" descr="High speed output driver amplitude settings, default = 6&quot;d63.\; amplitude scaling = (AMP+1) / 64" access="RW" offset="0x0.24" size="0x0.6" />
+	<field name="fir_post1" descr="Signed value for TX FIR taps.\;tap scaling = fir_tap/63.\;for 100G per lane 5 taps, \;for 50G per lane 4 taps are used (no pre3),\;or 25G per lane 3 taps are used (no pre3,pre2)\;Valid values for taps:\;fir_main [34,63]\;fir_pre1 [-23,0]\;fir_pre2 [0,8]\;fir_pre3 [-5,0]\;fir_post1 [-21,0]\;\;Need to guarantee that the sum of the coefficient magnitude equals sum |c(i)| &lt;= 63.\;NRZ speeds must guarantee sum|c(i)| = 63\;Note: Configured taps may get effective value of +/-1 from the value that has been set." access="RW" offset="0x4.8" size="0x0.8" />
+	<field name="fir_main" descr="Signed value for TX FIR taps.\;tap scaling = fir_tap/63.\;for 100G per lane 5 taps, \;for 50G per lane 4 taps are used (no pre3),\;or 25G per lane 3 taps are used (no pre3,pre2)\;Valid values for taps:\;fir_main [34,63]\;fir_pre1 [-23,0]\;fir_pre2 [0,8]\;fir_pre3 [-5,0]\;fir_post1 [-21,0]\;\;Need to guarantee that the sum of the coefficient magnitude equals sum |c(i)| &lt;= 63.\;NRZ speeds must guarantee sum|c(i)| = 63\;Note: Configured taps may get effective value of +/-1 from the value that has been set." access="RW" offset="0x4.16" size="0x0.8" />
+	<field name="fir_pre1" descr="Signed value for TX FIR taps.\;tap scaling = fir_tap/63.\;for 100G per lane 5 taps, \;for 50G per lane 4 taps are used (no pre3),\;or 25G per lane 3 taps are used (no pre3,pre2)\;Valid values for taps:\;fir_main [34,63]\;fir_pre1 [-23,0]\;fir_pre2 [0,8]\;fir_pre3 [-5,0]\;fir_post1 [-21,0]\;\;Need to guarantee that the sum of the coefficient magnitude equals sum |c(i)| &lt;= 63.\;NRZ speeds must guarantee sum|c(i)| = 63\;Note: Configured taps may get effective value of +/-1 from the value that has been set." access="RW" offset="0x4.24" size="0x0.8" />
+</node>
+
+<node name="sltp_reg_ext" descr="" size="0x4c.0" >
+	<field name="c_db" descr="copy transmitter parameters to Data Base. \;" access="OP" offset="0x0.0" size="0x0.1" />
+	<field name="port_type" descr="For HCA supported only when indicated by PCAM \;0: Network_Port\;1: NearEnd_Port - (For Retimer/Gearbox - Host side)\;2: Internal_IC_LR_Port \;3: FarEnd_Port - (For Retimer/Gearbox - Line side)\;\;" access="INDEX" enum="Network_Port=0x0,NearEnd_Port=0x1,Internal_IC_LR_Port=0x2,FarEnd_Port=0x3" offset="0x0.1" size="0x0.3" />
+	<field name="lane_speed" descr="Reserved for PCIe.\;The lane speed for TX settings:\;0 - SDR / Gen1 (PCIe)\;1 - DDR / Gen2 (PCIe) / 5GBASE-R\;2 - QDR / Gen3 (PCIe)\;3 - FDR10 (10GE / 40GE)\;4 - FDR (56GE) / Gen4 (PCIe)\;5 - EDR (25GE / 50GE / 100GE) / Gen5 (PCIe)\;6 - HDR (50GE / 200GE / 400GE)\;7 - NDR /100GE / 200GE / 400GE / 800GE (53.125 Gbd / 106.25Gb/s)\;8 - XDR (106.25 Gbd / 212.5Gb/s)\;9 - Reserved\;10 - 1GE\;11 - 2.5GE (XAUI)\;12 - 50GE-KR4\;13-15 - Reserved" access="RW" offset="0x0.4" size="0x0.4" />
+	<field name="lane" descr="Logical lane number" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="tx_policy" descr="Configures Tx parameter set policy\;0 - Tx parameters will be set according to best possible configuration chosen by the system\;1 - Tx parameters will be set according to Data Base only and will not be overridden by link training (e.g KR-Startup)" access="RW" offset="0x0.13" size="0x0.1" />
+	<field name="pnat" descr="Port number access type. determines the way local_port is interpreted:\;0 - Local port number\;1 - IB port number\;" access="INDEX" offset="0x0.14" size="0x0.2" />
+	<field name="local_port" descr="Local port number [7:0]" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="version" descr="0: prod_40nm\;1: prod_28nm\;3: prod_16nm\;4: prod_7nm\;5: prod_5nm" access="RO" enum="prod_40nm=0x0,prod_28nm=0x1,prod_16nm=0x3,prod_7nm=0x4,prod_5nm=0x5" offset="0x0.24" size="0x0.4" />
+	<field name="status" descr="Indicates that Tx setting readout is valid and active. In particular, for links that do AN/LT, valid will be set when link operational status is UP (PAOS.oper_status=0x1).\;For links without AN/LT, valid will be set when Tx is enabled.\;\;0 - Invalid\;1 - Valid\;\;Note: Get and Set operations can be set when status = invalid." access="RO" offset="0x0.28" size="0x0.1" />
+	<field name="lp_msb" descr="Local port number [9:8]" access="INDEX" offset="0x0.30" size="0x0.2" />
+	<field name="page_data" descr="Table 1576, &quot;SLTP - Serdes Lane Transmit Parameters Register Layout for 28nm and 40nm,&quot; on page 1855\;Table 1578, &quot;SLTP - Serdes Lane Transmit Parameters Register Layout for 16nm,&quot; on page 1856\;Table 1582, &quot;SLTP - Serdes Lane Transmit Parameters Register Layout for 7nm,&quot; on page 1858" subnode="sltp_reg_page_data_auto_ext" access="RW" condition="$(parent).version" offset="0x4.0" size="0x48.0" />
+</node>
+
+<node name="sltp_reg_page_data_auto_ext" descr="" attr_is_union="1" is_conditional="1" size="0x48.0" >
+	<field name="sltp_28nm_40nm_ext" descr="" subnode="sltp_28nm_40nm_ext" condition="($(parent).port_type == Network_Port) AND ($(parent).version == prod_40nm | $(parent).version == prod_28nm)" offset="0x0.0" size="0x48.0" />
+	<field name="sltp_16nm_ext" descr="" subnode="sltp_16nm_ext" condition="($(parent).port_type == Network_Port | $(parent).port_type == Internal_IC_LR_Port) AND ($(parent).version == prod_16nm)" offset="0x0.0" size="0x48.0" />
+	<field name="sltp_7nm_ext" descr="" subnode="sltp_7nm_ext" condition="($(parent).port_type == Network_Port | $(parent).port_type == Internal_IC_LR_Port) AND ($(parent).version == prod_7nm)" offset="0x0.0" size="0x48.0" />
+</node>
+
+<node name="stat_bufferx_reg_ext" descr="" size="0x8.0" >
+	<field name="watermark" descr="Watermark in cells (max buffer usage since last clear)\;For stat_shared_headroom_pool, this field is reserved." access="RO" offset="0x0.0" size="0x0.16" />
+	<field name="used_buffer" descr="Number of used buffer cells.\;For stat_port_shared_headroom_pool this field is reserved." access="RO" offset="0x4.0" size="0x0.16" />
+</node>
+
+<node name="string_db_parameters_ext" descr="" size="0x8.0" >
+	<field name="string_db_base_address" descr="Offset of the first string of the section, relative to the entire string data base, given in bytes." access="RO" offset="0x0.0" size="0x4.0" />
+	<field name="string_db_size" descr="Size of string database section, given in bytes" access="RO" offset="0x4.0" size="0x0.24" />
+</node>
+
+<node name="uint64" descr="" size="0x8.0" >
+	<field name="hi" descr="" offset="0x0.0" size="0x4.0" />
+	<field name="lo" descr="" offset="0x4.0" size="0x4.0" />
+</node>
+
+<node name="ukdri_ext" descr="" size="0x10.0" >
+	<field name="local_port" descr="Local port." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="clear" descr="Clear Indications" access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="ktu_disccard_vec" descr="Per bit:\;Bit0: VersionFail - Version is not zero\;Bit1: ProtocolTypeFail - Protocol is not correct\;Bit2: MsgVSActualSizeFail - Msg size does not match actual size\;Bit3: SkMtdNotExist - No MTD in SK message\;Bit4: SkMtdAlignment - MTD in SK is not DW align\;Bit5: SkSecAlignment - SEC in SK in not DW align\;Bit6: MsgSizeVsDsHeaderFail - Msg size vs header mismatch\;Bit7: MsgSizeTooSmall - Actual header size is smaller then minimum size." access="RO" offset="0x8.0" size="0x4.0" />
+	<field name="nvle_msg_disccard_vec" descr="Per bit:\;Bit0: MsgSizeNotMatchOpcode - MSG size does not match the opcode\;Bit1: VersionFail - NVLE wrong version\;Bit2: CmdOpcodeFail - Wrong NVLE cmd_opcode\;Bit3: PortNumFail - Wrong port number in NVLE header\;Bit4: PipeNumFail - Invalid pipe number \;Bit5: DataSizeFail - wrong data size \;Bit6: SlotIndexFail - Invalid slot index\;Bit7: NVLEMsgSizeTooSmall - NVLE msg size is smaller then 3." access="RO" offset="0xC.0" size="0x4.0" />
+</node>
+
+<node name="undfd_ext" descr="" size="0x8.0" >
+	<field name="pipe_index" descr="Pipe\;For GB100 can be either 0 or 1" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="local_port" descr="" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="dfd_en" descr="DFD en, when enabled the encryption will set an authentication error tag:\;0: DFD disabled (default)\;1: DFD enabled" access="RW" offset="0x4.0" size="0x0.1" />
+</node>
+
+<node name="undri_ext" descr="" size="0x10.0" >
+	<field name="pipe_index" descr="Pipe\;For GB100 can be either 0 or 1" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="dir" descr="Direction:\;0: Decr\;1: Encr" access="INDEX" offset="0x0.12" size="0x0.1" />
+	<field name="local_port" descr="Local port." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="clear" descr="Clear Indications" access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="discard_vec" descr="Per bit:\;Bit0: BadPktType\;Bit1: NoNVSecTag\;Bit2: NvsetagBadVersion\;Bit3: BadPktLen\;Bit4: PktLenMinSize\;Bit5: AR_MissMatch\;Bit6: FlowMapEntryNotValid\;Bit7: StateEntryNotValid\;Bit8: KeyEntryNotValid\;Bit9: FeedbackOverrun\;Bit10: NVSecTagError\;Bit11: NVLECreditIssue\;Decryption only:\;Bit12: AuthenticationFail\;Bit13: ReplayFail" subnode="uint64" access="RO" offset="0x8.0" size="0x8.0" />
+</node>
+
+<node name="unrc_ext" descr="" size="0x40.0" >
+	<field name="pipe_index" descr="Pipe\;For GB100 can be either 0 or 1" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="local_port" descr="" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="clear" descr="Clear counters" access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="ing_error_packets" descr="count number of error packets ingressing to the NVLE.\;Note: this counter count all the error packet in NVLE - it includes the ing_auth_error counter.\;For counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x10.0" size="0x8.0" />
+	<field name="ing_good_packets" descr="count number of good packets ingressing the NVLEFor counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x18.0" size="0x8.0" />
+	<field name="egr_good_packets" descr="count number of good packets egressing the NVLEFor counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x20.0" size="0x8.0" />
+	<field name="egr_error_packets" descr="count number of error packets egressing the NVLE\;Note: egr_good_packets + egr_error_packets = sum of all packets egressing the NVLE\;For counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x28.0" size="0x8.0" />
+	<field name="ktu_msg_cnt" descr="Number of messages that was sent from the KTU to the NVLEs.\;Note - this counter is not per pipe.\;For counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x30.0" size="0x8.0" />
+	<field name="ing_auth_error" descr="Number of authentication errors.\;For counter layout see Table 16, &quot;Counter Layout,&quot; on page 12" subnode="uint64" access="RO" offset="0x38.0" size="0x8.0" />
+</node>
+
+<node name="unrsa_ext" descr="" size="0x18.0" >
+	<field name="pipe_index" descr="Pipe\;For GB100 can be either 0 or 1" access="INDEX" offset="0x0.8" size="0x0.4" />
+	<field name="dir" descr="Direction:\;0: Decr\;1: Encr" access="INDEX" offset="0x0.12" size="0x0.1" />
+	<field name="local_port" descr="" access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="entry_index" descr="Entry Index\;Decr range 0..255\;Encr range 0...127" access="INDEX" offset="0x4.0" size="0x0.16" />
+	<field name="ev" descr="Entry Valid:\;0: Entry is not valid\;1: Entry is valid\;All RO fields have no meaning when ev=0" access="RO" offset="0x8.24" size="0x0.1" />
+	<field name="packet_number" descr="Packet number\;Note: GB100 HW has only 56 bits\;FW note: for Decr read from expected packet number, for Encr read from SADB" subnode="uint64" access="RO" offset="0x10.0" size="0x8.0" />
+</node>
+
+<node name="unwkm_ext" descr="" size="0x8c.0" >
+	<field name="status" descr="Return status:\;0: OK\;\;FW will parse these fields and set the relevant bit if the value is not valid (1-4 are only for SK):\;Bit1: ktu_msg.SK.common_header_version!=0\;Bit2: ktu_msg.SK.Protocol != NVLE\;Bit3: ktu_msg.SK.nvle_version !=0\;Bit4: ktu_msg.SK.hw_port == not_valid\;Bit5: ktu_msg.op != 1, 2, 3\;Bit6: ktu_msg.size &gt; 22\;\;Bit15: at least one of the bits in errors is set" access="RO" offset="0x0.0" size="0x0.16" />
+	<field name="local_port" descr="Local port." access="INDEX" offset="0x0.16" size="0x0.8" />
+	<field name="lpv" descr="Local port valid:\;0: local_port field is reserved. FW will look at ktu_msg\;1: local_port is valid. FW will ignore hw_port in ktu_msg if exist." access="OP" offset="0x0.31" size="0x0.1" />
+	<field name="errors" descr="KTU error vector, each error set the corresponding bit in the error vector:\;Bit3: CMD_VER_ERR - the command is specified with unsupported KTU_CMD.VER.\;Bit4: CMD_OP_ERR - the command is specified with unsupported KTU_CMD.OP.\;Bit5: CMD_AA_ERR - The command is specified with unsupported KTU_CMD.AA for the given\;KTU_CMD.OP.\;Bit6: CMD_ARG_ERR - The command is specified with unsupported KTU_CMD.ARGs for the given\;KTU_CMD.OP.\;Bit8: INS_IWK_DIS_ERR - INS_IWK command is started but INS_IWK was disabled.\;Bit9: INS_WK_DIS_ERR - INS_WK command is started but INS_WK was disabled.\;Bit10: INS_SK_DIS_ERR - INS_SK command is started\;but INS_SK was disabled.\;Bit11: INS_WK_NWK_ERR - INS_WK command is started but no previous valid WK is available.\;Bit12: INS_SK_NWK_ERR - INS_SK command is started but no valid WK is available.\;Bit14: CMD_AUTH_ERR - The authentication check of the triggered command fails.\;Bit16: ANTI_REPLAY_CNT_CHK_ERR - Anti-replay Counter check fails.\;Bit17: OUTPUT_ERR - Output to the downstream unit is returned with error responses.\;Bit31: MAX_CMD_FAILURE_ERR - 10 commands failure. the count resets after IWK or WK succeeds." access="RW" offset="0x4.0" size="0x4.0" />
+	<field name="ktu_msg" descr="Table 4, &quot;KTU Message Layout,&quot; on page 5\;FW will extract these fields of the CM:\;1. protocol type - make sure KUW TBD &apos;0&apos;\;2. version - make sure FW can parse this version TBD 0\;3. hw_port - note: hw port = local_port-1\;Note: this is a WO field, cannot be read" access="WO" high_bound="31" low_bound="0" offset="0xC.0" size="0x80.0" />
+</node>
+
+<node name="root" size="0x110.0" descr="" >
+	<field name="register_access_table_gpu_Nodes" offset="0x0.0" size="0x110.0" subnode="register_access_table_gpu_Nodes" descr="" />
+</node>
+
+<node name="register_access_table_gpu_Nodes" size="0x110.0" attr_is_union="1" descr="" >
+	<field name="access_reg_summary_selector_ext" offset="0x0.0" size="0x110.0" subnode="access_reg_summary_selector_ext" descr="" />
+</node>
+</NodesDefinition>

--- a/tools_layouts/prm_adb_db.cpp
+++ b/tools_layouts/prm_adb_db.cpp
@@ -46,8 +46,8 @@ using namespace std;
 string PrmAdbDB::prm_adb_db_ltrim(const string& s)
 {
     const char* cs = s.c_str();
-    while (isspace(*cs))
-    {
+
+    while (isspace(*cs)) {
         cs++;
     }
     return string(cs);
@@ -55,18 +55,16 @@ string PrmAdbDB::prm_adb_db_ltrim(const string& s)
 
 string PrmAdbDB::prm_adb_db_rtrim(const string& s)
 {
-    // todo rewrite it
+    /* todo rewrite it */
     unsigned int i = s.size();
-    if (i == 0)
-    {
+
+    if (i == 0) {
         return s;
     }
-    while (--i > 0 && isspace(s[i]))
-    {
+    while (--i > 0 && isspace(s[i])) {
         ;
     }
-    if (i == 0 && isspace(s[i]))
-    {
+    if ((i == 0) && isspace(s[i])) {
         return "";
     }
     return s.substr(0, i + 1);
@@ -77,12 +75,13 @@ string PrmAdbDB::prm_adb_db_trim(const string& s)
     return prm_adb_db_rtrim(prm_adb_db_ltrim(s));
 }
 
-string PrmAdbDB::getDefaultDBName(bool isSwitch)
+string PrmAdbDB::getDefaultDBName(dm_dev_id_t devID)
 {
     const string dbDirName = "prm_dbs";
     const string dbFileName = "register_access_table.adb";
-    const string hcaOrSwitch = isSwitch ? "switch" : "hca";
-    string dbPathName = "";
+    const string hcaOrSwitch = (dm_is_gpu(devID) ? "gpu" : dm_dev_is_switch(devID) ? "switch" : "hca");
+    string       dbPathName = "";
+
 #ifdef __WIN__
     char execFilePathCStr[1024] = {0x0};
     GetModuleFileName(GetModuleHandle("libmtcr-1.dll"), execFilePathCStr, 1024);
@@ -92,38 +91,30 @@ string PrmAdbDB::getDefaultDBName(bool isSwitch)
 #elif defined MST_UL
     dbPathName = DATA_PATH "/" + dbDirName + "/" + hcaOrSwitch + "/ext/" + dbFileName;
 #else
-    char line[1024] = {0};
+    char   line[1024] = {0};
     string confFile = string(ROOT_PATH) + string("etc/mft/mft.conf");
-    FILE* fd = fopen(confFile.c_str(), "r");
-    if (!fd)
-    {
+    FILE * fd = fopen(confFile.c_str(), "r");
+    if (!fd) {
         throw PrmDBException("Failed to open conf file : %s\n", confFile.c_str());
     }
     string prefix = "", dataPath = "";
-    while ((fgets(line, 1024, fd)))
-    {
+    while ((fgets(line, 1024, fd))) {
         string l = line;
-        if (l.find(dbDirName) != string::npos)
-        {
+        if (l.find(dbDirName) != string::npos) {
             size_t eqPos = l.find("=");
-            if (eqPos != string::npos)
-            {
+            if (eqPos != string::npos) {
                 dataPath = l.substr(eqPos + 1);
                 dataPath = prm_adb_db_trim(dataPath);
             }
-        }
-        else if (l.find("mft_prefix_location") != string::npos)
-        {
+        } else if (l.find("mft_prefix_location") != string::npos) {
             size_t eqPos = l.find("=");
-            if (eqPos != string::npos)
-            {
+            if (eqPos != string::npos) {
                 prefix = l.substr(eqPos + 1);
                 prefix = prm_adb_db_trim(prefix);
             }
         }
     }
-    if (!prefix.empty() && !dataPath.empty())
-    {
+    if (!prefix.empty() && !dataPath.empty()) {
         dbPathName = prefix + dataPath + "/" + hcaOrSwitch + "/ext/" + dbFileName;
     }
     fclose(fd);
@@ -133,15 +124,18 @@ string PrmAdbDB::getDefaultDBName(bool isSwitch)
 
 /*************************** PrmDBException Implementation ***************************/
 
-PrmDBException::PrmDBException() {}
+PrmDBException::PrmDBException()
+{
+}
 
 /**
  * Function: PrmDBException::PrmDBException
  **/
 PrmDBException::PrmDBException(const char* fmt, ...)
 {
-    char tmp[1024];
+    char    tmp[1024];
     va_list args;
+
     va_start(args, fmt);
     vsprintf(tmp, fmt, args);
     va_end(args);
@@ -151,12 +145,16 @@ PrmDBException::PrmDBException(const char* fmt, ...)
 /**
  * Function: PrmDBException::PrmDBException
  **/
-PrmDBException::PrmDBException(string msg) : _msg(msg) {}
+PrmDBException::PrmDBException(string msg) : _msg(msg)
+{
+}
 
 /**
  * Function: PrmDBException::~PrmDBException
  **/
-PrmDBException::~PrmDBException() throw() {}
+PrmDBException::~PrmDBException() throw()
+{
+}
 
 /**
  * Function: PrmDBException::what

--- a/tools_layouts/prm_adb_db.h
+++ b/tools_layouts/prm_adb_db.h
@@ -41,6 +41,7 @@
 
 #include <string>
 #include <exception>
+#include "dev_mgt/tools_dev_types.h"
 
 class PrmAdbDB
 {
@@ -48,13 +49,13 @@ public:
     static std::string prm_adb_db_trim(const std::string& s);
     static std::string prm_adb_db_rtrim(const std::string& s);
     static std::string prm_adb_db_ltrim(const std::string& s);
-    static std::string getDefaultDBName(bool isSwitch);
+    static std::string getDefaultDBName(dm_dev_id_t devID);
 };
 
-class PrmDBException : public std::exception
+class PrmDBException: public std::exception
 {
 public:
-    // Methods
+    /* Methods */
     PrmDBException();
     PrmDBException(const char* msg, ...) __attribute__((format(__printf__, 2, 3)));
     PrmDBException(std::string msg);

--- a/tools_res_mgmt/tools_res_mgmt.c
+++ b/tools_res_mgmt/tools_res_mgmt.c
@@ -205,7 +205,7 @@ static struct device_sem_info g_dev_sem_info_db[] = {
     0,            // vsec_sem_supported
   },
   {
-    DeviceBW00, // dev_id
+    DeviceGB100, // dev_id
     {0xe74e0},   // hw_sem_addr find correct one for 0x2900
     1,           // vsec_sem_supported
   },


### PR DESCRIPTION
Description: adding support for PCI Bar0 GPU devices

1. adding PCI ID ranges discovery.
2. adding cr_space_offset + device endianness support.
3. routing mtcr_ul flows to use pci_cr device.
4. adding GPU external PRM support.


Tested OS: Linux
Tested devices: GB100
Tested flows: resourcedump, mstreg, mstlink

Issue: 3988451

