### PR TITLE
fix for #4188532: FW burn with flint (mft 4.30) has much longer time

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -1369,9 +1369,28 @@ int mtcr_pciconf_set_addr_space(mfile* mf, u_int16_t space)
     READ4_PCI(mf, &val, mf->vsec_addr + PCI_CTRL_OFFSET, "read domain", return ME_PCI_READ_ERROR);
     val = MERGE(val, space, PCI_SPACE_BIT_OFFS, PCI_SPACE_BIT_LEN);
     WRITE4_PCI(mf, val, mf->vsec_addr + PCI_CTRL_OFFSET, "write domain", return ME_PCI_WRITE_ERROR);
+
+    /* Check if we succedded to write the space (i.e. that its MSB is not ignored by FW) */
+    u_int32_t read_val = 0;
+    READ4_PCI(mf, &read_val, mf->vsec_addr + PCI_CTRL_OFFSET, "read status", return ME_PCI_READ_ERROR);
+
+    // Extract only the first 16 bits, as we need to check what's written in "space"
+    unsigned int mask = 0xFFFF;
+    unsigned int expected_value = val & mask;
+    unsigned int actual_value = read_val & mask;
+
+    /* Check if the space written is indeed the space we attempted to write */
+    if (actual_value != expected_value)
+    {
+        DBG_PRINTF("actual_space_value != expected_space_value. expected_space_value: 0x%x actual_space_value: 0x%x. Meaning space: 0x%x is not supported.\n",
+          expected_value,
+          actual_value,
+          expected_value);
+        return ME_PCI_SPACE_NOT_SUPPORTED;
+    }
+
     /* read status and make sure space is supported */
-    READ4_PCI(mf, &val, mf->vsec_addr + PCI_CTRL_OFFSET, "read status", return ME_PCI_READ_ERROR);
-    if (EXTRACT(val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0) {
+    if (EXTRACT(read_val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0) {
         return ME_PCI_SPACE_NOT_SUPPORTED;
     }
     return ME_OK;


### PR DESCRIPTION
fix for #4188532: FW burn with flint (mft 4.30) has much longer time for FW burn per module for BM vs other systems (Croc, Gorilla)"
Description: When checking whether the PCI VSC spaces are supported, the status bit is 1, indicating that they are, which causes each failure in reading/writing to go to the function check_syndrome that tells us whether we should switch to the PCI VSC space. this overhead is what caused this bug. Since FW has a bug where they ignore the MSB of the space, each time we attempt to check whether a PCI VSC space is supported, what's actually written is the core VSC space, hence the status FW returns is 1 and we wrongly conclude they are supported. Fixed by adding a check to see whether what's written to the space field in VSC is indeed what we attempted to write.

Tested OS: Linux
Tested devices:qunatum3
Tested flows:
time mlxfwmanager -u -f -y -d /dev/mst/mt54004_pciconf0 -i /mswg/release/sx_mlnx_fw/QTM3/fw-QTM3-rel-35_2014_2096-FIT.mfa & time mlxfwmanager -u -f -y -d /dev/mst/mt54004_pciconf1 -i /mswg/release/sx_mlnx_fw/QTM3/fw-QTM3-rel-35_2014_2096-FIT.mfa &

Known gaps (with RM ticket): n/a

Issue: 4188532