### PR TITLE
Makefile.am, configure.ac: fix hard coded static and include path

### DIFF
--- a/cmdif/Makefile.am
+++ b/cmdif/Makefile.am
@@ -53,7 +53,7 @@ libcmdif_la_SOURCES = tools_cif.c tools_cif.h icmd_cif_common.c icmd_cif_common.
 cmdif_pylibdir = $(libdir)/mstflint/python_tools/
 cmdif_pylib_DATA = ${CCMDIF_SO} cmdif.py
 ${CCMDIF_SO}: libcmdif.la
-	$(CC) -g -Wall -pthread -shared ${CFLAGS} *.o -o ${CCMDIF_SO} \
-	$(top_builddir)/tools_layouts/.libs/libtools_layouts.a $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a
+	$(CC) -g -Wall -pthread -shared ${CFLAGS} .libs/*.o -o ${CCMDIF_SO} \
+	$(top_builddir)/tools_layouts/.libs/libtools_layouts.a $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.so
 
 CLEANFILES = ${CCMDIF_SO}

--- a/configure.ac
+++ b/configure.ac
@@ -187,16 +187,11 @@ AC_ARG_ENABLE(xml2,
             [enable_xml2="no"])
 AC_MSG_RESULT($enable_xml2)
 if test [ "x$enable_xml2" = "xyes" ] || [ test "x$enable_fw_mgr" = "xyes" ]; then
-    # XML2 checks
-    AC_LANG_PUSH([C++])
-        if test "x$OS" = "xFreeBSD"; then
-            CXXFLAGS="${CXXFLAGS} -isystem /usr/local/include/libxml2"
-        else
-            CXXFLAGS="${CXXFLAGS} -isystem /usr/include/libxml2"
-        fi
-        AC_CHECK_HEADER([libxml2/libxml/xpath.h],[],[AC_MSG_ERROR([libxml2: xpath.h is not found in the system PATH. make sure libxml2 headers are installed.])])
-        AC_CHECK_LIB(xml2, xmlDocDumpFormatMemoryEnc,, AC_MSG_ERROR([cannot find xml2 xmlDocDumpFormatMemoryEnc() function. Try re-installing the library...]))
-    AC_LANG_POP([C++])
+	PKG_CHECK_MODULES(xml, [libxml-2.0])
+	AC_SUBST(xml_CFLAGS)
+	AC_SUBST(xml_LIBS)
+	CXXFLAGS="$CXXFLAGS $xml_CFLAGS"
+	CFLAGS="$CFLAGS $xml_CFLAGS"
 fi
 
 AM_CONDITIONAL(DISABLE_XML2, [test  "x$enable_xml2" = "xno"])

--- a/configure.ac
+++ b/configure.ac
@@ -275,6 +275,7 @@ AC_ARG_ENABLE([all_static],
     [enable_all_static="no"])
 AC_MSG_RESULT($enable_all_static)
 
+BUILD_DYNAMIC="yes"
 AS_IF([test "x$enable_all_static" = "xyes"], [
   if test "x$enable_dc" = "xyes"; then
     AC_MSG_ERROR([cannot enable all static with enable dc . add --disable-dc to remove dependency with dynamic zlib])
@@ -285,9 +286,13 @@ AS_IF([test "x$enable_all_static" = "xyes"], [
   if test "x$enable_inband" = "xyes"; then
     AC_MSG_ERROR([cannot enable all static with enable inband . add --disable-inband to remove dependency with dynamic inband])
   fi
+  BUILD_DYNAMIC="no"
   LDFLAGS="$LDFLAGS -all-static"
   CFLAGS="$CFLAGS -DSQLITE_OMIT_LOAD_EXTENSION=0 -DIBVSMAD_DLOPEN"
 ])
+
+# Define conditionals for the Makefile.am
+AM_CONDITIONAL([BUILD_DYNAMIC], [test "$BUILD_DYNAMIC" = "yes"])
 
 AC_SUBST(TOOLS_CRYPTO)
 AM_CONDITIONAL(ENABLE_OPENSSL, [test "x$enable_openssl" = "xyes" ])

--- a/configure.ac
+++ b/configure.ac
@@ -139,11 +139,20 @@ AC_ARG_ENABLE(fw-mgr,
              [enable_fw_mgr="no"])
 AC_MSG_RESULT($enable_fw_mgr)
 if test "x$enable_fw_mgr" = "xyes"; then
+    # Find curl using pkg-config
+    PKG_CHECK_MODULES([CURL], [libcurl], [
+        CURL_INC_DIR=$(pkg-config --cflags-only-I libcurl | sed 's/-I//')
+    ], [
+        AC_MSG_ERROR([Cannot find curl via pkg-config. Please install libcurl development files.])
+    ])
+
     AC_CHECK_HEADER(curl/curl.h,,AC_MSG_ERROR([cannot find curl/curl.h . this header is needed for compiling fw manager tool]))
+
     AC_CHECK_HEADER(zlib.h,,AC_MSG_ERROR([cannot find zlib.h . this header is needed for compiling fw manager tool]))
     AC_CHECK_LIB(z, uncompress,, AC_MSG_ERROR([cannot find zlib uncompress() function.]))
     AC_CHECK_HEADER(lzma.h,,AC_MSG_ERROR([Cannot find lzma.h.]))
-    CURL_INC_DIR=/usr/include/curl/
+
+    AC_SUBST([CURL_INC_DIR])
 fi
 
 # mlxdpa

--- a/dev_mgt/Makefile.am
+++ b/dev_mgt/Makefile.am
@@ -52,9 +52,9 @@ dev_mgt_pylib_DATA = c_dev_mgt.so
 dist_dev_mgt_pylib_DATA = dev_mgt.py
 
 c_dev_mgt.so: libdev_mgt.la
-	$(CC) -g -Wall -pthread -shared ${CFLAGS} tools_dev_types.o -o c_dev_mgt.so \
+	$(CC) -g -Wall -pthread -shared ${CFLAGS} .libs/tools_dev_types.o -o c_dev_mgt.so \
 	$(top_builddir)/reg_access/.libs/libreg_access.a \
 	$(top_builddir)/tools_layouts/.libs/libtools_layouts.a \
-	$(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a
+	$(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.so
 
 CLEANFILES = c_dev_mgt.so

--- a/flint/Makefile.am
+++ b/flint/Makefile.am
@@ -71,7 +71,7 @@ mstflint_DEPENDENCIES = \
 
 LDADD_mstflint = ${LDL}
 
-mstflint_LDFLAGS = -static
+#mstflint_LDFLAGS = -static
 
 if ENABLE_DC
 LDADD_mstflint += -lz

--- a/mlxarchive/Makefile.am
+++ b/mlxarchive/Makefile.am
@@ -92,7 +92,7 @@ mstarchive_LDADD = libmstarchive.la \
                    $(CURL_LIBS) \
                    -llzma -lm ${LDL}
 
-mstarchive_LDFLAGS = -static
+#mstarchive_LDFLAGS = -static
 
 if ENABLE_OPENSSL
 mstarchive_LDADD += $(top_builddir)/mlxsign_lib/libmlxsign.la -lcrypto -lssl

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -100,7 +100,7 @@ mstconfig_DEPENDENCIES = \
 
 mstconfig_LDADD = $(mstconfig_DEPENDENCIES) ${LDL}
 
-mstconfig_LDFLAGS = -static
+#mstconfig_LDFLAGS = -static
 
 if DISABLE_XML2
 AM_CXXFLAGS += -DDISABLE_XML2

--- a/mlxfwupdate/Makefile.am
+++ b/mlxfwupdate/Makefile.am
@@ -134,4 +134,4 @@ mstfwmanager_DEPENDENCIES += $(top_builddir)/mlxdpa/libmstdpa.a
 endif
 
 mstfwmanager_LDADD = $(mstfwmanager_DEPENDENCIES) $(LDADD_mstfwmanager)
-mstfwmanager_LDFLAGS = -static
+#mstfwmanager_LDFLAGS = -static

--- a/mlxlink/Makefile.am
+++ b/mlxlink/Makefile.am
@@ -69,4 +69,4 @@ mstlink_DEPENDENCIES = \
 
 mstlink_LDADD = $(mstlink_DEPENDENCIES) -llzma ${LDL} -lexpat
 
-mstlink_LDFLAGS = -static
+#mstlink_LDFLAGS = -static

--- a/mlxreg/Makefile.am
+++ b/mlxreg/Makefile.am
@@ -62,4 +62,4 @@ mstreg_DEPENDENCIES = \
 
 mstreg_LDADD = $(mstreg_DEPENDENCIES) -llzma ${LDL} -lexpat
 
-mstreg_LDFLAGS = -static
+#mstreg_LDFLAGS = -static

--- a/mlxsign_lib/Makefile.am
+++ b/mlxsign_lib/Makefile.am
@@ -38,7 +38,13 @@ AM_CPPFLAGS = \
 AM_CXXFLAGS = -Wall -W  -g -MP -MD -pipe $(COMPILER_FPIC)
 AM_CXXFLAGS += -DTOOLS_CRYPTO_KEY='$(TOOLS_CRYPTO_KEY)' -DTOOLS_CRYPTO_IV='$(TOOLS_CRYPTO_IV)'
 
+if BUILD_DYNAMIC
+pkglib_LTLIBRARIES = libmlxsign.la
+libmlxsign_la_LDFLAGS = -version-info 0:0:0 -no-undefined
+else
 noinst_LTLIBRARIES = libmlxsign.la
+endif
+
 libmlxsign_la_SOURCES = mlxsign_lib.cpp mlxsign_lib.h mlxsign_com_def.h \
                        mlxsign_signer_interface.h mlxsign_signer_interface.cpp
 

--- a/mstdump/crd_main/Makefile.am
+++ b/mstdump/crd_main/Makefile.am
@@ -39,5 +39,5 @@ bin_PROGRAMS = mstregdump
 mstregdump_SOURCES = mstdump.c
 mstregdump_LDADD = ../crd_lib/libcrdump.a ../../dev_mgt/libdev_mgt.la ../../reg_access/libreg_access.la ../../tools_layouts/libtools_layouts.la \
 			../../${MTCR_CONF_DIR}/libmtcr_ul.la  -lm ${LDL}
-mstregdump_LDFLAGS = -static
+#mstregdump_LDFLAGS = -static
 mstregdump_CFLAGS = -DMSTDUMP_NAME=\"mstregdump\" -DDEV_EXAMPLE=\"0b:00.0\"

--- a/mtcr_py/Makefile.am
+++ b/mtcr_py/Makefile.am
@@ -35,6 +35,6 @@ mtcr_pylibdir = $(libdir)/mstflint/python_tools/
 mtcr_pylib_DATA = cmtcr.so
 dist_mtcr_pylib_DATA = mtcr.py
 cmtcr.so:
-	$(CC) -g -Wall -pthread -shared ${CFLAGS} -o cmtcr.so -Wl,--whole-archive $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a -Wl,--no-whole-archive
+	$(CC) -g -Wall -pthread -shared ${CFLAGS} -o cmtcr.so $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.so
 
 CLEANFILES = cmtcr.so

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -32,7 +32,12 @@
 
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include/mtcr_ul -I$(top_srcdir)/common -I$(top_srcdir)/dev_mgt
 
+if BUILD_DYNAMIC
 pkglib_LTLIBRARIES = libmtcr_ul.la
+libmtcr_ul_la_LDFLAGS = -version-info 0:0:0 -no-undefined
+else
+noinst_LTLIBRARIES = libmtcr_ul.la
+endif
 
 libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
 			mtcr_ib_res_mgt.h mtcr_ib_res_mgt.c\

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -33,7 +33,7 @@
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_srcdir)/include/mtcr_ul -I$(top_srcdir)/common -I$(top_srcdir)/dev_mgt
 
 if BUILD_DYNAMIC
-pkglib_LTLIBRARIES = libmtcr_ul.la
+lib_LTLIBRARIES = libmtcr_ul.la
 libmtcr_ul_la_LDFLAGS = -version-info 0:0:0 -no-undefined
 else
 noinst_LTLIBRARIES = libmtcr_ul.la

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -54,7 +54,3 @@ endif
 
 libraryincludedir=$(includedir)/mstflint
 libraryinclude_HEADERS = $(top_srcdir)/include/mtcr_ul/mtcr.h  $(top_srcdir)/include/mtcr_ul/mtcr_com_defs.h  $(top_srcdir)/include/mtcr_ul/mtcr_mf.h
-
-install-exec-hook:
-	rm -f $(DESTDIR)$(pkglibdir)/libmtcr_ul.so* $(DESTDIR)$(pkglibdir)/libmtcr_ul.la
-	ln -snf mstflint/libmtcr_ul.a $(DESTDIR)$(libdir)/

--- a/reg_access/Makefile.am
+++ b/reg_access/Makefile.am
@@ -57,7 +57,7 @@ reg_access_pylib_DATA = ${RREG_ACCESS_SO}
 dist_reg_access_pylib_DATA = regaccess.py regaccess_hca_ext_structs.py regaccess_switch_ext_structs.py
 
 ${RREG_ACCESS_SO}: libreg_access.la
-	$(CC) -g -Wall -pthread -shared ${CFLAGS} *.o -o ${RREG_ACCESS_SO} \
-	$(top_builddir)/tools_layouts/.libs/libtools_layouts.a $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a
+	$(CC) -g -Wall -pthread -shared ${CFLAGS} .libs/*.o -o ${RREG_ACCESS_SO} \
+	$(top_builddir)/tools_layouts/.libs/libtools_layouts.a $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.so
 
 CLEANFILES = ${RREG_ACCESS_SO}

--- a/resourcetools/resourcedump_lib/src/sdk/Makefile.am
+++ b/resourcetools/resourcedump_lib/src/sdk/Makefile.am
@@ -63,7 +63,7 @@ libraryinclude_HEADERS = \
 # if WIN_BUILD
 # MTCR_LIB = $(MTCR_DIR)/.libs/libmtcr.dll.a
 # else
-MTCR_LIB = $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a
+MTCR_LIB = $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.so
 # endif
 
 if ENABLE_RDMEM
@@ -86,7 +86,7 @@ resource_dump_sdk_so_DEPS = \
 
 # if !WIN_BUILD
 libresource_dump_sdk.so: libresource_dump_sdk.la
-	$(CC) -Wall -pthread -shared ${CFLAGS} $(COMPILER_FPIC) libresource_dump_sdk_la-resource_dump_sdk.o \
+	$(CC) -Wall -pthread -shared ${CFLAGS} $(COMPILER_FPIC) .libs/libresource_dump_sdk_la-resource_dump_sdk.o \
 	-o libresource_dump_sdk.so ${AM_LDFLAGS} $(resource_dump_sdk_so_DEPS)
 # else
 # libresource_dump_sdk.dll: libresource_dump_sdk.la

--- a/small_utils/Makefile.am
+++ b/small_utils/Makefile.am
@@ -48,12 +48,12 @@ bin_SCRIPTS = mstfwreset
 mstmread_SOURCES = mread.c
 mstmread_DEPENDENCIES = $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 mstmread_LDADD = $(mstmread_DEPENDENCIES) ${LDL}
-mstmread_LDFLAGS = -static
+#mstmread_LDFLAGS = -static
 
 mstmwrite_SOURCES = mwrite.c
 mstmwrite_DEPENDENCIES = $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 mstmwrite_LDADD = $(mstmwrite_DEPENDENCIES) ${LDL}
-mstmwrite_LDFLAGS = -static
+#mstmwrite_LDFLAGS = -static
 
 mstvpd_SOURCES = vpd.c
 mstvpd_DEPENDENCIES = $(top_builddir)/mvpd/libmvpd.la \
@@ -62,7 +62,7 @@ mstvpd_DEPENDENCIES = $(top_builddir)/mvpd/libmvpd.la \
                $(top_builddir)/reg_access/libreg_access.la \
                $(top_builddir)/tools_layouts/libtools_layouts.la
 mstvpd_LDADD = $(mstvpd_DEPENDENCIES) ${LDL}
-mstvpd_LDFLAGS = -static
+#mstvpd_LDFLAGS = -static
 
 mstcongestion_SOURCES = congestion.cpp
 mstcongestion_DEPENDENCIES = $(top_builddir)/cmdif/libcmdif.la \
@@ -72,12 +72,12 @@ mstcongestion_DEPENDENCIES = $(top_builddir)/cmdif/libcmdif.la \
                       $(top_builddir)/cmdparser/libcmdparser.a \
                       $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 mstcongestion_LDADD = $(mstcongestion_DEPENDENCIES) ${LDL}
-mstcongestion_LDFLAGS = -static
+#mstcongestion_LDFLAGS = -static
 
 mstmcra_SOURCES = mcra.c
 mstmcra_DEPENDENCIES = $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 mstmcra_LDADD = $(mstmcra_DEPENDENCIES) ${LDL}
-mstmcra_LDFLAGS = -static
+#mstmcra_LDFLAGS = -static
 
 if LINUX_BUILD
 bin_PROGRAMS += mstfwctrl
@@ -87,14 +87,14 @@ mstfwctrl_DEPENDENCIES = $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la \
                			 $(top_builddir)/dev_mgt/libdev_mgt.la \
  	                     $(top_builddir)/reg_access/libreg_access.la
 mstfwctrl_LDADD = $(mstfwctrl_DEPENDENCIES) ${LDL}
-mstfwctrl_LDFLAGS = -static
+#mstfwctrl_LDFLAGS = -static
 endif
 
 mstmtserver_SOURCES = mtserver.c tcp.c tcp.h
 mstmtserver_CFLAGS = -DMST_UL
 mstmtserver_DEPENDENCIES = $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 mstmtserver_LDADD = $(mstmtserver_DEPENDENCIES) ${LDL}
-mstmtserver_LDFLAGS = -static
+#mstmtserver_LDFLAGS = -static
 
 SUBDIRS = mlxfwresetlib
 MSTFWRESET_PYTHON_WRAPPER=mstfwreset


### PR DESCRIPTION
This serie is used to avoid hard coded path that do not work for any distributions. For instance, when buildroot is used or when cross compilation is used, the path of the headers cannot be enforce with /usr/include .