### PR TITLE
fix for "[MSTFLINT] Bug SW #4215561: [mstflint][freebsd] build issue"

### DIFF
--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -3259,9 +3259,9 @@ int is_zombiefish_device(mfile* mf)
     {
         return 0;
     }
-    if (mf->hw_dev_id != DeviceConnectX8_HwId && mf->hw_dev_id != DeviceQuantum3_HwId &&
-        mf->hw_dev_id != DeviceConnectX9_HwId && mf->hw_dev_id != DeviceQuantum4_HwId &&
-        mf->hw_dev_id != DeviceConnectX7_HwId && mf->hw_dev_id != DeviceBlueField3_HwId)
+    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId &&
+        mf->device_hw_id != DeviceConnectX9_HwId && mf->device_hw_id != DeviceQuantum4_HwId &&
+        mf->device_hw_id != DeviceConnectX7_HwId && mf->device_hw_id != DeviceBlueField3_HwId)
     {
         return 0;
     }


### PR DESCRIPTION
 fix for "[MSTFLINT] Bug SW #4215561: [mstflint][freebsd] building mstflint for freebsd from master devel is broken"
Description:fixed compilation issue

Tested OS:freeBSD
Tested devices:n/a
Tested flows:./autogen.sh && ./configure && make

Known gaps (with RM ticket): n/a

Issue:4215561