### PR TITLE
fix for "when VPD length is aligned on a 4B boundary, mstvpd fails"

### DIFF
--- a/mvpd/mvpd.c
+++ b/mvpd/mvpd.c
@@ -584,6 +584,7 @@ int mvpd_get_vpd_size(mfile* mf, int* size)
             len = VPD_TAG_HEAD(buff) + VPD_TAG_LENGTH(buff);
             if (VPD_TAG_NAME(buff) == VPD_TAG_END)
             {
+                mvpd_len += len; // Ensure the final length includes the end tag
                 break;
             }
             if (VPD_TAG_NAME(buff) != VPD_TAG_ID && VPD_TAG_NAME(buff) != VPD_TAG_R && VPD_TAG_NAME(buff) != VPD_TAG_W)


### PR DESCRIPTION
fix for "when VPD length is aligned on a 4B boundary, mstvpd fails due "-E- Failed to parse VPD from 21:00.0!"

Description: mvpd_len was not calculated correctly: It always missed the 1-byte length of the end tag. this was masked by the fact that mvpd_get_raw_vpd() calls my_vpd_read() and always reads 4 bytes at a time, so when the vpd len is not aligned on a 4B boundary, the 4B read covered the extra byte needed with the end tag len since it is only 1 byte. but when the vpd len is aligned on a 4B boundary, mvpd_len is calculated by reading all the VPD, yet not the end tag, which causes this error: "-E- Failed to parse VPD from 21:00.0!"

Tested OS: linux
Tested devices: n/a
Tested flows: mstvpd 21:00.0

Known gaps (with RM ticket): n/a

Issue: 4209502