### PR TITLE
[CX7][BF-3] - add support to Zombiefish mode

### DIFF
--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -3259,7 +3259,9 @@ int is_zombiefish_device(mfile* mf)
     {
         return 0;
     }
-    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId)
+    if (mf->hw_dev_id != DeviceConnectX8_HwId && mf->hw_dev_id != DeviceQuantum3_HwId &&
+        mf->hw_dev_id != DeviceConnectX9_HwId && mf->hw_dev_id != DeviceQuantum4_HwId &&
+        mf->hw_dev_id != DeviceConnectX7_HwId && mf->hw_dev_id != DeviceBlueField3_HwId)
     {
         return 0;
     }

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -4022,7 +4022,9 @@ int is_zombiefish_device(mfile* mf)
     {
         return 0;
     }
-    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId)
+    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId &&
+        mf->device_hw_id != DeviceConnectX9_HwId && mf->device_hw_id != DeviceQuantum4_HwId &&
+        mf->device_hw_id != DeviceConnectX7_HwId && mf->device_hw_id != DeviceBlueField3_HwId)
     {
         return 0;
     }


### PR DESCRIPTION
Description: added support to ZF mode in ConnectX7 and BlueField3
HLD: https://confluence.nvidia.com/pages/viewpage.action?pageId=2855575683

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: n/a

Known gaps (with RM ticket):n/a

Issue: 4148208