### PR TITLE
[HTOC] removing padding to a value whose size is unknown

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -5790,7 +5790,6 @@ Fs4Operations::TocArray::TocArray()
 
 Fs4Operations::HTOC::HTOC(vector<u_int8_t> img, u_int32_t htoc_start_addr, u_int32_t size)
 {
-    memset(entries, 0, MAX_HTOC_ENTRIES_NUM * sizeof(image_layout_htoc_entry));
     this->htoc_start_addr = htoc_start_addr;
     //* Parse header
     vector<u_int8_t> header_data(img.begin() + htoc_start_addr,


### PR DESCRIPTION
Description: merge problem - pading by memset with wrong size. the size will be calculated in thte future.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: mstflint -i /mswg/tmp/cx7_image.bin --private_key /mswg/projects/mft/regression/bug_repro/mstflint_bug/mstflint_bug_private_key.bin --key_uuid 233a4d49b0839447f2fdf9f7a347a22e --public_key /mswg/projects/mft/regression/bug_repro/mstflint_bug/mstflint_bug_public_key.bin rsa_sign

Known gaps (with RM ticket): no

Issue: 4257791