### PR TITLE
[ConnectX-8] External WP# for CX8

### DIFF
--- a/flint/subcommands.h
+++ b/flint/subcommands.h
@@ -586,6 +586,7 @@ class HwSubCommand : public SubCommand
 {
 private:
     FlintStatus printAttr(const ext_flash_attr_t& attr);
+    bool PrintWriteProtectedBits(const ext_flash_attr_t& attr);
 
 public:
     HwSubCommand();


### PR DESCRIPTION
Description:
* adding to flint -d <dev> hw query a "TBS, BP[3:0]" field that displays the bits as they exist in the register status

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: ConnectX6DX, ConnectX8
Tested flows:
* flint -d <dev> -ocr hw query

Known gaps (with RM ticket): no

Issue: 4174429
Change-Id: I84fa36d191284f223cff16f28219241327e38289