### PR TITLE
mlxconfig: Add support to invalidate single TLV

### DIFF
--- a/mlxconfig/mlxcfg_commander.h
+++ b/mlxconfig/mlxcfg_commander.h
@@ -66,6 +66,7 @@ public:
     virtual void setCfg(std::vector<ParamView>&, bool) = 0;
     virtual void clearSemaphore() = 0;
     virtual void invalidateCfgs() = 0;
+    virtual void invalidateCfg(const std::string& configName) = 0;
     virtual const char* loadConfigurationGetStr() = 0;
     virtual void setRawCfg(std::vector<u_int32_t> rawTlvVec) = 0;
     virtual std::vector<u_int32_t> getRawCfg(std::vector<u_int32_t> rawTlvVec) = 0;

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -899,6 +899,20 @@ void GenericCommander::invalidateCfg(const std::string& configName)
         {
             tlvArr.push_back(*it);
         }
+        else
+        {
+            string upper = mft_utils::to_uppercase_copy(configName);
+            auto ret = _dbManager->getMlxconfigNamePortModule(upper, _mf);
+            string mlxconfigNameNoPortModuleName = mft_utils::to_lowercase_copy(get<0>(ret));
+            u_int32_t port = get<1>(ret);
+            int32_t module = get<2>(ret);
+            (*it)->_port = port;
+            (*it)->_module = module;
+            if ((*it)->_name == mlxconfigNameNoPortModuleName)
+            {
+                tlvArr.push_back(*it);
+            }
+        }
     }
     if (tlvArr.empty())
     {

--- a/mlxconfig/mlxcfg_parser.cpp
+++ b/mlxconfig/mlxcfg_parser.cpp
@@ -102,7 +102,8 @@ void MlxCfg::printHelp()
     printf(IDENT2 "%-24s : %s\n", "clear_semaphore", "clear the tool semaphore.");
     printf(IDENT2 "%-24s : %s\n", "i|show_confs", "display information about all configurations.");
     printf(IDENT2 "%-24s : %s\n", "q|query", "query supported configurations.");
-    printf(IDENT2 "%-24s : %s\n", "r|reset", "reset all configurations to their default value.");
+    printf(IDENT2 "%-24s : %s\n", "r|reset",
+           "reset all configurations to their default value. Optionally, resets specific TLV if given.");
     printf(IDENT2 "%-24s : %s\n", "s|set", "set configurations to a specific device.");
     printf(IDENT2 "%-24s : %s\n", "set_raw", "set raw configuration file(5th Generation and above).");
     printf(IDENT2 "%-24s : %s\n", "get_raw", "get raw configuration (5th Generation and above).");
@@ -141,6 +142,8 @@ void MlxCfg::printHelp()
     printf(IDENT2 "%-35s: %s\n", "To set raw configuration",
            MLXCFG_NAME " -d " MST_DEV_EXAMPLE2 " -f conf_file set_raw");
     printf(IDENT2 "%-35s: %s\n", "To reset configuration", MLXCFG_NAME " -d " MST_DEV_EXAMPLE " reset");
+    printf(IDENT2 "%-35s: %s\n", "To reset specific configuration",
+           MLXCFG_NAME " -d " MST_DEV_EXAMPLE " reset NV_GLOBAL_PCI_CONF_4");
     printf("\n");
 }
 
@@ -584,10 +587,6 @@ mlxCfgStatus MlxCfg::parseArgs(int argc, char* argv[])
     {
         return err(true, "missing configuration arguments. For more information please run " MLXCFG_NAME " -h|--help.");
     }
-    if (i != argc && (_mlxParams.cmd == Mc_Reset))
-    {
-        return err(true, "%s command expects no argument but %d argument received", "reset", argc - i);
-    }
 
     if ((_mlxParams.cmd == Mc_Set || _mlxParams.cmd == Mc_Clr_Sem || _mlxParams.cmd == Mc_Set_Raw ||
          _mlxParams.cmd == Mc_Get_Raw || _mlxParams.cmd == Mc_Backup || _mlxParams.cmd == Mc_ShowConfs || 
@@ -668,7 +667,7 @@ mlxCfgStatus MlxCfg::parseArgs(int argc, char* argv[])
 
     try
     {
-        if (_mlxParams.cmd == Mc_Query)
+        if (_mlxParams.cmd == Mc_Query || _mlxParams.cmd == Mc_Reset)
         {
             return extractQueryCfgArgs(argc - i, &(argv[i]));
         }

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -1114,7 +1114,17 @@ mlxCfgStatus MlxCfg::resetDevCfg(const char* dev)
     try
     {
         commander = Commander::create(dev, _mlxParams.dbName);
+        if (_mlxParams.setParams.size() == 0)
+        {
         commander->invalidateCfgs();
+        }
+        else
+        {
+            VECTOR_ITERATOR(ParamView, _mlxParams.setParams, p)
+            {
+                commander->invalidateCfg((*p).mlxconfigName);
+            }
+        }
         commander->loadConfigurationGetStr(); // why to call this? seems needless
     }
     catch (MlxcfgException& e)

--- a/mlxconfig/mlxcfg_utils.cpp
+++ b/mlxconfig/mlxcfg_utils.cpp
@@ -144,24 +144,20 @@ MError nvqcCom5thGen(mfile* mf, u_int32_t tlvType, bool& suppRead, bool& suppWri
 
 MError nvdiCom5thGen(mfile* mf, u_int32_t tlvType)
 {
-    struct reg_access_hca_mnvdi_reg_ext nvdiTlv;
-    memset(&nvdiTlv, 0, sizeof(struct reg_access_hca_mnvdi_reg_ext));
+    struct tools_open_mnvdi mnvdiTlv;
+    memset(&mnvdiTlv, 0, sizeof(struct tools_open_mnvdi));
 
-    nvdiTlv.configuration_item_header.length = 0;
-    // nvdiTlv.configuration_item_header.rd_en = 0;
-    // nvdiTlv.configuration_item_header.over_en = 1; // ask Dan
+    mnvdiTlv.nv_hdr.rd_en = 0;
+    mnvdiTlv.nv_hdr.over_en = 1;
+    mnvdiTlv.nv_hdr.writer_id = WRITER_ID_ICMD_MLXCONFIG;
     // tlvType should be in the correct endianess
-    u_int32_t reversed = __be32_to_cpu(tlvType);
-    u_int8_t* ptr_buff = (u_int8_t*)&reversed;
-    reg_access_hca_config_item_type_auto_ext_pack(&nvdiTlv.configuration_item_header.type, ptr_buff);
-    int type_class = __be32_to_cpu(tlvType) & 0xF000;
-    printf("type_class = %d\n", type_class); // should be some number between 0-9
+    mnvdiTlv.nv_hdr.type.tlv_type_dw.tlv_type_dw = __be32_to_cpu(tlvType);
 
     MError rc;
     // "suspend" signals as we are going to take semaphores
     mft_signal_set_handling(1);
     // DEBUG_PRINT_SEND(&nvdiTlv, nvdi);
-    rc = reg_access_mnvdi(mf, REG_ACCESS_METHOD_SET, &nvdiTlv);
+    rc = reg_access_mnvdi(mf, REG_ACCESS_METHOD_SET, &mnvdiTlv);
     // DEBUG_PRINT_RECEIVE(&nvdiTlv, nvdi);
     dealWithSignal();
     if (rc)

--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -264,13 +264,16 @@ reg_access_status_t reg_access_mnvgc(mfile* mf, reg_access_method_t method, stru
     REG_ACCCESS(mf, method, REG_ID_MNVGC, mnvgc, mnvgc_reg_ext, reg_access_hca);
 }
 
-reg_access_status_t reg_access_mnvdi(mfile* mf, reg_access_method_t method, struct reg_access_hca_mnvdi_reg_ext* mnvdi)
+reg_access_status_t reg_access_mnvdi(mfile* mf, reg_access_method_t method, struct tools_open_mnvdi* mnvdi)
 {
+    u_int32_t reg_size = mnvdi->nv_hdr.length + tools_open_nv_hdr_fifth_gen_size();
+    u_int32_t r_size_reg = reg_size;
+    u_int32_t w_size_reg = reg_size;
     if (method != REG_ACCESS_METHOD_SET)
     { // this register supports only set method
         return ME_REG_ACCESS_BAD_METHOD;
     }
-    REG_ACCCESS(mf, method, REG_ID_MNVDI, mnvdi, mnvdi_reg_ext, reg_access_hca);
+    REG_ACCCESS_VAR(mf, method, REG_ID_MNVDI, mnvdi, mnvdi, reg_size, r_size_reg, w_size_reg, tools_open);
 }
 
 /************************************

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -87,9 +87,8 @@ struct tools_mjtag;
 reg_access_status_t reg_access_mjtag(mfile* mf, reg_access_method_t method, struct tools_mjtag* mjtag);
 struct tools_open_mnvda;
 reg_access_status_t reg_access_mnvda(mfile* mf, reg_access_method_t method, struct tools_open_mnvda* mnvda);
-struct reg_access_hca_mnvdi_reg_ext;
-reg_access_status_t
-  reg_access_mnvdi(mfile* mf, reg_access_method_t method, struct reg_access_hca_mnvdi_reg_ext* mnvdi);
+    struct tools_open_mnvdi;
+    reg_access_status_t reg_access_mnvdi(mfile* mf, reg_access_method_t method, struct tools_open_mnvdi* mnvdi);
 struct reg_access_hca_mnvia_reg_ext;
 reg_access_status_t
   reg_access_mnvia(mfile* mf, reg_access_method_t method, struct reg_access_hca_mnvia_reg_ext* mnvia);

--- a/tools_layouts/tools_open_layouts.c
+++ b/tools_layouts/tools_open_layouts.c
@@ -997,6 +997,30 @@ void tools_open_mnvda_dump(const struct tools_open_mnvda *ptr_struct, FILE *fd)
 	tools_open_mnvda_print(ptr_struct, fd, 0);
 }
 
+void tools_open_mnvdi_pack(const struct tools_open_mnvdi *ptr_struct, u_int8_t *ptr_buff)
+{
+	u_int32_t offset;
+	offset = 0;
+	tools_open_nv_hdr_fifth_gen_pack(&(ptr_struct->nv_hdr), ptr_buff + offset / 8);	
+}
+void tools_open_mnvdi_unpack(struct tools_open_mnvdi *ptr_struct, const u_int8_t *ptr_buff)
+{
+	u_int32_t offset;
+	offset = 0;
+	tools_open_nv_hdr_fifth_gen_unpack(&(ptr_struct->nv_hdr), ptr_buff + offset / 8);
+}
+void tools_open_mnvdi_print(const struct tools_open_mnvdi *ptr_struct, FILE *fd, int indent_level)
+{
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "======== tools_open_mnvdi ========\n");
+	adb2c_add_indentation(fd, indent_level);
+	fprintf(fd, "nv_hdr:\n");
+	tools_open_nv_hdr_fifth_gen_print(&(ptr_struct->nv_hdr), fd, indent_level + 1);
+}
+unsigned int tools_open_mnvdi_size(void)
+{
+	return TOOLS_OPEN_MNVDI_SIZE;
+}
 void tools_open_mnvgn_pack(const struct tools_open_mnvgn *ptr_struct, u_int8_t *ptr_buff)
 {
 	u_int32_t offset;

--- a/tools_layouts/tools_open_layouts.h
+++ b/tools_layouts/tools_open_layouts.h
@@ -401,6 +401,12 @@ struct tools_open_mnvda {
 	u_int8_t data[256];
 };
 
+struct tools_open_mnvdi {
+/*---------------- DWORD[0] (Offset 0x0) ----------------*/
+	/* Description -  */
+	/* 0x0.0 - 0x8.31 */
+	struct tools_open_nv_hdr_fifth_gen nv_hdr;
+};
 /* Description -   */
 /* Size in bytes - 156 */
 struct tools_open_mnvgn {
@@ -1021,6 +1027,12 @@ void tools_open_mnvda_print(const struct tools_open_mnvda *ptr_struct, FILE *fd,
 unsigned int tools_open_mnvda_size(void);
 #define TOOLS_OPEN_MNVDA_SIZE    (0x10c)
 void tools_open_mnvda_dump(const struct tools_open_mnvda *ptr_struct, FILE *fd);
+/* mnvdi */
+void tools_open_mnvdi_pack(const struct tools_open_mnvdi *ptr_struct, u_int8_t *ptr_buff);
+void tools_open_mnvdi_unpack(struct tools_open_mnvdi *ptr_struct, const u_int8_t *ptr_buff);
+void tools_open_mnvdi_print(const struct tools_open_mnvdi *ptr_struct, FILE *fd, int indent_level);
+unsigned int tools_open_mnvdi_size(void);
+#define TOOLS_OPEN_MNVDI_SIZE    (0xc)
 /* mnvgn */
 void tools_open_mnvgn_pack(const struct tools_open_mnvgn *ptr_struct, u_int8_t *ptr_buff);
 void tools_open_mnvgn_unpack(struct tools_open_mnvgn *ptr_struct, const u_int8_t *ptr_buff);


### PR DESCRIPTION
Description: There is an option to invalidate all TLVs. Now there is an option to reset a specific TLV using te reset command with a tlv as parameter.