### PR TITLE
[mget_temp] bugfix - double-free

### DIFF
--- a/small_utils/mget_temp.c
+++ b/small_utils/mget_temp.c
@@ -131,7 +131,6 @@ int parseAndRun(int argc, char** argv)
     if (rc != TDFW_SUCCESS || !data)
     {
         fprintf(stderr, "Thermal diode read failed (%s)\n", td_fw_err_str);
-        td_fw_release_data(data);
         mclose(mf);
         exit(1);
     }


### PR DESCRIPTION
Description:

MSTFlint port needed: yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 4195631