### PR TITLE
Allow RPM build on s390x architecture

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -27,7 +27,7 @@ Url: http://openfabrics.org
 Group: System Environment/Base
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
 Source: %{name}-%{version}.tar.gz
-ExclusiveArch: i386 i486 i586 i686 x86_64 ia64 ppc ppc64 ppc64le arm64 aarch64
+ExclusiveArch: i386 i486 i586 i686 x86_64 ia64 ppc ppc64 ppc64le arm64 aarch64 s390x
 
 %if 0%{?suse_version}
 %define openssl_devel_lib libopenssl-devel


### PR DESCRIPTION
successfully tested on Fedora 41.