### PR TITLE
Set the correct address space in case of failure

### DIFF
--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -47,159 +47,160 @@ extern "C"
 #include <mtcr_ul/mtcr_ib.h>
 #endif
 
-#define SLV_ADDRS_NUM 128
+#define SLV_ADDRS_NUM                                 128
 #define INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE 0
-#define AUTHENTICATION_FAILURE 0xffa6
+#define AUTHENTICATION_FAILURE                        0xffa6
 
-    typedef enum mtcr_access_method
-    {
-        MTCR_ACCESS_ERROR = MST_ERROR,
-        MTCR_ACCESS_MEMORY = MST_PCI,
-        MTCR_ACCESS_CONFIG = MST_PCICONF,
-        MTCR_ACCESS_INBAND = MST_IB
-    } mtcr_access_method_t;
-    /*
-     * Read 4 bytes, return number of succ. read bytes or -1 on failure
-     */
-    int mread4(mfile* mf, unsigned int offset, u_int32_t* value);
+typedef enum mtcr_access_method {
+    MTCR_ACCESS_ERROR  = MST_ERROR,
+    MTCR_ACCESS_MEMORY = MST_PCI,
+    MTCR_ACCESS_CONFIG = MST_PCICONF,
+    MTCR_ACCESS_INBAND = MST_IB
+} mtcr_access_method_t;
+/*
+ * Read 4 bytes, return number of succ. read bytes or -1 on failure
+ */
+int mread4(mfile* mf, unsigned int offset, u_int32_t* value);
 
-    /*
-     * Write 4 bytes, return number of succ. written bytes or -1 on failure
-     */
-    int mwrite4(mfile* mf, unsigned int offset, u_int32_t value);
+/*
+ * Write 4 bytes, return number of succ. written bytes or -1 on failure
+ */
+int mwrite4(mfile* mf, unsigned int offset, u_int32_t value);
 
-    int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len);
-    int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len);
+int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len);
+int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len);
 
-    int msw_reset(mfile* mf);
-    int mhca_reset(mfile* mf);
+int msw_reset(mfile* mf);
+int mhca_reset(mfile* mf);
 
-    /*
-     * Get list of MST (Mellanox Software Tools) devices.
-     * Put all device names as null-terminated strings to buf.
-     *
-     * Return number of devices found or -1 if buf overflow
-     */
-    int mdevices(char* buf, int len, int mask);
+/*
+ * Get list of MST (Mellanox Software Tools) devices.
+ * Put all device names as null-terminated strings to buf.
+ *
+ * Return number of devices found or -1 if buf overflow
+ */
+int mdevices(char* buf, int len, int mask);
 
-    /*
-     * Get list of MST (Mellanox Software Tools) devices info records.
-     * Return a dynamic allocated array of dev_info records.
-     * len will be updated to hold the array length
-     *
-     */
-    dev_info* mdevices_info(int mask, int* len);
+/*
+ * Get list of MST (Mellanox Software Tools) devices info records.
+ * Return a dynamic allocated array of dev_info records.
+ * len will be updated to hold the array length
+ *
+ */
+dev_info* mdevices_info(int mask, int* len);
 
-    /*
-     *  * Get list of MST (Mellanox Software Tools) devices info records.
-     *  * Return a dynamic allocated array of dev_info records.
-     *  * len will be updated to hold the array length
-     *  * Verbosity will decide whether to get all the Physical functions or not.
-     */
+/*
+ *  * Get list of MST (Mellanox Software Tools) devices info records.
+ *  * Return a dynamic allocated array of dev_info records.
+ *  * len will be updated to hold the array length
+ *  * Verbosity will decide whether to get all the Physical functions or not.
+ */
 
-    dev_info* mdevices_info_v(int mask, int* len, int verbosity);
+dev_info* mdevices_info_v(int mask, int* len, int verbosity);
 
-    void mdevice_info_destroy(dev_info* dev_info, int len);
-    void mdevices_info_destroy(dev_info* dev_info, int len);
+void mdevice_info_destroy(dev_info* dev_info, int len);
+void mdevices_info_destroy(dev_info* dev_info, int len);
 
-    int mget_mdevs_type(mfile* mf, u_int32_t* mtype);
+int mget_mdevs_type(mfile* mf, u_int32_t* mtype);
 
-    /*
-     * Open Mellanox Software tools (mst) driver. Device type==INFINIHOST
-     * Return valid mfile ptr or 0 on failure
-     */
-    mfile* mopen(const char* name);
+/*
+ * Open Mellanox Software tools (mst) driver. Device type==INFINIHOST
+ * Return valid mfile ptr or 0 on failure
+ */
+mfile* mopen(const char* name);
 
-    mfile* mopend(const char* name, DType dtype);
+mfile* mopend(const char* name, DType dtype);
 
-    // mfile* mopen_fw_ctx(void *fw_cmd_context, void *fw_cmd_func, void *extra_data);
+/* mfile* mopen_fw_ctx(void *fw_cmd_context, void *fw_cmd_func, void *extra_data); */
 
-    mfile* mopen_adv(const char* name, MType mtype);
+mfile* mopen_adv(const char* name, MType mtype);
 
-    /*
-     * Close Mellanox driver
-     * req. descriptor
-     */
-    int mclose(mfile* mf);
+/*
+ * Close Mellanox driver
+ * req. descriptor
+ */
+int mclose(mfile* mf);
 
-    void get_pci_dev_rdma(mfile* mf, char* buf);
+void get_pci_dev_rdma(mfile* mf, char* buf);
 
-    unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave);
+unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave);
 
-    int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags);
+int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags);
 
-    int maccess_reg_mad(mfile* mf, u_int8_t* data);
+int maccess_reg_mad(mfile* mf, u_int8_t* data);
 
-    int mos_reg_access(mfile* mf, int reg_access, void* reg_data, u_int32_t cmd_type);
+int mos_reg_access(mfile* mf, int reg_access, void* reg_data, u_int32_t cmd_type);
 
-    int maccess_reg_cmdif(mfile* mf, reg_access_t reg_access, void* reg_data, u_int32_t cmd_type);
+int maccess_reg_cmdif(mfile* mf, reg_access_t reg_access, void* reg_data, u_int32_t cmd_type);
 
-    int maccess_reg(mfile* mf,
-                    u_int16_t reg_id,
-                    maccess_reg_method_t reg_method,
-                    void* reg_data,
-                    u_int32_t reg_size,
-                    u_int32_t r_size_reg, // used when sending via icmd interface (how much data should be read back to
-                                          // the user)
-                    u_int32_t w_size_reg, // used when sending via icmd interface (how much data should be written to
-                                          // the scratchpad) if you dont know what you are doing then r_size_reg =
-                                          // w_size_reg = your_register_size
-                    int* reg_status);
+int maccess_reg(mfile              * mf,
+                u_int16_t            reg_id,
+                maccess_reg_method_t reg_method,
+                void               * reg_data,
+                u_int32_t            reg_size,
+                u_int32_t            r_size_reg, /* used when sending via icmd interface (how much data should be read back to */
+                                                 /* the user) */
+                u_int32_t            w_size_reg, /* used when sending via icmd interface (how much data should be written to */
+                                                 /* the scratchpad) if you dont know what you are doing then r_size_reg = */
+                                                 /* w_size_reg = your_register_size */
+                int* reg_status);
 
-    int icmd_send_command(mfile* mf, int opcode, void* data, int data_size, int skip_write);
+int icmd_send_command(mfile* mf, int opcode, void* data, int data_size, int skip_write);
 
-    int icmd_clear_semaphore(mfile* mf);
+int icmd_clear_semaphore(mfile* mf);
 
-    int tools_cmdif_send_inline_cmd(mfile* mf,
-                                    u_int64_t in_param,
-                                    u_int64_t* out_param,
-                                    u_int32_t input_modifier,
-                                    u_int16_t opcode,
-                                    u_int8_t opcode_modifier);
+int tools_cmdif_send_inline_cmd(mfile    * mf,
+                                u_int64_t  in_param,
+                                u_int64_t* out_param,
+                                u_int32_t  input_modifier,
+                                u_int16_t  opcode,
+                                u_int8_t   opcode_modifier);
 
-    int tools_cmdif_send_mbox_command(mfile* mf,
-                                      u_int32_t input_modifier,
-                                      u_int16_t opcode,
-                                      u_int8_t opcode_modifier,
-                                      int data_offs_in_mbox,
-                                      void* data,
-                                      int data_size,
-                                      int skip_write);
+int tools_cmdif_send_mbox_command(mfile   * mf,
+                                  u_int32_t input_modifier,
+                                  u_int16_t opcode,
+                                  u_int8_t  opcode_modifier,
+                                  int       data_offs_in_mbox,
+                                  void    * data,
+                                  int       data_size,
+                                  int       skip_write);
 
-    int tools_cmdif_unlock_semaphore(mfile* mf);
+int tools_cmdif_unlock_semaphore(mfile* mf);
 
-    int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method);
-    int supports_reg_access_gmp(mfile* mf, maccess_reg_method_t reg_method);
+int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method);
+int supports_reg_access_gmp(mfile* mf, maccess_reg_method_t reg_method);
 
-    const char* m_err2str(MError status);
+const char* m_err2str(MError status);
 
-    int mread_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
-    int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
+int mread_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
+int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
 
-    int mget_vsec_supp(mfile* mf);
+int mget_vsec_supp(mfile* mf);
 
-    int mget_addr_space(mfile* mf);
-    int mset_addr_space(mfile* mf, int space);
+int mget_addr_space(mfile* mf);
+int mset_addr_space(mfile* mf, int space);
 
-    int mclear_pci_semaphore(const char* name);
+int mclear_pci_semaphore(const char* name);
 
-    int mvpd_read4(mfile* mf, unsigned int offset, u_int8_t value[4]);
+int mvpd_read4(mfile* mf, unsigned int offset, u_int8_t value[4]);
 
-    int mvpd_write4(mfile* mf, unsigned int offset, u_int8_t value[4]);
+int mvpd_write4(mfile* mf, unsigned int offset, u_int8_t value[4]);
 
-    MTCR_API int MWRITE4_SEMAPHORE(mfile* mf, int offset, int value);
+MTCR_API int MWRITE4_SEMAPHORE(mfile* mf, int offset, int value);
 
-    MTCR_API int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr);
+MTCR_API int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr);
 
-    void set_increase_poll_time(int new_value);
+void set_increase_poll_time(int new_value);
 
-    int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount);
+int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount);
 
-    int release_dma_pages(mfile* mf, int page_amount);
+int release_dma_pages(mfile* mf, int page_amount);
 
-    int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data);
+int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data);
 
-    int is_zombiefish_device(mfile* mf);
+int is_zombiefish_device(mfile* mf);
+
+void swap_pci_address_space(mfile* mf);
 
 #ifdef __cplusplus
 }
@@ -208,4 +209,4 @@ extern "C"
 #define DEV_MST_EXAMPLE1 "mlx4_0"
 #define DEV_MST_EXAMPLE2 "03:00.0"
 
-#endif
+#endif /* ifndef MTCR_H */

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -57,7 +57,7 @@ typedef __int8 int8_t;
 typedef __int16 int16_t;
 typedef __int32 int32_t;
 typedef __int64 int64_t;
-#endif // !_MSC_VER
+#endif /* !_MSC_VER */
 typedef unsigned __int8 u_int8_t;
 typedef unsigned __int16 u_int16_t;
 typedef unsigned __int32 u_int32_t;
@@ -89,17 +89,16 @@ typedef long long int64_t;
 
 #include <sys/types.h>
 #define MTCR_API
-#define LOCK_FILE_DIR "/tmp/mstflint_lockfiles"
-#define LOCK_FILE_FORMAT "/tmp/mstflint_lockfiles/%04x:%02x:%02x.%x_%s"
+#define LOCK_FILE_DIR                "/tmp/mstflint_lockfiles"
+#define LOCK_FILE_FORMAT             "/tmp/mstflint_lockfiles/%04x:%02x:%02x.%x_%s"
 #define LOCK_VIRTUAL_PCI_FILE_FORMAT "/tmp/mstflint_lockfiles/%s_%s"
-#define MAX_RETRY_CNT 4096
-#endif
+#define MAX_RETRY_CNT                4096
+#endif /* ifdef __WIN__ */
 
-#define DEV_NAME_SZ 512
-#define MAX_PAGES_SIZE 8
+#define DEV_NAME_SZ           512
+#define MAX_PAGES_SIZE        8
 #define SMP_SEMAPHOE_LOCK_CMD 0xff53
-#define ADDRESS_OUT_OF_RANGE 0x3 // syndrome_code value
-#define PXIR_SPACE_OFFSET 0x100
+#define ADDRESS_OUT_OF_RANGE  0x3 /* syndrome_code value */
 
 #define CX8_HW_ID 0x21e
 #define CX9_HW_ID 0x225
@@ -107,35 +106,32 @@ typedef long long int64_t;
 /*
  * MST <--> MTCR API defines
  */
-#define MST_HEADER_VERSION 1
-#define MST_META_DATA_MAJOR 1
-#define MST_META_DATA_MINOR 0
+#define MST_HEADER_VERSION              1
+#define MST_META_DATA_MAJOR             1
+#define MST_META_DATA_MINOR             0
 #define MTCR_SUPP_MST_API_MAJOR_VERSION 1
 
-// Service name.
+/* Service name. */
 #define MST_PREFIX_64_BIT "mst64_"
 #define MST_PREFIX_32_BIT "mst32_"
 #define MST_SUFFIX_MAXLEN 11
 #define MST_SERVICE_NAME_SIZE \
-    (sizeof(MST_PREFIX_64_BIT) + sizeof(MFT_VERSION_STR) + MST_SUFFIX_MAXLEN + 9) // 9 is just in case reserve
+    (sizeof(MST_PREFIX_64_BIT) + sizeof(MFT_VERSION_STR) + MST_SUFFIX_MAXLEN + 9) /* 9 is just in case reserve */
 
-//#ifndef USE_IB_MGT
-typedef struct mib_private_t
-{
+/*#ifndef USE_IB_MGT */
+typedef struct mib_private_t {
     int dummy;
 } MIB_Private;
-//#else
-//#include "mtcr_ib_private.h"
-//#endif
+/*#else */
+/*#include "mtcr_ib_private.h" */
+/*#endif */
 
-typedef enum
-{
+typedef enum {
     SEM_LOCK_GET = 0x0,
     SEM_LOCK_SET = 0x1
 } sem_lock_method_t;
 
-typedef enum MError
-{
+typedef enum MError {
     ME_OK = 0,
     ME_ERROR,
     ME_BAD_PARAMS,
@@ -160,8 +156,8 @@ typedef enum MError
     ME_UNSUPPORTED_ACCESS_TYPE,
     ME_GMP_MAD_UNSUPPORTED_OPERATION,
 
-    // errors regarding REG_ACCESS
-    ME_REG_ACCESS_OK = 0,
+    /* errors regarding REG_ACCESS */
+    ME_REG_ACCESS_OK             = 0,
     ME_REG_ACCESS_BAD_STATUS_ERR = 0x100,
     ME_REG_ACCESS_BAD_METHOD,
     ME_REG_ACCESS_NOT_SUPPORTED,
@@ -182,8 +178,8 @@ typedef enum MError
     ME_REG_ACCESS_ERASE_EXEEDED,
     ME_REG_ACCESS_INTERNAL_ERROR,
 
-    // errors regarding ICMD
-    ME_ICMD_STATUS_CR_FAIL = 0x200, // cr-space access failure
+    /* errors regarding ICMD */
+    ME_ICMD_STATUS_CR_FAIL = 0x200, /* cr-space access failure */
     ME_ICMD_INVALID_OPCODE,
     ME_ICMD_INVALID_CMD,
     ME_ICMD_OPERATIONAL_ERROR,
@@ -191,8 +187,8 @@ typedef enum MError
     ME_ICMD_BUSY,
     ME_ICMD_INIT_FAILED,
     ME_ICMD_NOT_SUPPORTED,
-    ME_ICMD_STATUS_SEMAPHORE_TO, // timed out while trying to take semaphore
-    ME_ICMD_STATUS_EXECUTE_TO,   // timed out while waiting for command to execute
+    ME_ICMD_STATUS_SEMAPHORE_TO, /* timed out while trying to take semaphore */
+    ME_ICMD_STATUS_EXECUTE_TO,   /* timed out while waiting for command to execute */
     ME_ICMD_STATUS_IFC_BUSY,
     ME_ICMD_STATUS_ICMD_NOT_READY,
     ME_ICMD_UNSUPPORTED_ICMD_VERSION,
@@ -201,7 +197,7 @@ typedef enum MError
     ME_ICMD_WRITE_PROTECT,
     ME_ICMD_SIZE_EXCEEDS_LIMIT,
 
-    // errors regarding Tools CMDIF
+    /* errors regarding Tools CMDIF */
     ME_CMDIF_BUSY = 0x300,
     ME_CMDIF_TOUT,
     ME_CMDIF_BAD_STATUS,
@@ -212,7 +208,7 @@ typedef enum MError
     ME_CMDIF_RES_STATE,
     ME_CMDIF_UNKN_STATUS,
 
-    // errors regarding MAD IF
+    /* errors regarding MAD IF */
     ME_MAD_BUSY = 0x400,
     ME_MAD_REDIRECT,
     ME_MAD_BAD_VER,
@@ -221,7 +217,7 @@ typedef enum MError
     ME_MAD_BAD_DATA,
     ME_MAD_GENERAL_ERR,
 
-    // errors regarding gearbox icmd new interface gateway
+    /* errors regarding gearbox icmd new interface gateway */
     ME_GB_ICMD_OK = 0x500,
     ME_GB_ICMD_FAILED,
     ME_GB_ICMD_FAILED_ACCESS,
@@ -233,44 +229,42 @@ typedef enum MError
     ME_LAST
 } MError;
 
-// typedefs for UEFI
+/* typedefs for UEFI */
 #ifdef UEFI_BUILD
 #include <mft_uefi_common.h>
 #endif
-typedef enum MType_t
-{
-    MST_ERROR = 0x0,
-    MST_FPGA = 0x1, // Unsupported
-    MST_MLNXOS = 0x2,
-    MST_LPC = 0x4,
-    MST_PCI = 0x8,
+typedef enum MType_t {
+    MST_ERROR   = 0x0,
+    MST_FPGA    = 0x1, /* Unsupported */
+    MST_MLNXOS  = 0x2,
+    MST_LPC     = 0x4,
+    MST_PCI     = 0x8,
     MST_PCICONF = 0x10,
     /*MST_CALBR,*/
-    MST_USB = 0x20,
-    MST_IB = 0x40,
+    MST_USB                  = 0x20,
+    MST_IB                   = 0x40,
     MST_FWCTL_CONTROL_DRIVER = 0x80,
-    MST_PPC = 0x100,
-    MST_USB_DIMAX = 0x200,
-    MST_FWCTX = 0x400,
-    MST_REMOTE = 0x800,
+    MST_PPC                  = 0x100,
+    MST_USB_DIMAX            = 0x200,
+    MST_FWCTX                = 0x400,
+    MST_REMOTE               = 0x800,
 #ifdef ENABLE_MST_DEV_I2C
     MST_DEV_I2C = 0x1000,
 #endif
-    MST_CALBR = 0x2000,
-    MST_FPGA_ICMD = 0x4000, // Unsupported
-    MST_CABLE = 0x8000,
-    MST_FPGA_DRIVER = 0x10000, // Unsupported
-    MST_SOFTWARE = 0x20000,
+    MST_CALBR       = 0x2000,
+    MST_FPGA_ICMD   = 0x4000, /* Unsupported */
+    MST_CABLE       = 0x8000,
+    MST_FPGA_DRIVER = 0x10000, /* Unsupported */
+    MST_SOFTWARE    = 0x20000,
     MST_DRIVER_CONF = 0x40000,
-    MST_DRIVER_CR = 0x80000,
-    MST_LINKX_CHIP = 0x100000,
+    MST_DRIVER_CR   = 0x80000,
+    MST_LINKX_CHIP  = 0x100000,
     MST_BAR0_GW_PCI = 0x200000,
-    MST_GEARBOX = 0x400000,
-    MST_DEFAULT = 0xffffffff & ~MST_CABLE & ~MST_FPGA & ~MST_FPGA_ICMD & ~MST_FPGA_DRIVER & ~MST_LINKX_CHIP
+    MST_GEARBOX     = 0x400000,
+    MST_DEFAULT     = 0xffffffff & ~MST_CABLE & ~MST_FPGA & ~MST_FPGA_ICMD & ~MST_FPGA_DRIVER & ~MST_LINKX_CHIP
 } MType;
 
-typedef enum DType_t
-{
+typedef enum DType_t {
     MST_GAMLA,
     MST_TAVOR,
     MST_DIMM,
@@ -278,227 +272,202 @@ typedef enum DType_t
 } DType;
 #define MST_ANAFA2 MST_TAVOR
 #define MST_EEPROM MST_GAMLA
-typedef enum Mdevs_t
-{
-    MDEVS_GAMLA = 0x01,         /*  Each device that actually is a Gamla */
-    MDEVS_I2CM = 0x02,          /*  Each device that can work as I2C master */
-    MDEVS_MEM = 0x04,           /*  Each device that is a memory driver (vtop) */
-    MDEVS_TAVOR_DDR = 0x08,     /*  Each device that maps to DDR */
-    MDEVS_TAVOR_UAR = 0x10,     /*  Each device that maps to UAR */
-    MDEVS_TAVOR_CR = 0x20,      /*  Each device that maps to CR */
-    MDEVS_REM = 0x80,           /*  Remote devices */
-    MDEVS_PPC = 0x100,          /*  PPC devices */
-    MDEVS_DEV_I2C = 0x200,      /* Generic linux kernel i2c device */
-    MDEVS_IB = 0x400,           /* Cr access over IB Mads */
-    MDEVS_MLNX_OS = 0x800,      /* access by CmdIf in MlnxOS */
-    MDEVS_FWCTX = 0x900,        /* access by func/context (like UEFI) */
-    MDEVS_LPC = 0x1000,         /* Access LPC region */
-    MDEVS_FPGA = 0x2000,        /* Access LPC region - DEPRECATED */
+typedef enum Mdevs_t {
+    MDEVS_GAMLA       = 0x01,   /*  Each device that actually is a Gamla */
+    MDEVS_I2CM        = 0x02,   /*  Each device that can work as I2C master */
+    MDEVS_MEM         = 0x04,   /*  Each device that is a memory driver (vtop) */
+    MDEVS_TAVOR_DDR   = 0x08,   /*  Each device that maps to DDR */
+    MDEVS_TAVOR_UAR   = 0x10,   /*  Each device that maps to UAR */
+    MDEVS_TAVOR_CR    = 0x20,   /*  Each device that maps to CR */
+    MDEVS_REM         = 0x80,   /*  Remote devices */
+    MDEVS_PPC         = 0x100,  /*  PPC devices */
+    MDEVS_DEV_I2C     = 0x200,  /* Generic linux kernel i2c device */
+    MDEVS_IB          = 0x400,  /* Cr access over IB Mads */
+    MDEVS_MLNX_OS     = 0x800,  /* access by CmdIf in MlnxOS */
+    MDEVS_FWCTX       = 0x900,  /* access by func/context (like UEFI) */
+    MDEVS_LPC         = 0x1000, /* Access LPC region */
+    MDEVS_FPGA        = 0x2000, /* Access LPC region - DEPRECATED */
     MDEVS_FPGA_NEWTON = 0x4000, /* Access LPC region - DEPRECATED */
-    MDEVS_CABLE = 0x8000,
-    MDEVS_SOFTWARE = 0x10000, /* Software system char dev */
-    MDEVS_LINKX_CHIP = 0x200000,
-    MDEVS_GBOX = 0x400000,
-    MDEVS_TAVOR = (MDEVS_TAVOR_DDR | MDEVS_TAVOR_UAR | MDEVS_TAVOR_CR),
-    MDEVS_ALL = 0xffffffff
+    MDEVS_CABLE       = 0x8000,
+    MDEVS_SOFTWARE    = 0x10000, /* Software system char dev */
+    MDEVS_LINKX_CHIP  = 0x200000,
+    MDEVS_GBOX        = 0x400000,
+    MDEVS_TAVOR       = (MDEVS_TAVOR_DDR | MDEVS_TAVOR_UAR | MDEVS_TAVOR_CR),
+    MDEVS_ALL         = 0xffffffff
 } Mdevs;
 
-typedef enum
-{
-    MACCESS_REG_METHOD_GET = 1,
-    MACCESS_REG_METHOD_SET = 2,
+typedef enum {
+    MACCESS_REG_METHOD_GET  = 1,
+    MACCESS_REG_METHOD_SET  = 2,
     MACCESS_LAST_REG_METHOD = 3
 } maccess_reg_method_t;
 
-typedef enum
-{
-    VCC_INITIALIZED = 0x0,
-    VCC_ICMD_EXT_SPACE_SUPPORTED = 0x1,
-    VCC_CRSPACE_SPACE_SUPPORTED = 0x2,
-    VCC_ICMD_SPACE_SUPPORTED = 0x3,
-    VCC_NODNIC_INIT_SEG_SPACE_SUPPORTED = 0x4,
-    VCC_EXPANSION_ROM_SPACE_SUPPORTED = 0x5,
-    VCC_ND_CRSPACE_SPACE_SUPPORTED = 0x6,
-    VCC_SCAN_CRSPACE_SPACE_SUPPORTED = 0x7,
-    VCC_SEMAPHORE_SPACE_SUPPORTED = 0x8,
-    VCC_MAC_SPACE_SUPPORTED = 0x9,
-    VCC_PCI_ICMD_SPACE_SUPPORTED = 0xa,
-    VCC_PCI_CRSPACE_SPACE_SUPPORTED = 0xb,
-    VCC_PCI_ALL_ICMD_SPACE_SUPPORTED = 0xc,
-    VCC_PCI_SCAN_CRSPACE_SPACE_SUPPORTED = 0xd,
+typedef enum {
+    VCC_INITIALIZED                          = 0x0,
+    VCC_ICMD_EXT_SPACE_SUPPORTED             = 0x1,
+    VCC_CRSPACE_SPACE_SUPPORTED              = 0x2,
+    VCC_ICMD_SPACE_SUPPORTED                 = 0x3,
+    VCC_NODNIC_INIT_SEG_SPACE_SUPPORTED      = 0x4,
+    VCC_EXPANSION_ROM_SPACE_SUPPORTED        = 0x5,
+    VCC_ND_CRSPACE_SPACE_SUPPORTED           = 0x6,
+    VCC_SCAN_CRSPACE_SPACE_SUPPORTED         = 0x7,
+    VCC_SEMAPHORE_SPACE_SUPPORTED            = 0x8,
+    VCC_MAC_SPACE_SUPPORTED                  = 0x9,
+    VCC_PCI_ICMD_SPACE_SUPPORTED             = 0xa,
+    VCC_PCI_CRSPACE_SPACE_SUPPORTED          = 0xb,
+    VCC_PCI_ALL_ICMD_SPACE_SUPPORTED         = 0xc,
+    VCC_PCI_SCAN_CRSPACE_SPACE_SUPPORTED     = 0xd,
     VCC_PCI_GLOBAL_SEMAPHORE_SPACE_SUPPORTED = 0xe,
-    VCC_RECOVERY_SPACE_SUPPORTED = 0xf
+    VCC_RECOVERY_SPACE_SUPPORTED             = 0xf
 } VSCCapCom;
 
-typedef enum
-{
-    AS_ICMD_EXT = 0x1,
-    AS_CR_SPACE = 0x2,
-    AS_ICMD = 0x3,
-    AS_NODNIC_INIT_SEG = 0x4,
-    AS_EXPANSION_ROM = 0x5,
-    AS_ND_CRSPACE = 0x6,
-    AS_SCAN_CRSPACE = 0x7,
-    AS_SEMAPHORE = 0xa,
-    AS_RECOVERY = 0Xc,
-    AS_MAC = 0xf,
-    AS_PCI_ICMD = 0x101,
-    AS_PCI_CRSPACE = 0x102,
-    AS_PCI_ALL_ICMD = 0x103,
-    AS_PCI_SCAN_CRSPACE = 0x107,
+typedef enum {
+    AS_ICMD_EXT             = 0x1,
+    AS_CR_SPACE             = 0x2,
+    AS_ICMD                 = 0x3,
+    AS_NODNIC_INIT_SEG      = 0x4,
+    AS_EXPANSION_ROM        = 0x5,
+    AS_ND_CRSPACE           = 0x6,
+    AS_SCAN_CRSPACE         = 0x7,
+    AS_SEMAPHORE            = 0xa,
+    AS_RECOVERY             = 0Xc,
+    AS_MAC                  = 0xf,
+    AS_PCI_ICMD             = 0x101,
+    AS_PCI_CRSPACE          = 0x102,
+    AS_PCI_ALL_ICMD         = 0x103,
+    AS_PCI_SCAN_CRSPACE     = 0x107,
     AS_PCI_GLOBAL_SEMAPHORE = 0x10a,
     AS_END
 } address_space_t;
 
-typedef struct vf_info_t
-{
-    char dev_name[512];
+typedef struct vf_info_t {
+    char      dev_name[512];
     u_int16_t domain;
-    u_int8_t bus;
-    u_int8_t dev;
-    u_int8_t func;
-    char** net_devs; // Null terminated array
-    char** ib_devs;  // Null terminated array
+    u_int8_t  bus;
+    u_int8_t  dev;
+    u_int8_t  func;
+    char   ** net_devs; /* Null terminated array */
+    char   ** ib_devs; /* Null terminated array */
 } vf_info;
 
-typedef struct dev_info_t
-{
+typedef struct dev_info_t {
     Mdevs type;
-    char dev_name[512];
-    int ul_mode;
+    char  dev_name[512];
+    int   ul_mode;
 
-    union
-    {
-        struct
-        {
+    union {
+        struct {
             u_int16_t domain;
-            u_int8_t bus;
-            u_int8_t dev;
-            u_int8_t func;
-
+            u_int8_t  bus;
+            u_int8_t  dev;
+            u_int8_t  func;
             u_int16_t dev_id;
             u_int16_t vend_id;
             u_int32_t class_id;
             u_int16_t subsys_id;
             u_int16_t subsys_vend_id;
-
-            char cr_dev[512];
-            char conf_dev[512];
-            char** net_devs;      // Null terminated array
-            char** ib_devs;       // Null terminated array
-            char numa_node[4096]; //
-            vf_info* virtfn_arr;
+            char      cr_dev[512];
+            char      conf_dev[512];
+            char   ** net_devs;   /* Null terminated array */
+            char   ** ib_devs;    /* Null terminated array */
+            char      numa_node[4096]; /* */
+            vf_info * virtfn_arr;
             u_int16_t virtfn_count;
         } pci;
 
-        struct
-        {
+        struct {
             u_int32_t mtusb_serial;
             u_int32_t TBD;
         } usb;
 
-        struct
-        {
+        struct {
             u_int32_t TBD;
         } ib;
 
-        struct
-        {
+        struct {
             char remote_device_name[512];
         } remote;
     };
 } dev_info;
 
-typedef enum
-{
+typedef enum {
     RA_MFPA = 0x9010,
     RA_MFBA = 0x9011,
     RA_MFBE = 0x9012,
 } reg_access_t;
 typedef struct dma_lib_hdl_t dma_lib_hdl;
 
-typedef enum
-{
-    GEARBPX_OVER_MTUSB = 1,
-    GEARBPX_OVER_I2C = 2,
-    GEARBPX_OVER_SWITCH = 3,
+typedef enum {
+    GEARBPX_OVER_MTUSB          = 1,
+    GEARBPX_OVER_I2C            = 2,
+    GEARBPX_OVER_SWITCH         = 3,
     GEARBPXO_UNKNOWN_CONNECTION = 0
 } gearbox_connection_t;
-typedef enum
-{
+typedef enum {
     MTCR_STATUS_UNKNOWN,
     MTCR_STATUS_TRUE,
     MTCR_STATUS_FALSE,
 } mtcr_status_e;
 
-typedef struct icmd_params_t
-{
-    int icmd_opened;
-    int took_semaphore;
-    int ctrl_addr;
-    int cmd_addr;
-    u_int32_t max_cmd_size;
-    int semaphore_addr;
-    int static_cfg_not_done_addr;
-    int static_cfg_not_done_offs;
-    u_int32_t lock_key;
-    int ib_semaphore_lock_supported;
-    u_int64_t dma_pa;
-    u_int32_t dma_size;
-    int dma_icmd;
+typedef struct icmd_params_t {
+    int           icmd_opened;
+    int           took_semaphore;
+    int           ctrl_addr;
+    int           cmd_addr;
+    u_int32_t     max_cmd_size;
+    int           semaphore_addr;
+    int           static_cfg_not_done_addr;
+    int           static_cfg_not_done_offs;
+    u_int32_t     lock_key;
+    int           ib_semaphore_lock_supported;
+    u_int64_t     dma_pa;
+    u_int32_t     dma_size;
+    int           dma_icmd;
     mtcr_status_e icmd_ready;
 } icmd_params;
 
-typedef struct ctx_params_t
-{
+typedef struct ctx_params_t {
     void* fw_cmd_context;
     void* fw_cmd_func;
     void* fw_cmd_dma;
 } ctx_params;
 
-typedef struct io_region_t
-{
+typedef struct io_region_t {
     unsigned int start;
     unsigned int end;
 } io_region;
 
-typedef struct tools_hcr_params_t
-{
-    int supp_cr_mbox; // 1: mbox supported , -1: mbox not supported
+typedef struct tools_hcr_params_t {
+    int supp_cr_mbox; /* 1: mbox supported , -1: mbox not supported */
 } tools_hcr_params;
 
-// max_reg_size depends on the desired method operated on the register.
-// max_reg_size[<method_enum_value>] will give the relevant max_reg_size.
-// For example max_reg_size[MACCESS_REG_METHOD_GET] will give max_reg_size for Get() method.
-typedef struct access_reg_params_t
-{
+/* max_reg_size depends on the desired method operated on the register. */
+/* max_reg_size[<method_enum_value>] will give the relevant max_reg_size. */
+/* For example max_reg_size[MACCESS_REG_METHOD_GET] will give max_reg_size for Get() method. */
+typedef struct access_reg_params_t {
     int max_reg_size[MACCESS_LAST_REG_METHOD];
 } access_reg_params;
 
 typedef struct mfile_t mfile;
 
-struct mtcr_page_addresses
-{
+struct mtcr_page_addresses {
     u_int64_t dma_address;
     u_int64_t virtual_address;
 };
 
-struct page_list
-{
-    // User space buffer page aligned.
+struct page_list {
+    /* User space buffer page aligned. */
     char* page_list;
-    int page_amount;
+    int   page_amount;
 };
 
-struct mtcr_page_info
-{
-    unsigned int page_amount;
-    unsigned long page_pointer_start;
+struct mtcr_page_info {
+    unsigned int               page_amount;
+    unsigned long              page_pointer_start;
     struct mtcr_page_addresses page_addresses_array[MAX_PAGES_SIZE];
 };
 
-struct mtcr_read_dword_from_config_space
-{
+struct mtcr_read_dword_from_config_space {
     unsigned int offset;
     unsigned int data;
 };
@@ -509,48 +478,45 @@ typedef void (*f_mpci_change)(mfile* mf);
 #define GEARBOX_SLAVE_ADDR 0x48
 #define GB_MNGR_SLAVE_ADDR 0x33
 
-typedef enum
-{
+typedef enum {
     GB_UNKNOWN = 0,
     GB_AMOS,
     GB_ABIR
 } gearbox_type;
 
-typedef struct gearbox_info_t
-{
-    gearbox_type gb_type;
-    u_int8_t is_gearbox;
-    u_int8_t is_gb_mngr;
-    int gearbox_index;
-    int ilne_card_id;
+typedef struct gearbox_info_t {
+    gearbox_type         gb_type;
+    u_int8_t             is_gearbox;
+    u_int8_t             is_gb_mngr;
+    int                  gearbox_index;
+    int                  ilne_card_id;
     gearbox_connection_t gb_conn_type;
-    char gb_mngr_full_name[DEV_NAME_SZ];
-    char gearbox_full_name[DEV_NAME_SZ];
-    unsigned char i2c_slave;
-    u_int8_t addr_width;
-    char device_orig_name[DEV_NAME_SZ];
-    char device_real_name[DEV_NAME_SZ];
-    u_int32_t data_req_addr;
-    u_int32_t data_res_addr;
+    char                 gb_mngr_full_name[DEV_NAME_SZ];
+    char                 gearbox_full_name[DEV_NAME_SZ];
+    unsigned char        i2c_slave;
+    u_int8_t             addr_width;
+    char                 device_orig_name[DEV_NAME_SZ];
+    char                 device_real_name[DEV_NAME_SZ];
+    u_int32_t            data_req_addr;
+    u_int32_t            data_res_addr;
 } gearbox_info;
 
-typedef struct cables_info_t
-{
+typedef struct cables_info_t {
     int slave_addr_additional_offset;
 } cables_info;
 
-#define VSEC_MIN_SUPPORT_UL(mf) \
-    (((mf)->vsec_cap_mask & (1 << VCC_INITIALIZED)) && \
-     ((mf)->vsec_cap_mask & (1 << VCC_CRSPACE_SPACE_SUPPORTED)) && \
+#define VSEC_MIN_SUPPORT_UL(mf)                                     \
+    (((mf)->vsec_cap_mask & (1 << VCC_INITIALIZED)) &&              \
+     ((mf)->vsec_cap_mask & (1 << VCC_CRSPACE_SPACE_SUPPORTED)) &&  \
      ((mf)->vsec_cap_mask & (1 << VCC_ICMD_EXT_SPACE_SUPPORTED)) && \
      ((mf)->vsec_cap_mask & (1 << VCC_SEMAPHORE_SPACE_SUPPORTED)))
 
 #define VSEC_PXIR_SUPPORT(mf) \
     (((mf)->device_hw_id == CX8_HW_ID) || ((mf)->device_hw_id == CX9_HW_ID))
 
-// Macro for VSEC_SUPPORTED_UL
+/* Macro for VSEC_SUPPORTED_UL */
 #define VSEC_SUPPORTED_UL(mf) \
     ((mf)->functional_vsec_supp && (VSEC_MIN_SUPPORT_UL(mf) || VSEC_PXIR_SUPPORT(mf)))
 
 
-#endif
+#endif /* ifndef _MTCR_COM_DEFS_H */

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -39,126 +39,124 @@
 #include <sys/pciio.h>
 #endif
 
-struct mft_core_wrapper
-{
+struct mft_core_wrapper {
     void* config_space_access;
     void* reg_access;
     void* reset_access;
 };
 
 #ifdef __FreeBSD__
-struct page_list_fbsd
-{
-    // User space buffer page aligned.
+struct page_list_fbsd {
+    /* User space buffer page aligned. */
     char* page_list[MAX_PAGES_SIZE];
-    int page_amount;
+    int   page_amount;
 };
 #endif
 
 /*  All fields in follow structure are not supposed to be used */
 /*  or modified by user programs. Except i2c_slave that may be */
 /*  modified before each access to target I2C slave address */
-struct mfile_t
-{
-    MType tp; /*  type of driver */
-    MType orig_tp;
-    MType res_tp;         /*  Will be used with HCR if need */
-    DType dtype;          /*  target device to access to */
-    DType itype;          /*  interface device to access via */
-    u_int32_t device_hw_id;
-    int is_i2cm;          /*  use device as I2C master */
-    int is_vm;            /*  if the machine is VM    */
-    int cr_access;        /* If cr access is allowed in MLNXOS devices */
-    cables_info ext_info; /*keeps info for calculate the correct slave address (0x50 + offset) */
+struct mfile_t {
+    MType         tp; /*  type of driver */
+    MType         orig_tp;
+    MType         res_tp; /*  Will be used with HCR if need */
+    DType         dtype;  /*  target device to access to */
+    DType         itype;  /*  interface device to access via */
+    u_int32_t     device_hw_id;
+    int           is_i2cm; /*  use device as I2C master */
+    int           is_vm;  /*  if the machine is VM    */
+    int           cr_access; /* If cr access is allowed in MLNXOS devices */
+    cables_info   ext_info; /*keeps info for calculate the correct slave address (0x50 + offset) */
     unsigned char i2c_slave;
-    int gpio_en;
-    io_region* iorw_regions; /* For LPC devices */
-    int regions_num;
-    char* dev_name;
-    int fd;
-    int res_fd;          /*  Will be used with HCR if need*/
-    int sock;            /*  in not -1 - remote interface */
-    int is_mtserver_req; // request came from mtServer - means came from remote client
-    void* bar_virtual_addr;
-    unsigned int map_size;
-    unsigned int bar0_gw_offset; // for MST_BAR0_GW_PCI devices, offset from BAR0 - gateway - for R/W operations
-    int file_lock_descriptor; // file descriptor to the lock file aka semaphore in order to protect parallel read/write
-                              // GW operations
+    int           gpio_en;
+    io_region   * iorw_regions; /* For LPC devices */
+    int           regions_num;
+    char        * dev_name;
+    int           fd;
+    int           res_fd; /*  Will be used with HCR if need*/
+    int           sock;  /*  in not -1 - remote interface */
+    int           is_mtserver_req; /* request came from mtServer - means came from remote client */
+    void        * bar_virtual_addr;
+    unsigned int  map_size;
+    unsigned int  bar0_gw_offset; /* for MST_BAR0_GW_PCI devices, offset from BAR0 - gateway - for R/W operations */
+    int           file_lock_descriptor; /* file descriptor to the lock file aka semaphore in order to protect parallel read/write */
+                                        /* GW operations */
     unsigned long long start_idx;
     /************************ FPGA DDR3 *********************************/
-    void* ddr3_ptr;
+    void             * ddr3_ptr;
     unsigned long long ddr3_start_idx;
-    unsigned int ddr3_map_size;
+    unsigned int       ddr3_map_size;
     /********************************************************************/
-    MIB_Private mib; /*  Data for IB interface (if relevant) */
-    void* ctx;
-    void* fallback_mf;
+    MIB_Private  mib; /*  Data for IB interface (if relevant) */
+    void       * ctx;
+    void       * fallback_mf;
     unsigned int i2c_RESERVED; /*  Reserved for internal usage (i2c internal) */
-    int i2c_smbus;
+    int          i2c_smbus;
     enum Mdevs_t flags;
-    u_int32_t connectx_wa_slot; /* apply connectx cr write workaround */
-    int connectx_wa_last_op_write;
-    u_int32_t connectx_wa_stat;
-    u_int64_t connectx_wa_max_retries;
-    u_int64_t connectx_wa_num_of_writes;
-    u_int64_t connectx_wa_num_of_retry_writes;
-    int server_ver_major;
-    int server_ver_minor;
+    u_int32_t    connectx_wa_slot; /* apply connectx cr write workaround */
+    int          connectx_wa_last_op_write;
+    u_int32_t    connectx_wa_stat;
+    u_int64_t    connectx_wa_max_retries;
+    u_int64_t    connectx_wa_num_of_writes;
+    u_int64_t    connectx_wa_num_of_retry_writes;
+    int          server_ver_major;
+    int          server_ver_minor;
     unsigned int proto_type;
-    dev_info* dinfo;
+    dev_info   * dinfo;
 
-    // for ICMD access
+    /* for ICMD access */
     icmd_params icmd;
-    // for UEFI
+    /* for UEFI */
     ctx_params context;
-    // for mst driver compatibility
-    int old_mst;
+    /* for mst driver compatibility */
+    int            old_mst;
     unsigned short mst_version_major;
-    unsigned int mst_version_minor;
-    int functional_vsec_supp;
-    u_int8_t vsec_type;
-    mtcr_status_e icmd_support;
-    unsigned int vsec_addr;
-    u_int32_t vsec_cap_mask;
-    int address_space;
-    int multifunction;
-    // for tools HCR access
+    unsigned int   mst_version_minor;
+    int            functional_vsec_supp;
+    u_int8_t       vsec_type;
+    mtcr_status_e  icmd_support;
+    unsigned int   vsec_addr;
+    u_int32_t      vsec_cap_mask;
+    int            address_space;
+    int            multifunction;
+    /* for tools HCR access */
     tools_hcr_params hcr_params;
-    // for sending access registers
+    /* for sending access registers */
     access_reg_params acc_reg_params;
-    // UL
+    /* UL */
     void* ul_ctx;
-    // Dynamic libs Ctx
+    /* Dynamic libs Ctx */
     void* dl_context;
-    // Cables CTX
-    int is_cable;
-    void* cable_ctx;
-    unsigned int linkx_chip_devid;
-    void* cable_chip_ctx; // TODO change the name
+    /* Cables CTX */
+    int           is_cable;
+    void        * cable_ctx;
+    unsigned int  linkx_chip_devid;
+    void        * cable_chip_ctx; /* TODO change the name */
     f_mpci_change mpci_change;
-    // Amos gear-box
+    /* Amos gear-box */
     gearbox_info gb_info;
 #ifdef __FreeBSD__
-    struct pcisel sel;
-    unsigned int vpd_cap_addr;
-    int wo_addr;
-    int connectx_flush;
-    int fdlock;
+    struct pcisel         sel;
+    unsigned int          vpd_cap_addr;
+    int                   wo_addr;
+    int                   connectx_flush;
+    int                   fdlock;
     struct page_list_fbsd user_page_list;
-    void* ptr;
+    void                * ptr;
 #else
     struct page_list user_page_list;
 #endif
 
-    // For dma purpose
+    /* For dma purpose */
     void* dma_props;
 
-    // MFT core wrapper objects.
+    /* MFT core wrapper objects. */
     struct mft_core_wrapper mft_core_object;
-    char* fwctl_env_var_debug;
-    int is_remote;
-    int is_zombiefish;
-    int vsc_recovery_space_flash_control_vld;
+    char                  * fwctl_env_var_debug;
+    int                     is_remote;
+    int                     is_zombiefish;
+    int                     vsc_recovery_space_flash_control_vld;
+    int                     pxir_vsec_supp;
 };
 
-#endif
+#endif /* ifndef __MTCR_MF__ */

--- a/mtcr_freebsd/Makefile.am
+++ b/mtcr_freebsd/Makefile.am
@@ -55,6 +55,8 @@ libmtcr_ul_la_SOURCES = \
     $(top_srcdir)/mtcr_ul/packets_common.h\
     $(top_srcdir)/mtcr_ul/packets_layout.c \
     $(top_srcdir)/mtcr_ul/packets_layout.h \
+    $(top_srcdir)/mtcr_ul/mtcr_common.h \
+    $(top_srcdir)/mtcr_ul/mtcr_common.c \
     mtcr_mf.h \
     mtcr_ul.c \
     mtcr_ul_com_defs.h

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -76,25 +76,24 @@
 #include <sys/file.h>
 
 #define MST_VPD_DFLT_TIMEOUT 2000
-#define PCI_VPD_ADDR 0x2
-#define PCI_CAP_ID_VPD 0x3
-#define PCI_VPD_DATA 0x4
-#define HW_ID_ADDR 0xf0014
+#define PCI_VPD_ADDR         0x2
+#define PCI_CAP_ID_VPD       0x3
+#define PCI_VPD_DATA         0x4
+#define HW_ID_ADDR           0xf0014
 
 /* Mellanox VSC */
 #define MLX_VSC_TYPE_OFFSET 24
-#define MLX_VSC_TYPE_LEN 8
-#define FUNCTIONAL_VSC 0
-#define RECOVERY_VSC 2
+#define MLX_VSC_TYPE_LEN    8
+#define FUNCTIONAL_VSC      0
+#define RECOVERY_VSC        2
 
 #define _PATH_DEVPCI "/dev/pci"
 
-typedef enum
-{
+typedef enum {
     Clear_Vsec_Semaphore = 0x1
 } adv_opt_t;
 
-#define FREEBSD_LOCK_FILE_DIR "/tmp/mft_lockfiles"
+#define FREEBSD_LOCK_FILE_DIR    "/tmp/mft_lockfiles"
 #define FREEBSD_LOCK_FILE_FORMAT "/tmp/mft_lockfiles/%s"
 
 #define CHECK_LOCK(rc) \
@@ -107,20 +106,16 @@ typedef enum
 static int _flock_int(int fdlock, int operation)
 {
     int cnt = 0;
-    if (fdlock == 0)
-    {
-        // in case we failed to create the lock file we ignore the locking mechanism
+
+    if (fdlock == 0) {
+        /* in case we failed to create the lock file we ignore the locking mechanism */
         return 0;
     }
-    do
-    {
-        if (flock(fdlock, operation | LOCK_NB) == 0)
-        {
+    do{
+        if (flock(fdlock, operation | LOCK_NB) == 0) {
             return 0;
-        }
-        else if (errno != EWOULDBLOCK)
-        {
-            break; // BAD! lock/free failed
+        } else if (errno != EWOULDBLOCK) {
+            break; /* BAD! lock/free failed */
         }
         mft_usleep(10);
         cnt++;
@@ -132,24 +127,21 @@ static int _flock_int(int fdlock, int operation)
 static int _create_lock(mfile* mf, char* devname)
 {
     char fname[64] = {0};
-    int rc;
-    int fd = 0;
+    int  rc;
+    int  fd = 0;
 
     snprintf(fname, sizeof(fname) - 1, FREEBSD_LOCK_FILE_FORMAT, devname);
     rc = mkdir("/tmp", 0777);
-    if (rc && errno != EEXIST)
-    {
+    if (rc && (errno != EEXIST)) {
         goto cl_clean_up;
     }
     rc = mkdir(FREEBSD_LOCK_FILE_DIR, 0777);
-    if (rc && errno != EEXIST)
-    {
+    if (rc && (errno != EEXIST)) {
         goto cl_clean_up;
     }
 
     fd = open(fname, O_RDONLY | O_CREAT, 0777);
-    if (fd < 0)
-    {
+    if (fd < 0) {
         goto cl_clean_up;
     }
 
@@ -165,20 +157,18 @@ cl_clean_up:
 void mtcr_connectx_flush(void* ptr, int fdlock)
 {
     u_int32_t value;
-    int rc = _flock_int(fdlock, LOCK_EX);
-    if (rc)
-    {
+    int       rc = _flock_int(fdlock, LOCK_EX);
+
+    if (rc) {
         return;
     }
     *((u_int32_t*)((char*)ptr + 0xf0380)) = 0x0;
-    do
-    {
-        asm volatile("" ::: "memory");
+    do{
+        asm volatile ("" ::: "memory");
         value = __be32_to_cpu(*((u_int32_t*)((char*)ptr + 0xf0380)));
     } while (value);
     rc = _flock_int(fdlock, LOCK_UN);
-    if (rc)
-    {
+    if (rc) {
         return;
     }
 }
@@ -191,35 +181,32 @@ int read_device_id(mfile* mf, u_int32_t* device_id)
 int mtcr_check_signature(mfile* mf)
 {
     unsigned signature;
-    int rc;
+    int      rc;
+
     rc = read_device_id(mf, &signature);
-    if (rc != 4)
-    {
-        if (!errno)
-        {
+    if (rc != 4) {
+        if (!errno) {
             errno = EIO;
         }
         return -1;
     }
 
-    switch (signature & 0xffff)
-    {
-        case 0x190: /* 400 */
-            if (signature == 0xa00190 && mf->ptr)
-            {
-                mf->connectx_flush = 1;
-                mtcr_connectx_flush(mf->ptr, mf->fdlock);
-            }
+    switch (signature & 0xffff) {
+    case 0x190:     /* 400 */
+        if ((signature == 0xa00190) && mf->ptr) {
+            mf->connectx_flush = 1;
+            mtcr_connectx_flush(mf->ptr, mf->fdlock);
+        }
 
-        case 0x5a44: /* 23108 */
-        case 0x6278: /* 25208 */
-        case 0x5e8c: /* 24204 */
-        case 0x6274: /* 25204 */
-            return 0;
+    case 0x5a44:     /* 23108 */
+    case 0x6278:     /* 25208 */
+    case 0x5e8c:     /* 24204 */
+    case 0x6274:     /* 25204 */
+        return 0;
 
-        default:
-            errno = ENOTTY;
-            return -1;
+    default:
+        errno = ENOTTY;
+        return -1;
     }
 }
 
@@ -271,98 +258,83 @@ int mtcr_check_signature(mfile* mf)
         }                                                         \
     } while (0)
 
-#define PCI_CONF_ADDR (0x00000058)
-#define PCI_CONF_DATA (0x0000005c)
+#define PCI_CONF_ADDR          (0x00000058)
+#define PCI_CONF_DATA          (0x0000005c)
 #define VENDOR_SPECIFIC_CAP_ID 0x9
 
 /* PCI address space related enum*/
-enum
-{
-    PCI_CAP_PTR = 0x34,
-    PCI_HDR_SIZE = 0x40,
+enum {
+    PCI_CAP_PTR        = 0x34,
+    PCI_HDR_SIZE       = 0x40,
     PCI_EXT_SPACE_ADDR = 0xff,
 
-    PCI_CTRL_OFFSET = 0x4, // for space / semaphore / auto-increment bit
-    PCI_COUNTER_OFFSET = 0x8,
+    PCI_CTRL_OFFSET      = 0x4, /* for space / semaphore / auto-increment bit */
+    PCI_COUNTER_OFFSET   = 0x8,
     PCI_SEMAPHORE_OFFSET = 0xc,
-    PCI_ADDR_OFFSET = 0x10,
-    PCI_DATA_OFFSET = 0x14,
+    PCI_ADDR_OFFSET      = 0x10,
+    PCI_DATA_OFFSET      = 0x14,
 
     PCI_FLAG_BIT_OFFS = 31,
 
     PCI_SPACE_BIT_OFFS = 0,
-    PCI_SPACE_BIT_LEN = 16,
+    PCI_SPACE_BIT_LEN  = 16,
 
     PCI_STATUS_BIT_OFFS = 29,
-    PCI_STATUS_BIT_LEN = 3,
+    PCI_STATUS_BIT_LEN  = 3,
 
-    PCI_SYNDROME_BIT_OFFSET = 30,
-    PCI_SYNDROME_BIT_LEN = 1,
+    PCI_SYNDROME_BIT_OFFSET      = 30,
+    PCI_SYNDROME_BIT_LEN         = 1,
     PCI_SYNDROME_CODE_BIT_OFFSET = 24,
-    PCI_SYNDROME_CODE_BIT_LEN = 4,
+    PCI_SYNDROME_CODE_BIT_LEN    = 4,
 
     PCI_HEADER_OFFS = 0x0,
     PCI_SUBSYS_OFFS = 0x2c,
-    PCI_CLASS_OFFS = 0x8,
+    PCI_CLASS_OFFS  = 0x8,
 };
 
 /* Mellanox vendor specific enum */
-enum
-{
-    CAP_ID = 0x9,
+enum {
+    CAP_ID          = 0x9,
     IFC_MAX_RETRIES = 0x10000,
     SEM_MAX_RETRIES = 0x1000
 };
 
 /* PCI operation enum(read or write)*/
-enum
-{
-    READ_OP = 0,
+enum {
+    READ_OP  = 0,
     WRITE_OP = 1,
 };
 
 int read_config(mfile* mf, unsigned int reg, uint32_t* data, int width)
 {
     struct pci_io pi = {};
+
     pi.pi_sel = mf->sel;
     pi.pi_reg = reg;
     pi.pi_width = width;
 
-    if (ioctl(mf->fd, PCIOCREAD, &pi) < 0)
-    {
-        // printf("PCIOCREAD ioctl failed when trying to access this space: %d. errno: %d\n",
-        //             mf->address_space, errno);
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
-
-            if (ioctl(mf->fd, PCIOCREAD, &pi) < 0)
-            {
+    if (ioctl(mf->fd, PCIOCREAD, &pi) < 0) {
+        /* printf("PCIOCREAD ioctl failed when trying to access this space: %d. errno: %d\n", */
+        /*             mf->address_space, errno); */
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
+            if (ioctl(mf->fd, PCIOCREAD, &pi) < 0) {
                 errno = EIO;
-                // printf(
-                //     "PCIOCREAD ioctl failed when trying to access this space: %d. errno: %d\n",
-                //     mf->address_space, errno);
+                /* printf( */
+                /*     "PCIOCREAD ioctl failed when trying to access this space: %d. errno: %d\n", */
+                /*     mf->address_space, errno); */
                 return -1;
             }
-            // printf("PCIOCREAD ioctl successfully accessed this space: %d\n",
-            //             mf->address_space);
-        }
-        else
-        {
+            /* printf("PCIOCREAD ioctl successfully accessed this space: %d\n", */
+            /*             mf->address_space); */
+        } else {
             errno = EIO;
             return -1;
         }
     }
 
-    // printf("%s:  dev:%d reg=%x width=%d data=%x\n", __FUNCTION__, pi.pi_sel.pc_dev, reg, width, pi.pi_data);
+    /* printf("%s:  dev:%d reg=%x width=%d data=%x\n", __FUNCTION__, pi.pi_sel.pc_dev, reg, width, pi.pi_data); */
     *data = (pi.pi_data);
 
     return 0;
@@ -371,42 +343,30 @@ int read_config(mfile* mf, unsigned int reg, uint32_t* data, int width)
 int write_config(mfile* mf, unsigned int reg, uint32_t data, int width)
 {
     struct pci_io pi = {};
+
     pi.pi_sel = mf->sel;
     pi.pi_reg = reg;
     pi.pi_width = width;
     pi.pi_data = data;
 
-    // printf("%s: dev:%d reg:%x width:%d data:%x\n", __FUNCTION__, pi.pi_sel.pc_dev, pi.pi_reg, pi.pi_width,
-    // pi.pi_data);
-    if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0)
-    {
-        // printf("PCIOCWRITE ioctl failed when trying to access this space: %d. errno: %d\n",
-        //             mf->address_space, errno);
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
-
-            if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0)
-            {
+    /* printf("%s: dev:%d reg:%x width:%d data:%x\n", __FUNCTION__, pi.pi_sel.pc_dev, pi.pi_reg, pi.pi_width, */
+    /* pi.pi_data); */
+    if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0) {
+        /* printf("PCIOCWRITE ioctl failed when trying to access this space: %d. errno: %d\n", */
+        /*             mf->address_space, errno); */
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
+            if (ioctl(mf->fd, PCIOCWRITE, &pi) < 0) {
                 errno = EIO;
                 printf(
                     "PCIOCWRITE ioctl failed when trying to access this space: %d. errno: %d\n",
                     mf->address_space, errno);
                 return -1;
             }
-            // printf("PCIOCWRITE ioctl successfully accessed this space: %d\n",
-            //             mf->address_space);
-        }
-        else
-        {
+            /* printf("PCIOCWRITE ioctl successfully accessed this space: %d\n", */
+            /*             mf->address_space); */
+        } else {
             errno = EIO;
             return -1;
         }
@@ -421,34 +381,31 @@ int write_config(mfile* mf, unsigned int reg, uint32_t data, int width)
 
 static int is_wo_pciconf_gw(mfile* mf)
 {
-    unsigned offset = HW_ID_ADDR;
+    unsigned  offset = HW_ID_ADDR;
     u_int32_t data = 0;
-    int lock_rc;
+    int       lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     int rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-    if (rc < 0)
-    {
+
+    if (rc < 0) {
         goto cleanup;
     }
     rc = read_config(mf, PCI_CONF_ADDR, &data, 4);
-    if (rc < 0)
-    {
+    if (rc < 0) {
         rc = 0;
         goto cleanup;
     }
-    // printf("-D- Data: %#x\n", data);
-    if (data == WO_REG_ADDR_DATA)
-    {
+    /* printf("-D- Data: %#x\n", data); */
+    if (data == WO_REG_ADDR_DATA) {
         rc = 1;
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return rc;
     }
     return rc;
@@ -463,60 +420,52 @@ cleanup:
 /* Read Write new functions (4Bytes, Block)*/
 int pci_find_capability(mfile* mf, int cap_id)
 {
-    unsigned offset;
+    unsigned      offset;
     unsigned char visited[256] = {0}; /* Prevent infinite loops */
-    uint32_t reg;
-    int ret;
-    int curr_cap;
+    uint32_t      reg;
+    int           ret;
+    int           curr_cap;
+    int           lock_rc;
 
-    int lock_rc;
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     ret = read_config(mf, PCI_CAP_PTR, &reg, 4);
 
-    if (ret)
-    {
+    if (ret) {
         ret = 0;
         goto cleanup;
     }
 
     offset = ((unsigned char*)&reg)[0];
-    while (1)
-    {
-        if (offset < PCI_HDR_SIZE || offset > PCI_EXT_SPACE_ADDR)
-        {
+    while (1) {
+        if ((offset < PCI_HDR_SIZE) || (offset > PCI_EXT_SPACE_ADDR)) {
             ret = 0;
             goto cleanup;
         }
         ret = read_config(mf, offset, &reg, 4);
-        if (ret)
-        {
+        if (ret) {
             ret = 0;
             goto cleanup;
         }
 
         visited[offset] = 1;
         curr_cap = ((unsigned char*)&reg)[0];
-        if (curr_cap == cap_id)
-        {
+        if (curr_cap == cap_id) {
             ret = offset;
             goto cleanup;
         }
 
         offset = ((unsigned char*)&reg)[1];
-        if (visited[offset])
-        {
+        if (visited[offset]) {
             ret = 0;
             goto cleanup;
         }
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return ret;
     }
     return ret;
@@ -526,35 +475,30 @@ static int _vendor_specific_sem(mfile* mf, int state)
 {
     uint32_t lock_val;
     uint32_t counter = 0;
-    int retries = 0;
-    if (!state)
-    {
-        // unlock
+    int      retries = 0;
+
+    if (!state) {
+        /* unlock */
         WRITE4_PCI(mf, 0, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "unlock semaphore", return -1);
-    }
-    else
-    {
-        // lock
-        do
-        {
-            if (retries > SEM_MAX_RETRIES)
-            {
+    } else {
+        /* lock */
+        do{
+            if (retries > SEM_MAX_RETRIES) {
                 return -1;
             }
-            // read semaphore untill 0x0
+            /* read semaphore untill 0x0 */
             READ4_PCI(mf, &lock_val, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "read counter", return -1);
-            if (lock_val)
-            {
-                // semaphore is taken
+            if (lock_val) {
+                /* semaphore is taken */
                 retries++;
-                msleep(1); // wait for current op to end
+                msleep(1); /* wait for current op to end */
                 continue;
             }
-            // read ticket
+            /* read ticket */
             READ4_PCI(mf, &counter, mf->vsec_addr + PCI_COUNTER_OFFSET, "read counter", return -1);
-            // write ticket to semaphore dword
+            /* write ticket to semaphore dword */
             WRITE4_PCI(mf, counter, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "write counter to semaphore", return -1);
-            // read back semaphore make sure ticket == semaphore else repeat
+            /* read back semaphore make sure ticket == semaphore else repeat */
             READ4_PCI(mf, &lock_val, mf->vsec_addr + PCI_SEMAPHORE_OFFSET, "read counter", return -1);
             retries++;
         } while (counter != lock_val);
@@ -564,12 +508,11 @@ static int _vendor_specific_sem(mfile* mf, int state)
 
 static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 {
-    int retries = 0;
+    int      retries = 0;
     uint32_t flag;
-    do
-    {
-        if (retries > IFC_MAX_RETRIES)
-        {
+
+    do{
+        if (retries > IFC_MAX_RETRIES) {
             return -1;
         }
 
@@ -577,10 +520,9 @@ static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 
         flag = EXTRACT(flag, PCI_FLAG_BIT_OFFS, 1);
         retries++;
-        if ((retries & 0xf) == 0)
-        {
-            // dont sleep always
-            // usleep_range(1,5);
+        if ((retries & 0xf) == 0) {
+            /* dont sleep always */
+            /* usleep_range(1,5); */
         }
     } while (flag != expected_val);
     return 0;
@@ -588,16 +530,15 @@ static int _wait_on_flag(mfile* mf, u_int8_t expected_val)
 
 int check_syndrome(mfile* mf)
 {
-    // in case syndrome is set, if syndrome_code is 0x3 (address_out_of_range), return error, so that the ioctl will
-    // fail and then we'll retry with PCI space.
+    /* in case syndrome is set, if syndrome_code is 0x3 (address_out_of_range), return error, so that the ioctl will */
+    /* fail and then we'll retry with PCI space. */
     uint32_t syndrome = 0;
+
     READ4_PCI(mf, &syndrome, mf->vsec_addr + PCI_ADDR_OFFSET, "read domain", return -1);
-    if (syndrome)
-    {
+    if (syndrome) {
         uint32_t syndrome_code = 0;
         READ4_PCI(mf, &syndrome_code, mf->vsec_addr + PCI_CTRL_OFFSET, "read domain", return -1);
-        if (EXTRACT(syndrome_code, PCI_SYNDROME_CODE_BIT_OFFSET, PCI_SYNDROME_CODE_BIT_LEN) == ADDRESS_OUT_OF_RANGE)
-        {
+        if (EXTRACT(syndrome_code, PCI_SYNDROME_CODE_BIT_OFFSET, PCI_SYNDROME_CODE_BIT_LEN) == ADDRESS_OUT_OF_RANGE) {
             return ME_ADDRESS_OUT_OF_RANGE;
         }
     }
@@ -606,34 +547,34 @@ int check_syndrome(mfile* mf)
 
 static int _set_addr_space(mfile* mf, u_int16_t space)
 {
-    // read modify write
+    /* read modify write */
     uint32_t val;
+
     READ4_PCI(mf, &val, mf->vsec_addr + PCI_CTRL_OFFSET, "read domain", return -1);
     val = MERGE(val, space, PCI_SPACE_BIT_OFFS, PCI_SPACE_BIT_LEN);
     WRITE4_PCI(mf, val, mf->vsec_addr + PCI_CTRL_OFFSET, "write domain", return -1);
 
     /* Check if we succedded to write the space (i.e. that its MSB is not ignored by FW) */
     u_int32_t read_val = 0;
+
     READ4_PCI(mf, &read_val, mf->vsec_addr + PCI_CTRL_OFFSET, "read status", return -1);
 
-    // Extract only the first 16 bits, as we need to check what's written in "space"
+    /* Extract only the first 16 bits, as we need to check what's written in "space" */
     unsigned int mask = 0xFFFF;
     unsigned int expected_value = val & mask;
     unsigned int actual_value = read_val & mask;
 
     /* Check if the space written is indeed the space we attempted to write */
-    if (actual_value != expected_value)
-    {
-        // printf("actual_space_value != expected_space_value. expected_space_value: 0x%x actual_space_value: 0x%x. Meaning space: 0x%x is not supported.\n",
-        //   expected_value,
-        //   actual_value,
-        //   expected_value);
+    if (actual_value != expected_value) {
+        /* printf("actual_space_value != expected_space_value. expected_space_value: 0x%x actual_space_value: 0x%x. Meaning space: 0x%x is not supported.\n", */
+        /*   expected_value, */
+        /*   actual_value, */
+        /*   expected_value); */
         return ME_PCI_SPACE_NOT_SUPPORTED;
     }
 
-    // read status and make sure space is supported
-    if (EXTRACT(read_val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0) // Check if the address space is supported by FW
-    {
+    /* read status and make sure space is supported */
+    if (EXTRACT(read_val, PCI_STATUS_BIT_OFFS, PCI_STATUS_BIT_LEN) == 0) { /* Check if the address space is supported by FW */
         return -1;
     }
     return 0;
@@ -641,36 +582,31 @@ static int _set_addr_space(mfile* mf, u_int16_t space)
 
 static int _pciconf_rw(mfile* mf, unsigned int offset, uint32_t* data, int rw)
 {
-    int ret = 0;
+    int      ret = 0;
     uint32_t address = offset;
 
-    // last 2 bits must be zero as we only allow 30 bits addresses
-    if (EXTRACT(address, 30, 2))
-    {
+    /* last 2 bits must be zero as we only allow 30 bits addresses */
+    if (EXTRACT(address, 30, 2)) {
         return -1;
     }
 
     address = MERGE(address, (rw ? 1 : 0), PCI_FLAG_BIT_OFFS, 1);
-    if (rw == WRITE_OP)
-    {
-        // write data
+    if (rw == WRITE_OP) {
+        /* write data */
         WRITE4_PCI(mf, *data, mf->vsec_addr + PCI_DATA_OFFSET, "write value", return -1);
-        // write address
+        /* write address */
         WRITE4_PCI(mf, address, mf->vsec_addr + PCI_ADDR_OFFSET, "write offset", return -1);
-        // wait on flag
+        /* wait on flag */
         ret = _wait_on_flag(mf, 0);
-    }
-    else
-    {
-        // write address
+    } else {
+        /* write address */
         WRITE4_PCI(mf, address, mf->vsec_addr + PCI_ADDR_OFFSET, "write offset", return -1);
-        // wait on flag
+        /* wait on flag */
         ret = _wait_on_flag(mf, 1);
-        // read data
+        /* read data */
         READ4_PCI(mf, data, mf->vsec_addr + PCI_DATA_OFFSET, "read value", return -1);
     }
-    if (VSEC_PXIR_SUPPORT(mf))
-    {
+    if (VSEC_PXIR_SUPPORT(mf)) {
         ret = check_syndrome(mf);
     }
     return ret;
@@ -680,24 +616,22 @@ static int _send_pci_cmd_int(mfile* mf, int space, unsigned int offset, uint32_t
 {
     int ret = 0;
 
-    // take semaphore
+    /* take semaphore */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
-        // printf("-D- Failed to take Semaphore!\n");
+    if (ret) {
+        /* printf("-D- Failed to take Semaphore!\n"); */
         return ret;
     }
-    // set address space
+    /* set address space */
     ret = _set_addr_space(mf, space);
-    if (ret)
-    {
-        // printf("-D- Failed to set space!\n");
+    if (ret) {
+        /* printf("-D- Failed to set space!\n"); */
         goto cleanup;
     }
-    // read/write the data
+    /* read/write the data */
     ret = _pciconf_rw(mf, offset, data, rw);
 cleanup:
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
     return ret;
 }
@@ -707,27 +641,23 @@ static int _block_op(mfile* mf, int space, unsigned int offset, int size, uint32
     int i;
     int ret = 0;
     int wrote_or_read = size;
-    if (size % 4)
-    {
+
+    if (size % 4) {
         return -1;
     }
-    // lock semaphore and set address space
+    /* lock semaphore and set address space */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
-    // set address space
+    /* set address space */
     ret = _set_addr_space(mf, space);
-    if (ret)
-    {
+    if (ret) {
         wrote_or_read = -1;
         goto cleanup;
     }
-    for (i = 0; i < size; i += 4)
-    {
-        if (_pciconf_rw(mf, offset + i, &(data[(i >> 2)]), rw))
-        {
+    for (i = 0; i < size; i += 4) {
+        if (_pciconf_rw(mf, offset + i, &(data[(i >> 2)]), rw)) {
             wrote_or_read = i;
             goto cleanup;
         }
@@ -742,8 +672,7 @@ static int mwrite4_new(mfile* mf, unsigned int offset, uint32_t data)
     int ret;
 
     ret = _send_pci_cmd_int(mf, mf->address_space, offset, &data, WRITE_OP);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
     return 4;
@@ -754,8 +683,7 @@ static int mread4_new(mfile* mf, unsigned int offset, uint32_t* data)
     int ret;
 
     ret = _send_pci_cmd_int(mf, mf->address_space, offset, data, READ_OP);
-    if (ret)
-    {
+    if (ret) {
         return -1;
     }
     return 4;
@@ -764,67 +692,52 @@ static int mread4_new(mfile* mf, unsigned int offset, uint32_t* data)
 static int mwrite4_block_new(mfile* mf, unsigned int offset, int size, uint32_t* data)
 {
     int rc = _block_op(mf, mf->address_space, offset, size, data, WRITE_OP);
-    if (rc == -1)
-    {
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
+
+    if (rc == -1) {
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
             rc = _block_op(mf, mf->address_space, offset, size, data, WRITE_OP);
-            // printf(
-            //   "Entered VSC pci space support flow. PCI address_space now set to: %d. second attempt to run _block_op with VSC PCI address space returned with rc: %d.\n",
-            //   mf->address_space,
-            //   rc);
+            /* printf( */
+            /*   "Entered VSC pci space support flow. PCI address_space now set to: %d. second attempt to run _block_op with VSC PCI address space returned with rc: %d.\n", */
+            /*   mf->address_space, */
+            /*   rc); */
         }
     }
-    return rc;}
+    return rc;
+}
 
 static int mread4_block_new(mfile* mf, unsigned int offset, int size, uint32_t* data)
 {
     int rc = _block_op(mf, mf->address_space, offset, size, data, READ_OP);
-    if (rc == -1)
-    {
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
+
+    if (rc == -1) {
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
             rc = _block_op(mf, mf->address_space, offset, size, data, READ_OP);
-            // printf(
-            //   "Entered VSC pci space support flow. PCI address_space now set to: %d. second attempt to run _block_op with VSC PCI address space returned with rc: %d.\n",
-            //   mf->address_space,
-            //   rc);
+            /* printf( */
+            /*   "Entered VSC pci space support flow. PCI address_space now set to: %d. second attempt to run _block_op with VSC PCI address space returned with rc: %d.\n", */
+            /*   mf->address_space, */
+            /*   rc); */
         }
     }
-    return rc;}
+    return rc;
+}
 
 static int vsec_spaces_supported(mfile* mf)
 {
-    // take semaphore
+    /* take semaphore */
     int supported = 1;
     int ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+
+    if (ret) {
         return supported;
     }
-    if (_set_addr_space(mf, AS_CR_SPACE) || _set_addr_space(mf, AS_ICMD) || _set_addr_space(mf, AS_SEMAPHORE))
-    {
+    if (_set_addr_space(mf, AS_CR_SPACE) || _set_addr_space(mf, AS_ICMD) || _set_addr_space(mf, AS_SEMAPHORE)) {
         supported = 0;
     }
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
     return supported;
 }
@@ -843,56 +756,45 @@ int device_exists(const char* devname);
 #if __FreeBSD_version > 700000
 int getsel(const char* str, struct pcisel* selout)
 {
-    char* ep = strchr(str, '@');
-    char* epbase;
+    char        * ep = strchr(str, '@');
+    char        * epbase;
     struct pcisel sel;
     unsigned long selarr[4];
-    int i;
-    // printf("__FreeBSD_version > 700000 detected.\n");
+    int           i;
 
-    if (ep == NULL)
-    {
+    /* printf("__FreeBSD_version > 700000 detected.\n"); */
+
+    if (ep == NULL) {
         ep = (char*)str;
-    }
-    else
-    {
+    } else {
         ep++;
     }
 
     epbase = ep;
 
-    if (strncmp(ep, "pci", 3) == 0)
-    {
+    if (strncmp(ep, "pci", 3) == 0) {
         ep += 3;
         i = 0;
-        do
-        {
+        do{
             selarr[i++] = strtoul(ep, &ep, 10);
         } while ((*ep == ':' || *ep == '.') && *++ep != '\0' && i < 4);
 
-        if (i > 2)
-        {
+        if (i > 2) {
             sel.pc_func = selarr[--i];
-        }
-        else
-        {
+        } else {
             sel.pc_func = 0;
         }
         sel.pc_dev = selarr[--i];
         sel.pc_bus = selarr[--i];
-        if (i > 0)
-        {
+        if (i > 0) {
             sel.pc_domain = selarr[--i];
-        }
-        else
-        {
+        } else {
             sel.pc_domain = 0;
         }
     }
-    if (*ep != '\x0' || ep == epbase)
-    {
+    if ((*ep != '\x0') || (ep == epbase)) {
         return 1;
-        // errx(1, "cannot parse selector %s ep:'%s' epbase:%s, %d", str, ep, epbase, *ep);
+        /* errx(1, "cannot parse selector %s ep:'%s' epbase:%s, %d", str, ep, epbase, *ep); */
     }
 
     *selout = sel;
@@ -902,80 +804,69 @@ int getsel(const char* str, struct pcisel* selout)
 #else
 int getsel(const char* str, struct pcisel* selout)
 {
-    char* ep = strchr(str, '@');
-    char* epbase;
+    char        * ep = strchr(str, '@');
+    char        * epbase;
     struct pcisel sel;
 
-    // printf("__FreeBSD_version < 700000 detected: %d\n", __FreeBSD_version);
+    /* printf("__FreeBSD_version < 700000 detected: %d\n", __FreeBSD_version); */
 
-    if (ep == NULL)
-    {
+    if (ep == NULL) {
         ep = (char*)str;
-    }
-    else
-    {
+    } else {
         ep++;
     }
 
     epbase = ep;
 
-    if (strncmp(ep, "pci", 3) == 0)
-    {
+    if (strncmp(ep, "pci", 3) == 0) {
         ep += 3;
         sel.pc_bus = strtoul(ep, &ep, 0);
-        if (!ep || *ep++ != ':')
-        {
+        if (!ep || (*ep++ != ':')) {
             errno = EINVAL;
             return 1;
-            // errx(1, "cannot parse selector %s", str);
+            /* errx(1, "cannot parse selector %s", str); */
         }
         sel.pc_dev = strtoul(ep, &ep, 0);
-        if (!ep || *ep != ':')
-        {
+        if (!ep || (*ep != ':')) {
             sel.pc_func = 0;
-        }
-        else
-        {
+        } else {
             ep++;
             sel.pc_func = strtoul(ep, &ep, 0);
         }
-        if (*ep == ':')
-        {
+        if (*ep == ':') {
             ep++;
         }
     }
-    if (*ep != '\x0' || ep == epbase)
-    {
+    if ((*ep != '\x0') || (ep == epbase)) {
         return 1;
-        // errx(1, "cannot parse selector %s", str);
+        /* errx(1, "cannot parse selector %s", str); */
     }
 
     *selout = sel;
 
     return 0;
 }
-#endif
+#endif /* if __FreeBSD_version > 700000 */
 
 int mtcr_open_config(mfile* mf, const char* name)
 {
-    // printf("open_config %s %s mf:%p\n", name, _PATH_DEVPCI, mf);
+    /* printf("open_config %s %s mf:%p\n", name, _PATH_DEVPCI, mf); */
 
-    if (!mf)
-    {
+    if (!mf) {
         printf("Internal: Uninitialized mfile\n");
         exit(1);
     }
 
     mf->fd = open(_PATH_DEVPCI, O_RDWR, 0);
-    if (mf->fd < 0)
-    {
+    if (mf->fd < 0) {
         printf("err opening: %s", _PATH_DEVPCI);
         return -1;
     }
 
-    // printf("open_config name:%s fd:%d\n", name, mf->fd);
+    /* printf("open_config name:%s fd:%d\n", name, mf->fd); */
     int ret = getsel(name, &mf->sel);
-    // printf("open_config getsel done %d\n", mf->sel.pc_dev);
+
+    /* printf("open_config getsel done %d\n", mf->sel.pc_dev); */
     mf->tp = MST_PCICONF;
 
     return ret;
@@ -984,99 +875,86 @@ int mtcr_open_config(mfile* mf, const char* name)
 mfile* mopen_int(const char* name, u_int32_t adv_opt)
 {
     char* real_name = (char*)name;
-    int is_cable = 0;
+    int   is_cable = 0;
+
 #ifndef MST_UL
     int port = 0;
 #endif
-    if (getuid() != 0)
-    {
+    if (getuid() != 0) {
         errno = EACCES;
         return NULL;
     }
-    // printf("%s: open %s\n", __FUNCTION__, name);
+    /* printf("%s: open %s\n", __FUNCTION__, name); */
 #ifndef MST_UL
-    char tmp_name[512] = {0};
+    char  tmp_name[512] = {0};
     char* p_cable = strstr(name, "_cable");
-    if (p_cable != 0)
-    {
+    if (p_cable != 0) {
         strncpy(tmp_name, name, 512 - 1);
         tmp_name[p_cable - name] = 0;
         is_cable = 1;
         real_name = tmp_name;
 
-        // printf("-D- splitting name: %s\n", real_name);
-        if (strstr(p_cable + 1, "_") != NULL)
-        {
+        /* printf("-D- splitting name: %s\n", real_name); */
+        if (strstr(p_cable + 1, "_") != NULL) {
             p_cable += 7;
-            if (*p_cable != '\0')
-            {
+            if (*p_cable != '\0') {
                 port = atoi(p_cable);
             }
         }
     }
 #endif
-    if (!device_exists(real_name))
-    {
+    if (!device_exists(real_name)) {
         errno = ENOENT;
         return NULL;
     }
     mfile* mf = malloc(sizeof(mfile));
     memset(mf, 0, sizeof(mfile));
-    if (!mf)
-    {
+    if (!mf) {
         return NULL;
     }
     mf->sock = -1;
     mf->user_page_list.page_amount = 0;
 
     mf->flags = MDEVS_TAVOR_CR;
-    if (!mtcr_open_config(mf, real_name))
-    {
+    if (!mtcr_open_config(mf, real_name)) {
         _create_lock(mf, real_name);
         mf->wo_addr = is_wo_pciconf_gw(mf);
-        // printf("-D- is_wo_pciconf_gw: %d\n", mf->wo_addr);
+        /* printf("-D- is_wo_pciconf_gw: %d\n", mf->wo_addr); */
         mf->vsec_addr = pci_find_capability(mf, VENDOR_SPECIFIC_CAP_ID);
 
         uint32_t vsec_type = 0;
-        int rc = read_config(mf, mf->vsec_addr, &vsec_type, 4);
-        if (rc)
-        {
-            // printf("-E- Failed to read first dword from VSC - Attempt to read VSC type failed.\n");
+        int      rc = read_config(mf, mf->vsec_addr, &vsec_type, 4);
+        if (rc) {
+            /* printf("-E- Failed to read first dword from VSC - Attempt to read VSC type failed.\n"); */
         }
         mf->vsec_type = EXTRACT(vsec_type, MLX_VSC_TYPE_OFFSET, MLX_VSC_TYPE_LEN);
-        // printf("Device ID: %d mf->wo_addr:%d mf->vsec_addr:%#x mf->vsec_type:%d\n", mf->hw_dev_id, mf->wo_addr, mf->vsec_addr, mf->vsec_type);
+        /* printf("Device ID: %d mf->wo_addr:%d mf->vsec_addr:%#x mf->vsec_type:%d\n", mf->hw_dev_id, mf->wo_addr, mf->vsec_addr, mf->vsec_type); */
 
         mf->vpd_cap_addr = pci_find_capability(mf, PCI_CAP_ID_VPD);
         mf->is_cable = is_cable;
         mf->functional_vsec_supp = 0;
-        if (mf->vsec_addr && mf->vsec_type == FUNCTIONAL_VSC)
-        {
-            if (adv_opt & Clear_Vsec_Semaphore)
-            {
+        if (mf->vsec_addr && (mf->vsec_type == FUNCTIONAL_VSC)) {
+            if (adv_opt & Clear_Vsec_Semaphore) {
                 _vendor_specific_sem(mf, 0);
             }
             mf->functional_vsec_supp = vsec_spaces_supported(mf);
             mf->address_space = AS_CR_SPACE;
         }
-        // printf("mtcr_open_config Succeeded FUNCTIONAL_VSEC_SUPP: %d\n", mf->functional_vsec_supp);
+        /* printf("mtcr_open_config Succeeded FUNCTIONAL_VSEC_SUPP: %d\n", mf->functional_vsec_supp); */
 #ifndef MST_UL
-        if (mf->is_cable)
-        {
+        if (mf->is_cable) {
             mf->flags = MDEVS_CABLE;
             mf->dl_context = mtcr_utils_load_dl_ctx(DL_CABLES);
             dl_handle_t* hdl = (dl_handle_t*)mf->dl_context;
-            if (!hdl || !hdl->mcables.mcables_open || hdl->mcables.mcables_open(mf, port))
-            {
+            if (!hdl || !hdl->mcables.mcables_open || hdl->mcables.mcables_open(mf, port)) {
                 mclose(mf);
                 return 0;
             }
         }
 #endif
         return mf;
-    }
-    else
-    {
-        // printf("mtcr_open_config failed\n");
+    } else {
+        /* printf("mtcr_open_config failed\n"); */
         errno = ENOENT;
         free(mf);
         return NULL;
@@ -1096,14 +974,11 @@ mfile* mopend(char const* name, DType dtype)
 mfile* mopen_adv(const char* name, MType mtype)
 {
     mfile* mf = mopend(name, MST_TAVOR);
-    if (mf)
-    {
-        if (mf->tp & mtype)
-        {
+
+    if (mf) {
+        if (mf->tp & mtype) {
             return mf;
-        }
-        else
-        {
+        } else {
             errno = EPERM;
             mclose(mf);
             return NULL;
@@ -1114,7 +989,7 @@ mfile* mopen_adv(const char* name, MType mtype)
 
 mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_func, void* extra_data)
 {
-    // not relevant for freebsd
+    /* not relevant for freebsd */
     (void)fw_cmd_context;
     (void)fw_cmd_func;
     (void)dma_func;
@@ -1128,34 +1003,29 @@ mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_func, voi
  */
 int mclose(mfile* mf)
 {
-    if (!mf)
-    {
+    if (!mf) {
         return 0;
     }
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = -1;
         CALL_DL_FUNC(mcables, mcables_close, ret, mf);
-        if (ret != -1)
-        {
+        if (ret != -1) {
             mtcr_utils_free_dl_ctx(mf->dl_context);
         }
     }
 #endif
-    // printf("closing\n");
+    /* printf("closing\n"); */
     close(mf->fd);
-    if (mf->fdlock)
-    {
+    if (mf->fdlock) {
         close(mf->fdlock);
     }
 
-    if (mf->user_page_list.page_amount)
-    {
+    if (mf->user_page_list.page_amount) {
         release_dma_pages(mf, mf->user_page_list.page_amount);
     }
 
-    // printf("freeing\n");
+    /* printf("freeing\n"); */
     free(mf);
     return 0;
 }
@@ -1168,36 +1038,33 @@ int mclose(mfile* mf)
 int mread4_old(mfile* mf, unsigned int offset, u_int32_t* value)
 {
     int rc;
+
     offset = __cpu_to_le32(offset);
-    if (mf->wo_addr)
-    {
+    if (mf->wo_addr) {
         offset |= 0x1;
     }
 
     int lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
     rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-    if (rc)
-    {
+    if (rc) {
         goto cleanup;
     }
 
     rc = read_config(mf, PCI_CONF_DATA, value, 4);
 
-    if (rc)
-    {
+    if (rc) {
         goto cleanup;
     }
 
     *value = __le32_to_cpu(*value);
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc || rc)
-    {
+    if (lock_rc || rc) {
         return 0;
     }
     return 4;
@@ -1206,22 +1073,17 @@ cleanup:
 int mread4(mfile* mf, unsigned int offset, u_int32_t* value)
 {
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int rc = 0;
         CALL_DL_FUNC(mcables, mcables_read4, rc, mf, offset, value);
-        if (!rc)
-        {
+        if (!rc) {
             return 4;
-        }
-        else
-        {
+        } else {
             return -1;
         }
     }
 #endif
-    if (mf->functional_vsec_supp)
-    {
+    if (mf->functional_vsec_supp) {
         return mread4_new(mf, offset, value);
     }
     return mread4_old(mf, offset, value);
@@ -1251,8 +1113,8 @@ int mwrite64(mfile* mf, unsigned int offset, void* data, int length)
     return -1;
 }
 
-// read_config(int fd, struct pcisel *sel, unsigned long reg, int width);
-// write_config(mf->fd, int fd, struct pcisel *sel, unsigned long reg, unsigned long data, int width)
+/* read_config(int fd, struct pcisel *sel, unsigned long reg, int width); */
+/* write_config(mf->fd, int fd, struct pcisel *sel, unsigned long reg, unsigned long data, int width) */
 
 /*
  * Write 4 bytes, return number of succ. written bytes or -1 on failure
@@ -1265,42 +1127,34 @@ int mwrite4_old(mfile* mf, unsigned int offset, u_int32_t value)
     value = __cpu_to_le32(value);
 
     int lock_rc;
+
     lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 0;
     }
-    if (mf->wo_addr)
-    {
+    if (mf->wo_addr) {
         rc = write_config(mf, PCI_CONF_DATA, (unsigned long)value, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
         rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
-    }
-    else
-    {
+    } else {
         rc = write_config(mf, PCI_CONF_ADDR, (unsigned long)offset, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
         rc = write_config(mf, PCI_CONF_DATA, (unsigned long)value, 4);
-        if (rc)
-        {
+        if (rc) {
             goto cleanup;
         }
     }
 
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc || rc)
-    {
+    if (lock_rc || rc) {
         return 0;
     }
     return 4;
@@ -1309,40 +1163,33 @@ cleanup:
 int mwrite4(mfile* mf, unsigned int offset, u_int32_t value)
 {
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int rc = 0;
         CALL_DL_FUNC(mcables, mcables_write4, rc, mf, offset, value);
-        if (!rc)
-        {
+        if (!rc) {
             return 4;
-        }
-        else
-        {
+        } else {
             return -1;
         }
     }
 #endif
-    if (mf->functional_vsec_supp)
-    {
+    if (mf->functional_vsec_supp) {
         return mwrite4_new(mf, offset, value);
     }
     return mwrite4_old(mf, offset, value);
 }
-//////////// NEW   ////////////////////
+/*////////// NEW   //////////////////// */
 
 static int mread_chunk_as_multi_mread4(mfile* mf, unsigned int offset, void* data, int length)
 {
     int i;
-    if (length % 4)
-    {
+
+    if (length % 4) {
         return -EINVAL;
     }
-    for (i = 0; i < length; i += 4)
-    {
+    for (i = 0; i < length; i += 4) {
         u_int32_t value;
-        if (mread4(mf, offset + i, &value) != 4)
-        {
+        if (mread4(mf, offset + i, &value) != 4) {
             return -1;
         }
         memcpy((char*)data + i, &value, 4);
@@ -1353,16 +1200,14 @@ static int mread_chunk_as_multi_mread4(mfile* mf, unsigned int offset, void* dat
 static int mwrite_chunk_as_multi_mwrite4(mfile* mf, unsigned int offset, void* data, int length)
 {
     int i;
-    if (length % 4)
-    {
+
+    if (length % 4) {
         return -EINVAL;
     }
-    for (i = 0; i < length; i += 4)
-    {
+    for (i = 0; i < length; i += 4) {
         u_int32_t value;
         memcpy(&value, (char*)data + i, 4);
-        if (mwrite4(mf, offset + i, value) != 4)
-        {
+        if (mwrite4(mf, offset + i, value) != 4) {
             return -1;
         }
     }
@@ -1372,22 +1217,20 @@ static int mwrite_chunk_as_multi_mwrite4(mfile* mf, unsigned int offset, void* d
 int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 {
     int rc = byte_len;
+
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = 0;
         CALL_DL_FUNC(mcables, mcables_read4_block, ret, mf, offset, data, byte_len);
-        if (ret != 0)
-        {
-            rc -= ret; // Return less than byte_len to ensure error in reading
+        if (ret != 0) {
+            rc -= ret; /* Return less than byte_len to ensure error in reading */
         }
         return rc;
     }
 #endif
-    if (mf->functional_vsec_supp)
-    {
+    if (mf->functional_vsec_supp) {
         int rc = mread4_block_new(mf, offset, byte_len, data);
-        // printf("-D- MREAD BLOCK LEN: %d, RC: %d\n", byte_len, rc);
+        /* printf("-D- MREAD BLOCK LEN: %d, RC: %d\n", byte_len, rc); */
         return rc;
     }
     rc = mread_chunk_as_multi_mread4(mf, offset, data, byte_len);
@@ -1397,20 +1240,18 @@ int mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 {
     int rc = byte_len;
+
 #ifndef MST_UL
-    if (mf->tp == MST_CABLE)
-    {
+    if (mf->tp == MST_CABLE) {
         int ret = 0;
         CALL_DL_FUNC(mcables, mcables_write4_block, ret, mf, offset, data, byte_len);
-        if (ret != 0)
-        {
-            rc -= ret; // Return less than byte_len to ensure error in reading
+        if (ret != 0) {
+            rc -= ret; /* Return less than byte_len to ensure error in reading */
         }
         return rc;
     }
 #endif
-    if (mf->functional_vsec_supp)
-    {
+    if (mf->functional_vsec_supp) {
         return mwrite4_block_new(mf, offset, byte_len, data);
     }
     rc = mwrite_chunk_as_multi_mwrite4(mf, offset, data, byte_len);
@@ -1435,7 +1276,8 @@ int mi2c_detect(mfile* mf, u_int8_t slv_arr[SLV_ADDRS_NUM])
     (void)slv_arr;
     return 1;
 }
-int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data,
+                   int length)
 {
     (void)mf;
     (void)i2c_slave;
@@ -1446,7 +1288,12 @@ int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsi
     return 0;
 }
 
-int mwrite_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mwrite_i2cblock(mfile       * mf,
+                    unsigned char i2c_slave,
+                    u_int8_t      addr_width,
+                    unsigned int  offset,
+                    void        * data,
+                    int           length)
 {
     (void)mf;
     (void)i2c_slave;
@@ -1457,22 +1304,22 @@ int mwrite_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, uns
     return 0;
 }
 
-// TODO: Introduce a module to keep platform-independent routines like this one below
+/* TODO: Introduce a module to keep platform-independent routines like this one below */
 void mtcr_fix_endianness(u_int32_t* buf, int len)
 {
     int i;
 
-    for (i = 0; i < (len / 4); ++i)
-    {
-        // printf("-D- before: buf[%d] = %#x\n", i, buf[i]);
+    for (i = 0; i < (len / 4); ++i) {
+        /* printf("-D- before: buf[%d] = %#x\n", i, buf[i]); */
         buf[i] = __be32_to_cpu(buf[i]);
-        // printf("-D- before: buf[%d] = %#x\n", i, buf[i]);
+        /* printf("-D- before: buf[%d] = %#x\n", i, buf[i]); */
     }
 }
 
 int mread_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
 {
     int rc;
+
     rc = mread4_block(mf, offset, (u_int32_t*)data, byte_len);
     mtcr_fix_endianness((u_int32_t*)data, byte_len);
     return rc;
@@ -1486,8 +1333,7 @@ int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
 
 int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 {
-    if (mf == NULL || devs_flags == NULL)
-    {
+    if ((mf == NULL) || (devs_flags == NULL)) {
         errno = -EINVAL;
         return 1;
     }
@@ -1498,8 +1344,7 @@ int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 
 int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 {
-    if (mf == NULL || mtype == NULL)
-    {
+    if ((mf == NULL) || (mtype == NULL)) {
         errno = -EINVAL;
         return 1;
     }
@@ -1511,13 +1356,11 @@ int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
 {
     unsigned char ret;
-    if (mf)
-    {
+
+    if (mf) {
         ret = mf->i2c_slave;
         mf->i2c_slave = new_i2c_slave;
-    }
-    else
-    {
+    } else {
         ret = 0xff;
     }
     return ret;
@@ -1525,8 +1368,7 @@ unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
 
 int mget_i2c_slave(mfile* mf, unsigned char* new_i2c_slave_p)
 {
-    if (mf)
-    {
+    if (mf) {
         *new_i2c_slave_p = mf->i2c_slave;
         return 0;
     }
@@ -1538,36 +1380,33 @@ int mget_i2c_slave(mfile* mf, unsigned char* new_i2c_slave_p)
 
 static int get_device_ids(const char* dev_name, dev_info* dinfo)
 {
-    mfile* mf = mopen(dev_name);
-    int rc = 0;
+    mfile   * mf = mopen(dev_name);
+    int       rc = 0;
     u_int32_t buf = 0;
-    if (!mf)
-    {
+
+    if (!mf) {
         return 1;
     }
 
     int lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+
+    if (lock_rc) {
         return 1;
     }
     rc = read_config(mf, PCI_HEADER_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.vend_id = EXTRACT(buf, 0, 16);
     dinfo->pci.dev_id = EXTRACT(buf, 16, 16);
 
     rc = read_config(mf, PCI_CLASS_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.class_id = EXTRACT(buf, 8, 24);
     rc = read_config(mf, PCI_SUBSYS_OFFS, &buf, 4);
-    if (rc)
-    {
+    if (rc) {
         goto exit;
     }
     dinfo->pci.subsys_vend_id = EXTRACT(buf, 0, 16);
@@ -1576,24 +1415,25 @@ static int get_device_ids(const char* dev_name, dev_info* dinfo)
 exit:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
     mclose(mf);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         return 1;
     }
     return rc;
 }
-static int
-  get_dev_dbdf(const char* dev_name, unsigned int* domain, unsigned int* bus, unsigned int* dev, unsigned int* func)
+static int get_dev_dbdf(const char  * dev_name,
+                        unsigned int* domain,
+                        unsigned int* bus,
+                        unsigned int* dev,
+                        unsigned int* func)
 {
     char* dbdf_str = strstr(dev_name, "pci");
-    int rc = 0;
-    if (!dbdf_str)
-    {
+    int   rc = 0;
+
+    if (!dbdf_str) {
         return 1;
     }
     rc = sscanf(dbdf_str, "pci%u:%u:%u:%u", domain, bus, dev, func);
-    if (rc != 4)
-    {
+    if (rc != 4) {
         return 1;
     }
     return 0;
@@ -1602,9 +1442,9 @@ static int
 int get_device_flags(const char* name)
 {
     int mask = 0;
+
     mask = MDEVS_TAVOR_CR;
-    if (strstr(name, "cable"))
-    {
+    if (strstr(name, "cable")) {
         mask = MDEVS_CABLE;
     }
     return mask;
@@ -1632,37 +1472,33 @@ int get_device_flags(const char* name)
 
 int mdevices_v(char* buf, int len, int mask, int verbosity)
 {
-    int i;
-    int s, b, d, f, tmp;
-    int rc = 0;
-    int cnt = 0;
+    int   i;
+    int   s, b, d, f, tmp;
+    int   rc = 0;
+    int   cnt = 0;
     FILE* fp;
-    char dev_line[1035];
+    char  dev_line[1035];
     char* p = buf;
-    if (mask & MDEVS_TAVOR_CR)
-    {
+
+    if (mask & MDEVS_TAVOR_CR) {
         /* Get all Mellanox devices - this cmd will return the needed devices one in every line */
         fp =
-          popen("pciconf -lv | grep -B 1 Mellanox | grep pci | cut -f1 | cut -f2 -d \"@\" | cut -f1-4 -d \":\"", "r");
-        if (fp == NULL)
-        {
+            popen("pciconf -lv | grep -B 1 Mellanox | grep pci | cut -f1 | cut -f2 -d \"@\" | cut -f1-4 -d \":\"",
+                  "r");
+        if (fp == NULL) {
             return -1;
         }
 
         /* Read the output one line at a time */
-        while (fgets(dev_line, sizeof(dev_line) - 1, fp) != NULL)
-        {
+        while (fgets(dev_line, sizeof(dev_line) - 1, fp) != NULL) {
             tmp = sscanf(dev_line, "pci%d:%d:%d:%d\n", &s, &b, &d, &f);
-            (void)tmp; // TODO: check sscanf ret value
-            if (!verbosity && f != 0)
-            {
+            (void)tmp; /* TODO: check sscanf ret value */
+            if (!verbosity && (f != 0)) {
                 continue;
             }
-            for (i = 0; !(dev_line[i] == '\n'); i++)
-            {
+            for (i = 0; !(dev_line[i] == '\n'); i++) {
                 *p++ = dev_line[i];
-                if (++cnt >= len)
-                {
+                if (++cnt >= len) {
                     pclose(fp);
                     return -1;
                 }
@@ -1673,22 +1509,18 @@ int mdevices_v(char* buf, int len, int mask, int verbosity)
         /* close */
         pclose(fp);
     }
-    if (mask & MDEVS_CABLE)
-    {
+    if (mask & MDEVS_CABLE) {
         /*
          * Get cables
          */
-        DIR* dir = opendir(CABLES_DIR);
+        DIR          * dir = opendir(CABLES_DIR);
         struct dirent* dirent;
-        if (dir != NULL)
-        {
+        if (dir != NULL) {
             dirent = readdir(dir);
-            while (dirent != NULL)
-            {
+            while (dirent != NULL) {
                 char* name = dirent->d_name;
                 /* According to mask */
-                if (get_device_flags(name) & MDEVS_CABLE)
-                {
+                if (get_device_flags(name) & MDEVS_CABLE) {
                     PUTS(name);
                     PUTC('\0');
                     rc++;
@@ -1709,27 +1541,24 @@ int mdevices(char* buf, int len, int mask)
 static void remove_newline_chars(char* str)
 {
     int i;
-    for (i = strlen(str) - 1; i >= 0 && (str[i] == '\n' || str[i] == '\r'); i--)
-    {
+
+    for (i = strlen(str) - 1; i >= 0 && (str[i] == '\n' || str[i] == '\r'); i--) {
         str[i] = '\0';
     }
 }
 
-// replace with a new string
-// free the old one
+/* replace with a new string */
+/* free the old one */
 static char* manipulate_ib_dev_line(char* line)
 {
-    if (!line)
-    {
+    if (!line) {
         return NULL;
     }
     char* old_str = line;
     char* new_str = NULL;
 
-    while (*line != '.')
-    {
-        if (!(*line))
-        {
+    while (*line != '.') {
+        if (!(*line)) {
             goto cleanup;
         }
         line++;
@@ -1738,43 +1567,31 @@ static char* manipulate_ib_dev_line(char* line)
 
     char* end = line;
     char* num = NULL;
-    int count_dots = 0;
-    while (1)
-    {
-        if (!(*end))
-        {
+    int   count_dots = 0;
+
+    while (1) {
+        if (!(*end)) {
             goto cleanup;
-        }
-        else if (*end == '.')
-        {
-            if (count_dots)
-            {
+        } else if (*end == '.') {
+            if (count_dots) {
                 *end = '\0';
                 break;
-            }
-            else
-            {
+            } else {
                 count_dots++;
-                if (*(end + 1))
-                {
+                if (*(end + 1)) {
                     num = end + 1;
-                }
-                else
-                {
+                } else {
                     goto cleanup;
                 }
             }
-        }
-        else if (*end == '_')
-        {
+        } else if (*end == '_') {
             *(end + 1) = '\0';
         }
         end++;
     }
     line = strcat(line, num);
     new_str = (char*)malloc(strlen(line) + 1);
-    if (!new_str)
-    {
+    if (!new_str) {
         errno = ENOMEM;
         goto cleanup;
     }
@@ -1785,16 +1602,15 @@ cleanup:
     return new_str;
 }
 
-// number_of_first_entries_to_skip should be 0 for regular array destruction
+/* number_of_first_entries_to_skip should be 0 for regular array destruction */
 static void destroy_str_arr(char** arr, int number_of_first_entries_to_skip)
 {
-    if (!arr)
-    {
+    if (!arr) {
         return;
     }
     int i;
-    for (i = number_of_first_entries_to_skip; arr[i]; i++)
-    {
+
+    for (i = number_of_first_entries_to_skip; arr[i]; i++) {
         free(arr[i]);
         arr[i] = NULL;
     }
@@ -1802,30 +1618,27 @@ static void destroy_str_arr(char** arr, int number_of_first_entries_to_skip)
     arr = NULL;
 }
 
-// copying file lines into a an array of char*, while manipulating each line with a special function (if supplied)
-// caller should destroy the array
+/* copying file lines into a an array of char*, while manipulating each line with a special function (if supplied) */
+/* caller should destroy the array */
 static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
 {
-    char* line = NULL;
+    char * line = NULL;
     size_t len = 0;
-    int lines_allocated = 8; // can realloc later
-    int error = 0;
-    int i = 0;
-
+    int    lines_allocated = 8; /* can realloc later */
+    int    error = 0;
+    int    i = 0;
     char** arr = (char**)malloc((lines_allocated + 1) * sizeof(char*));
-    if (!arr)
-    {
+
+    if (!arr) {
         errno = ENOMEM;
         error = 1;
         goto cleanup;
     }
     memset(arr, 0, (lines_allocated + 1) * sizeof(char*));
 
-    while (getline(&line, &len, fp) != -1)
-    {
+    while (getline(&line, &len, fp) != -1) {
         arr[i] = (char*)malloc(len * sizeof(char));
-        if (!arr[i])
-        {
+        if (!arr[i]) {
             errno = ENOMEM;
             error = 1;
             goto cleanup;
@@ -1836,21 +1649,17 @@ static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
         len = 0;
 
         remove_newline_chars(arr[i]);
-        if (string_mainpulation_func_ptr)
-        {
+        if (string_mainpulation_func_ptr) {
             arr[i] = (*string_mainpulation_func_ptr)(arr[i]);
         }
-        if (!arr[i])
-        {
+        if (!arr[i]) {
             continue;
         }
         i++;
-        if (i >= lines_allocated)
-        {
+        if (i >= lines_allocated) {
             lines_allocated *= 2;
             char** tmp = realloc(arr, (lines_allocated + 1) * sizeof(char*));
-            if (!tmp)
-            {
+            if (!tmp) {
                 errno = ENOMEM;
                 error = 1;
                 goto cleanup;
@@ -1859,18 +1668,15 @@ static char** file2array(FILE* fp, char* (*string_mainpulation_func_ptr)(char*))
         }
     }
 cleanup:
-    // This is done so the caller can free all the array cells without knowing its size
-    // Iterate until NULL termination
-    if (arr)
-    {
+    /* This is done so the caller can free all the array cells without knowing its size */
+    /* Iterate until NULL termination */
+    if (arr) {
         arr[i] = NULL;
     }
-    if (line)
-    {
+    if (line) {
         free(line);
     }
-    if (error || i == 0)
-    {
+    if (error || (i == 0)) {
         destroy_str_arr(arr, 0);
         return NULL;
     }
@@ -1878,24 +1684,25 @@ cleanup:
     return arr;
 }
 
-// Execute cmd and get output in a strings array, after desired output manipulation
-// via a speacial manipulation function (if supplied)
-// if there is relevant input to the special function pass it as well.
+/* Execute cmd and get output in a strings array, after desired output manipulation */
+/* via a speacial manipulation function (if supplied) */
+/* if there is relevant input to the special function pass it as well. */
 static char** exec_cmd_get_output(char* cmd, char* (*string_mainpulation_func_ptr)(char*))
 {
     char* wrapped_cmd = (char*)malloc(strlen(cmd) + strlen(" 2>/dev/null") + 2);
-    if (!wrapped_cmd)
-    {
+
+    if (!wrapped_cmd) {
         return NULL;
     }
     sprintf(wrapped_cmd, "%s %s", cmd, " 2>/dev/null");
     FILE* fp = popen(wrapped_cmd, "r");
+
     free(wrapped_cmd);
-    if (!fp)
-    {
+    if (!fp) {
         return NULL;
     }
     char** output = file2array(fp, string_mainpulation_func_ptr);
+
     pclose(fp);
     return output;
 }
@@ -1903,7 +1710,8 @@ static char** exec_cmd_get_output(char* cmd, char* (*string_mainpulation_func_pt
 static char* exec_cmd_get_output_first_line(char* cmd, char* (*string_mainpulation_func_ptr)(char*))
 {
     char** res = exec_cmd_get_output(cmd, string_mainpulation_func_ptr);
-    char* out = res[0];
+    char * out = res[0];
+
     destroy_str_arr(res, 1);
     return out;
 }
@@ -1912,12 +1720,13 @@ static char** get_ports(char* ib_dev)
 {
     char* cmd = (char*)malloc(strlen("sysctl sys.class.infiniband..ports | awk -F. '{print $6}' | uniq | sort") +
                               strlen(ib_dev) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl sys.class.infiniband.%s.ports | awk -F. '{print $6}' | uniq | sort", ib_dev);
     char** out = exec_cmd_get_output(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1925,13 +1734,14 @@ static char** get_ports(char* ib_dev)
 static char* get_link_layer(char* ib_dev, char* port)
 {
     char* cmd =
-      (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..link_layer") + strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+        (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..link_layer") + strlen(ib_dev) + strlen(port) + 1);
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sys.class.infiniband.%s.ports.%s.link_layer", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1940,12 +1750,13 @@ static char* get_eth_net_dev(char* ib_dev, char* port)
 {
     char* cmd = (char*)malloc(strlen("sysctl -n sysctl sys.class.infiniband..ports..gid_attrs.ndevs.0") +
                               strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sysctl sys.class.infiniband.%s.ports.%s.gid_attrs.ndevs.0", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
@@ -1960,67 +1771,56 @@ static char* get_gid(char* ib_dev, char* port)
     char* cmd = (char*)malloc(strlen("sysctl -n sys.class.infiniband..ports..gids.0 |"
                                      " cut -b 21- | sed -e 's/://g'") +
                               strlen(ib_dev) + strlen(port) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -n sys.class.infiniband.%s.ports.%s.gids.0 | cut -b 21- | sed -e 's/://g'", ib_dev, port);
     char* out = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return out;
 }
 
 static char* lladdr_to_gid_format(char* lladdr)
 {
-    if (!lladdr)
-    {
+    if (!lladdr) {
         return NULL;
     }
 
     int end = strlen(lladdr) - 1;
     int i;
     int dot_count = 0;
-    for (i = end; i >= 0; i--)
-    {
-        if (lladdr[i] == '.')
-        {
+
+    for (i = end; i >= 0; i--) {
+        if (lladdr[i] == '.') {
             dot_count++;
         }
-        if (dot_count == 8)
-        {
+        if (dot_count == 8) {
             lladdr = &lladdr[i];
             break;
         }
-        if (i == 0)
-        {
+        if (i == 0) {
             return NULL;
         }
     }
-    if (*(lladdr + 1) && *(lladdr + 2) && *(lladdr + 2) != '.')
-    {
+    if (*(lladdr + 1) && *(lladdr + 2) && (*(lladdr + 2) != '.')) {
         lladdr++;
     }
     char* curptr = lladdr;
-    while (*curptr)
-    {
-        if (*curptr == '.')
-        {
-            if (*(curptr + 1) && ((*(curptr + 2) == '.') || !(*(curptr + 2))))
-            {
+
+    while (*curptr) {
+        if (*curptr == '.') {
+            if (*(curptr + 1) && ((*(curptr + 2) == '.') || !(*(curptr + 2)))) {
                 *curptr = '0';
                 curptr++;
-            }
-            else
-            {
+            } else {
                 *curptr = '\0';
-                if (*(curptr + 1))
-                {
+                if (*(curptr + 1)) {
                     lladdr = strcat(lladdr, curptr + 1);
                 }
             }
-        }
-        else
-        {
+        } else {
             curptr++;
         }
     }
@@ -2030,12 +1830,13 @@ static char* lladdr_to_gid_format(char* lladdr)
 static char* get_lladdr(char* ifc)
 {
     char* cmd = (char*)malloc(strlen("ifconfig  | grep lladdr | awk '{print $2}'") + strlen(ifc) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "ifconfig %s | grep lladdr | awk '{print $2}'", ifc);
     char* lladdr = exec_cmd_get_output_first_line(cmd, NULL);
+
     free(cmd);
     return lladdr_to_gid_format(lladdr);
 }
@@ -2043,23 +1844,20 @@ static char* get_lladdr(char* ifc)
 static char* get_inband_net_dev(char* ib_dev, char* port, char** ifcs)
 {
     char* gid = get_gid(ib_dev, port);
-    if (!gid)
-    {
+
+    if (!gid) {
         return NULL;
     }
     int i;
-    for (i = 0; ifcs[i]; i++)
-    {
-        if (strstr(ifcs[i], "ib") == ifcs[i])
-        {
+
+    for (i = 0; ifcs[i]; i++) {
+        if (strstr(ifcs[i], "ib") == ifcs[i]) {
             char* lladdr = get_lladdr(ifcs[i]);
-            if (!strcmp(lladdr, gid))
-            {
+            if (!strcmp(lladdr, gid)) {
                 free(lladdr);
                 free(gid);
                 char* netdev = (char*)malloc(strlen(ifcs[i]) + 1);
-                if (!netdev)
-                {
+                if (!netdev) {
                     errno = ENOMEM;
                     return NULL;
                 }
@@ -2075,71 +1873,58 @@ static char* get_inband_net_dev(char* ib_dev, char* port, char** ifcs)
 
 static char** get_net_devs(char** ib_devs)
 {
-    if (!ib_devs)
-    {
+    if (!ib_devs) {
         return NULL;
     }
     char** ifcs = get_ifcs();
-    if (!ifcs)
-    {
+
+    if (!ifcs) {
         return NULL;
     }
     char** ports = NULL;
-    char* link_layer = NULL;
-    int i;
-    int error = 0;
-    int lines_allocated = 8; // can realloc later
-
+    char * link_layer = NULL;
+    int    i;
+    int    error = 0;
+    int    lines_allocated = 8; /* can realloc later */
     char** net_devs = (char**)malloc((lines_allocated + 1) * sizeof(char*));
-    if (!net_devs)
-    {
+
+    if (!net_devs) {
         errno = ENOMEM;
         error = 1;
         goto cleanup;
     }
     memset(net_devs, 0, (lines_allocated + 1) * sizeof(char*));
     int k = 0;
-    for (i = 0; ib_devs[i]; i++)
-    {
+
+    for (i = 0; ib_devs[i]; i++) {
         ports = get_ports(ib_devs[i]);
-        if (!ports)
-        {
+        if (!ports) {
             error = 1;
             goto cleanup;
         }
         int j;
-        for (j = 0; ports[j]; j++)
-        {
+        for (j = 0; ports[j]; j++) {
             link_layer = get_link_layer(ib_devs[i], ports[j]);
-            if (!link_layer)
-            {
+            if (!link_layer) {
                 error = 1;
                 goto cleanup;
             }
             char* netdev;
-            if (!strcmp(link_layer, "Ethernet"))
-            {
+            if (!strcmp(link_layer, "Ethernet")) {
                 netdev = get_eth_net_dev(ib_devs[i], ports[j]);
-            }
-            else if (!strcmp(link_layer, "InfiniBand"))
-            {
+            } else if (!strcmp(link_layer, "InfiniBand")) {
                 netdev = get_inband_net_dev(ib_devs[i], ports[j], ifcs);
-            }
-            else
-            {
+            } else {
                 error = 1;
                 goto cleanup;
             }
-            if (netdev)
-            {
+            if (netdev) {
                 net_devs[k] = netdev;
                 k++;
-                if (k > lines_allocated)
-                {
+                if (k > lines_allocated) {
                     lines_allocated *= 2;
                     char** tmp = realloc(net_devs, (lines_allocated + 1) * sizeof(char*));
-                    if (!tmp)
-                    {
+                    if (!tmp) {
                         errno = ENOMEM;
                         error = 1;
                         goto cleanup;
@@ -2151,8 +1936,7 @@ static char** get_net_devs(char** ib_devs)
     }
     net_devs[k] = NULL;
 cleanup:
-    if (error)
-    {
+    if (error) {
         destroy_str_arr(net_devs, 0);
         net_devs = NULL;
     }
@@ -2166,12 +1950,13 @@ cleanup:
 static char** get_ib_devs(char conf_dev[512])
 {
     char* cmd = (char*)malloc(strlen("sysctl -a | grep mlx | grep pci | grep ") + strlen(conf_dev) + 1);
-    if (!cmd)
-    {
+
+    if (!cmd) {
         return NULL;
     }
     sprintf(cmd, "sysctl -a | grep mlx | grep pci | grep %s", conf_dev);
     char** ib_devs = exec_cmd_get_output(cmd, manipulate_ib_dev_line);
+
     free(cmd);
     return ib_devs;
 }
@@ -2185,21 +1970,18 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
 {
     char* devs = 0;
     char* dev_name;
-    int size = 2048;
-    int rc;
-    int i;
+    int   size = 2048;
+    int   rc;
+    int   i;
 
-    // Get list of devices
-    do
-    {
-        if (devs)
-        {
+    /* Get list of devices */
+    do{
+        if (devs) {
             free(devs);
         }
         size *= 2;
         devs = malloc(size);
-        if (!devs)
-        {
+        if (!devs) {
             errno = ENOMEM;
             return NULL;
         }
@@ -2207,16 +1989,15 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
     } while (rc == -1);
     *len = rc;
     dev_info* dev_info_arr = malloc(sizeof(dev_info) * rc);
-    if (!dev_info_arr)
-    {
+
+    if (!dev_info_arr) {
         errno = ENOMEM;
         free(devs);
         return NULL;
     }
     memset(dev_info_arr, 0, sizeof(dev_info) * rc);
     dev_name = devs;
-    for (i = 0; i < *len; i++)
-    {
+    for (i = 0; i < *len; i++) {
         unsigned int domain = 0;
         unsigned int bus = 0;
         unsigned int dev = 0;
@@ -2224,27 +2005,23 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
         dev_info_arr[i].type = get_device_flags(dev_name);
         strcpy(dev_info_arr[i].dev_name, dev_name);
         strcpy(dev_info_arr[i].pci.conf_dev, dev_name);
-        if (dev_info_arr[i].type & MDEVS_TAVOR_CR)
-        {
-            if (get_dev_dbdf(dev_name, &domain, &bus, &dev, &func))
-            {
+        if (dev_info_arr[i].type & MDEVS_TAVOR_CR) {
+            if (get_dev_dbdf(dev_name, &domain, &bus, &dev, &func)) {
                 goto next;
             }
             dev_info_arr[i].pci.domain = domain;
             dev_info_arr[i].pci.bus = bus;
             dev_info_arr[i].pci.dev = dev;
             dev_info_arr[i].pci.func = func;
-            if (get_device_ids(dev_name, &dev_info_arr[i]))
-            {
+            if (get_device_ids(dev_name, &dev_info_arr[i])) {
                 goto next;
             }
         }
-        if (verbosity)
-        {
+        if (verbosity) {
             dev_info_arr[i].pci.ib_devs = get_ib_devs(dev_info_arr[i].pci.conf_dev);
             dev_info_arr[i].pci.net_devs = get_net_devs(dev_info_arr[i].pci.ib_devs);
         }
-    next:
+next:
         dev_name += strlen(dev_name) + 1;
     }
     free(devs);
@@ -2255,16 +2032,12 @@ void mdevices_info_destroy(dev_info* dev_info, int len)
 {
     int i;
 
-    if (dev_info)
-    {
-        for (i = 0; i < len; i++)
-        {
-            if (dev_info[i].pci.ib_devs)
-            {
+    if (dev_info) {
+        for (i = 0; i < len; i++) {
+            if (dev_info[i].pci.ib_devs) {
                 destroy_str_arr(dev_info[i].pci.ib_devs, 0);
             }
-            if (dev_info[i].pci.net_devs)
-            {
+            if (dev_info[i].pci.net_devs) {
                 destroy_str_arr(dev_info[i].pci.net_devs, 0);
             }
         }
@@ -2274,122 +2047,116 @@ void mdevices_info_destroy(dev_info* dev_info, int len)
 }
 
 #define TLV_OPERATION_SIZE 4
-#define OP_TLV_SIZE 16
+#define OP_TLV_SIZE        16
 #define REG_TLV_HEADER_LEN 4
 
-enum
-{
+enum {
     MAD_CLASS_REG_ACCESS = 1,
 };
-enum
-{
-    TLV_END = 0,
+enum {
+    TLV_END       = 0,
     TLV_OPERATION = 1,
-    TLV_DR = 2,
-    TLV_REG = 3,
+    TLV_DR        = 2,
+    TLV_REG       = 3,
     TLV_USER_DATA = 4,
 };
 
-#define REGISTER_HEADERS_SIZE 20
-#define INBAND_MAX_REG_SIZE 44
-#define ICMD_MAX_REG_SIZE (ICMD_MAX_CMD_SIZE - REGISTER_HEADERS_SIZE)
-#define FWCTX_MAX_REG_SIZE 16
+#define REGISTER_HEADERS_SIZE  20
+#define INBAND_MAX_REG_SIZE    44
+#define ICMD_MAX_REG_SIZE      (ICMD_MAX_CMD_SIZE - REGISTER_HEADERS_SIZE)
+#define FWCTX_MAX_REG_SIZE     16
 #define TOOLS_HCR_MAX_REG_SIZE (TOOLS_HCR_MAX_MBOX - REGISTER_HEADERS_SIZE)
 
 static int supports_icmd(mfile* mf);
 static int supports_tools_cmdif_reg(mfile* mf);
 static int init_operation_tlv(struct OperationTlv* operation_tlv, u_int16_t reg_id, u_int8_t method);
 static int mreg_send_wrapper(mfile* mf, u_int8_t* data, int r_icmd_size, int w_icmd_size);
-static int mreg_send_raw(mfile* mf,
-                         u_int16_t reg_id,
+static int mreg_send_raw(mfile              * mf,
+                         u_int16_t            reg_id,
                          maccess_reg_method_t method,
-                         void* reg_data,
-                         u_int32_t reg_size,
-                         u_int32_t r_size_reg,
-                         u_int32_t w_size_reg,
-                         int* reg_status);
+                         void               * reg_data,
+                         u_int32_t            reg_size,
+                         u_int32_t            r_size_reg,
+                         u_int32_t            w_size_reg,
+                         int                * reg_status);
 int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method);
 
-// maccess_reg: Do a reg_access for the mf device.
-// - reg_data is both in and out
-// TODO: When the reg operation succeeds but the reg status is != 0,
-//       a specific
+/* maccess_reg: Do a reg_access for the mf device. */
+/* - reg_data is both in and out */
+/* TODO: When the reg operation succeeds but the reg status is != 0, */
+/*       a specific */
 
-int maccess_reg(mfile* mf,
-                u_int16_t reg_id,
+int maccess_reg(mfile              * mf,
+                u_int16_t            reg_id,
                 maccess_reg_method_t reg_method,
-                void* reg_data,
-                u_int32_t reg_size,
-                u_int32_t r_size_reg,
-                u_int32_t w_size_reg,
-                int* reg_status)
+                void               * reg_data,
+                u_int32_t            reg_size,
+                u_int32_t            r_size_reg,
+                u_int32_t            w_size_reg,
+                int                * reg_status)
 {
     int rc;
-    if (mf == NULL || reg_data == NULL || reg_status == NULL || reg_size <= 0)
-    {
+
+    if ((mf == NULL) || (reg_data == NULL) || (reg_status == NULL) || (reg_size <= 0)) {
         return ME_BAD_PARAMS;
     }
-    // check register size
+    /* check register size */
     u_int32_t max_size = (u_int32_t)mget_max_reg_size(mf, reg_method);
-    if (reg_size > max_size)
-    {
-        // reg too big
+
+    if (reg_size > max_size) {
+        /* reg too big */
         return ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT;
     }
     rc = mreg_send_raw(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg, reg_status);
 
-    if (rc)
-    {
+    if (rc) {
         return rc;
-    }
-    else if (*reg_status)
-    {
-        switch (*reg_status)
-        {
-            case 1:
-                return ME_REG_ACCESS_DEV_BUSY;
+    } else if (*reg_status) {
+        switch (*reg_status) {
+        case 1:
+            return ME_REG_ACCESS_DEV_BUSY;
 
-            case 2:
-                return ME_REG_ACCESS_VER_NOT_SUPP;
+        case 2:
+            return ME_REG_ACCESS_VER_NOT_SUPP;
 
-            case 3:
-                return ME_REG_ACCESS_UNKNOWN_TLV;
+        case 3:
+            return ME_REG_ACCESS_UNKNOWN_TLV;
 
-            case 4:
-                return ME_REG_ACCESS_REG_NOT_SUPP;
+        case 4:
+            return ME_REG_ACCESS_REG_NOT_SUPP;
 
-            case 5:
-                return ME_REG_ACCESS_CLASS_NOT_SUPP;
+        case 5:
+            return ME_REG_ACCESS_CLASS_NOT_SUPP;
 
-            case 6:
-                return ME_REG_ACCESS_METHOD_NOT_SUPP;
+        case 6:
+            return ME_REG_ACCESS_METHOD_NOT_SUPP;
 
-            case 7:
-                return ME_REG_ACCESS_BAD_PARAM;
+        case 7:
+            return ME_REG_ACCESS_BAD_PARAM;
 
-            case 8:
-                return ME_REG_ACCESS_RES_NOT_AVLBL;
+        case 8:
+            return ME_REG_ACCESS_RES_NOT_AVLBL;
 
-            case 9:
-                return ME_REG_ACCESS_MSG_RECPT_ACK;
+        case 9:
+            return ME_REG_ACCESS_MSG_RECPT_ACK;
 
-            case 0x22:
-                return ME_REG_ACCESS_CONF_CORRUPT;
+        case 0x22:
+            return ME_REG_ACCESS_CONF_CORRUPT;
 
-            case 0x24:
-                return ME_REG_ACCESS_LEN_TOO_SMALL;
+        case 0x24:
+            return ME_REG_ACCESS_LEN_TOO_SMALL;
 
-            case 0x20:
-                return ME_REG_ACCESS_BAD_CONFIG;
+        case 0x20:
+            return ME_REG_ACCESS_BAD_CONFIG;
 
-            case 0x21:
-                return ME_REG_ACCESS_ERASE_EXEEDED;
+        case 0x21:
+            return ME_REG_ACCESS_ERASE_EXEEDED;
 
-            case 0x70:
-                return ME_REG_ACCESS_INTERNAL_ERROR;
+        case 0x70:
+            return ME_REG_ACCESS_INTERNAL_ERROR;
 
-            default:
-                return ME_REG_ACCESS_UNKNOWN_ERR;
+        default:
+            return ME_REG_ACCESS_UNKNOWN_ERR;
         }
     }
     return ME_OK;
@@ -2407,60 +2174,54 @@ static int init_operation_tlv(struct OperationTlv* operation_tlv, u_int16_t reg_
     return 0;
 }
 
-///////////////////  Function that sends the register via the correct interface ///////////////////////////
+/*/////////////////  Function that sends the register via the correct interface /////////////////////////// */
 
 static int mreg_send_wrapper(mfile* mf, u_int8_t* data, int r_icmd_size, int w_icmd_size)
 {
     int rc;
-    if (supports_icmd(mf))
-    {
+
+    if (supports_icmd(mf)) {
         rc = icmd_send_command_int(mf, FLASH_REG_ACCESS, data, w_icmd_size, r_icmd_size, 0);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
-    }
-    else if (supports_tools_cmdif_reg(mf))
-    {
+    } else if (supports_tools_cmdif_reg(mf)) {
         rc = tools_cmdif_reg_access(mf, data, w_icmd_size, r_icmd_size);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
-    }
-    else
-    {
+    } else {
         return ME_NOT_IMPLEMENTED;
     }
     return ME_OK;
 }
 
-static int mreg_send_raw(mfile* mf,
-                         u_int16_t reg_id,
+static int mreg_send_raw(mfile              * mf,
+                         u_int16_t            reg_id,
                          maccess_reg_method_t method,
-                         void* reg_data,
-                         u_int32_t reg_size,
-                         u_int32_t r_size_reg,
-                         u_int32_t w_size_reg,
-                         int* reg_status)
+                         void               * reg_data,
+                         u_int32_t            reg_size,
+                         u_int32_t            r_size_reg,
+                         u_int32_t            w_size_reg,
+                         int                * reg_status)
 {
-    // printf("-D- reg_id = %d, reg_size = %d, r_size_reg = %d , w_size_reg =
-    // %d\n",reg_id,reg_size,r_size_reg,w_size_reg);
-    int mad_rc, cmdif_size = 0;
+    /* printf("-D- reg_id = %d, reg_size = %d, r_size_reg = %d , w_size_reg = */
+    /* %d\n",reg_id,reg_size,r_size_reg,w_size_reg); */
+    int                 mad_rc, cmdif_size = 0;
     struct OperationTlv tlv;
-    struct reg_tlv tlv_info;
-    u_int8_t buffer[1024];
+    struct reg_tlv      tlv_info;
+    u_int8_t            buffer[1024];
 
     init_operation_tlv(&(tlv), reg_id, method);
-    // Fill Reg TLV
+    /* Fill Reg TLV */
     memset(&tlv_info, 0, sizeof(tlv_info));
     tlv_info.Type = TLV_REG;
-    tlv_info.len = (reg_size + REG_TLV_HEADER_LEN) >> 2; // length is in dwords
-    // Pack the mad
+    tlv_info.len = (reg_size + REG_TLV_HEADER_LEN) >> 2; /* length is in dwords */
+    /* Pack the mad */
 
     cmdif_size += OperationTlv_pack(&tlv, buffer);
     cmdif_size += reg_tlv_pack(&tlv_info, buffer + OP_TLV_SIZE);
-    // put the reg itself into the buffer
+    /* put the reg itself into the buffer */
     memcpy(buffer + OP_TLV_SIZE + REG_TLV_HEADER_LEN, reg_data, reg_size);
     cmdif_size += reg_size;
 
@@ -2471,18 +2232,18 @@ static int mreg_send_raw(mfile* mf,
     fprintf(stdout, "\tReg Tlv\n");
     reg_tlv_dump(&tlv_info, stdout);
 #endif
-    // printf("-D- reg_info.len = |%d, OP_TLV: %d, REG_TLV= %d, cmdif_size = %d\n", reg_info.len, OP_TLV_SIZE,
-    // REG_RLV_HEADER_LEN, cmdif_size); update r/w_size_reg with the size of op tlv and reg tlv as we need to read/write
-    // them as well
+    /* printf("-D- reg_info.len = |%d, OP_TLV: %d, REG_TLV= %d, cmdif_size = %d\n", reg_info.len, OP_TLV_SIZE, */
+    /* REG_RLV_HEADER_LEN, cmdif_size); update r/w_size_reg with the size of op tlv and reg tlv as we need to read/write */
+    /* them as well */
     r_size_reg += OP_TLV_SIZE + REG_TLV_HEADER_LEN;
     w_size_reg += OP_TLV_SIZE + REG_TLV_HEADER_LEN;
-    // printf("-D- reg_size = %d, r_size_reg = %d , w_size_reg = %d\n",reg_size,r_size_reg,w_size_reg);
+    /* printf("-D- reg_size = %d, r_size_reg = %d , w_size_reg = %d\n",reg_size,r_size_reg,w_size_reg); */
 
     mad_rc = mreg_send_wrapper(mf, buffer, r_size_reg, w_size_reg);
-    // Unpack the mad
+    /* Unpack the mad */
     OperationTlv_unpack(&tlv, buffer);
     reg_tlv_unpack(&tlv_info, buffer + OP_TLV_SIZE);
-    // copy register back from the buffer
+    /* copy register back from the buffer */
     memcpy(reg_data, buffer + OP_TLV_SIZE + REG_TLV_HEADER_LEN, reg_size);
 
 #ifdef _ENABLE_DEBUG_
@@ -2492,10 +2253,9 @@ static int mreg_send_raw(mfile* mf,
     fprintf(stdout, "\tReg Tlv\n");
     reg_tlv_dump(&tlv_info, stdout);
 #endif
-    // Check the return value
+    /* Check the return value */
     *reg_status = tlv.status;
-    if (mad_rc)
-    {
+    if (mad_rc) {
         return mad_rc;
     }
 
@@ -2503,27 +2263,24 @@ static int mreg_send_raw(mfile* mf,
 }
 
 
-
-#define CONNECTX3_HW_ID 0x1f5
+#define CONNECTX3_HW_ID     0x1f5
 #define CONNECTX3_PRO_HW_ID 0x1f7
 
 static int supports_icmd(mfile* mf)
 {
     u_int32_t dev_id;
 
-    if (read_device_id(mf, &dev_id) != 4)
-    {
-        // cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd
+    if (read_device_id(mf, &dev_id) != 4) {
+        /* cr might be locked and retured 0xbad0cafe but we dont care we search for device that supports icmd */
         return 0;
     }
-    switch (dev_id & 0xffff)
-    { // that the hw device id
-        case CONNECTX3_HW_ID:
-        case CONNECTX3_PRO_HW_ID:
-            return 0;
+    switch (dev_id & 0xffff) { /* that the hw device id */
+    case CONNECTX3_HW_ID:
+    case CONNECTX3_PRO_HW_ID:
+        return 0;
 
-        default:
-            break;
+    default:
+        break;
     }
     return 1;
 }
@@ -2532,219 +2289,210 @@ static int supports_tools_cmdif_reg(mfile* mf)
 {
     u_int32_t dev_id;
 
-    if (read_device_id(mf, &dev_id) != 4)
-    {
+    if (read_device_id(mf, &dev_id) != 4) {
         return 0;
     }
-    switch (dev_id & 0xffff)
-    {                             // that the hw device id
-        case CONNECTX3_HW_ID:     // Cx3
-        case CONNECTX3_PRO_HW_ID: // Cx3-pro
-            if (tools_cmdif_is_supported(mf) == ME_OK)
-            {
-                return 1;
-            }
-            return 0;
+    switch (dev_id & 0xffff) {    /* that the hw device id */
+    case CONNECTX3_HW_ID:         /* Cx3 */
+    case CONNECTX3_PRO_HW_ID:     /* Cx3-pro */
+        if (tools_cmdif_is_supported(mf) == ME_OK) {
+            return 1;
+        }
+        return 0;
 
-        default:
-            return 0;
+    default:
+        return 0;
     }
 }
 
 int mget_max_reg_size(mfile* mf, maccess_reg_method_t reg_method)
 {
-    if (mf->acc_reg_params.max_reg_size[reg_method])
-    {
+    if (mf->acc_reg_params.max_reg_size[reg_method]) {
         return mf->acc_reg_params.max_reg_size[reg_method];
-    }
-    else if (supports_icmd(mf))
-    {
-        // we support icmd and we dont use IB interface -> we use icmd for reg access
-        // TOOD: get size dynamically from icmd_params once we have support by fw for mfba with size field greater than
-        // 8 bits
+    } else if (supports_icmd(mf)) {
+        /* we support icmd and we dont use IB interface -> we use icmd for reg access */
+        /* TOOD: get size dynamically from icmd_params once we have support by fw for mfba with size field greater than */
+        /* 8 bits */
         mf->acc_reg_params.max_reg_size[reg_method] = ICMD_MAX_REG_SIZE;
-    }
-    else if (supports_tools_cmdif_reg(mf))
-    {
+    } else if (supports_tools_cmdif_reg(mf)) {
         mf->acc_reg_params.max_reg_size[reg_method] = TOOLS_HCR_MAX_REG_SIZE;
     }
     return mf->acc_reg_params.max_reg_size[reg_method];
 }
 
 /************************************
- * Function: m_err2str
- ************************************/
+* Function: m_err2str
+************************************/
 const char* m_err2str(MError status)
 {
-    switch (status)
-    {
-        case ME_OK:
-            return "ME_OK";
+    switch (status) {
+    case ME_OK:
+        return "ME_OK";
 
-        case ME_ERROR:
-            return "General error";
+    case ME_ERROR:
+        return "General error";
 
-        case ME_BAD_PARAMS:
-            return "ME_BAD_PARAMS";
+    case ME_BAD_PARAMS:
+        return "ME_BAD_PARAMS";
 
-        case ME_CR_ERROR:
-            return "ME_CR_ERROR";
+    case ME_CR_ERROR:
+        return "ME_CR_ERROR";
 
-        case ME_NOT_IMPLEMENTED:
-            return "ME_NOT_IMPLEMENTED";
+    case ME_NOT_IMPLEMENTED:
+        return "ME_NOT_IMPLEMENTED";
 
-        case ME_SEM_LOCKED:
-            return "Semaphore locked";
+    case ME_SEM_LOCKED:
+        return "Semaphore locked";
 
-        case ME_MEM_ERROR:
-            return "ME_MEM_ERROR";
+    case ME_MEM_ERROR:
+        return "ME_MEM_ERROR";
 
-        case ME_UNSUPPORTED_OPERATION:
-            return "ME_UNSUPPORTED_OPERATION";
+    case ME_UNSUPPORTED_OPERATION:
+        return "ME_UNSUPPORTED_OPERATION";
 
-        case ME_MAD_SEND_FAILED:
-            return "ME_MAD_SEND_FAILED";
+    case ME_MAD_SEND_FAILED:
+        return "ME_MAD_SEND_FAILED";
 
-        case ME_UNKOWN_ACCESS_TYPE:
-            return "ME_UNKOWN_ACCESS_TYPE";
+    case ME_UNKOWN_ACCESS_TYPE:
+        return "ME_UNKOWN_ACCESS_TYPE";
 
-        case ME_UNSUPPORTED_ACCESS_TYPE:
-            return "ME_UNSUPPORTED_ACCESS_TYPE";
+    case ME_UNSUPPORTED_ACCESS_TYPE:
+        return "ME_UNSUPPORTED_ACCESS_TYPE";
 
-        case ME_UNSUPPORTED_DEVICE:
-            return "ME_UNSUPPORTED_DEVICE";
+    case ME_UNSUPPORTED_DEVICE:
+        return "ME_UNSUPPORTED_DEVICE";
 
-        // Reg access errors
-        case ME_REG_ACCESS_BAD_STATUS_ERR:
-            return "ME_REG_ACCESS_BAD_STATUS_ERR";
+    /* Reg access errors */
+    case ME_REG_ACCESS_BAD_STATUS_ERR:
+        return "ME_REG_ACCESS_BAD_STATUS_ERR";
 
-        case ME_REG_ACCESS_BAD_METHOD:
-            return "Bad method";
+    case ME_REG_ACCESS_BAD_METHOD:
+        return "Bad method";
 
-        case ME_REG_ACCESS_NOT_SUPPORTED:
-            return "The Register access is not supported by the device";
+    case ME_REG_ACCESS_NOT_SUPPORTED:
+        return "The Register access is not supported by the device";
 
-        case ME_REG_ACCESS_DEV_BUSY:
-            return "Device is busy";
+    case ME_REG_ACCESS_DEV_BUSY:
+        return "Device is busy";
 
-        case ME_REG_ACCESS_VER_NOT_SUPP:
-            return "Version not supported";
+    case ME_REG_ACCESS_VER_NOT_SUPP:
+        return "Version not supported";
 
-        case ME_REG_ACCESS_UNKNOWN_TLV:
-            return "Unknown TLV";
+    case ME_REG_ACCESS_UNKNOWN_TLV:
+        return "Unknown TLV";
 
-        case ME_REG_ACCESS_REG_NOT_SUPP:
-            return "Register not supported";
+    case ME_REG_ACCESS_REG_NOT_SUPP:
+        return "Register not supported";
 
-        case ME_REG_ACCESS_CLASS_NOT_SUPP:
-            return "Class not supported";
+    case ME_REG_ACCESS_CLASS_NOT_SUPP:
+        return "Class not supported";
 
-        case ME_REG_ACCESS_METHOD_NOT_SUPP:
-            return "Method not supported";
+    case ME_REG_ACCESS_METHOD_NOT_SUPP:
+        return "Method not supported";
 
-        case ME_REG_ACCESS_BAD_PARAM:
-            return "Bad parameter";
+    case ME_REG_ACCESS_BAD_PARAM:
+        return "Bad parameter";
 
-        case ME_REG_ACCESS_RES_NOT_AVLBL:
-            return "Resource unavailable";
+    case ME_REG_ACCESS_RES_NOT_AVLBL:
+        return "Resource unavailable";
 
-        case ME_REG_ACCESS_MSG_RECPT_ACK:
-            return "Message receipt ack";
+    case ME_REG_ACCESS_MSG_RECPT_ACK:
+        return "Message receipt ack";
 
-        case ME_REG_ACCESS_UNKNOWN_ERR:
-            return "Unknown register error";
+    case ME_REG_ACCESS_UNKNOWN_ERR:
+        return "Unknown register error";
 
-        case ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
-            return "Register is too large";
+    case ME_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
+        return "Register is too large";
 
-        case ME_REG_ACCESS_CONF_CORRUPT:
-            return "Config Section Corrupted";
+    case ME_REG_ACCESS_CONF_CORRUPT:
+        return "Config Section Corrupted";
 
-        case ME_REG_ACCESS_LEN_TOO_SMALL:
-            return "The given Register length is too small for the Tlv";
+    case ME_REG_ACCESS_LEN_TOO_SMALL:
+        return "The given Register length is too small for the Tlv";
 
-        case ME_REG_ACCESS_BAD_CONFIG:
-            return "The configuration is rejected";
+    case ME_REG_ACCESS_BAD_CONFIG:
+        return "The configuration is rejected";
 
-        case ME_REG_ACCESS_ERASE_EXEEDED:
-            return "The erase count exceeds its limit";
+    case ME_REG_ACCESS_ERASE_EXEEDED:
+        return "The erase count exceeds its limit";
 
-        case ME_REG_ACCESS_INTERNAL_ERROR:
-            return "Firmware internal error";
+    case ME_REG_ACCESS_INTERNAL_ERROR:
+        return "Firmware internal error";
 
-        // ICMD access errors
-        case ME_ICMD_STATUS_CR_FAIL:
-            return "ME_ICMD_STATUS_CR_FAIL";
+    /* ICMD access errors */
+    case ME_ICMD_STATUS_CR_FAIL:
+        return "ME_ICMD_STATUS_CR_FAIL";
 
-        case ME_ICMD_STATUS_SEMAPHORE_TO:
-            return "ME_ICMD_STATUS_SEMAPHORE_TO";
+    case ME_ICMD_STATUS_SEMAPHORE_TO:
+        return "ME_ICMD_STATUS_SEMAPHORE_TO";
 
-        case ME_ICMD_STATUS_EXECUTE_TO:
-            return "ME_ICMD_STATUS_EXECUTE_TO";
+    case ME_ICMD_STATUS_EXECUTE_TO:
+        return "ME_ICMD_STATUS_EXECUTE_TO";
 
-        case ME_ICMD_STATUS_IFC_BUSY:
-            return "ME_ICMD_STATUS_IFC_BUSY";
+    case ME_ICMD_STATUS_IFC_BUSY:
+        return "ME_ICMD_STATUS_IFC_BUSY";
 
-        case ME_ICMD_STATUS_ICMD_NOT_READY:
-            return "ME_ICMD_STATUS_ICMD_NOT_READY";
+    case ME_ICMD_STATUS_ICMD_NOT_READY:
+        return "ME_ICMD_STATUS_ICMD_NOT_READY";
 
-        case ME_ICMD_UNSUPPORTED_ICMD_VERSION:
-            return "ME_ICMD_UNSUPPORTED_ICMD_VERSION";
+    case ME_ICMD_UNSUPPORTED_ICMD_VERSION:
+        return "ME_ICMD_UNSUPPORTED_ICMD_VERSION";
 
-        case ME_ICMD_NOT_SUPPORTED:
-            return "ME_REG_ACCESS_ICMD_NOT_SUPPORTED";
+    case ME_ICMD_NOT_SUPPORTED:
+        return "ME_REG_ACCESS_ICMD_NOT_SUPPORTED";
 
-        case ME_ICMD_INVALID_OPCODE:
-            return "ME_ICMD_INVALID_OPCODE";
+    case ME_ICMD_INVALID_OPCODE:
+        return "ME_ICMD_INVALID_OPCODE";
 
-        case ME_ICMD_INVALID_CMD:
-            return "ME_ICMD_INVALID_CMD";
+    case ME_ICMD_INVALID_CMD:
+        return "ME_ICMD_INVALID_CMD";
 
-        case ME_ICMD_OPERATIONAL_ERROR:
-            return "ME_ICMD_OPERATIONAL_ERROR";
+    case ME_ICMD_OPERATIONAL_ERROR:
+        return "ME_ICMD_OPERATIONAL_ERROR";
 
-        case ME_ICMD_BAD_PARAM:
-            return "ME_ICMD_BAD_PARAM";
+    case ME_ICMD_BAD_PARAM:
+        return "ME_ICMD_BAD_PARAM";
 
-        case ME_ICMD_BUSY:
-            return "ME_ICMD_BUSY";
+    case ME_ICMD_BUSY:
+        return "ME_ICMD_BUSY";
 
-        case ME_ICMD_ICM_NOT_AVAIL:
-            return "ME_ICMD_ICM_NOT_AVAIL";
+    case ME_ICMD_ICM_NOT_AVAIL:
+        return "ME_ICMD_ICM_NOT_AVAIL";
 
-        case ME_ICMD_WRITE_PROTECT:
-            return "ME_ICMD_WRITE_PROTECT";
+    case ME_ICMD_WRITE_PROTECT:
+        return "ME_ICMD_WRITE_PROTECT";
 
-        case ME_ICMD_UNKNOWN_STATUS:
-            return "ME_ICMD_UNKNOWN_STATUS";
+    case ME_ICMD_UNKNOWN_STATUS:
+        return "ME_ICMD_UNKNOWN_STATUS";
 
-        case ME_ICMD_SIZE_EXCEEDS_LIMIT:
-            return "ME_ICMD_SIZE_EXCEEDS_LIMIT";
+    case ME_ICMD_SIZE_EXCEEDS_LIMIT:
+        return "ME_ICMD_SIZE_EXCEEDS_LIMIT";
 
-        // MAD IFC errors
-        case ME_MAD_BUSY:
-            return "Temporarily busy. MAD discarded. This is not an error";
+    /* MAD IFC errors */
+    case ME_MAD_BUSY:
+        return "Temporarily busy. MAD discarded. This is not an error";
 
-        case ME_MAD_REDIRECT:
-            return "Redirection. This is not an error";
+    case ME_MAD_REDIRECT:
+        return "Redirection. This is not an error";
 
-        case ME_MAD_BAD_VER:
-            return "Bad version";
+    case ME_MAD_BAD_VER:
+        return "Bad version";
 
-        case ME_MAD_METHOD_NOT_SUPP:
-            return "Method not supported";
+    case ME_MAD_METHOD_NOT_SUPP:
+        return "Method not supported";
 
-        case ME_MAD_METHOD_ATTR_COMB_NOT_SUPP:
-            return "Method and attribute combination isn't supported";
+    case ME_MAD_METHOD_ATTR_COMB_NOT_SUPP:
+        return "Method and attribute combination isn't supported";
 
-        case ME_MAD_BAD_DATA:
-            return "Bad attribute modifer or field";
+    case ME_MAD_BAD_DATA:
+        return "Bad attribute modifer or field";
 
-        case ME_MAD_GENERAL_ERR:
-            return "Unknown MAD error";
+    case ME_MAD_GENERAL_ERR:
+        return "Unknown MAD error";
 
-        default:
-            return "Unknown error code";
+    default:
+        return "Unknown error code";
     }
 }
 
@@ -2792,19 +2540,18 @@ int mget_addr_space(mfile* mf)
 }
 int mset_addr_space(mfile* mf, int space)
 {
-    switch (space)
-    {
-        case AS_CR_SPACE:
-        case AS_ICMD:
-        case AS_SEMAPHORE:
-        case AS_PCI_CRSPACE:
-        case AS_PCI_ALL_ICMD:
-        case AS_PCI_GLOBAL_SEMAPHORE:
-        case AS_RECOVERY:
-            break;
+    switch (space) {
+    case AS_CR_SPACE:
+    case AS_ICMD:
+    case AS_SEMAPHORE:
+    case AS_PCI_CRSPACE:
+    case AS_PCI_ALL_ICMD:
+    case AS_PCI_GLOBAL_SEMAPHORE:
+    case AS_RECOVERY:
+        break;
 
-        default:
-            return -1;
+    default:
+        return -1;
     }
     mf->address_space = space;
     return 0;
@@ -2814,31 +2561,27 @@ int device_exists(const char* devname)
 {
     char* devs = NULL;
     char* pdevs;
-    int size = 512;
-    int rc = 0;
-    int i = 0;
-    int res = 0;
-    // Get list of devices
-    do
-    {
-        if (devs)
-        {
+    int   size = 512;
+    int   rc = 0;
+    int   i = 0;
+    int   res = 0;
+
+    /* Get list of devices */
+    do{
+        if (devs) {
             free(devs);
         }
         size *= 2;
         devs = malloc(size);
-        if (!devs)
-        {
+        if (!devs) {
             errno = ENOMEM;
             return 0;
         }
         rc = mdevices_v(devs, size, MDEVS_ALL, 1);
     } while (rc == -1);
     pdevs = devs;
-    while (i < rc)
-    {
-        if (!strcmp(devname, pdevs))
-        {
+    while (i < rc) {
+        if (!strcmp(devname, pdevs)) {
             res = 1;
             goto cleanup;
         }
@@ -2846,8 +2589,7 @@ int device_exists(const char* devname)
         i++;
     }
 cleanup:
-    if (devs)
-    {
+    if (devs) {
         free(devs);
     }
     return res;
@@ -2856,14 +2598,13 @@ cleanup:
 int mclear_pci_semaphore(const char* name)
 {
     mfile* mf;
-    int rc = ME_OK;
+    int    rc = ME_OK;
+
     mf = mopen_int(name, Clear_Vsec_Semaphore);
-    if (!mf)
-    {
+    if (!mf) {
         return ME_ERROR;
     }
-    if (mf->tp != MST_PCICONF)
-    {
+    if (mf->tp != MST_PCICONF) {
         rc = ME_UNSUPPORTED_ACCESS_TYPE;
     }
     mclose(mf);
@@ -2872,68 +2613,57 @@ int mclear_pci_semaphore(const char* name)
 
 int mvpd_read4_int(mfile* mf, unsigned int offset, u_int8_t value[4])
 {
-    int vpd_cap = mf->vpd_cap_addr;
+    int      vpd_cap = mf->vpd_cap_addr;
     uint16_t write_addr;
     uint32_t read_addr;
-    int res;
-    int count_to_timeout;
-    int done = 0;
+    int      res;
+    int      count_to_timeout;
+    int      done = 0;
 
-    if (!mf || !value)
-    {
+    if (!mf || !value) {
         return ME_BAD_PARAMS;
     }
-    if (!vpd_cap)
-    {
+    if (!vpd_cap) {
         return ME_UNSUPPORTED_OPERATION;
     }
     int lock_rc = _flock_int(mf->fdlock, LOCK_EX);
-    if (lock_rc)
-    {
+
+    if (lock_rc) {
         perror("READ VPD");
         return ME_ERROR;
     }
     /* sets F bit to zero and write VPD addr */
     write_addr = (0x7fff & offset);
     res = write_config(mf, vpd_cap + PCI_VPD_ADDR, write_addr, 2);
-    if (res)
-    {
+    if (res) {
         res = ME_CR_ERROR;
         goto cleanup;
     }
 
     /* wait for data until F bit is set with one */
-    for (count_to_timeout = 0; count_to_timeout < MST_VPD_DFLT_TIMEOUT; count_to_timeout++)
-    {
+    for (count_to_timeout = 0; count_to_timeout < MST_VPD_DFLT_TIMEOUT; count_to_timeout++) {
         res = read_config(mf, vpd_cap + PCI_VPD_ADDR, &read_addr, 2);
-        if (res)
-        {
+        if (res) {
             res = ME_CR_ERROR;
             goto cleanup;
         }
-        if (read_addr & 0x8000)
-        {
+        if (read_addr & 0x8000) {
             done = 1;
             break;
         }
         sched_yield();
     }
-    if (done)
-    {
+    if (done) {
         res = read_config(mf, vpd_cap + PCI_VPD_DATA, (uint32_t*)value, 4);
-        if (res)
-        {
+        if (res) {
             res = ME_CR_ERROR;
         }
-    }
-    else
-    {
+    } else {
         res = ME_TIMEOUT;
     }
 cleanup:
     lock_rc = _flock_int(mf->fdlock, LOCK_UN);
-    if (lock_rc)
-    {
+    if (lock_rc) {
         perror("READ VPD");
         return ME_ERROR;
     }
@@ -2942,22 +2672,18 @@ cleanup:
 
 int mvpd_read4(mfile* mf, unsigned int offset, u_int8_t value[4])
 {
-    if (offset % 4)
-    {
-        u_int8_t qword[8] = {0};
-        int rc = 0;
+    if (offset % 4) {
+        u_int8_t     qword[8] = {0};
+        int          rc = 0;
         unsigned int aligned_offset = (offset / 4) * 4;
         rc = mvpd_read4_int(mf, aligned_offset, qword);
-        if (rc)
-        {
+        if (rc) {
             return rc;
         }
         rc = mvpd_read4_int(mf, aligned_offset + 4, qword + 4);
         memcpy(value, qword + (offset % 4), 4);
         return 0;
-    }
-    else
-    {
+    } else {
         return mvpd_read4_int(mf, offset, value);
     }
 }
@@ -2984,77 +2710,67 @@ int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount)
     int page_counter = 0;
     int ret_code = ME_OK;
 
-    // Parameter validation.
-    if (!mf || !page_info)
-    {
+    /* Parameter validation. */
+    if (!mf || !page_info) {
         return ME_BAD_PARAMS;
     }
 
-    // Open the memory device file.
+    /* Open the memory device file. */
     int file_descriptor = open("/dev/mem", O_RDWR);
 
-    // Pin the memory in the kernel space.
-    for (page_counter = 0; page_counter < page_amount; page_counter++)
-    {
-        // Allocate the buffer.
+    /* Pin the memory in the kernel space. */
+    for (page_counter = 0; page_counter < page_amount; page_counter++) {
+        /* Allocate the buffer. */
         char* current_page = aligned_alloc(PAGE_SIZE, PAGE_SIZE);
 
-        // Page allocated ?
-        if (!current_page)
-        {
+        /* Page allocated ? */
+        if (!current_page) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
         page_allocated_counter++;
 
-        if ((uintptr_t)current_page % PAGE_SIZE)
-        {
+        if ((uintptr_t)current_page % PAGE_SIZE) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // We need to call mlock after the pages allocation in order to
-        //   lock the virtual address space into RAM and preventing that
-        //   memory from being paged to the swap area.
-        if (mlock(current_page, PAGE_SIZE))
-        {
+        /* We need to call mlock after the pages allocation in order to */
+        /*   lock the virtual address space into RAM and preventing that */
+        /*   memory from being paged to the swap area. */
+        if (mlock(current_page, PAGE_SIZE)) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // Save the virtual address in order to deallocate
-        //   the memory at the close function.
+        /* Save the virtual address in order to deallocate */
+        /*   the memory at the close function. */
         mf->user_page_list.page_list[page_counter] = current_page;
 
-        // Building the ioctl structure.
+        /* Building the ioctl structure. */
         struct mem_extract memory_user = {};
         memory_user.me_vaddr = (uintptr_t)current_page;
 
-        // Pin the user memory in the kernel space.
+        /* Pin the user memory in the kernel space. */
         int return_code = ioctl(file_descriptor, MEM_EXTRACT_PADDR, &memory_user);
 
-        if (return_code || (memory_user.me_state != ME_STATE_MAPPED))
-        {
+        if (return_code || (memory_user.me_state != ME_STATE_MAPPED)) {
             ret_code = ME_MEM_ERROR;
             break;
         }
 
-        // Save the PA and VA for the tool.
+        /* Save the PA and VA for the tool. */
         page_info->page_addresses_array[page_counter].dma_address = memory_user.me_paddr;
         page_info->page_addresses_array[page_counter].virtual_address = (uintptr_t)current_page;
     }
 
-    // Close the device file /dev/mem.
+    /* Close the device file /dev/mem. */
     close(file_descriptor);
 
-    if (ret_code)
-    {
+    if (ret_code) {
         release_dma_pages(mf, page_allocated_counter);
-    }
-
-    else
-    {
+    } else {
         mf->user_page_list.page_amount = page_amount;
     }
 
@@ -3063,26 +2779,23 @@ int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount)
 
 int release_dma_pages(mfile* mf, int page_amount)
 {
-    // Parameter validation.
-    if (!mf)
-    {
+    /* Parameter validation. */
+    if (!mf) {
         return -1;
     }
 
-    // Deallocate the pages.
-    for (int page_counter = 0; page_counter < page_amount; page_counter++)
-    {
-        if (!mf->user_page_list.page_list[page_counter])
-        {
+    /* Deallocate the pages. */
+    for (int page_counter = 0; page_counter < page_amount; page_counter++) {
+        if (!mf->user_page_list.page_list[page_counter]) {
             continue;
         }
 
-        // Unlocking the virtual address of the page,
-        //    so that pages in the specified virtual address range may
-        //    once more to be swapped out if required by the kernel memory manager.
+        /* Unlocking the virtual address of the page, */
+        /*    so that pages in the specified virtual address range may */
+        /*    once more to be swapped out if required by the kernel memory manager. */
         munlock(mf->user_page_list.page_list[page_counter], PAGE_SIZE);
 
-        // Free the user space memory.
+        /* Free the user space memory. */
         free(mf->user_page_list.page_list[page_counter]);
 
         mf->user_page_list.page_list[page_counter] = NULL;
@@ -3124,29 +2837,26 @@ int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data)
 {
     int ret = 0;
 
-    // Parameters validation.
-    if (!mf || !data)
-    {
+    /* Parameters validation. */
+    if (!mf || !data) {
         return -1;
     }
 
-    // take semaphore.
+    /* take semaphore. */
     ret = _vendor_specific_sem(mf, 1);
-    if (ret)
-    {
+    if (ret) {
         return ret;
     }
 
-    // set address space.
+    /* set address space. */
     ret = _set_addr_space(mf, mf->address_space);
 
-    if (!ret)
-    {
-        // read the data.
+    if (!ret) {
+        /* read the data. */
         READ4_PCI(mf, data, offset, "read value", return -1);
     }
 
-    // clear semaphore
+    /* clear semaphore */
     _vendor_specific_sem(mf, 0);
 
     return ret;
@@ -3172,7 +2882,11 @@ int mcables_remote_operation_client_side(mfile* mf, u_int32_t address, u_int32_t
     return 0;
 }
 
-int mlxcables_remote_operation_client_side(mfile* mf, const char* device_name, char op, char flags, const char* reg_name)
+int mlxcables_remote_operation_client_side(mfile     * mf,
+                                           const char* device_name,
+                                           char        op,
+                                           char        flags,
+                                           const char* reg_name)
 {
     (void)mf;
     (void)device_name;
@@ -3184,8 +2898,7 @@ int mlxcables_remote_operation_client_side(mfile* mf, const char* device_name, c
 
 int is_remote_dev(mfile* mf)
 {
-    if (mf)
-    {
+    if (mf) {
         return mf->is_remote;
     }
 
@@ -3195,57 +2908,55 @@ int is_remote_dev(mfile* mf)
 
 static int check_zf_through_memory(mfile* mf)
 {
-    uint32_t gis = 0; // Global image status
-    size_t gis_address = 0;
-    switch (mf->device_hw_id)
-    {
-        case DeviceQuantum3_HwId:
-            gis_address = 0x152080;
-            break;
-        default:
-            return 0; // Device does not support Zombiefish mode
+    uint32_t gis = 0; /* Global image status */
+    size_t   gis_address = 0;
+
+    switch (mf->device_hw_id) {
+    case DeviceQuantum3_HwId:
+        gis_address = 0x152080;
+        break;
+
+    default:
+        return 0;     /* Device does not support Zombiefish mode */
     }
     int rc = mread4(mf, gis_address, &gis);
 
-    if (rc != 4)
-    {
-        // printf("-E- Failed to read global_image_status from CR space (BAR0).\n");
+    if (rc != 4) {
+        /* printf("-E- Failed to read global_image_status from CR space (BAR0).\n"); */
         return 0;
     }
-    gis = EXTRACT(gis, 0, 16); // Extract the first 16 bits
+    gis = EXTRACT(gis, 0, 16); /* Extract the first 16 bits */
     return gis == AUTHENTICATION_FAILURE;
 }
 
 static int check_zf_through_vsc(mfile* mf)
 {
     int prev_address_space = mf->address_space;
-    // If the device is in LF mode or the recovery space is not supported, the device is not in Zombiefish mode.
-    if (is_livefish_device(mf) || mset_addr_space(mf, AS_RECOVERY) == -1)
-    {
+
+    /* If the device is in LF mode or the recovery space is not supported, the device is not in Zombiefish mode. */
+    if (is_livefish_device(mf) || (mset_addr_space(mf, AS_RECOVERY) == -1)) {
         return 0;
     }
 
     uint32_t first_dword = 0;
-    int rc = mread4(mf, INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE, &first_dword);
+    int      rc = mread4(mf, INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE, &first_dword);
 
-    if (rc != 4)
-    {
+    if (rc != 4) {
         mset_addr_space(mf, prev_address_space);
-        // printf("-E- Failed to read the first dword in VSC recovery space.\n");
+        /* printf("-E- Failed to read the first dword in VSC recovery space.\n"); */
         return 0;
     }
 
-    uint32_t in_recovery = EXTRACT(first_dword, 1, 1);       // Extract bit 1
-    uint32_t flash_control_vld = EXTRACT(first_dword, 2, 1); // Extract bit 2
-    uint32_t initializing = EXTRACT(first_dword, 0, 1);      // Extract bit 0
+    uint32_t in_recovery = EXTRACT(first_dword, 1, 1);       /* Extract bit 1 */
+    uint32_t flash_control_vld = EXTRACT(first_dword, 2, 1); /* Extract bit 2 */
+    uint32_t initializing = EXTRACT(first_dword, 0, 1);      /* Extract bit 0 */
 
     mf->vsc_recovery_space_flash_control_vld = flash_control_vld;
     mset_addr_space(mf, prev_address_space);
 
-    if (in_recovery && initializing)
-    {
-        // printf("Device with HW ID: %u is in ZombieFish mode. flash_control_vld: %u\n", mf->device_hw_id,
-        //            flash_control_vld);
+    if (in_recovery && initializing) {
+        /* printf("Device with HW ID: %u is in ZombieFish mode. flash_control_vld: %u\n", mf->device_hw_id, */
+        /*            flash_control_vld); */
         return 1;
     }
 
@@ -3255,26 +2966,26 @@ static int check_zf_through_vsc(mfile* mf)
 int is_zombiefish_device(mfile* mf)
 {
     u_int32_t dev_id = 0;
-    if (read_device_id(mf, &dev_id) != 4)
-    {
+
+    if (read_device_id(mf, &dev_id) != 4) {
         return 0;
     }
-    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId &&
-        mf->device_hw_id != DeviceConnectX9_HwId && mf->device_hw_id != DeviceQuantum4_HwId &&
-        mf->device_hw_id != DeviceConnectX7_HwId && mf->device_hw_id != DeviceBlueField3_HwId)
-    {
+    if ((mf->device_hw_id != DeviceConnectX8_HwId) && (mf->device_hw_id != DeviceQuantum3_HwId) &&
+        (mf->device_hw_id != DeviceConnectX9_HwId) && (mf->device_hw_id != DeviceQuantum4_HwId) &&
+        (mf->device_hw_id != DeviceConnectX7_HwId) && (mf->device_hw_id != DeviceBlueField3_HwId)) {
         return 0;
     }
 
-    switch (mf->tp)
-    {
-        case MST_PCI:
-            mf->is_zombiefish = check_zf_through_memory(mf);
-            return mf->is_zombiefish;
-        case MST_PCICONF:
-            mf->is_zombiefish = check_zf_through_vsc(mf);
-            return mf->is_zombiefish;
-        default:
-            return 0;
+    switch (mf->tp) {
+    case MST_PCI:
+        mf->is_zombiefish = check_zf_through_memory(mf);
+        return mf->is_zombiefish;
+
+    case MST_PCICONF:
+        mf->is_zombiefish = check_zf_through_vsc(mf);
+        return mf->is_zombiefish;
+
+    default:
+        return 0;
     }
 }

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -40,7 +40,8 @@ libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
 			mtcr_ul_icmd_cif.c mtcr_icmd_cif.h\
 			mtcr_mem_ops.c mtcr_mem_ops.h\
 			mtcr_ul_com_defs.h mtcr_mf.h\
-			mtcr_ul_com.h mtcr_ul_com.c\
+			mtcr_ul_com.h mtcr_ul_com.c \
+			mtcr_common.h mtcr_common.c \
 			packets_common.c packets_common.h\
 			packets_layout.c packets_layout.h \
 			fwctrl.c fwctrl.h fwctrl_ioctl.h

--- a/mtcr_ul/mtcr_common.c
+++ b/mtcr_ul/mtcr_common.c
@@ -1,0 +1,53 @@
+#include "mtcr_common.h"
+
+void swap_pci_address_space(mfile* mf)
+{
+    switch (mf->address_space) {
+    case AS_ICMD_EXT:
+        mf->address_space = AS_PCI_ICMD;
+        break;
+
+    case AS_ND_CRSPACE:
+    case AS_CR_SPACE:
+        mf->address_space = AS_PCI_CRSPACE;
+        break;
+
+    case AS_ICMD:
+        mf->address_space = AS_PCI_ALL_ICMD;
+        break;
+
+    case AS_SCAN_CRSPACE:
+        mf->address_space = AS_PCI_SCAN_CRSPACE;
+        break;
+
+    case AS_SEMAPHORE:
+        mf->address_space = AS_PCI_GLOBAL_SEMAPHORE;
+        break;
+
+    case AS_PCI_ICMD:
+        mf->address_space = AS_ICMD_EXT;
+        break;
+
+    case AS_PCI_CRSPACE:
+        mf->address_space = AS_CR_SPACE;
+        break;
+
+    case AS_PCI_ALL_ICMD:
+        mf->address_space = AS_ICMD;
+        break;
+
+    case AS_PCI_SCAN_CRSPACE:
+        mf->address_space = AS_SCAN_CRSPACE;
+        break;
+
+    case AS_PCI_GLOBAL_SEMAPHORE:
+        mf->address_space = AS_SEMAPHORE;
+        break;
+
+    default:
+        DBG_PRINTF("MTCR: swap_pci_address_space: no address_space found: %x\n", mf->address_space);
+        return;
+    }
+
+    DBG_PRINTF("mf->address_space swapped to: %x\n", mf->address_space);
+}

--- a/mtcr_ul/mtcr_common.h
+++ b/mtcr_ul/mtcr_common.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef _MTCR_COMMON_H_
+#define _MTCR_COMMON_H_
+
+#include <mtcr.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define DBG_PRINTF(...)                   \
+    do                                    \
+    {                                     \
+        if (getenv("MFT_DEBUG") != NULL)  \
+        {                                 \
+            fprintf(stderr, __VA_ARGS__); \
+        }                                 \
+    } while (0)
+
+void swap_pci_address_space(mfile* mf);
+
+#endif

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -64,14 +64,13 @@ int mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data, int byte_len)
 int msw_reset(mfile* mf)
 {
 #ifndef NO_INBAND
-    switch (mf->tp)
-    {
-        case MST_IB:
-            return mib_swreset(mf);
+    switch (mf->tp) {
+    case MST_IB:
+        return mib_swreset(mf);
 
-        default:
-            errno = EPERM;
-            return -1;
+    default:
+        errno = EPERM;
+        return -1;
     }
 #else
     (void)mf;
@@ -104,27 +103,20 @@ dev_info* mdevices_info_v(int mask, int* len, int verbosity)
 void mdevices_info_destroy(dev_info* dev_info, int len)
 {
     int i, j;
-    if (dev_info)
-    {
-        for (i = 0; i < len; i++)
-        {
-            if (dev_info[i].type == MDEVS_TAVOR_CR && dev_info[i].pci.ib_devs)
-            {
-                for (j = 0; dev_info[i].pci.ib_devs[j]; j++)
-                {
-                    if (dev_info[i].pci.ib_devs[j])
-                    {
+
+    if (dev_info) {
+        for (i = 0; i < len; i++) {
+            if ((dev_info[i].type == MDEVS_TAVOR_CR) && dev_info[i].pci.ib_devs) {
+                for (j = 0; dev_info[i].pci.ib_devs[j]; j++) {
+                    if (dev_info[i].pci.ib_devs[j]) {
                         free(dev_info[i].pci.ib_devs[j]);
                     }
                 }
                 free(dev_info[i].pci.ib_devs);
             }
-            if (dev_info[i].type == MDEVS_TAVOR_CR && dev_info[i].pci.net_devs)
-            {
-                for (j = 0; dev_info[i].pci.net_devs[j]; j++)
-                {
-                    if (dev_info[i].pci.net_devs[j])
-                    {
+            if ((dev_info[i].type == MDEVS_TAVOR_CR) && dev_info[i].pci.net_devs) {
+                for (j = 0; dev_info[i].pci.net_devs[j]; j++) {
+                    if (dev_info[i].pci.net_devs[j]) {
                         free(dev_info[i].pci.net_devs[j]);
                     }
                 }
@@ -142,8 +134,7 @@ mfile* mopen(const char* name)
 
 mfile* mopend(const char* name, DType dtype)
 {
-    if (dtype != MST_TAVOR)
-    {
+    if (dtype != MST_TAVOR) {
         return NULL;
     }
     return mopen(name);
@@ -157,14 +148,11 @@ int mclose(mfile* mf)
 mfile* mopen_adv(const char* name, MType mtype)
 {
     mfile* mf = mopend(name, MST_TAVOR);
-    if (mf)
-    {
-        if (mf->tp & mtype)
-        {
+
+    if (mf) {
+        if (mf->tp & mtype) {
             return mf;
-        }
-        else
-        {
+        } else {
             errno = EPERM;
             mclose(mf);
             return NULL;
@@ -175,7 +163,7 @@ mfile* mopen_adv(const char* name, MType mtype)
 
 mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* extra_data)
 {
-    // not implemented
+    /* not implemented */
     TOOLS_UNUSED(fw_cmd_context);
     TOOLS_UNUSED(fw_cmd_func);
     TOOLS_UNUSED(extra_data);
@@ -184,12 +172,9 @@ mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* extra_data)
 
 void get_pci_dev_rdma(mfile* mf, char* buf)
 {
-    if (mf != NULL && mf->dinfo != NULL && strlen(mf->dinfo->pci.ib_devs[0]) > 0)
-    {
+    if ((mf != NULL) && (mf->dinfo != NULL) && (strlen(mf->dinfo->pci.ib_devs[0]) > 0)) {
         snprintf(buf, 32, "%s", mf->dinfo->pci.ib_devs[0]);
-    }
-    else
-    {
+    } else {
         *buf = '\0';
     }
 }
@@ -237,14 +222,14 @@ int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len)
     return mwrite_buffer_ul(mf, offset, data, byte_len);
 }
 
-int maccess_reg(mfile* mf,
-                u_int16_t reg_id,
+int maccess_reg(mfile              * mf,
+                u_int16_t            reg_id,
                 maccess_reg_method_t reg_method,
-                void* reg_data,
-                u_int32_t reg_size,
-                u_int32_t r_size_reg,
-                u_int32_t w_size_reg,
-                int* reg_status)
+                void               * reg_data,
+                u_int32_t            reg_size,
+                u_int32_t            r_size_reg,
+                u_int32_t            w_size_reg,
+                int                * reg_status)
 {
     return maccess_reg_ul(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg, reg_status);
 }
@@ -271,24 +256,21 @@ MTCR_API int mget_addr_space(mfile* mf)
 
 MTCR_API int mset_addr_space(mfile* mf, int space)
 {
-    if (space < 0 || space >= AS_END)
-    {
+    if ((space < 0) || (space >= AS_END)) {
         return -1;
     }
-    if (VSEC_SUPPORTED_UL(mf) && (mf->vsec_cap_mask & (1 << space_to_cap_offset(space))))
-    {
+    if (VSEC_SUPPORTED_UL(mf) && (mf->vsec_cap_mask & (1 << space_to_cap_offset(space)))) {
         mf->address_space = space;
-        // printf("VSC address space was set successfully to: %d\n", mf->address_space);
+        /* printf("VSC address space was set successfully to: %d\n", mf->address_space); */
         return 0;
     }
-    // printf("failed to set VSC address space to: %d. mf->address_space = %d\n", space, mf->address_space);
+    /* printf("failed to set VSC address space to: %d. mf->address_space = %d\n", space, mf->address_space); */
     return -1;
 }
 
 int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 {
-    if (mf == NULL || devs_flags == NULL)
-    {
+    if ((mf == NULL) || (devs_flags == NULL)) {
         errno = EINVAL;
         return 1;
     }
@@ -299,8 +281,7 @@ int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags)
 
 int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
 {
-    if (mf == NULL || mtype == NULL)
-    {
+    if ((mf == NULL) || (mtype == NULL)) {
         errno = EINVAL;
         return 1;
     }

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -645,10 +645,10 @@ enum {
     PCI_STATUS_BIT_OFFS = 29,
     PCI_STATUS_BIT_LEN  = 3,
 
-    PCI_SYNDROME_BIT_OFFSET = 30,
-    PCI_SYNDROME_BIT_LEN = 1,
+    PCI_SYNDROME_BIT_OFFSET      = 30,
+    PCI_SYNDROME_BIT_LEN         = 1,
     PCI_SYNDROME_CODE_BIT_OFFSET = 24,
-    PCI_SYNDROME_CODE_BIT_LEN = 4,
+    PCI_SYNDROME_CODE_BIT_LEN    = 4,
 };
 
 /* Mellanox vendor specific enum */
@@ -740,44 +740,28 @@ int mtcr_driver_mread4(mfile* mf, unsigned int offset, u_int32_t* value)
     memset(&r4, 0, sizeof(struct mst_read4_st));
     r4.address_space = (unsigned int)mf->address_space;
     r4.offset = offset;
-    if ((ioctl(mf->fd, PCICONF_READ4, &r4)) < 0)
-    {
+    if ((ioctl(mf->fd, PCICONF_READ4, &r4)) < 0) {
         DBG_PRINTF("PCICONF_READ4 ioctl failed when trying to access this space: %d. errno: %d\n",
-                    mf->address_space, errno);
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
+                   mf->address_space, errno);
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
             r4.address_space = mf->address_space;
 
-            if (ioctl(mf->fd, PCICONF_READ4, &r4) < 0)
-            {
+            if (ioctl(mf->fd, PCICONF_READ4, &r4) < 0) {
                 rc = -1;
                 DBG_PRINTF(
                     "PCICONF_READ4 ioctl failed when trying to access this space: %d. errno: %d\n",
                     mf->address_space, errno);
-            }
-            else
-            {
+            } else {
                 *value = r4.data;
                 DBG_PRINTF("PCICONF_READ4 ioctl successfully accessed this space: %d\n",
-                            mf->address_space);
+                           mf->address_space);
             }
-        }
-        else
-        {
+        } else {
             rc = -1;
         }
-    }
-    else
-    {
+    } else {
         *value = r4.data;
     }
 
@@ -794,44 +778,28 @@ int mtcr_driver_mwrite4(mfile* mf, unsigned int offset, u_int32_t value)
     r4.offset = offset;
     r4.data = value;
     r4.address_space = (unsigned int)mf->address_space;
-    if ((ioctl(mf->fd, PCICONF_WRITE4, &r4) < 0))
-    {
+    if ((ioctl(mf->fd, PCICONF_WRITE4, &r4) < 0)) {
         DBG_PRINTF("PCICONF_WRITE4 ioctl failed when trying to access this space: %d. errno: %d\n",
-                    mf->address_space, errno);
-        // support PCI space
-        if (VSEC_PXIR_SUPPORT(mf))
-        {
-            if (mf->address_space < PXIR_SPACE_OFFSET)
-            {
-                mf->address_space += PXIR_SPACE_OFFSET;
-            }
-            else
-            {
-                mf->address_space -= PXIR_SPACE_OFFSET;
-            }
+                   mf->address_space, errno);
+        /* support PCI space */
+        if (VSEC_PXIR_SUPPORT(mf)) {
+            swap_pci_address_space(mf);
             r4.address_space = mf->address_space;
 
-            if (ioctl(mf->fd, PCICONF_WRITE4, &r4) < 0)
-            {
+            if (ioctl(mf->fd, PCICONF_WRITE4, &r4) < 0) {
                 rc = -1;
                 DBG_PRINTF(
                     "PCICONF_WRITE4 ioctl failed when trying to access this space: %d. errno: %d\n",
                     mf->address_space, errno);
-            }
-            else
-            {
+            } else {
                 rc = 4;
                 DBG_PRINTF("PCICONF_WRITE4 ioctl successfully accessed this space: %d\n",
-                            mf->address_space);
+                           mf->address_space);
             }
-        }
-        else
-        {
+        } else {
             rc = -1;
         }
-    }
-    else
-    {
+    } else {
         rc = 4;
     }
 
@@ -853,13 +821,10 @@ int mtcr_fwctl_driver_mread4(mfile* mf, unsigned int offset, u_int32_t* value)
 {
     int rc = -1;
 
-    if (offset == HW_ID_ADDR)
-    {
+    if (offset == HW_ID_ADDR) {
         *value = mf->device_hw_id;
         rc = 4;
-    }
-    else
-    {
+    } else {
         FWCTL_DEBUG_PRINT(mf, "fwctl driver doesn't support VSEC access.\n")
     }
 
@@ -972,26 +937,16 @@ static int driver_mwrite4_block(mfile* mf, unsigned int offset, u_int32_t* data,
             write4_buf.size = towrite;
             memcpy(write4_buf.data, dest_ptr, towrite);
             int ret = ioctl(mf->fd, PCICONF_WRITE4_BUFFER, &write4_buf);
-            if (ret < 0)
-            {
+            if (ret < 0) {
                 DBG_PRINTF("PCICONF_WRITE4_BUFFER ioctl failed when trying to access this space: %d. errno: %d\n",
-                            mf->address_space, errno);
-                // support PCI space
-                if (VSEC_PXIR_SUPPORT(mf))
-                {
-                    if (mf->address_space < PXIR_SPACE_OFFSET)
-                    {
-                        mf->address_space += PXIR_SPACE_OFFSET;
-                    }
-                    else
-                    {
-                        mf->address_space -= PXIR_SPACE_OFFSET;
-                    }
+                           mf->address_space, errno);
+                /* support PCI space */
+                if (VSEC_PXIR_SUPPORT(mf)) {
+                    swap_pci_address_space(mf);
                     write4_buf.address_space = mf->address_space;
 
                     ret = ioctl(mf->fd, PCICONF_WRITE4_BUFFER, &write4_buf);
-                    if (ret < 0)
-                    {
+                    if (ret < 0) {
                         DBG_PRINTF(
                             "PCICONF_WRITE4_BUFFER ioctl failed when trying to access this space: %d. errno: %d\n",
                             mf->address_space, errno);
@@ -1028,19 +983,13 @@ static int driver_mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, 
             if ((ret = ioctl(mf->fd, PCICONF_READ4_BUFFER_EX, &read4_buf)) < 0) {
                 if ((ret = ioctl(mf->fd, PCICONF_READ4_BUFFER, &read4_buf)) < 0) {
                     if ((ret = ioctl(mf->fd, PCICONF_READ4_BUFFER_BC, &read4_buf)) < 0) {
-                        DBG_PRINTF("PCICONF_READ4_BUFFER_EX ioctl failed when trying to access this space: %d. errno: %d\n",
-                            mf->address_space, errno);
-                        // support PCI space
-                        if (VSEC_PXIR_SUPPORT(mf))
-                        {
-                            if (mf->address_space < PXIR_SPACE_OFFSET)
-                            {
-                                mf->address_space += PXIR_SPACE_OFFSET;
-                            }
-                            else
-                            {
-                                mf->address_space -= PXIR_SPACE_OFFSET;
-                            }
+                        DBG_PRINTF(
+                            "PCICONF_READ4_BUFFER_EX ioctl failed when trying to access this space: %d. errno: %d\n",
+                            mf->address_space,
+                            errno);
+                        /* support PCI space */
+                        if (VSEC_PXIR_SUPPORT(mf)) {
+                            swap_pci_address_space(mf);
                             read4_buf.address_space = mf->address_space;
                             if ((ret = ioctl(mf->fd, PCICONF_READ4_BUFFER_EX, &read4_buf)) < 0) {
                                 if ((ret = ioctl(mf->fd, PCICONF_READ4_BUFFER, &read4_buf)) < 0) {
@@ -1049,9 +998,7 @@ static int driver_mread4_block(mfile* mf, unsigned int offset, u_int32_t* data, 
                                     }
                                 }
                             }
-                        }
-                        else
-                        {
+                        } else {
                             return -1;
                         }
                     }
@@ -1345,16 +1292,15 @@ int mtcr_pciconf_wait_on_flag(mfile* mf, u_int8_t expected_val)
 
 int check_syndrome(mfile* mf)
 {
-    // in case syndrome is set, if syndrome_code is 0x3 (address_out_of_range), return error, so that the ioctl will
-    // fail and then we'll retry with PCI space.
+    /* in case syndrome is set, if syndrome_code is 0x3 (address_out_of_range), return error, so that the ioctl will */
+    /* fail and then we'll retry with PCI space. */
     u_int32_t syndrome = 0;
+
     READ4_PCI(mf, &syndrome, mf->vsec_addr + PCI_ADDR_OFFSET, "read domain", return ME_PCI_READ_ERROR);
-    if (syndrome)
-    {
+    if (syndrome) {
         u_int32_t syndrome_code = 0;
         READ4_PCI(mf, &syndrome_code, mf->vsec_addr + PCI_CTRL_OFFSET, "read domain", return ME_PCI_READ_ERROR);
-        if (EXTRACT(syndrome_code, PCI_SYNDROME_CODE_BIT_OFFSET, PCI_SYNDROME_CODE_BIT_LEN) == ADDRESS_OUT_OF_RANGE)
-        {
+        if (EXTRACT(syndrome_code, PCI_SYNDROME_CODE_BIT_OFFSET, PCI_SYNDROME_CODE_BIT_LEN) == ADDRESS_OUT_OF_RANGE) {
             return ME_ADDRESS_OUT_OF_RANGE;
         }
     }
@@ -1372,20 +1318,21 @@ int mtcr_pciconf_set_addr_space(mfile* mf, u_int16_t space)
 
     /* Check if we succedded to write the space (i.e. that its MSB is not ignored by FW) */
     u_int32_t read_val = 0;
+
     READ4_PCI(mf, &read_val, mf->vsec_addr + PCI_CTRL_OFFSET, "read status", return ME_PCI_READ_ERROR);
 
-    // Extract only the first 16 bits, as we need to check what's written in "space"
+    /* Extract only the first 16 bits, as we need to check what's written in "space" */
     unsigned int mask = 0xFFFF;
     unsigned int expected_value = val & mask;
     unsigned int actual_value = read_val & mask;
 
     /* Check if the space written is indeed the space we attempted to write */
-    if (actual_value != expected_value)
-    {
-        DBG_PRINTF("actual_space_value != expected_space_value. expected_space_value: 0x%x actual_space_value: 0x%x. Meaning space: 0x%x is not supported.\n",
-          expected_value,
-          actual_value,
-          expected_value);
+    if (actual_value != expected_value) {
+        DBG_PRINTF(
+            "actual_space_value != expected_space_value. expected_space_value: 0x%x actual_space_value: 0x%x. Meaning space: 0x%x is not supported.\n",
+            expected_value,
+            actual_value,
+            expected_value);
         return ME_PCI_SPACE_NOT_SUPPORTED;
     }
 
@@ -1425,8 +1372,7 @@ int mtcr_pciconf_rw(mfile* mf, unsigned int offset, u_int32_t* data, int rw)
         /* read data */
         READ4_PCI(mf, data, mf->vsec_addr + PCI_DATA_OFFSET, "read value", return ME_PCI_READ_ERROR);
     }
-    if (VSEC_PXIR_SUPPORT(mf))
-    {
+    if (VSEC_PXIR_SUPPORT(mf)) {
         rc = check_syndrome(mf);
     }
     return rc;
@@ -1690,6 +1636,7 @@ static int mtcr_pciconf_open(mfile* mf, const char* name, u_int32_t adv_opt)
 {
     ul_ctx_t* ctx = mf->ul_ctx;
     u_int32_t vsec_type = 0;
+
     mf->functional_vsec_supp = 0;
 
     mf->fd = -1;
@@ -1700,13 +1647,11 @@ static int mtcr_pciconf_open(mfile* mf, const char* name, u_int32_t adv_opt)
 
     mf->tp = MST_PCICONF;
 
-    if (mf->vsec_addr = pci_find_capability(mf, CAP_ID))
-    {
+    if (mf->vsec_addr = pci_find_capability(mf, CAP_ID)) {
         READ4_PCI(mf, &vsec_type, mf->vsec_addr, "read vsc type", return ME_PCI_READ_ERROR);
         mf->vsec_type = EXTRACT(vsec_type, MLX_VSC_TYPE_OFFSET, MLX_VSC_TYPE_LEN);
         DBG_PRINTF("in mtcr_pciconf_open function. mf->vsec_type: %d\n", mf->vsec_type);
-        if (mf->vsec_type == FUNCTIONAL_VSC)
-        {
+        if (mf->vsec_type == FUNCTIONAL_VSC) {
             DBG_PRINTF("FUNCTIONAL VSC Supported\n");
             mf->functional_vsec_supp = 1;
 
@@ -1739,18 +1684,16 @@ static int mtcr_pciconf_open(mfile* mf, const char* name, u_int32_t adv_opt)
 
             mtcr_pciconf_cap9_sem(mf, 0);
 
-            if (VSEC_SUPPORTED_UL(mf)) 
-            {
+            if (VSEC_SUPPORTED_UL(mf)) {
                 mf->address_space = AS_CR_SPACE;
                 ctx->mread4 = mtcr_pciconf_mread4;
                 ctx->mwrite4 = mtcr_pciconf_mwrite4;
                 ctx->mread4_block = mread4_block_pciconf;
                 ctx->mwrite4_block = mwrite4_block_pciconf;
-            } 
+            }
         }
     }
-    if (!mf->functional_vsec_supp)
-    {
+    if (!mf->functional_vsec_supp) {
         ctx->wo_addr = is_wo_pciconf_gw(mf);
         DBG_PRINTF("Write Only Address: %d\n", ctx->wo_addr);
         ctx->mread4 = mtcr_pciconf_mread4_old;
@@ -1901,7 +1844,7 @@ static MType mtcr_parse_name(const char* name,
         goto name_parsed;
     }
 
-    if(strstr(name, "fwctl")) {
+    if (strstr(name, "fwctl")) {
         return MST_FWCTL_CONTROL_DRIVER;
     }
 
@@ -3229,20 +3172,18 @@ int maccess_reg_ul(mfile              * mf,
     if (reg_size <= INBAND_MAX_REG_SIZE) {
         if (supports_reg_access_smp(mf)) {
             rc = mreg_send_raw(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg, reg_status);
-            // support PCI space
-            if (return_by_reg_status(*reg_status) == ME_REG_ACCESS_REG_NOT_SUPP)
-            {
-                if (VSEC_PXIR_SUPPORT(mf) && (mf->address_space < PXIR_SPACE_OFFSET)) // If supported - attempt to
-                                                                                            // send the register on PCI VSC
-                                                                                            // space
-                {
-                    mf->address_space += PXIR_SPACE_OFFSET;
+            /* support PCI space */
+            if (return_by_reg_status(*reg_status) == ME_REG_ACCESS_REG_NOT_SUPP) {
+                if (VSEC_PXIR_SUPPORT(mf)) { /* If supported - attempt to */
+                    /* send the register on PCI VSC */
+                    /* space */
+                    swap_pci_address_space(mf);
                     rc = mreg_send_raw(mf, reg_id, reg_method, reg_data, reg_size, r_size_reg, w_size_reg,
-                                        reg_status);
+                                       reg_status);
                     DBG_PRINTF(
                         "Entered PCI VSC space support flow. Second attempt to run mreg_send_raw with VSC address space: %d returned with rc: %d. Restoring address space back to CORE's address space\n",
-                        mf->address_space, rc);
-                    mf->address_space -= PXIR_SPACE_OFFSET; // Restore VSC space to CORE VSC space
+                        mf->address_space,
+                        rc);
                 }
             }
         }
@@ -3274,7 +3215,7 @@ int maccess_reg_ul(mfile              * mf,
     if (supports_reg_access_gmp_ul(mf, reg_method)) {
         rc = mib_send_gmp_access_reg_mad_ul(mf, (u_int32_t*)reg_data, reg_size, reg_id, reg_method, reg_status);
         if ((rc == ME_OK) && (*reg_status == 0)) {
-            DBG_PRINTF("AccessRegisterGMP Sent Successfully!\n");
+            ("AccessRegisterGMP Sent Successfully!\n");
             return ME_OK;
         }
         DBG_PRINTF("AccessRegisterGMP Failed!\n");
@@ -3952,8 +3893,7 @@ int read_dword_from_conf_space(mfile* mf, u_int32_t offset, u_int32_t* data)
 
 int is_remote_dev(mfile* mf)
 {
-    if (mf)
-    {
+    if (mf) {
         return mf->is_remote;
     }
 
@@ -3963,51 +3903,50 @@ int is_remote_dev(mfile* mf)
 
 static int check_zf_through_memory(mfile* mf)
 {
-    uint32_t gis = 0; // Global image status
-    size_t gis_address = 0;
-    switch (mf->device_hw_id)
-    {
-        case DeviceQuantum3_HwId:
-            gis_address = 0x152080;
-            break;
-        default:
-            return 0; // Device does not support Zombiefish mode
+    uint32_t gis = 0; /* Global image status */
+    size_t   gis_address = 0;
+
+    switch (mf->device_hw_id) {
+    case DeviceQuantum3_HwId:
+        gis_address = 0x152080;
+        break;
+
+    default:
+        return 0;     /* Device does not support Zombiefish mode */
     }
     int rc = mread4(mf, gis_address, &gis);
 
-    if (rc != 4)
-    {
+    if (rc != 4) {
         DBG_PRINTF("-E- Failed to read global_image_status from CR space (BAR0).\n");
         return 0;
     }
-    gis = EXTRACT(gis, 0, 16); // Extract the first 16 bits
+    gis = EXTRACT(gis, 0, 16); /* Extract the first 16 bits */
     return gis == AUTHENTICATION_FAILURE;
 }
 
 static int check_zf_through_vsc(mfile* mf)
 {
     int prev_address_space = mf->address_space;
+
     mset_addr_space(mf, AS_RECOVERY);
 
     uint32_t first_dword = 0;
-    int rc = mread4(mf, INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE, &first_dword);
+    int      rc = mread4(mf, INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE, &first_dword);
 
-    if (rc != 4)
-    {
+    if (rc != 4) {
         mset_addr_space(mf, prev_address_space);
         DBG_PRINTF("-E- Failed to read the first dword in VSC recovery space.\n");
         return 0;
     }
 
-    uint32_t in_recovery = EXTRACT(first_dword, 1, 1);       // Extract bit 1
-    uint32_t flash_control_vld = EXTRACT(first_dword, 2, 1); // Extract bit 2
-    uint32_t initializing = EXTRACT(first_dword, 0, 1);      // Extract bit 0
+    uint32_t in_recovery = EXTRACT(first_dword, 1, 1);       /* Extract bit 1 */
+    uint32_t flash_control_vld = EXTRACT(first_dword, 2, 1); /* Extract bit 2 */
+    uint32_t initializing = EXTRACT(first_dword, 0, 1);      /* Extract bit 0 */
 
     mf->vsc_recovery_space_flash_control_vld = flash_control_vld;
     mset_addr_space(mf, prev_address_space);
 
-    if (in_recovery && initializing)
-    {
+    if (in_recovery && initializing) {
         DBG_PRINTF("Device with HW ID: %u is in ZombieFish mode. flash_control_vld: %u\n", mf->device_hw_id,
                    flash_control_vld);
         return 1;
@@ -4018,26 +3957,25 @@ static int check_zf_through_vsc(mfile* mf)
 
 int is_zombiefish_device(mfile* mf)
 {
-    if (mread4(mf, HW_ID_ADDR, &mf->device_hw_id) != 4)
-    {
+    if (mread4(mf, HW_ID_ADDR, &mf->device_hw_id) != 4) {
         return 0;
     }
-    if (mf->device_hw_id != DeviceConnectX8_HwId && mf->device_hw_id != DeviceQuantum3_HwId &&
-        mf->device_hw_id != DeviceConnectX9_HwId && mf->device_hw_id != DeviceQuantum4_HwId &&
-        mf->device_hw_id != DeviceConnectX7_HwId && mf->device_hw_id != DeviceBlueField3_HwId)
-    {
+    if ((mf->device_hw_id != DeviceConnectX8_HwId) && (mf->device_hw_id != DeviceQuantum3_HwId) &&
+        (mf->device_hw_id != DeviceConnectX9_HwId) && (mf->device_hw_id != DeviceQuantum4_HwId) &&
+        (mf->device_hw_id != DeviceConnectX7_HwId) && (mf->device_hw_id != DeviceBlueField3_HwId)) {
         return 0;
     }
 
-    switch (mf->tp)
-    {
-        case MST_PCI:
-            mf->is_zombiefish = check_zf_through_memory(mf);
-            return mf->is_zombiefish;
-        case MST_PCICONF:
-            mf->is_zombiefish = check_zf_through_vsc(mf);
-            return mf->is_zombiefish;
-        default:
-            return 0;
+    switch (mf->tp) {
+    case MST_PCI:
+        mf->is_zombiefish = check_zf_through_memory(mf);
+        return mf->is_zombiefish;
+
+    case MST_PCICONF:
+        mf->is_zombiefish = check_zf_through_vsc(mf);
+        return mf->is_zombiefish;
+
+    default:
+        return 0;
     }
 }


### PR DESCRIPTION
We dont yet have a way to check whether we should access the old or new PCI core address space. So if we get an error, we should try the other one.