### PR TITLE
fix for "[MFT] Bug SW #4220920: [pci_space][freebsd] MFE_BAD_PARAMS after reading from pci space address"

### DIFF
--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -116,6 +116,7 @@ struct mfile_t
     unsigned short mst_version_major;
     unsigned int mst_version_minor;
     int functional_vsec_supp;
+    unsigned int pxir_vsec_supp;
     u_int8_t vsec_type;
     mtcr_status_e icmd_support;
     unsigned int vsec_addr;
@@ -161,4 +162,3 @@ struct mfile_t
     int vsc_recovery_space_flash_control_vld;
 };
 
-#endif

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -1250,7 +1250,26 @@ static int is_pci_device(mfile* mf)
 {
     return (mf->flags & MDEVS_I2CM) || (mf->flags & (MDEVS_CABLE | MDEVS_LINKX_CHIP)) || (mf->flags & MDEVS_SOFTWARE);
 }
-#endif
+#endif /* ifndef __FreeBSD__ */
+
+int is_livefish_device(mfile* mf)
+{
+    if (!mf || !mf->dinfo) {
+        return 0;
+    }
+
+    unsigned int hwdevid = 0;
+
+    if (mf->tp == MST_SOFTWARE) {
+        return 1;
+    }
+    int rc = read_device_id(mf, &hwdevid);
+
+    if (rc == 4) {
+        return ((!is_gpu_pci_device(mf->dinfo->pci.dev_id)) && (mf->dinfo->pci.dev_id == hwdevid));
+    }
+    return 0;
+}
 
 int icmd_open(mfile* mf)
 {


### PR DESCRIPTION
fix for "[MFT] Bug SW #4220920: [pci_space][freebsd] MFE_BAD_PARAMS after reading from pci space address"
Description:
1. initialize mf->pxir_vsec_supp in mopen by checking VSC address_space support of the VSC address_spaces that belong to PCI. This is opposed to before where we based the support on the dev ID, which then caused unexpected behaviour in scenarios where the dev ID was not initialized.
2. aligned the "swap and retry" mechanism to Linux implementation.
3. after reading from the PCI config space the dword at offset VSC+0x10 - extract the syndrome bit.
4. changed mset_addr_space implementation to be aligned to Linux implementation
5. in _set_addr_space we now directly write to the space field instead of reading the whole dwrod, modifying it and writing back. this is because when writing a full dword (32 bits) we fail to write 0x102 in space while when writing half a dword the operation finishes successfully. this lets us write 0x102 in the space field:
pciconf -w -h pci0:9:0 0x60 0x102
while this does not wrok:
pciconf -w  pci0:9:0 0x60 0x102

Issue:4220920