### PR TITLE
[flint][fw_comps_mgr] Support new state of secure_host register

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -261,6 +261,7 @@ typedef enum
     FWCOMPS_FAIL_TO_LOCK_FLASH_SEMAPHORE,
     FWCOMPS_VERIFY_FAILED,
     FWCOMPS_DEVICE_NOT_PRESENT,
+    FWCOMPS_COMP_BLOCKED,
 
     // MCC Return codes
     FWCOMPS_MCC_ERR_CODES = 0x100,
@@ -574,6 +575,7 @@ private:
     bool isDMAAccess();
     bool fallbackToRegisterAccess();
     bool IsDevicePresent(FwComponent::comps_ids_t compType);
+    bool IsCfgComponentType(FwComponent::comps_ids_t type);
 
     std::vector<comp_query_st> _compsQueryMap;
     bool _fwSupport;
@@ -609,5 +611,6 @@ private:
 #ifndef UEFI_BUILD
     trm_ctx _trm;
 #endif
+    u_int8_t _secureHostState;
 };
 #endif /* USER_MLXFWOPS_LIB_FW_COMPS_MGR_H_ */


### PR DESCRIPTION
Description: Due to new values for lock state in secure_host register we need to change current check from bool based (if != 0) to a more specific check.
During MCC init we check if state == 1 which means general lock state. During MCC burn we check for specific block according to the given component ID for update.

Issue: 4122407