### PR TITLE
[tools filesystem] - unifying isFile and is_regular_file functions im…

### DIFF
--- a/mlxarchive/Makefile.am
+++ b/mlxarchive/Makefile.am
@@ -88,6 +88,7 @@ mstarchive_LDADD = libmstarchive.la \
                    $(top_builddir)/xz_utils/libxz_utils.la \
                    $(top_builddir)/ext_libs/minixz/libminixz.la \
                    $(top_builddir)/xz_utils/libxz_utils.la \
+                   $(top_builddir)/common/libcommon.la \
                    $(CURL_LIBS) \
                    -llzma -lm ${LDL}
 

--- a/mlxarchive/mlxarchive.cpp
+++ b/mlxarchive/mlxarchive.cpp
@@ -157,7 +157,8 @@ void Mlxarchive::paramValidate()
         {
             if (fexists(_outFile))
             {
-                if (!isFile(_outFile))
+                Filesystem::path p(_outFile);
+                if (!Filesystem::is_regular_file(p))
                 {
                     fprintf(stderr, "Output file: %s is expected to be a file\n", _outFile.c_str());
                 }

--- a/mlxarchive/mlxarchive.h
+++ b/mlxarchive/mlxarchive.h
@@ -34,6 +34,8 @@
 
 #include <iostream>
 #include <cmdparser/cmdparser.h>
+#include "common/tools_filesystem.h"
+namespace Filesystem = mstflint::common::filesystem;
 
 namespace mlxarchive
 {

--- a/mlxfwupdate/Makefile.am
+++ b/mlxfwupdate/Makefile.am
@@ -102,6 +102,7 @@ mstfwmanager_DEPENDENCIES = \
     $(top_builddir)/tools_layouts/libtools_layouts.la \
     $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
     $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la \
+    $(top_builddir)/common/libcommon.la \
     $(JSON_LIBS) \
     $(INIPARSER_LIBS) \
     $(MUPARSER_LIBS) \

--- a/mlxfwupdate/mlxfwmanager.cpp
+++ b/mlxfwupdate/mlxfwmanager.cpp
@@ -923,7 +923,8 @@ bool checkCmdParams(CmdLineParams& cmd_params, config_t& config)
     if (cmd_params.use_lookup_file)
     {
         cmd_params.lookup_file = adjustRelPath(cmd_params.lookup_file, config.adjuster_path);
-        if (!isFile(cmd_params.lookup_file))
+        Filesystem::path p(cmd_params.lookup_file);
+        if (!Filesystem::is_regular_file(p))
         {
             fprintf(stderr, "-E- Can't find file %s\n", cmd_params.lookup_file.c_str());
             return false;
@@ -931,7 +932,8 @@ bool checkCmdParams(CmdLineParams& cmd_params, config_t& config)
     }
     if (cmd_params.use_mfa_file)
     {
-        if (!isFile(adjustRelPath(cmd_params.mfa_file, config.adjuster_path)))
+        Filesystem::path p(adjustRelPath(cmd_params.mfa_file, config.adjuster_path));
+        if (!Filesystem::is_regular_file(p))
         {
             fprintf(stderr, "-E- Can't find file %s\n", cmd_params.mfa_file.c_str());
             return false;
@@ -940,7 +942,8 @@ bool checkCmdParams(CmdLineParams& cmd_params, config_t& config)
     if (cmd_params.onlineQueryPsids.length() || cmd_params.download || cmd_params.update_online)
     {
         cmd_params.certificate = adjustRelPath(cmd_params.certificate, config.adjuster_path);
-        if (!isFile(cmd_params.certificate))
+        Filesystem::path p(cmd_params.certificate);
+        if (!Filesystem::is_regular_file(p))
         {
             fprintf(stderr, "-E- Can't find Certificate %s\n", cmd_params.certificate.c_str());
             return false;
@@ -1601,7 +1604,7 @@ int getMFAListFromPSIDs(string mfa_path, vector<string>& psid_list, vector<PsidQ
                 errorMsg += imgacc.getlastWarning();
             }
         }
-        else if (isFile(mfa_path))
+        else if (Filesystem::is_regular_file(Filesystem::path(mfa_path)))
         {
             _FileOrDir = 2;
             rc = imgacc.queryPsid(mfa_path, psid_list[i], arch, 1, ri);
@@ -1812,7 +1815,8 @@ bool getIniParams(config_t& config)
     string file = config.exe_path;
     file += "/mlxfwmanager.ini";
 
-    if (!isFile(file))
+    Filesystem::path p(file);
+    if (!Filesystem::is_regular_file(p))
     { // If file does not exist then ignore
         return true;
     }

--- a/mlxfwupdate/mlxfwmanager.h
+++ b/mlxfwupdate/mlxfwmanager.h
@@ -59,6 +59,9 @@
 #include "mlxfwmanager_common.h"
 #include "menu.h"
 
+#include "common/tools_filesystem.h"
+namespace Filesystem = mstflint::common::filesystem;
+
 FILE* FLog = NULL;
 FILE* FOut = stdout;
 FILE* FErr = stderr;


### PR DESCRIPTION
…plementations

Description: After learning thst is_regular_file is another duplication of isFile function - I unified all implementations + calls to it so that now:
* in cpp file we call is_regular_file function implemented in user/common/tools_filesystem.cpp

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: ConnectX6DX
Tested flows: N/A

Known gaps (with RM ticket): N/A

Issue: 4093824
Change-Id: I1c86c319681105cefd6e658f0670a7a73efed66d