### PR TITLE
fix for "Bug SW #4162297: [CX9] Flint Q Returns Image Type as FSCTRL"

### DIFF
--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -844,7 +844,7 @@ bool FsCtrlOperations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams&
 
 bool FsCtrlOperations::isMultiAsicSystemComponent()
 {
-    if (_hwDevId == QUANTUM3_HW_ID || _hwDevId == CX8_HW_ID)
+    if (_hwDevId == QUANTUM3_HW_ID || _hwDevId == CX8_HW_ID ||  _hwDevId == CX9_HW_ID)
     {
         return true;
     }

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -1449,6 +1449,7 @@ const FwOperations::HwDevData FwOperations::hwDevData[] = {
   {"ConnectX-6LX", CX6LX_HW_ID, CT_CONNECTX6LX, CFT_HCA, 0, {4127, 0}, {{UNKNOWN_BIN, {0}}}},
   {"ConnectX-7", CX7_HW_ID, CT_CONNECTX7, CFT_HCA, 0, {4129, 0}, {{UNKNOWN_BIN, {0}}}},
   {"ConnectX-8", CX8_HW_ID, CT_CONNECTX8, CFT_HCA, 0, {4131, 0}, {{UNKNOWN_BIN, {0}}}},
+  {"ConnectX-9", CX9_HW_ID, CT_CONNECTX9, CFT_HCA, 0, {4133, 0}, {{UNKNOWN_BIN, {0}}}},
   {"BlueField", BF_HW_ID, CT_BLUEFIELD, CFT_HCA, 0, {41680, 41681, 41682, 0}, {{UNKNOWN_BIN, {0}}}},
   {"BlueField2", BF2_HW_ID, CT_BLUEFIELD2, CFT_HCA, 0, {41684, 41685, 41686, 0}, {{UNKNOWN_BIN, {0}}}},
   {"BlueField3", BF3_HW_ID, CT_BLUEFIELD3, CFT_HCA, 0, {41690, 41691, 41692, 0}, {{UNKNOWN_BIN, {0}}}},
@@ -1481,6 +1482,7 @@ const FwOperations::HwDev2Str FwOperations::hwDev2Str[] = {
   {"ConnectX-6LX", CX6LX_HW_ID, 0x00},
   {"ConnectX-7", CX7_HW_ID, 0x00},
   {"ConnectX-8", CX8_HW_ID, 0x00},
+  {"ConnectX-9", CX9_HW_ID, 0x00},
   {"BlueField", BF_HW_ID, 0x00},
   {"BlueField2", BF2_HW_ID, 0x00},
   {"BlueField3", BF3_HW_ID, 0x00},
@@ -2569,7 +2571,7 @@ u_int8_t FwOperations::GetFwFormatFromHwDevID(u_int32_t hwDevId)
         return FS_FS4_GEN;
     }
     else if ((hwDevId == QUANTUM3_HW_ID) || (hwDevId == CX8_HW_ID) || (hwDevId == BF4_HW_ID) ||
-             (hwDevId == ARCUSE_HW_ID))
+             (hwDevId == ARCUSE_HW_ID) || (hwDevId == CX9_HW_ID))
     {
         return FS_FS5_GEN;
     }

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -80,6 +80,7 @@
 #define CX6LX_HW_ID 534
 #define CX7_HW_ID 536
 #define CX8_HW_ID 542
+#define CX9_HW_ID 549
 #define BF_HW_ID 529
 #define BF2_HW_ID 532
 #define BF3_HW_ID 540
@@ -312,6 +313,7 @@ typedef enum chip_type
     CT_CONNECTX6LX,
     CT_CONNECTX7,
     CT_CONNECTX8,
+    CT_CONNECTX9,
     CT_SPECTRUM3,
     CT_BLUEFIELD2,
     CT_BLUEFIELD3,

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -282,6 +282,7 @@ enum
 #define CX6LX_HW_ID 534
 #define CX7_HW_ID 536
 #define CX8_HW_ID 542
+#define CX9_HW_ID 549
 #define BF_HW_ID 529
 #define BF2_HW_ID 532
 #define BF3_HW_ID 540
@@ -1045,6 +1046,7 @@ static int icmd_init_cr(mfile* mf)
         case (BF3_HW_ID):
         case (CX8_HW_ID):
         case (BF4_HW_ID):
+        case (CX9_HW_ID):
             cmd_ptr_addr = CMD_PTR_ADDR_CX7;
             hcr_address = HCR_ADDR_CX7;
             mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX7;
@@ -1165,6 +1167,7 @@ static int icmd_init_vcr_crspace_addr(mfile* mf)
         case (CX7_HW_ID):
         case (BF4_HW_ID):
         case (CX8_HW_ID):
+        case (CX9_HW_ID):
             mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
             mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5; // same bit offset as CX5
             break;


### PR DESCRIPTION
fix for "Bug SW #4162297: [CX9] Flint Q Returns Image Type as FSCTRL"

Description: added missing cx9 device ID

MSTFlint port needed:yes
Tested OS: Ubunto20
Tested devices:cx9 emulation
Tested flows:flint q

Known gaps (with RM ticket):n/a

Issue:4162297