### PR TITLE
fix for "Failed to run mstflint tools over devices after load mstflint_access.ko module"

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -1715,6 +1715,7 @@ static int mtcr_pciconf_open(mfile* mf, const char* name, u_int32_t adv_opt)
             get_space_support_status(mf, AS_PCI_ALL_ICMD);
             get_space_support_status(mf, AS_PCI_SCAN_CRSPACE);
             get_space_support_status(mf, AS_PCI_GLOBAL_SEMAPHORE);
+            get_space_support_status(mf, AS_RECOVERY);
             mf->vsec_cap_mask |= (1 << VCC_INITIALIZED);
 
             mtcr_pciconf_cap9_sem(mf, 0);


### PR DESCRIPTION
 fix for "[MSTFLINT] Bug SW #4143961: [mstflint kernel]: Failed to run mstflint tools over devices after load mstflint_access.ko module"

Description: The recovery space in VSC is supported only in ConnectX8, Quantum3, and above, so the get_space_support_status function should check whether it is supported after SS_ALL_SPACES_SUPPORTED is set; As this space is only for recovery, and SS_ALL_SPACES_SUPPORTED is relevant for functional devices.

Tested OS: Linux
Tested devices: ConnectX4
Tested flows:
insmod mstflint_access.ko
mstdlint -d 44:00.0 q

Known gaps (with RM ticket):n/a

Issue:4143961