### PR TITLE
[Coverity] make a common wrapper for json reader and use one time

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -32,6 +32,8 @@
 
 noinst_LTLIBRARIES = libcommon.la
 
+AM_CPPFLAGS = $(JSON_CFLAGS)
+
 libcommon_la_SOURCES = \
     bit_slice.h \
     compatibility.h \
@@ -43,7 +45,9 @@ libcommon_la_SOURCES = \
     tools_time.h \
     tools_utils.h \
     tools_utils.h \
-    tools_version.h
+    tools_version.h \
+    tools_json.cpp \
+    tools_json.h 
 
 commonincludedir = $(includedir)/mstflint/common/
 commoninclude_HEADERS = compatibility.h

--- a/common/tools_json.cpp
+++ b/common/tools_json.cpp
@@ -1,0 +1,25 @@
+
+#include "tools_json.h"
+
+namespace mstflint
+{
+namespace common
+{
+// Implementation of class ReaderWrapper
+// ////////////////////////////////
+ReaderWrapper::ReaderWrapper()
+{
+    reader = new Json::Reader{};
+}
+ReaderWrapper::~ReaderWrapper()
+{
+    delete reader;
+}
+Json::Reader* ReaderWrapper::getReader()
+{
+    return reader;
+}
+// Implementation of class ReaderWrapper
+// ////////////////////////////////
+} // namespace common
+} // namespace mstflint

--- a/common/tools_json.h
+++ b/common/tools_json.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+ * property and proprietary rights in and to this material, related
+ * documentation and any modifications thereto. Any use, reproduction,
+ * disclosure or distribution of this material and related documentation
+ * without an express license agreement from NVIDIA CORPORATION or
+ * its affiliates is strictly prohibited.
+ */
+
+#pragma once
+
+#include "json/reader.h"
+
+namespace mstflint
+{
+namespace common
+{
+class JSON_API ReaderWrapper
+{
+public:
+    ReaderWrapper();
+    ~ReaderWrapper();
+
+    Json::Reader* getReader();
+
+private:
+    Json::Reader* reader;
+};
+
+} // namespace common
+} // namespace mstflint

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -94,6 +94,7 @@ mstconfig_DEPENDENCIES = \
     $(top_builddir)/dev_mgt/libdev_mgt.la \
     $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
     $(top_builddir)/tools_res_mgmt/libtools_res_mgmt.la \
+    $(top_builddir)/common/libcommon.la \
     $(MUPARSER_LIBS) \
     $(SQLITE_LIBS)
 

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -686,8 +686,9 @@ mlxCfgStatus MlxCfg::queryDevCfg(Commander* commander,
     if (_mlxParams.isJsonOutputRequested)
     {
         ifstream jsonInputStream(_mlxParams.NVOutputFile);
-        Json::Reader reader;
-        bool rc = reader.parse(jsonInputStream, oJsonValue);
+        mstflint::common::ReaderWrapper readerWrapper;
+        Json::Reader* reader = readerWrapper.getReader();
+        bool rc = reader->parse(jsonInputStream, oJsonValue);
         jsonInputStream.close();
         if (!rc)
         {

--- a/mlxconfig/mlxcfg_ui.h
+++ b/mlxconfig/mlxcfg_ui.h
@@ -41,6 +41,7 @@
 #include <mtcr.h>
 #include <json/reader.h>
 #include <json/writer.h>
+#include "common/tools_json.h"
 
 #ifdef CABLES_SUPP
 #include <cable_access/cdb_cable_commander.h>

--- a/mlxfwupdate/server_request.cpp
+++ b/mlxfwupdate/server_request.cpp
@@ -84,8 +84,9 @@ int ServerRequest::parseQueryResponse(string jsonTxt, vector<PsidQueryItem>& res
 #ifdef USE_CURL
     string fileTag;
     Json::Value root;
-    Json::Reader reader;
-    bool rc = reader.parse(jsonTxt, root);
+    mstflint::common::ReaderWrapper readerWrapper;
+    Json::Reader* reader = readerWrapper.getReader();
+    bool rc = reader->parse(jsonTxt, root);
     if (!rc)
     {
         setError(rc, "-E- Failed To parse server response\n");
@@ -257,10 +258,11 @@ int ServerRequest::parseDownloadFilesResponse(string jsonTxt, vector<DownloadedF
 {
 #ifdef USE_CURL
     Json::Value root;
-    Json::Reader reader;
+    mstflint::common::ReaderWrapper readerWrapper;
+    Json::Reader* reader = readerWrapper.getReader();
     string url;
     // printf("response = %s\n", jsonTxt.c_str());
-    bool rc = reader.parse(jsonTxt, root);
+    bool rc = reader->parse(jsonTxt, root);
     if (!rc)
     {
         setError(rc, "-E- Failed To parse server response\n");
@@ -458,9 +460,10 @@ int ServerRequest::parseQueryAllMFAsRespone(string jsonTxt, vector <string> &res
 {
 
     Json::Value root;
-    Json::Reader reader;
+    mstflint::common::ReaderWrapper readerWrapper;
+    Json::Reader* reader = readerWrapper.getReader();
     string url;
-    bool rc = reader.parse(jsonTxt, root);
+    bool rc = reader->parse(jsonTxt, root);
     if (!rc) {
         setError(rc, "-E- Failed To parse server response\n");
         //To be removed

--- a/mlxfwupdate/server_request.h
+++ b/mlxfwupdate/server_request.h
@@ -41,6 +41,7 @@
 #include <tools_dev_types.h>
 #include "psid_query_item.h"
 #include "mlxfwmanager_common.h"
+#include "common/tools_json.h"
 #ifdef USE_CURL
 #include <json/reader.h>
 #include <json/writer.h>


### PR DESCRIPTION
Description: declaration on vars such as "Json::Reader oJsonReader{};" cause many coverity issues in the code - a wrapper was implemented

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: CX-6
Tested flows: N/A

Known gaps (with RM ticket): None

Issue: 4215440
Change-Id: Ib8cbc44bfaa21ab001f6bc850fc60585dd310b65