### PR TITLE
add CX9 support for pci-core VSC spaces separation

### DIFF
--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -102,6 +102,7 @@ typedef long long int64_t;
 #define PXIR_SPACE_OFFSET 0x100
 
 #define CX8_HW_ID 0x21e
+#define CX9_HW_ID 0x225
 
 /*
  * MST <--> MTCR API defines
@@ -544,7 +545,7 @@ typedef struct cables_info_t
      ((mf)->vsec_cap_mask & (1 << VCC_SEMAPHORE_SPACE_SUPPORTED)))
 
 #define VSEC_PXIR_SUPPORT(mf) \
-    ((mf)->device_hw_id == CX8_HW_ID)
+    (((mf)->device_hw_id == CX8_HW_ID) || ((mf)->device_hw_id == CX9_HW_ID))
 
 // Macro for VSEC_SUPPORTED_UL
 #define VSEC_SUPPORTED_UL(mf) \


### PR DESCRIPTION
Description: add CX9 support for pci-core VSC spaces separation

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: n/a

Known gaps (with RM ticket): n/a

Issue: 4176631