### PR TITLE
[ZF mode] - align flash gw base address

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -59,7 +59,7 @@
 #include "mflash_common_structs.h"
 #include "mflash_gw.h"
 #include "mflash_new_gw.h"
-#define ICMD_MAX_BLOCK_WRITE 128
+#define ICMD_MAX_BLOCK_WRITE   128
 #define INBAND_MAX_BLOCK_WRITE 32
 
 #define ARR_SIZE(arr) sizeof(arr) / sizeof(arr[0])
@@ -107,7 +107,7 @@
     (void)_diff_in_sec;            \
     (void)_diff_in_ms
 #define TIMER_START() GetSystemTime(&_start)
-#define TIMER_STOP() GetSystemTime(&_end)
+#define TIMER_STOP()  GetSystemTime(&_end)
 #define TIMER_PRINT(...)                                      \
     _diff_in_sec = _end.wSecond - _start.wSecond;             \
     _diff_in_ms = (_end.wMilliseconds - _start.wMilliseconds; \
@@ -159,47 +159,45 @@ int cntx_sst_get_log2size(u_int8_t density, int* log2spi_size);
 /* Constants: */
 
 /* General: */
-#define GPIO_DIR_L 0xf008c
-#define GPIO_POL_L 0xf0094
-#define GPIO_MOD_L 0xf009c
-#define GPIO_DAT_L 0xf0084
+#define GPIO_DIR_L       0xf008c
+#define GPIO_POL_L       0xf0094
+#define GPIO_MOD_L       0xf009c
+#define GPIO_DAT_L       0xf0084
 #define GPIO_DATACLEAR_L 0xf00d4
-#define GPIO_DATASET_L 0xf00dc
+#define GPIO_DATASET_L   0xf00dc
 
 #define SEMAP63 0xf03fc
 
 /* InfiniHost specific */
-#define IDLE 0
-#define READ4 (1 << 29)
+#define IDLE   0
+#define READ4  (1 << 29)
 #define WRITE1 (2 << 29)
 
 #define CR_FLASH 0xf01a4
 #define ADDR_MSK 0x7ffffUL
 #define CMD_MASK 0xe0000000UL
 
-#define SST_STATUS_REG_VAL 0x80
+#define SST_STATUS_REG_VAL   0x80
 #define ATMEL_STATUS_REG_VAL 0x0
 
 #define MAX_FLASH_PROG_SEM_RETRY_CNT 40
 
-#define CPUMODE_MSK 0xc0000000UL
+#define CPUMODE_MSK   0xc0000000UL
 #define CPUMODE_SHIFT 30
-#define CPUMODE 0xf0150
+#define CPUMODE       0xf0150
 
 #define COMMAND_MASK 0x00ff0000
 
 static mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_func, void* extra_data)
 {
-    if ((fw_cmd_context == NULL) || (fw_cmd_func == NULL) || (extra_data == NULL))
-    {
+    if ((fw_cmd_context == NULL) || (fw_cmd_func == NULL) || (extra_data == NULL)) {
         errno = EINVAL;
         return NULL;
     }
 
     mfile* mf = malloc(sizeof(mfile));
 
-    if (!mf)
-    {
+    if (!mf) {
         errno = ENOMEM;
         return NULL;
     }
@@ -226,30 +224,28 @@ static mfile* mopen_fw_ctx(void* fw_cmd_context, void* fw_cmd_func, void* dma_fu
 /* To test there's no performance degradation by these delay: set DELAYS to 0 and RETRIES to infinity, and compare perf.
  */
 
-enum IntelFlashCommand
-{
-    FC_ReadID = 0x90,
-    FC_Read = 0xFF,
-    FC_Erase = 0x20,
-    FC_Confirm = 0xD0,
-    FC_Clear = 0x50,
-    FC_Write = 0x40,
-    FC_LoadPB = 0xE0,
-    FC_PBWrite = 0x0C,
-    FC_Status = 0x70,
-    FC_Suspend = 0xB0,
-    FC_Resume = 0xD0,
-    FC_ReadESR = 0x71,
+enum IntelFlashCommand {
+    FC_ReadID   = 0x90,
+    FC_Read     = 0xFF,
+    FC_Erase    = 0x20,
+    FC_Confirm  = 0xD0,
+    FC_Clear    = 0x50,
+    FC_Write    = 0x40,
+    FC_LoadPB   = 0xE0,
+    FC_PBWrite  = 0x0C,
+    FC_Status   = 0x70,
+    FC_Suspend  = 0xB0,
+    FC_Resume   = 0xD0,
+    FC_ReadESR  = 0x71,
     FC_QueryCFI = 0x98,
     FC_SCSErase = 0x28,
     FC_SCSWrite = 0xE8
 };
 
-enum IntelFlashStatus
-{
-    FS_Ready = 0x80,
-    FS_Suspended = 0x40,
-    FS_Error = 0x3E,
+enum IntelFlashStatus {
+    FS_Ready      = 0x80,
+    FS_Suspended  = 0x40,
+    FS_Error      = 0x3E,
     FS_BlockError = 0x3F
 };
 
@@ -262,8 +258,7 @@ int my_memset(void* dst, u_int8_t data, u_int32_t len)
     u_int32_t i = 0;
     u_int8_t* bytes = (u_int8_t*)dst;
 
-    for (i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         bytes[i] = data;
     }
 
@@ -276,8 +271,7 @@ int my_memcpy(void* dst, void* src, u_int32_t len)
     u_int8_t* dbytes = (u_int8_t*)dst;
     u_int8_t* sbytes = (u_int8_t*)src;
 
-    for (i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         dbytes[i] = sbytes[i];
     }
 
@@ -288,30 +282,28 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
 {
     static bool env_vars_evaluated = false;
     static bool erase_verification_enable = false;
-    static int retries_num = 0;
-    int rc = 0;
-    if (!env_vars_evaluated)
-    {
+    static int  retries_num = 0;
+    int         rc = 0;
+
+    if (!env_vars_evaluated) {
         erase_verification_enable = getenv("MFLASH_ERASE_VERIFY") ? true : false;
         const char* retries_num_str = getenv("MFLASH_WRITE_RETRIES");
         retries_num = retries_num_str ? atoi(retries_num_str) : 0;
         env_vars_evaluated = true;
     }
     u_int8_t* p = (u_int8_t*)data;
-    int all_ffs = 0;
+    int       all_ffs = 0;
 
     /* TODO - Check MAX_WRITE_BUFFER_SIZE against block_size in open (or here) */
     u_int8_t tmp_buff[MAX_WRITE_BUFFER_SIZE];
 
-    if (!mfl)
-    {
+    if (!mfl) {
         return MFE_BAD_PARAMS;
     }
 
     /* printf("-D- write_chunks(addr=%x, size=%x)\n", addr, len); */
 
-    while (len)
-    {
+    while (len) {
         u_int32_t i = 0;
         u_int32_t prefix_pad_size = 0;
         u_int32_t suffix_pad_size = 0;
@@ -333,13 +325,11 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
 
         prefix_pad_size = addr - block_addr;
 
-        if ((addr & block_mask) == ((addr + len) & block_mask))
-        {
+        if ((addr & block_mask) == ((addr + len) & block_mask)) {
             suffix_pad_size = block_size - ((addr + len) % block_size);
         }
 
-        if (suffix_pad_size || prefix_pad_size)
-        {
+        if (suffix_pad_size || prefix_pad_size) {
             my_memset(tmp_buff, 0xff, block_size);
 
             data_size -= prefix_pad_size;
@@ -348,20 +338,15 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
             my_memcpy(tmp_buff + prefix_pad_size, p, data_size);
 
             block_data = tmp_buff;
-        }
-        else if (mfl->attr.page_write)
-        {
+        } else if (mfl->attr.page_write) {
             /* current write is aligned to block size, */
             /* write data to next page, or to last full block (if we're in the last block in a page) */
             u_int32_t page_mask = ~(mfl->attr.page_write - 1);
             u_int32_t next_page_addr = (addr + mfl->attr.page_write + 1) & page_mask;
             u_int32_t size_to_page_boundary = next_page_addr - addr;
-            if (len > size_to_page_boundary)
-            {
+            if (len > size_to_page_boundary) {
                 block_size = size_to_page_boundary;
-            }
-            else
-            {
+            } else {
                 block_size = len & block_mask;
             }
             data_size = block_size;
@@ -371,29 +356,23 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
         /* Check to see if there's something to do */
         /* */
         all_ffs = 1;
-        for (i = 0; i < block_size; i++)
-        {
-            if (block_data[i] != 0xff)
-            {
+        for (i = 0; i < block_size; i++) {
+            if (block_data[i] != 0xff) {
                 all_ffs = 0;
                 break;
             }
         }
 
-        if (!all_ffs)
-        {
-            if (erase_verification_enable)
-            {
+        if (!all_ffs) {
+            if (erase_verification_enable) {
                 u_int8_t verify_buffer[MAX_WRITE_BUFFER_SIZE] = {0};
                 rc = mfl->f_reset(mfl);
                 CHECK_RC(rc);
                 rc = mfl->f_read(mfl, addr, data_size, verify_buffer, false);
                 CHECK_RC(rc);
-                // Verify erase
-                for (i = 0; i < data_size; i++)
-                {
-                    if (verify_buffer[i] != 0xff)
-                    {
+                /* Verify erase */
+                for (i = 0; i < data_size; i++) {
+                    if (verify_buffer[i] != 0xff) {
                         printf("Erase verification failed. Address 0x%08x - expected:0x%02x actual: 0x%02x\n",
                                addr + i,
                                0xff,
@@ -404,44 +383,36 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
             }
 
             bool write_block_passed = false;
-            int retries_counter = 0;
-            while (!write_block_passed)
-            {
+            int  retries_counter = 0;
+            while (!write_block_passed) {
                 rc = mfl->f_write_blk(mfl, block_addr, block_size, block_data);
                 CHECK_RC(rc);
 
-                if (mfl->opts[MFO_NO_VERIFY] == 0)
-                {
+                if (mfl->opts[MFO_NO_VERIFY] == 0) {
                     u_int8_t verify_buffer[MAX_WRITE_BUFFER_SIZE] = {0};
                     rc = mfl->f_reset(mfl);
                     CHECK_RC(rc);
                     rc = mfl->f_read(mfl, addr, data_size, verify_buffer, false);
                     CHECK_RC(rc);
-                    // Verify data
+                    /* Verify data */
                     bool verify_pass = true;
-                    for (i = 0; i < data_size; i++)
-                    {
-                        if (verify_buffer[i] != block_data[i + prefix_pad_size])
-                        {
+                    for (i = 0; i < data_size; i++) {
+                        if (verify_buffer[i] != block_data[i + prefix_pad_size]) {
                             verify_pass = false;
                             FLASH_DPRINTF(
-                              ("Write verification failed. Address 0x%08x - expected:0x%02x actual: 0x%02x\n",
-                               addr + i,
-                               block_data[i + prefix_pad_size],
-                               verify_buffer[i]));
+                                ("Write verification failed. Address 0x%08x - expected:0x%02x actual: 0x%02x\n",
+                                 addr + i,
+                                 block_data[i + prefix_pad_size],
+                                 verify_buffer[i]));
 
-                            if (retries_counter >= retries_num)
-                            {
+                            if (retries_counter >= retries_num) {
                                 return MFE_VERIFY_ERROR;
-                            }
-                            else
-                            {
+                            } else {
                                 break;
                             }
                         }
                     }
-                    if (!verify_pass)
-                    {
+                    if (!verify_pass) {
                         retries_counter++;
                         FLASH_DPRINTF(("Retry number %d\n", retries_counter));
                         continue;
@@ -451,9 +422,9 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
             }
         }
 
-        //
-        // loop advance
-        //
+        /* */
+        /* loop advance */
+        /* */
 
         addr += data_size;
         p += data_size;
@@ -469,86 +440,82 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
 #define FD_LEGACY (1 << FD_8) | (1 << FD_16) | (1 << FD_32) | (1 << FD_64) | (1 << FD_128)
 
 flash_info_t g_flash_info_arr[] = {
-  {"M25PXxx", FV_ST, FMT_ST_M25PX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 0, 0, 0, 0, 0},
-  {"M25Pxx", FV_ST, FMT_ST_M25P, FD_LEGACY, MCS_STSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
-  {"N25Q0XX", FV_ST, FMT_N25QXXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 1, 0},
-  /*{MICRON_3V_NAME, FV_ST, FMT_N25QXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 0}, */
-  {MICRON_3V_NAME, FV_ST, FMT_N25QXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 1},
-  {MICRON_1V8_NAME, FV_ST, FMT_N25QUXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 1},
-  {SST_FLASH_NAME, FV_SST, FMT_SST_25, FD_LEGACY, MCS_SSTSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
-  {WINBOND_NAME, FV_WINBOND, FMT_WINBOND, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
-  {WINBOND_W25X, FV_WINBOND, FMT_WINBOND_W25X, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 0, 0, 0, 0, 0, 0},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_3V, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_3V, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IQ, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IM, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IQ, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IM, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  {ATMEL_NAME, FV_ATMEL, FMT_ATMEL, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 0, 0, 0, 0, 0, 0},
-  {S25FLXXXP_NAME, FV_S25FLXXXX, FMT_S25FLXXXP, FD_LEGACY, MCS_STSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
-  {S25FL116K_NAME, FV_S25FLXXXX, FMT_S25FL116K, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
-  {MACRONIX_NAME, FV_MX25K16XXX, FMT_MX25K16XXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {MACRONIX_3V_NAME, FV_MX25K16XXX, FMT_MX25K16XXX, (1 << FD_256), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {CYPRESS_3V_NAME, FV_S25FLXXXX, FMT_S25FLXXXL, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
-  /*{CYPRESS_3V_NAME, FV_S25FLXXXX, FMT_S25FLXXXL, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB,  1, 1, 1, 0, 0, 0}, */
-  {ISSI_3V_NAME, FV_IS25LPXXX, FMT_IS25LPXXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_32), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_28, (1 << FD_32), MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_256), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
-  {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_512), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
-  /* added by edwardg 06/09/2020 */
-  {ISSI_HUAWEY_NAME, FV_IS25LPXXX, FMT_IS25LPXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
-  {ISSI_NAME, FV_IS25LPXXX, FMT_IS25WPXXX, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
-  // https://www.issi.com/WW/pdf/25LP-WP512MG.pdf
-  {ISSI_NAME, FV_IS25LPXXX, FMT_IS25WPXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 1},
+    {"M25PXxx", FV_ST, FMT_ST_M25PX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 0, 0, 0, 0, 0},
+    {"M25Pxx", FV_ST, FMT_ST_M25P, FD_LEGACY, MCS_STSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
+    {"N25Q0XX", FV_ST, FMT_N25QXXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 1, 0},
+    /*{MICRON_3V_NAME, FV_ST, FMT_N25QXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 0}, */
+    {MICRON_3V_NAME, FV_ST, FMT_N25QXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 1},
+    {MICRON_1V8_NAME, FV_ST, FMT_N25QUXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 1, 1},
+    {SST_FLASH_NAME, FV_SST, FMT_SST_25, FD_LEGACY, MCS_SSTSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
+    {WINBOND_NAME, FV_WINBOND, FMT_WINBOND, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
+    {WINBOND_W25X, FV_WINBOND, FMT_WINBOND_W25X, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 0, 0, 0, 0, 0, 0},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_3V, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_3V, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IQ, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IM, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IQ, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {WINBOND_3V_NAME, FV_WINBOND, FMT_WINBOND_IM, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    {ATMEL_NAME, FV_ATMEL, FMT_ATMEL, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 0, 0, 0, 0, 0, 0},
+    {S25FLXXXP_NAME, FV_S25FLXXXX, FMT_S25FLXXXP, FD_LEGACY, MCS_STSPI, SFC_SE, FSS_64KB, 0, 0, 0, 0, 0, 0},
+    {S25FL116K_NAME, FV_S25FLXXXX, FMT_S25FL116K, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
+    {MACRONIX_NAME, FV_MX25K16XXX, FMT_MX25K16XXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {MACRONIX_3V_NAME, FV_MX25K16XXX, FMT_MX25K16XXX, (1 << FD_256), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {CYPRESS_3V_NAME, FV_S25FLXXXX, FMT_S25FLXXXL, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 0, 0},
+    /*{CYPRESS_3V_NAME, FV_S25FLXXXX, FMT_S25FLXXXL, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB,  1, 1, 1, 0, 0, 0}, */
+    {ISSI_3V_NAME, FV_IS25LPXXX, FMT_IS25LPXXX, FD_LEGACY, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_32), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_28, (1 << FD_32), MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_256), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 0},
+    {MACRONIX_1V8_NAME, FV_MX25K16XXX, FMT_SST_25, (1 << FD_512), MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 0, 0, 1},
+    /* added by edwardg 06/09/2020 */
+    {ISSI_HUAWEY_NAME, FV_IS25LPXXX, FMT_IS25LPXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
+    {ISSI_NAME, FV_IS25LPXXX, FMT_IS25WPXXX, 1 << FD_32, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
+    /* https://www.issi.com/WW/pdf/25LP-WP512MG.pdf */
+    {ISSI_NAME, FV_IS25LPXXX, FMT_IS25WPXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 1},
 
-  {GIGA_3V_NAME, FV_GD25QXXX, FVT_GD25QXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
-  {GIGA_3V_NAME, FV_GD25QXXX, FVT_GD25QXXX, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
-  // https://www.gigadevice.com.cn/Public/Uploads/uploadfile/files/20231213/DS-01012-GD25LB512MF-Rev1.0.pdf
-  {GIGA_1V8_NAME, FV_GD25QXXX, FVT_GD25LBXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0}};
+    {GIGA_3V_NAME, FV_GD25QXXX, FVT_GD25QXXX, 1 << FD_256, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
+    {GIGA_3V_NAME, FV_GD25QXXX, FVT_GD25QXXX, 1 << FD_128, MCS_STSPI, SFC_SSE, FSS_4KB, 1, 1, 1, 1, 1, 0},
+    /* https://www.gigadevice.com.cn/Public/Uploads/uploadfile/files/20231213/DS-01012-GD25LB512MF-Rev1.0.pdf */
+    {GIGA_1V8_NAME, FV_GD25QXXX, FVT_GD25LBXXX, 1 << FD_512, MCS_STSPI, SFC_4SSE, FSS_4KB, 1, 1, 1, 1, 1, 0}
+};
 
 int cntx_sst_get_log2size(u_int8_t density, int* log2spi_size)
 {
-    switch (density)
-    {
-        case 0x41:
-            *log2spi_size = 0x15;
-            break;
+    switch (density) {
+    case 0x41:
+        *log2spi_size = 0x15;
+        break;
 
-        case 0x4A:
-            *log2spi_size = 0x16;
-            break;
+    case 0x4A:
+        *log2spi_size = 0x16;
+        break;
 
-        case 0x8D:
-            *log2spi_size = 0x13;
-            break;
+    case 0x8D:
+        *log2spi_size = 0x13;
+        break;
 
-        case 0x8E:
-            *log2spi_size = 0x14;
-            break;
+    case 0x8E:
+        *log2spi_size = 0x14;
+        break;
 
-        default:
-            return MFE_UNSUPPORTED_FLASH_TOPOLOGY;
+    default:
+        return MFE_UNSUPPORTED_FLASH_TOPOLOGY;
     }
     return 0;
 }
 
 int get_log2size_by_vendor_type_density(u_int8_t vendor, u_int8_t type, u_int8_t density, int* log2size)
 {
-    if ((type == FMT_SST_25) && (vendor == FV_SST))
-    {
+    if ((type == FMT_SST_25) && (vendor == FV_SST)) {
         return cntx_sst_get_log2size(density, log2size);
     }
-    if ((((type == FMT_WINBOND || type == FMT_WINBOND_3V) && vendor == FV_WINBOND) ||
-         (type == FMT_N25QXXX && vendor == FV_ST) || (type == FMT_IS25WPXXX && vendor == FV_IS25LPXXX)) &&
-        density == 0x20)
-    {
+    if (((((type == FMT_WINBOND) || (type == FMT_WINBOND_3V)) && (vendor == FV_WINBOND)) ||
+         ((type == FMT_N25QXXX) && (vendor == FV_ST)) || ((type == FMT_IS25WPXXX) && (vendor == FV_IS25LPXXX))) &&
+        (density == 0x20)) {
         *log2size = 0x1a;
-    }
-    else
-    {
+    } else {
         *log2size = density;
     }
     return MFE_OK;
@@ -560,20 +527,16 @@ int get_type_index_by_vendor_type_density(u_int8_t vendor, u_int8_t type, u_int8
 
     arr_size = ARR_SIZE(g_flash_info_arr);
 
-    for (i = 0; i < arr_size; i++)
-    {
+    for (i = 0; i < arr_size; i++) {
         flash_info_t* flash_info = &g_flash_info_arr[i];
-        
-        if (flash_info->vendor == vendor && flash_info->type == type)
-        {
-            if (density == 0x20)
-            {
+
+        if ((flash_info->vendor == vendor) && (flash_info->type == type)) {
+            if (density == 0x20) {
                 density = 0x1a;
             }
         }
         if ((flash_info->vendor == vendor) && (flash_info->type == type) &&
-            ((flash_info->densities & (1 << density)) != 0))
-        {
+            ((flash_info->densities & (1 << density)) != 0)) {
             *type_index = i;
             return MFE_OK;
         }
@@ -587,25 +550,21 @@ void mf_flash_list(char* flash_arr, int flash_arr_size)
     int arr_index = 0;
     int arr_size = ARR_SIZE(g_flash_info_arr);
 
-    if (!flash_arr || (flash_arr_size < 1))
-    {
+    if (!flash_arr || (flash_arr_size < 1)) {
         return;
     }
 
-    for (i = 0; i < arr_size; i++)
-    {
+    for (i = 0; i < arr_size; i++) {
         flash_info_t* flash_info = &g_flash_info_arr[i];
-        int name_len = strlen(flash_info->name);
-        if (flash_arr_size - name_len <= 2)
-        {
+        int           name_len = strlen(flash_info->name);
+        if (flash_arr_size - name_len <= 2) {
             /* Out of space, append \0 and return */
             break;
         }
         strcpy(&flash_arr[arr_index], flash_info->name);
         arr_index += name_len;
         flash_arr_size -= name_len;
-        if (i != arr_size - 1)
-        {
+        if (i != arr_size - 1) {
             flash_arr[arr_index++] = ',';
             flash_arr[arr_index++] = ' ';
             flash_arr_size -= 2;
@@ -620,11 +579,9 @@ int get_type_index_by_name(const char* type_name, unsigned* type_index)
     unsigned i = 0, arr_size = 0;
 
     arr_size = ARR_SIZE(g_flash_info_arr);
-    for (i = 0; i < arr_size; i++)
-    {
+    for (i = 0; i < arr_size; i++) {
         flash_info_t* flash_info = &g_flash_info_arr[i];
-        if (!strcmp(type_name, flash_info->name))
-        {
+        if (!strcmp(type_name, flash_info->name)) {
             *type_index = i;
             return MFE_OK;
         }
@@ -636,8 +593,7 @@ int get_type_index_by_name(const char* type_name, unsigned* type_index)
 int is_no_flash_detected(u_int8_t type, u_int8_t vendor, u_int8_t capacity)
 {
     if (((type == 0xff) && (vendor == 0xff) && (capacity == 0xff)) ||
-        ((type == 0x0) && (vendor == 0x0) && (capacity == 0x0)))
-    {
+        ((type == 0x0) && (vendor == 0x0) && (capacity == 0x0))) {
         return 1;
     }
     return 0;
@@ -652,19 +608,14 @@ int get_flash_info_by_res(mflash* mfl, unsigned* type_index, int* log2size, u_in
     rc = mfl->f_spi_status(mfl, SFC_RES, es_p);
     CHECK_RC(rc);
     FLASH_DPRINTF(("get_flash_info_by_res: es = %#x\n", *es_p));
-    if (((*es_p >= 0x10) && (*es_p < 0x17)))
-    {
+    if (((*es_p >= 0x10) && (*es_p < 0x17))) {
         *log2size = *es_p + 1;
         /* This should return the same result for any FD value from [FD_8..FD_128]. */
         /* This is just to catch the FD_LEGACY bitmask. */
         return get_type_index_by_vendor_type_density(FV_ST, FMT_ST_M25P, *log2size, type_index);
-    }
-    else if ((*es_p == 0xff) || (*es_p == 0x0))
-    {
+    } else if ((*es_p == 0xff) || (*es_p == 0x0)) {
         *no_flash = 1;
-    }
-    else
-    {
+    } else {
         return MFE_UNSUPPORTED_FLASH_TYPE;
     }
     return MFE_OK;
@@ -672,10 +623,10 @@ int get_flash_info_by_res(mflash* mfl, unsigned* type_index, int* log2size, u_in
 
 int cntx_get_flash_info(mflash* mfl, flash_info_t* f_info, int* log2size, u_int8_t* no_flash)
 {
-    int rc = 0;
-    u_int8_t type = 0, capacity = 0, vendor = 0, no_flash_res = 0, no_flash_rdid = 0;
+    int           rc = 0;
+    u_int8_t      type = 0, capacity = 0, vendor = 0, no_flash_res = 0, no_flash_rdid = 0;
     unsigned char es = 0;
-    unsigned type_index = 0;
+    unsigned      type_index = 0;
 
     /* Assume there is a flash. */
     *no_flash = 0;
@@ -686,8 +637,7 @@ int cntx_get_flash_info(mflash* mfl, flash_info_t* f_info, int* log2size, u_int8
     FLASH_DPRINTF(("cntx_spi_get_type: rc: %#x, vendor=%#x, type=%#x, capacity=%#x\n", rc, vendor, type, capacity));
     FLASH_DPRINTF(("rc = %d, no_flash_rdid = %d\n", rc, no_flash_rdid));
 
-    if (no_flash_rdid)
-    {
+    if (no_flash_rdid) {
         FLASH_DPRINTF(("no support for rdid\n"));
         /* RDID Failed due to: */
         /* 1- RDID is not supported but RES is - Old flashes. */
@@ -696,38 +646,30 @@ int cntx_get_flash_info(mflash* mfl, flash_info_t* f_info, int* log2size, u_int8
 
         /* Trying RES */
         rc = get_flash_info_by_res(mfl, &type_index, log2size, &no_flash_res, &es);
-        if ((rc == 0) && (no_flash_res == 1))
-        {
+        if ((rc == 0) && (no_flash_res == 1)) {
             /* RES Succeeded due to: no flash, unsupported flash or old flash. */
             *no_flash = 1;
             /* when no_flash_rdid == 0 then "1- RDID is not supported but RES is - Old flashes." */
         }
-    }
-    else
-    {
+    } else {
         /*  RDID Succeded. */
         rc = MFE_OK;
-        if (get_log2size_by_vendor_type_density(vendor, type, capacity, log2size) != MFE_OK)
-        {
+        if (get_log2size_by_vendor_type_density(vendor, type, capacity, log2size) != MFE_OK) {
             printf("-E- SST SPI flash #%d (vendor: %#x, type: %#x, capacity:%#x) is not supported.\n",
                    get_bank_int(mfl), vendor, type, capacity);
             rc = MFE_UNSUPPORTED_FLASH_TOPOLOGY;
-        }
-        else if (get_type_index_by_vendor_type_density(vendor, type, *log2size, &type_index) != MFE_OK)
-        {
+        } else if (get_type_index_by_vendor_type_density(vendor, type, *log2size, &type_index) != MFE_OK) {
             rc = MFE_UNSUPPORTED_FLASH_TYPE;
         }
         /* found supported flash if rc == MFE_OK at this point. */
     }
 
-    if (rc == MFE_UNSUPPORTED_FLASH_TYPE)
-    {
+    if (rc == MFE_UNSUPPORTED_FLASH_TYPE) {
         printf("-E- SPI flash #%d (vendor: %#x, memory type: %#x, es: %#x) is not supported.\n", get_bank_int(mfl),
                vendor, type, es);
     }
     FLASH_DPRINTF(("rc = %d, no_flash_res = %d, type_index = %d.\n", rc, no_flash_res, type_index));
-    if ((rc == MFE_OK) && (*no_flash == 0))
-    {
+    if ((rc == MFE_OK) && (*no_flash == 0)) {
         memcpy(f_info, &g_flash_info_arr[type_index], sizeof(flash_info_t));
     }
 
@@ -736,8 +678,7 @@ int cntx_get_flash_info(mflash* mfl, flash_info_t* f_info, int* log2size, u_int8
     /* So in that case we override the erase command matching 4-bytes addr (32MB) to */
     /* erase command of 3-bytes addr */
     if (((mfl->dm_dev_id == DeviceConnectX4LX) || (mfl->dm_dev_id == DeviceConnectX5)) &&
-        (f_info->vendor == FV_GD25QXXX))
-    {
+        (f_info->vendor == FV_GD25QXXX)) {
         f_info->erase_command = SFC_SSE;
     }
 
@@ -757,15 +698,13 @@ int cntx_get_jedec_id_direct_access(mflash* mfl, u_int32_t* jedec_id_p)
 
 int compare_flash_params(flash_params_t* flash_params, int bank_num, const char* type_name, int log2size)
 {
-    if (strcmp(flash_params->type_name, type_name) != 0)
-    {
+    if (strcmp(flash_params->type_name, type_name) != 0) {
         printf("-E- SPI flash #%d (type: %s)differs in type from SPI flash #%d(type: %s). "
                "All flash devices must be of the same type.\n",
                bank_num, type_name, bank_num - 1, flash_params->type_name);
         return MFE_UNSUPPORTED_FLASH_TOPOLOGY;
     }
-    if (flash_params->log2size != log2size)
-    {
+    if (flash_params->log2size != log2size) {
         printf("-E- SPI flash #%d (log2size: %#x) differs in size from SPI flash #%d (log2size: %#x). "
                "All flash devices must be of the same size.\n",
                bank_num, log2size, bank_num - 1, flash_params->log2size);
@@ -777,7 +716,7 @@ int compare_flash_params(flash_params_t* flash_params, int bank_num, const char*
 int cntx_st_spi_get_status(mflash* mfl, u_int8_t op_type, u_int8_t* status)
 {
     u_int32_t flash_data = 0;
-    int rc = 0;
+    int       rc = 0;
 
     rc = mfl->f_int_spi_get_status_data(mfl, op_type, &flash_data, 1);
     CHECK_RC(rc);
@@ -790,8 +729,7 @@ int get_num_of_banks_int(mflash* mfl)
     int num = 0;
 
     if ((mfl->opts[MFO_USER_BANKS_NUM] == 0) && (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_NO) &&
-        ((num = get_num_of_banks(mfl->mf)) != -1))
-    {
+        ((num = get_num_of_banks(mfl->mf)) != -1)) {
         return num; /* if mfpa register is supported get the exact number of flash banks */
     }
     return mfl->opts[MFO_NUM_OF_BANKS];
@@ -799,9 +737,9 @@ int get_num_of_banks_int(mflash* mfl)
 
 int get_flash_params(mflash* mfl, flash_params_t* flash_params, flash_info_t* flash_info)
 {
-    int num_of_flashes = get_num_of_banks_int(mfl);
-    int spi_sel = 0, rc = 0;
-    int params_were_set = 0;
+    int          num_of_flashes = get_num_of_banks_int(mfl);
+    int          spi_sel = 0, rc = 0;
+    int          params_were_set = 0;
     flash_info_t tmp_flash_info;
 
     memset(flash_params, 0, sizeof(flash_params_t));
@@ -809,15 +747,13 @@ int get_flash_params(mflash* mfl, flash_params_t* flash_params, flash_info_t* fl
     memset(&tmp_flash_info, 0, sizeof(flash_info_t));
 
     /* if number of flash banks is zero exit with error */
-    if (num_of_flashes == 0)
-    {
+    if (num_of_flashes == 0) {
         return MFE_NO_FLASH_DETECTED;
     }
 
-    for (spi_sel = 0; spi_sel < num_of_flashes; spi_sel++)
-    {
-        int log2size = 0;
-        u_int8_t no_flash = 0;
+    for (spi_sel = 0; spi_sel < num_of_flashes; spi_sel++) {
+        int         log2size = 0;
+        u_int8_t    no_flash = 0;
         const char* type_name;
         rc = set_bank(mfl, spi_sel);
         CHECK_RC(rc);
@@ -825,12 +761,10 @@ int get_flash_params(mflash* mfl, flash_params_t* flash_params, flash_info_t* fl
         CHECK_RC(rc);
 
         FLASH_DPRINTF(
-          ("spi_sel = %d, num_of_flashes = %d, rc = %d, no_flash = %d\n", spi_sel, num_of_flashes, rc, no_flash));
-        if (no_flash == 1)
-        {
+            ("spi_sel = %d, num_of_flashes = %d, rc = %d, no_flash = %d\n", spi_sel, num_of_flashes, rc, no_flash));
+        if (no_flash == 1) {
             /* This bank is empty and also the following banks will be empty. */
-            if (flash_params->num_of_flashes == 0)
-            {
+            if (flash_params->num_of_flashes == 0) {
                 /* if we haven't detected any 'supported' flash, return an error. */
                 return MFE_NO_FLASH_DETECTED;
             }
@@ -840,29 +774,22 @@ int get_flash_params(mflash* mfl, flash_params_t* flash_params, flash_info_t* fl
         }
 
         type_name = tmp_flash_info.name;
-        if (params_were_set == 0)
-        {
+        if (params_were_set == 0) {
             memset(flash_params->type_name, 0, MAX_FLASH_NAME);
             strncpy(flash_params->type_name, type_name, MAX_FLASH_NAME - 1);
             flash_params->log2size = log2size;
             memcpy(flash_info, &tmp_flash_info, sizeof(flash_info_t));
             params_were_set = 1;
-        }
-        else
-        {
+        } else {
             rc = compare_flash_params(flash_params, spi_sel, type_name, log2size);
             CHECK_RC(rc);
         }
         /* Init SST flash. */
-        if (mfl->access_type == MFAT_MFILE)
-        {
-            if ((flash_info->vendor == FV_SST) && (flash_info->type == FMT_SST_25))
-            {
+        if (mfl->access_type == MFAT_MFILE) {
+            if ((flash_info->vendor == FV_SST) && (flash_info->type == FMT_SST_25)) {
                 rc = mfl->f_spi_write_status_reg(mfl, SST_STATUS_REG_VAL, SFC_WRSR, 1);
                 CHECK_RC(rc);
-            }
-            else if ((flash_info->vendor == FV_ATMEL) && (flash_info->type == FMT_ATMEL))
-            {
+            } else if ((flash_info->vendor == FV_ATMEL) && (flash_info->type == FMT_ATMEL)) {
                 rc = mfl->f_spi_write_status_reg(mfl, ATMEL_STATUS_REG_VAL, SFC_WRSR, 1);
                 CHECK_RC(rc);
             }
@@ -906,20 +833,18 @@ MfError gen_access_commands(mflash* mfl, flash_access_commands_t* access_command
 {
     MfError status;
 
-    if (!mfl || !access_commands)
-    {
+    if (!mfl || !access_commands) {
         return MFE_BAD_PARAMS;
     }
     memset(access_commands, 0, sizeof(*access_commands));
     int four_byte_address_needed = is_four_byte_address_needed(mfl, &status);
 
-    if (status != MFE_OK)
-    {
+    if (status != MFE_OK) {
         return status;
     }
     *access_commands =
-      ((mfl->attr.log2_bank_size >= FD_256 && four_byte_address_needed) ? gen_4byte_address_access_commands() :
-                                                                          gen_3byte_address_access_commands());
+        ((mfl->attr.log2_bank_size >= FD_256 && four_byte_address_needed) ? gen_4byte_address_access_commands() :
+         gen_3byte_address_access_commands());
     return MFE_OK;
 }
 
@@ -927,7 +852,7 @@ int spi_fill_attr_from_params(mflash* mfl, flash_params_t* flash_params, flash_i
 {
     mfl->attr.log2_bank_size = flash_params->log2size;
     flash_access_commands_t access_commands;
-    int rc = gen_access_commands(mfl, &access_commands);
+    int                     rc = gen_access_commands(mfl, &access_commands);
 
     CHECK_RC(rc);
     mfl->attr.access_commands = access_commands;
@@ -956,31 +881,26 @@ int spi_fill_attr_from_params(mflash* mfl, flash_params_t* flash_params, flash_i
 #define GET_FLASH_RETRY 2
 int st_spi_fill_attr(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
+    int             rc = 0;
     flash_params_t* cur_flash_params;
-    flash_params_t tmp_flash_params;
-    flash_info_t flash_info;
-    unsigned type_index = 0;
+    flash_params_t  tmp_flash_params;
+    flash_info_t    flash_info;
+    unsigned        type_index = 0;
 
-    if (flash_params == NULL)
-    {
+    if (flash_params == NULL) {
         int i = 0;
         /* Get flash params from the flash itself */
         cur_flash_params = &tmp_flash_params;
 
-        while (i < GET_FLASH_RETRY)
-        {
+        while (i < GET_FLASH_RETRY) {
             rc = get_flash_params(mfl, cur_flash_params, &flash_info);
-            if (rc != MFE_NO_FLASH_DETECTED)
-            {
+            if (rc != MFE_NO_FLASH_DETECTED) {
                 break;
             }
             i++;
         }
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         /* Get the flash params from the user. */
         rc = get_type_index_by_name(flash_params->type_name, &type_index);
         CHECK_RC(rc);
@@ -998,11 +918,10 @@ int st_spi_fill_attr(mflash* mfl, flash_params_t* flash_params)
 
 int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool verbose)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int8_t* p = (u_int8_t*)data;
 
-    if (!mfl)
-    {
+    if (!mfl) {
         return MFE_BAD_PARAMS;
     }
     u_int32_t original_len = len;
@@ -1019,12 +938,10 @@ int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool
     block_mask = ~(block_size - 1);
     u_int32_t perc = 0xffffffff;
 
-    if (verbose)
-    {
+    if (verbose) {
         printf("\33[2K\r"); /* clear the current line */
     }
-    while (len)
-    {
+    while (len) {
         u_int32_t i = 0;
         u_int32_t prefix_pad_size = 0;
         u_int32_t suffix_pad_size = 0;
@@ -1041,13 +958,11 @@ int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool
 
         prefix_pad_size = addr - block_addr;
 
-        if ((addr & block_mask) == ((addr + len) & block_mask))
-        {
+        if ((addr & block_mask) == ((addr + len) & block_mask)) {
             suffix_pad_size = block_size - ((addr + len) % block_size);
         }
 
-        if (suffix_pad_size || prefix_pad_size)
-        {
+        if (suffix_pad_size || prefix_pad_size) {
             /* block exceeds given buffer - read to a temp bufer and */
             /* copy the required data to user's bufer. */
             data_size -= suffix_pad_size;
@@ -1057,10 +972,8 @@ int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool
         rc = mfl->f_read_blk(mfl, block_addr, block_size, block_data, false);
         CHECK_RC(rc);
 
-        if (suffix_pad_size || prefix_pad_size)
-        {
-            for (i = 0; i < data_size; i++)
-            {
+        if (suffix_pad_size || prefix_pad_size) {
+            for (i = 0; i < data_size; i++) {
                 p[i] = tmp_buff[prefix_pad_size + i];
             }
         }
@@ -1073,11 +986,9 @@ int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool
         p += data_size;
         len -= data_size;
 
-        if (verbose)
-        {
+        if (verbose) {
             u_int32_t new_perc = 100 - 100 * (1.0 * len / original_len);
-            if (new_perc != perc)
-            {
+            if (new_perc != perc) {
                 printf("\r%s%d%c", "Reading flash section: ", new_perc, '%');
                 fflush(stdout);
                 perc = new_perc;
@@ -1096,10 +1007,8 @@ int read_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool
 
 int gw_wait_ready(mflash* mfl, const char* msg)
 {
-    if (mfl->mf->is_zombiefish)
-    {
-        if (!mfl->mf->vsc_recovery_space_flash_control_vld)
-        {
+    if (mfl->mf->is_zombiefish) {
+        if (!mfl->mf->vsc_recovery_space_flash_control_vld) {
             return MFE_VSC_RECOVERY_SPACE_FLASH_CONTROL_NOT_VALID;
         }
         mset_addr_space(mfl->mf, AS_RECOVERY);
@@ -1108,17 +1017,14 @@ int gw_wait_ready(mflash* mfl, const char* msg)
     u_int32_t cnt = 0;
 
     (void)msg; /* NOT USED FOR NOW */
-    do
-    {
+    do{
         /* Timeout checks */
-        if (++cnt > FLASH_CMD_CNT)
-        {
+        if (++cnt > FLASH_CMD_CNT) {
             /* return errmsg("Flash gateway timeout: %s.", msg); */
             return MFE_TIMEOUT;
         }
 
         MREAD4(mfl->gw_cmd_register_addr, &gw_cmd);
-
     } while (EXTRACT(gw_cmd, HBO_BUSY, 1));
 
     return MFE_OK;
@@ -1148,12 +1054,11 @@ int empty_set_bank(mflash* mfl, u_int32_t bank)
  * Consts needed to extract the needed data for the jedec ID
  *  from various flash types.
  */
-enum
-{
+enum {
     JEDEC_ATMEL_CAPACITY_BITOFF = 16,
     JEDEC_ATMEL_CAPACITY_BITLEN = 5,
-    JEDEC_ATMEL_TYPE_BITOFF = 21,
-    JEDEC_ATMEL_TYPE_BITLEN = 3,
+    JEDEC_ATMEL_TYPE_BITOFF     = 21,
+    JEDEC_ATMEL_TYPE_BITLEN     = 3,
 
     JEDEC_VENDOR_ID_BITOFF = 24,
     JEDEC_VENDOR_ID_BITLEN = 8,
@@ -1171,26 +1076,25 @@ int get_flash_info_for_atmel(u_int32_t jedec_id, u_int8_t* type, u_int8_t* densi
 
     tmp_cap = EXTRACT(jedec_id, JEDEC_ATMEL_CAPACITY_BITOFF, JEDEC_ATMEL_CAPACITY_BITLEN);
     *type = EXTRACT(jedec_id, JEDEC_ATMEL_TYPE_BITOFF, JEDEC_ATMEL_TYPE_BITLEN);
-    switch (tmp_cap)
-    {
-        case 0x4:
-            *density = 0x13;
-            break;
+    switch (tmp_cap) {
+    case 0x4:
+        *density = 0x13;
+        break;
 
-        case 0x5:
-            *density = 0x14;
-            break;
+    case 0x5:
+        *density = 0x14;
+        break;
 
-        case 0x6:
-            *density = 0x15;
-            break;
+    case 0x6:
+        *density = 0x15;
+        break;
 
-        case 0x7:
-            *density = 0x16;
-            break;
+    case 0x7:
+        *density = 0x16;
+        break;
 
-        default:
-            return MFE_UNSUPPORTED_FLASH_TOPOLOGY;
+    default:
+        return MFE_UNSUPPORTED_FLASH_TOPOLOGY;
     }
 
     return MFE_OK;
@@ -1200,13 +1104,10 @@ int get_info_from_jededc_id(u_int32_t jedec_id, u_int8_t* vendor, u_int8_t* type
     int rc = 0;
 
     *vendor = EXTRACT(jedec_id, JEDEC_VENDOR_ID_BITOFF, JEDEC_VENDOR_ID_BITLEN);
-    if (*vendor == FV_ATMEL)
-    {
+    if (*vendor == FV_ATMEL) {
         rc = get_flash_info_for_atmel(jedec_id, type, density);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         *type = EXTRACT(jedec_id, JEDEC_TYPE_BITOFF, JEDEC_TYPE_BITLEN);
         *density = EXTRACT(jedec_id, JEDEC_CAPACITY_BITOFF, JEDEC_CAPACITY_BITLEN);
     }
@@ -1216,19 +1117,15 @@ int get_info_from_jededc_id(u_int32_t jedec_id, u_int8_t* vendor, u_int8_t* type
 
 int mf_check_spi_channel(mfile* mf)
 {
-    int retVal = 1;
+    int       retVal = 1;
     u_int32_t value = 0;
 
-    if (mread4(mf, 0x21e4, &value) != sizeof(u_int32_t))
-    {
+    if (mread4(mf, 0x21e4, &value) != sizeof(u_int32_t)) {
         printf("-E- Cannot get SPI value.\n");
         retVal = 0;
-    }
-    else
-    {
+    } else {
         value = (value >> 8) & 3;
-        if ((value != 0x1) && (value != 2))
-        {
+        if ((value != 0x1) && (value != 2)) {
             retVal = 0;
         }
     }
@@ -1238,7 +1135,7 @@ int mf_check_spi_channel(mfile* mf)
 int cntx_spi_get_type(mflash* mfl, u_int8_t op_type, u_int8_t* vendor, u_int8_t* type, u_int8_t* density)
 {
     u_int32_t flash_data = 0;
-    int rc = 0;
+    int       rc = 0;
 
     rc = mfl->f_int_spi_get_status_data(mfl, op_type, &flash_data, 4);
     CHECK_RC(rc);
@@ -1254,16 +1151,14 @@ int cntx_spi_get_type(mflash* mfl, u_int8_t op_type, u_int8_t* vendor, u_int8_t*
 int spi_get_num_of_flashes(int prev_num_of_flashes)
 {
     char* mflash_env;
-    int num = 0;
+    int   num = 0;
 
-    if (prev_num_of_flashes != -1)
-    {
+    if (prev_num_of_flashes != -1) {
         return prev_num_of_flashes;
     }
 
     mflash_env = getenv(MFLASH_ENV);
-    if (mflash_env)
-    {
+    if (mflash_env) {
         num = atol(mflash_env);
         /* make sure the value makes sense */
         num = (num > 16 || num <= 0) ? -1 : num;
@@ -1278,20 +1173,14 @@ int spi_update_num_of_banks(mflash* mfl, int prev_num_of_flashes)
     int num_of_banks = 0;
 
     num_of_banks = spi_get_num_of_flashes(prev_num_of_flashes);
-    if (num_of_banks == -1)
-    {
-        if (IS_SIB(mfl->attr.hw_dev_id) || IS_SEN(mfl->attr.hw_dev_id) || IS_SIB2(mfl->attr.hw_dev_id))
-        {
+    if (num_of_banks == -1) {
+        if (IS_SIB(mfl->attr.hw_dev_id) || IS_SEN(mfl->attr.hw_dev_id) || IS_SIB2(mfl->attr.hw_dev_id)) {
             mfl->opts[MFO_NUM_OF_BANKS] = 2;
-        }
-        else
-        {
+        } else {
             mfl->opts[MFO_NUM_OF_BANKS] = 1;
         }
         mfl->opts[MFO_USER_BANKS_NUM] = 0;
-    }
-    else
-    {
+    } else {
         mfl->opts[MFO_NUM_OF_BANKS] = num_of_banks;
         mfl->opts[MFO_USER_BANKS_NUM] = 1;
     }
@@ -1300,20 +1189,18 @@ int spi_update_num_of_banks(mflash* mfl, int prev_num_of_flashes)
 int cntx_st_spi_page_read(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t* data, bool verbose)
 {
     (void)verbose;
-    int rc = 0;
+    int       rc = 0;
     u_int32_t last_blk_addr = 0;
     u_int32_t last_addr = 0;
-    u_int8_t is_first = 1;
-    u_int8_t is_last = 0;
+    u_int8_t  is_first = 1;
+    u_int8_t  is_last = 0;
     u_int8_t* p = data;
 
-    if (addr & ((u_int32_t)mfl->attr.block_write - 1))
-    {
+    if (addr & ((u_int32_t)mfl->attr.block_write - 1)) {
         return MFE_BAD_ALIGN;
     }
 
-    if (size & ((u_int32_t)mfl->attr.block_write - 1))
-    {
+    if (size & ((u_int32_t)mfl->attr.block_write - 1)) {
         return MFE_BAD_ALIGN;
     }
 
@@ -1322,10 +1209,8 @@ int cntx_st_spi_page_read(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t*
     last_addr = addr + size;
     last_blk_addr = last_addr - mfl->attr.block_write;
 
-    while (addr < last_addr)
-    {
-        if (addr == last_blk_addr)
-        {
+    while (addr < last_addr) {
+        if (addr == last_blk_addr) {
             is_last = 1;
         }
 
@@ -1347,11 +1232,11 @@ int cntx_st_spi_block_read(mflash* mfl, u_int32_t blk_addr, u_int32_t blk_size, 
 }
 int cntx_st_spi_page_write(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t* data)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int32_t last_blk_addr = 0;
     u_int32_t last_addr = 0;
-    u_int8_t is_first = 1;
-    u_int8_t is_last = 0;
+    u_int8_t  is_first = 1;
+    u_int8_t  is_last = 0;
     u_int8_t* p = data;
 
     WRITE_CHECK_ALIGN(addr, mfl->attr.block_write, size);
@@ -1359,10 +1244,8 @@ int cntx_st_spi_page_write(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t
     last_addr = addr + size;
     last_blk_addr = last_addr - mfl->attr.block_write;
 
-    while (addr < last_addr)
-    {
-        if (addr == last_blk_addr)
-        {
+    while (addr < last_addr) {
+        if (addr == last_blk_addr) {
             is_last = 1;
         }
         rc = mfl->f_st_spi_block_write_ex(mfl, addr, mfl->attr.block_write, p, is_first, is_last, size);
@@ -1378,7 +1261,7 @@ int cntx_st_spi_page_write(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t
 
 int cntx_sst_spi_byte_write(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_t* data)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int32_t last_addr = 0;
     u_int8_t* p = data;
 
@@ -1386,8 +1269,7 @@ int cntx_sst_spi_byte_write(mflash* mfl, u_int32_t addr, u_int32_t size, u_int8_
 
     last_addr = addr + size;
 
-    while (addr < last_addr)
-    {
+    while (addr < last_addr) {
         rc = mfl->f_sst_spi_block_write_ex(mfl, addr, mfl->attr.block_write, p);
         CHECK_RC(rc);
         addr++;
@@ -1404,8 +1286,7 @@ int cntx_st_spi_block_write(mflash* mfl, u_int32_t blk_addr, u_int32_t blk_size,
 
 f_mf_write get_write_blk_func(int command_set)
 {
-    if (command_set == MCS_STSPI)
-    {
+    if (command_set == MCS_STSPI) {
         return cntx_st_spi_page_write;
     }
     return cntx_sst_spi_byte_write;
@@ -1415,36 +1296,27 @@ int old_flash_lock(mflash* mfl, int lock_state)
 {
     /* Obtain GPIO Semaphore */
     static u_int32_t cnt;
-    u_int32_t word = 0;
+    u_int32_t        word = 0;
 
 #if !defined(UEFI_BUILD)
-    if (IS_CONNECTX_4TH_GEN_FAMILY(mfl->attr.hw_dev_id) && (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_NO))
-    {
+    if (IS_CONNECTX_4TH_GEN_FAMILY(mfl->attr.hw_dev_id) && (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_NO)) {
         int rc = 0;
-        if (lock_state)
-        {
-            if (!mfl->flash_prog_locked)
-            {
+        if (lock_state) {
+            if (!mfl->flash_prog_locked) {
                 rc = trm_lock(mfl->trm, TRM_RES_HCR_FLASH_PROGRAMING, MAX_FLASH_PROG_SEM_RETRY_CNT);
-                if (!rc)
-                {
+                if (!rc) {
                     mfl->flash_prog_locked = 1;
                 }
             }
-        }
-        else
-        {
-            if (mfl->unlock_flash_prog_allowed)
-            {
+        } else {
+            if (mfl->unlock_flash_prog_allowed) {
                 rc = trm_unlock(mfl->trm, TRM_RES_HCR_FLASH_PROGRAMING);
-                if (!rc)
-                {
+                if (!rc) {
                     mfl->flash_prog_locked = 0;
                 }
             }
         }
-        if (rc && (rc != TRM_STS_RES_NOT_SUPPORTED))
-        {
+        if (rc && (rc != TRM_STS_RES_NOT_SUPPORTED)) {
             return MFE_SEM_LOCKED;
         }
     }
@@ -1452,33 +1324,26 @@ int old_flash_lock(mflash* mfl, int lock_state)
     /* timeout at 5 seconds */
     TIMER_INIT_AND_START();
 
-    if (lock_state)
-    {
-        if (mfl->is_locked)
-        {
+    if (lock_state) {
+        if (mfl->is_locked) {
             return MFE_OK;
         }
-        do
-        {
-            if (++cnt > GPIO_SEM_TRIES)
-            {
+        do{
+            if (++cnt > GPIO_SEM_TRIES) {
                 cnt = 0;
                 printf("-E- Can not obtain Flash semaphore");
                 return MFE_SEM_LOCKED;
             }
             MREAD4(SEMAP63, &word);
-            if (word)
-            {
+            if (word) {
                 msleep(1);
             }
-            TIMER_CHECK(5, 0, cnt = 0; return MFE_SEM_LOCKED);
+            TIMER_CHECK(5, 0, cnt = 0;
+                        return MFE_SEM_LOCKED);
         } while (word);
-    }
-    else
-    {
+    } else {
         MWRITE4(SEMAP63, 0);
-        if (cnt > 1)
-        {
+        if (cnt > 1) {
             /* we are not alone... */
             msleep(1);
         }
@@ -1490,7 +1355,7 @@ int old_flash_lock(mflash* mfl, int lock_state)
 
 int cntx_flash_init_direct_access(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int32_t tmp = 0;
 
     FLASH_ACCESS_DPRINTF(("cntx_flash_init_direct_access(): Flash init to use direct-access\n"));
@@ -1499,8 +1364,7 @@ int cntx_flash_init_direct_access(mflash* mfl, flash_params_t* flash_params)
     /* When the ConnectX boots up without a valid FW , the PCIE link may be unstable. */
     /* In that case, turn off the auto reset on link down, so we'll be able to burn the device. */
     MREAD4(0x41270, &tmp);
-    if (tmp > 0xfff00000)
-    {
+    if (tmp > 0xfff00000) {
         /* we are in livefish. */
         u_int32_t tmp1 = 0;
         MREAD4(0xf3834, &tmp1);
@@ -1525,17 +1389,14 @@ int cntx_flash_init_direct_access(mflash* mfl, flash_params_t* flash_params)
     rc = st_spi_fill_attr(mfl, flash_params);
     CHECK_RC(rc);
 
-    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI))
-    {
+    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI)) {
         mfl->f_reset = empty_reset; /* Null func */
         mfl->f_write_blk = get_write_blk_func(mfl->attr.command_set);
 
         mfl->attr.page_write = 256;
         mfl->f_write = write_chunks;
         mfl->f_erase_sect = cntx_st_spi_erase_sect;
-    }
-    else
-    {
+    } else {
         return MFE_UNSUPPORTED_FLASH_TYPE;
     }
 
@@ -1563,46 +1424,38 @@ int is4_init_gpios(mflash* mfl)
 
 int is4_flash_lock(mflash* mfl, int lock_state)
 {
-    if (mfl->mf->is_zombiefish)
-    {
-        if (!mfl->mf->vsc_recovery_space_flash_control_vld)
-        {
+    if (mfl->mf->is_zombiefish) {
+        if (!mfl->mf->vsc_recovery_space_flash_control_vld) {
             return MFE_VSC_RECOVERY_SPACE_FLASH_CONTROL_NOT_VALID;
         }
         mset_addr_space(mfl->mf, AS_RECOVERY);
     }
     /* Obtain GPIO Semaphore */
     static u_int32_t cnt;
-    u_int32_t word = 0;
-    u_int32_t lock_status = 0;
+    u_int32_t        word = 0;
+    u_int32_t        lock_status = 0;
 
     /* timeout at 5 seconds */
     TIMER_INIT_AND_START();
 
-    if (lock_state)
-    {
-        do
-        {
-            if (++cnt > GPIO_SEM_TRIES)
-            {
+    if (lock_state) {
+        do{
+            if (++cnt > GPIO_SEM_TRIES) {
                 cnt = 0;
                 printf("-E- Can not obtain Flash semaphore");
                 return MFE_SEM_LOCKED;
             }
             MREAD4(mfl->gw_cmd_register_addr, &word);
             lock_status = EXTRACT(word, HBO_LOCK, 1);
-            if (lock_status)
-            {
+            if (lock_status) {
                 msleep(1);
             }
-            TIMER_CHECK(5, 0, cnt = 0; return MFE_SEM_LOCKED);
+            TIMER_CHECK(5, 0, cnt = 0;
+                        return MFE_SEM_LOCKED);
         } while (lock_status);
-    }
-    else
-    {
+    } else {
         MWRITE4(mfl->gw_cmd_register_addr, 0);
-        if (cnt > 1)
-        {
+        if (cnt > 1) {
             /* we are not alone */
             msleep(1);
         }
@@ -1615,10 +1468,8 @@ int is4_flash_lock(mflash* mfl, int lock_state)
 
 int disable_gcm(mflash* mfl)
 {
-    if (mfl->mf->is_zombiefish)
-    {
-        if (!mfl->mf->vsc_recovery_space_flash_control_vld)
-        {
+    if (mfl->mf->is_zombiefish) {
+        if (!mfl->mf->vsc_recovery_space_flash_control_vld) {
             return MFE_VSC_RECOVERY_SPACE_FLASH_CONTROL_NOT_VALID;
         }
         mset_addr_space(mfl->mf, AS_RECOVERY);
@@ -1655,39 +1506,34 @@ int restore_cache_replacemnt(mflash* mfl)
 
 void init_freq_configuration_fields(mflash* mfl)
 {
-    switch (mfl->dm_dev_id)
-    {
-        case DeviceConnectX7:
-            mfl->is_freq_handle_required = true;
-            mfl->core_clocks_per_usec_addr = 0x7f4;
-            mfl->flash_div_addr = 0xfe804;
-            break;
+    switch (mfl->dm_dev_id) {
+    case DeviceConnectX7:
+        mfl->is_freq_handle_required = true;
+        mfl->core_clocks_per_usec_addr = 0x7f4;
+        mfl->flash_div_addr = 0xfe804;
+        break;
 
-        case DeviceBlueField3:
-            mfl->is_freq_handle_required = true;
-            mfl->core_clocks_per_usec_addr = 0x7f4;
-            mfl->flash_div_addr = 0xff804;
-            break;
+    case DeviceBlueField3:
+        mfl->is_freq_handle_required = true;
+        mfl->core_clocks_per_usec_addr = 0x7f4;
+        mfl->flash_div_addr = 0xff804;
+        break;
 
-        default:
-            break;
+    default:
+        break;
     }
 }
 
 int read_freq_configurations(mflash* mfl)
 {
-    if (!mfl->core_clocks_per_usec)
-    { /* If field was already read then we skip */
-        if (mread4(mfl->mf, mfl->core_clocks_per_usec_addr, &(mfl->core_clocks_per_usec)) != 4)
-        {
+    if (!mfl->core_clocks_per_usec) { /* If field was already read then we skip */
+        if (mread4(mfl->mf, mfl->core_clocks_per_usec_addr, &(mfl->core_clocks_per_usec)) != 4) {
             printf("-E- Failed to read core_clocks_per_usec\n");
             return MFE_CR_ERROR;
         }
     }
-    if (!mfl->orig_flash_div_reg)
-    { /* If field was already read then we skip */
-        if (mread4(mfl->mf, mfl->flash_div_addr, &(mfl->orig_flash_div_reg)) != 4)
-        {
+    if (!mfl->orig_flash_div_reg) { /* If field was already read then we skip */
+        if (mread4(mfl->mf, mfl->flash_div_addr, &(mfl->orig_flash_div_reg)) != 4) {
             printf("-E- Failed to read flash_div_register\n");
             return MFE_CR_ERROR;
         }
@@ -1711,8 +1557,7 @@ int write_flash_div(mflash* mfl, u_int32_t new_flash_div)
     u_int32_t new_flash_div_register = MERGE(mfl->orig_flash_div_reg, new_flash_div, 0, 4);
 
     FLASH_DPRINTF(("Setting new flash_div = %d\n", new_flash_div));
-    if (mwrite4(mfl->mf, mfl->flash_div_addr, new_flash_div_register) != 4)
-    {
+    if (mwrite4(mfl->mf, mfl->flash_div_addr, new_flash_div_register) != 4) {
         printf("-E- Writing 0x%08x to flash_div register failed\n", new_flash_div_register);
         return MFE_CR_ERROR;
     }
@@ -1723,25 +1568,20 @@ int decrease_flash_freq(mflash* mfl)
 {
     int rc = MFE_OK;
 
-    if (mfl->is_freq_handle_required)
-    {
+    if (mfl->is_freq_handle_required) {
         u_int32_t freq = 0;
         rc = get_flash_freq(mfl, &freq);
         CHECK_RC(rc);
-        if (freq <= MAX_FLASH_FREQ)
-        {
+        if (freq <= MAX_FLASH_FREQ) {
             /* Flash freq is already in a valid range for OCR operation */
             mfl->is_freq_handle_required = false; /* Setting this will skip this logic next time we're here */
-        }
-        else
-        {
+        } else {
             /* Calculate new flash_div value to decrease flash frequency to valid value for OCR operation */
             u_int32_t new_flash_div = EXTRACT(mfl->orig_flash_div_reg, 0, 4); /* flash_div field is 4bits */
             FLASH_DPRINTF((
-              "Flash freq (%dMHz) higher than allowed (%dMHz) for OCR operation: core_clocks_per_usec = %d, flash_div = %d\n",
-              freq, MAX_FLASH_FREQ, mfl->core_clocks_per_usec, new_flash_div));
-            while (freq > MAX_FLASH_FREQ)
-            {
+                              "Flash freq (%dMHz) higher than allowed (%dMHz) for OCR operation: core_clocks_per_usec = %d, flash_div = %d\n",
+                              freq, MAX_FLASH_FREQ, mfl->core_clocks_per_usec, new_flash_div));
+            while (freq > MAX_FLASH_FREQ) {
                 new_flash_div++; /* Reducing freq by incrementing flash_div (incrementing by 1 should to be enough) */
                 freq = mfl->core_clocks_per_usec / (2 * (new_flash_div + 1));
             }
@@ -1758,8 +1598,7 @@ int restore_flash_freq(mflash* mfl)
 {
     int rc = MFE_OK;
 
-    if (mfl->is_freq_changed)
-    {
+    if (mfl->is_freq_changed) {
         u_int32_t orig_flash_div = EXTRACT(mfl->orig_flash_div_reg, 0, 4); /* flash_div field is 4bits */
         FLASH_DPRINTF(("Restoring original flash_div = %d\n", orig_flash_div));
         rc = write_flash_div(mfl, orig_flash_div);
@@ -1772,18 +1611,16 @@ int restore_flash_freq(mflash* mfl)
 int seventh_gen_flash_lock(mflash* mfl, int lock_state)
 {
     int rc = 0;
-    if (lock_state == 1)
-    { // lock the flash
+
+    if (lock_state == 1) { /* lock the flash */
         rc = is4_flash_lock(mfl, lock_state);
         CHECK_RC(rc);
         rc = disable_gcm(mfl);
         CHECK_RC(rc);
         rc = gw_wait_ready(mfl, "WAIT TO BUSY");
         CHECK_RC(rc);
-    }
-    else
-    { // unlock the flash
-        // Restoring GCM is handled by FW
+    } else { /* unlock the flash */
+        /* Restoring GCM is handled by FW */
         rc = is4_flash_lock(mfl, lock_state);
         CHECK_RC(rc);
     }
@@ -1794,8 +1631,7 @@ int sixth_gen_flash_lock(mflash* mfl, int lock_state)
 {
     int rc = 0;
 
-    if (lock_state == 1)
-    { /* lock the flash */
+    if (lock_state == 1) { /* lock the flash */
         rc = is4_flash_lock(mfl, lock_state);
         CHECK_RC(rc);
         rc = disable_gcm(mfl);
@@ -1806,9 +1642,7 @@ int sixth_gen_flash_lock(mflash* mfl, int lock_state)
         CHECK_RC(rc);
         rc = gw_wait_ready(mfl, "WAIT TO BUSY");
         CHECK_RC(rc);
-    }
-    else
-    { /* unlock the flash */
+    } else { /* unlock the flash */
         rc = restore_flash_freq(mfl);
         CHECK_RC(rc);
         rc = restore_cache_replacemnt(mfl);
@@ -1824,17 +1658,14 @@ int connectib_flash_lock(mflash* mfl, int lock_state)
 {
     int rc = 0;
 
-    if (lock_state == 1)
-    { /* lock the flash */
+    if (lock_state == 1) { /* lock the flash */
         rc = is4_flash_lock(mfl, lock_state);
         CHECK_RC(rc);
         rc = disable_cache_replacement(mfl);
         CHECK_RC(rc);
         rc = gw_wait_ready(mfl, "WAIT TO BUSY");
         CHECK_RC(rc);
-    }
-    else
-    { /* unlock the flash */
+    } else { /* unlock the flash */
         rc = restore_cache_replacemnt(mfl);
         CHECK_RC(rc);
         rc = is4_flash_lock(mfl, lock_state);
@@ -1845,11 +1676,11 @@ int connectib_flash_lock(mflash* mfl, int lock_state)
 
 #define SX_CS_SUPPORT_ADDR 0xF0420
 
-#define HW_DEV_ID 0xf0014
+#define HW_DEV_ID      0xf0014
 #define CX5_EFUSE_ADDR 0xf0c0c
 
-#define CACHE_REP_OFF_RAVEN 0xf0440
-#define CACHE_REP_CMD_RAVEN 0xf0448
+#define CACHE_REP_OFF_RAVEN       0xf0440
+#define CACHE_REP_CMD_RAVEN       0xf0448
 #define CACHE_REP_OFF_NEW_GW_ADDR 0xf0484
 #define CACHE_REP_CMD_NEW_GW_ADDR 0xf0488
 int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement)
@@ -1857,10 +1688,8 @@ int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement
     *needs_cache_replacement = 0;
 
     /* When we access via command interface, we assume there is a cache replacement! */
-    if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_MLNXOS_CMDIF)
-    {
-        if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD])
-        {
+    if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_MLNXOS_CMDIF) {
+        if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD]) {
             /* dont allow overidding cache replacement in mellanox OS env */
             return MFE_OCR_NOT_SUPPORTED;
         }
@@ -1868,37 +1697,30 @@ int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement
         return MFE_OK;
     }
 
-    if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
-    {
-        u_int32_t off = 0, cmd = 0, data = 0;
+    if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0) {
+        u_int32_t   off = 0, cmd = 0, data = 0;
         dm_dev_id_t devid_t = DeviceUnknown;
-        u_int32_t devid = 0;
-        u_int32_t revid = 0;
-        int rc = dm_get_device_id(mfl->mf, &devid_t, &devid, &revid);
-        if (rc)
-        {
+        u_int32_t   devid = 0;
+        u_int32_t   revid = 0;
+        int         rc = dm_get_device_id(mfl->mf, &devid_t, &devid, &revid);
+        if (rc) {
             return rc;
         }
 
-        // TODO - fix for QTM3/CX8/ArcusE/BF4
+        /* TODO - fix for QTM3/CX8/ArcusE/BF4 */
         /* Read the Cache replacement offset and cmd fields */
         if ((devid_t == DeviceQuantum2) || (devid_t == DeviceQuantum3) || (devid_t == DeviceSpectrum4) ||
-            (devid_t == DeviceConnectX7) || (devid_t == DeviceConnectX8))
-        {
+            (devid_t == DeviceConnectX7) || (devid_t == DeviceConnectX8)) {
             MREAD4(CACHE_REP_OFF_NEW_GW_ADDR, &data);
             off = data;
             MREAD4(CACHE_REP_CMD_NEW_GW_ADDR, &data);
             cmd = EXTRACT(data, 24, 8);
-        }
-        else if (!dm_dev_is_raven_family_switch(devid_t))
-        {
+        } else if (!dm_dev_is_raven_family_switch(devid_t)) {
             MREAD4(mfl->cache_rep_offset_field_addr, &data);
             off = EXTRACT(data, 0, 26);
             MREAD4(mfl->cache_rep_cmd_field_addr, &data);
             cmd = EXTRACT(data, 16, 8);
-        }
-        else
-        { /* switches */
+        } else { /* switches */
             MREAD4(CACHE_REP_OFF_RAVEN, &data);
             off = EXTRACT(data, 0, 26);
             MREAD4(CACHE_REP_CMD_RAVEN, &data);
@@ -1907,13 +1729,10 @@ int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement
         FLASH_ACCESS_DPRINTF(("check_cache_replacement_guard(): off=%d, cmd=%d\n", off, cmd));
 
         /* Check if the offset and cmd are zero in order to continue burning. */
-        if ((cmd != 0) || (off != 0))
-        {
+        if ((cmd != 0) || (off != 0)) {
             *needs_cache_replacement = 1;
         }
-    }
-    else
-    {
+    } else {
         /* Here we ignore the cache replacement check */
         /* We need to execute a write in order to do any needed cache replacement */
         /* Reset the HW ID which is read only register. */
@@ -1929,17 +1748,13 @@ int mfl_com_lock(mflash* mfl)
 
     /* if we already locked the semaphore we dont want to re-lock it */
     if (mfl->is_locked &&
-        ((mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_INBAND) || (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 1)))
-    { /* on inband w/o ocr we need to extend the lock */
+        ((mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_INBAND) || (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 1))) { /* on inband w/o ocr we need to extend the lock */
         return MFE_OK;
     }
     rc = mfl->f_lock(mfl, 1);
-    if (!mfl->opts[MFO_IGNORE_SEM_LOCK])
-    {
+    if (!mfl->opts[MFO_IGNORE_SEM_LOCK]) {
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         mfl->is_locked = 1;
         mfl->unlock_flash_prog_allowed = 1;
     }
@@ -1956,8 +1771,7 @@ int release_semaphore(mflash* mfl, int ignore_writer_lock)
 {
     int rc = 0;
 
-    if ((mfl->is_locked || mfl->flash_prog_locked) && mfl->f_lock && (!mfl->writer_lock || ignore_writer_lock))
-    {
+    if ((mfl->is_locked || mfl->flash_prog_locked) && mfl->f_lock && (!mfl->writer_lock || ignore_writer_lock)) {
         rc = mfl->f_lock(mfl, 0);
         CHECK_RC(rc);
     }
@@ -1997,16 +1811,13 @@ int gen6_flash_init_com(mflash* mfl, flash_params_t* flash_params)
     rc = st_spi_fill_attr(mfl, flash_params);
     CHECK_RC(rc);
 
-    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI))
-    {
+    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI)) {
         mfl->f_reset = empty_reset; /* Null func */
         mfl->f_write_blk = get_write_blk_func(mfl->attr.command_set);
         mfl->attr.page_write = 256;
         mfl->f_write = write_chunks;
         mfl->f_erase_sect = new_gw_st_spi_erase_sect;
-    }
-    else
-    {
+    } else {
         return MFE_UNSUPPORTED_FLASH_TYPE;
     }
 
@@ -2044,8 +1855,7 @@ int gen4_flash_init_com(mflash* mfl, flash_params_t* flash_params)
     rc = st_spi_fill_attr(mfl, flash_params);
     CHECK_RC(rc);
 
-    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI))
-    {
+    if ((mfl->attr.command_set == MCS_STSPI) || (mfl->attr.command_set == MCS_SSTSPI)) {
         mfl->f_reset = empty_reset; /* Null func */
         /* mfl->f_write_blk  = cntx_st_spi_block_write; */
 
@@ -2054,9 +1864,7 @@ int gen4_flash_init_com(mflash* mfl, flash_params_t* flash_params)
         mfl->attr.page_write = 256;
         mfl->f_write = write_chunks;
         mfl->f_erase_sect = cntx_st_spi_erase_sect;
-    }
-    else
-    {
+    } else {
         return MFE_UNSUPPORTED_FLASH_TYPE;
     }
 
@@ -2100,51 +1908,45 @@ int sx_flash_init_direct_access(mflash* mfl, flash_params_t* flash_params)
 
 void update_seventh_gen_addrs(mflash* mfl)
 {
-    // Registers addresses
-    if (mfl->dm_dev_id == DeviceQuantum3)
-    {
+    /* Registers addresses */
+    if (mfl->dm_dev_id == DeviceQuantum3) {
         mfl->gw_cmd_register_addr = HCR_7GEN_QTM3_FLASH_CMD;
         mfl->gw_data_field_addr = HCR_7GEN_QTM3_FLASH_DATA;
         mfl->gcm_en_addr = HCR_7GEN_QTM3_GCM_EN_ADDR;
         mfl->gw_addr_field_addr = HCR_7GEN_QTM3_FLASH_ADDR;
         mfl->gw_data_size_register_addr = HCR_7GEN_QTM3_FLASH_DATA_SIZE;
-        if (is_zombiefish_device(mfl->mf))
-        {
+        if (is_zombiefish_device(mfl->mf)) {
             mfl->gw_cmd_register_addr =
-              mfl->gw_cmd_register_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_cmd_register_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR +
+                VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_data_field_addr =
-              mfl->gw_data_field_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_data_field_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gcm_en_addr =
-              mfl->gcm_en_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gcm_en_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_addr_field_addr =
-              mfl->gw_addr_field_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_addr_field_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_data_size_register_addr = mfl->gw_data_size_register_addr - HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR +
                                               VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
         }
-    }
-    else if (mfl->dm_dev_id == DeviceConnectX8)
-    {
+    } else if (mfl->dm_dev_id == DeviceConnectX8) {
         mfl->gw_cmd_register_addr = HCR_7GEN_CX8_FLASH_CMD;
         mfl->gw_data_field_addr = HCR_7GEN_CX8_FLASH_DATA;
         mfl->gcm_en_addr = HCR_7GEN_CX8_GCM_EN_ADDR;
         mfl->gw_addr_field_addr = HCR_7GEN_CX8_FLASH_ADDR;
         mfl->gw_data_size_register_addr = HCR_7GEN_CX8_FLASH_DATA_SIZE;
-        if (is_zombiefish_device(mfl->mf))
-        {
+        if (is_zombiefish_device(mfl->mf)) {
             mfl->gw_cmd_register_addr =
-              mfl->gw_cmd_register_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_cmd_register_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_data_field_addr =
-              mfl->gw_data_field_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_data_field_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gcm_en_addr =
-              mfl->gcm_en_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gcm_en_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_addr_field_addr =
-              mfl->gw_addr_field_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+                mfl->gw_addr_field_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
             mfl->gw_data_size_register_addr = mfl->gw_data_size_register_addr - HCR_7GEN_CX8_FLASH_GW_BASE_ADDR +
                                               VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
         }
-    }
-    else if (mfl->dm_dev_id == DeviceArcusE)
-    {
+    } else if (mfl->dm_dev_id == DeviceArcusE) {
         mfl->gw_cmd_register_addr = HCR_7GEN_ARCUSE_FLASH_CMD;
         mfl->gw_data_field_addr = HCR_7GEN_ARCUSE_FLASH_DATA;
         mfl->gcm_en_addr = HCR_7GEN_ARCUSE_GCM_EN_ADDR;
@@ -2152,7 +1954,7 @@ void update_seventh_gen_addrs(mflash* mfl)
         mfl->gw_data_size_register_addr = HCR_7GEN_ARCUSE_FLASH_DATA_SIZE;
     }
 
-    // Fields bit offsets and lengths
+    /* Fields bit offsets and lengths */
     mfl->gw_rw_bit_offset = HBO_7GEN_RW;
     mfl->gw_cmd_phase_bit_offset = HBO_7GEN_CMD_PHASE;
     mfl->gw_addr_phase_bit_offset = HBO_7GEN_ADDR_PHASE;
@@ -2183,6 +1985,14 @@ void update_sixth_gen_addrs(mflash* mfl)
     mfl->cache_repacement_en_addr = HCR_NEW_GW_CACHE_REPLACEMNT_EN_ADDR;
     mfl->gcm_en_addr = HCR_NEW_GW_GCM_EN_ADDR;
     init_freq_configuration_fields(mfl);
+
+    if (is_zombiefish_device(mfl->mf)) {
+        mfl->gw_addr_field_addr =
+            mfl->gw_addr_field_addr - HCR_NEW_GW_FLASH_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+        mfl->cache_repacement_en_addr =
+            mfl->cache_repacement_en_addr - HCR_NEW_GW_FLASH_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+        mfl->gcm_en_addr = mfl->gcm_en_addr - HCR_NEW_GW_FLASH_ADDR + VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS;
+    }
 }
 
 int seventh_gen_init_direct_access(mflash* mfl, flash_params_t* flash_params)
@@ -2222,7 +2032,7 @@ int sx_get_flash_info(mflash* mfl, flash_info_t* f_info, int* log2size, u_int8_t
 
 int sx_get_jedec_id(mflash* mfl, u_int32_t* jedec_id_p)
 {
-    int rc = 0;
+    int               rc = 0;
     mfpa_command_args mfpa_args;
 
     memset(&mfpa_args, 0, sizeof(mfpa_args));
@@ -2301,8 +2111,7 @@ static int get_the_max_reg_size(mfile* mf, maccess_reg_method_t reg_method)
 {
     u_int32_t max_reg_size = mget_max_reg_size(mf, reg_method);
 
-    if (mf->flags & MDEVS_IB && (reg_method == MACCESS_REG_METHOD_SET) && (max_reg_size > INBAND_MAX_REG_SIZE))
-    {
+    if (mf->flags & MDEVS_IB && (reg_method == MACCESS_REG_METHOD_SET) && (max_reg_size > INBAND_MAX_REG_SIZE)) {
         max_reg_size = INBAND_MAX_REG_SIZE;
     }
     return max_reg_size;
@@ -2313,8 +2122,7 @@ static int update_max_write_size(mflash* mfl)
     u_int32_t max_reg_size = get_the_max_reg_size(mfl->mf, MACCESS_REG_METHOD_SET);
     u_int32_t max_block_size = MAX_BLOCK_SIZE(mfl->attr.hw_dev_id);
 
-    if (!max_reg_size)
-    {
+    if (!max_reg_size) {
         return MFE_BAD_PARAMS;
     }
     max_reg_size = NEAREST_POW2(max_reg_size);
@@ -2423,18 +2231,14 @@ int flash_init_fw_access(mflash* mfl, flash_params_t* flash_params)
 
     int rc = 0;
 
-    if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_NO)
-    {
+    if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_NO) {
         rc = flash_init_inband_access(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         return MFE_DIRECT_FW_ACCESS_DISABLED;
     }
 
-    if (mfl->opts[MFO_IGNORE_SEM_LOCK])
-    {
+    if (mfl->opts[MFO_IGNORE_SEM_LOCK]) {
         rc = mfl->f_lock(mfl, 0);
         CHECK_RC(rc);
     }
@@ -2443,19 +2247,16 @@ int flash_init_fw_access(mflash* mfl, flash_params_t* flash_params)
 
 int sx_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
+    int      rc = 0;
     u_int8_t needs_cache_replacement = 0;
 
     rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
+    if (needs_cache_replacement) {
         rc = flash_init_fw_access(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         rc = sx_flash_init_direct_access(mfl, flash_params);
         CHECK_RC(rc);
     }
@@ -2465,10 +2266,8 @@ int sx_flash_init(mflash* mfl, flash_params_t* flash_params)
 int icmd_init(mflash* mfl)
 {
     /* Clear  semaphore when asked to by flint or any tool using mflash */
-    if (mfl->opts[MFO_IGNORE_SEM_LOCK])
-    {
-        if (icmd_clear_semaphore(mfl->mf) != ME_OK)
-        {
+    if (mfl->opts[MFO_IGNORE_SEM_LOCK]) {
+        if (icmd_clear_semaphore(mfl->mf) != ME_OK) {
             return MFE_CR_ERROR;
         }
     }
@@ -2478,10 +2277,8 @@ int icmd_init(mflash* mfl)
 int tools_cmdif_init(mflash* mfl)
 {
     /* Clear  semaphore when asked to by flint or any tool using mflash */
-    if (mfl->opts[MFO_IGNORE_SEM_LOCK])
-    {
-        if (tools_cmdif_unlock_semaphore(mfl->mf) != ME_OK)
-        {
+    if (mfl->opts[MFO_IGNORE_SEM_LOCK]) {
+        if (tools_cmdif_unlock_semaphore(mfl->mf) != ME_OK) {
             return MFE_CR_ERROR;
         }
     }
@@ -2492,20 +2289,15 @@ int seven_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
     int rc = MFE_OK;
 
-    if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
+    if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0) {
+        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD) {
             rc = icmd_init(mfl);
             CHECK_RC(rc);
         }
         rc = flash_init_fw_access(mfl, flash_params);
-    }
-    else
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_MLNXOS_CMDIF)
-        {
-            // dont allow overidding cache replacement in mellanox OS env
+    } else {
+        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_MLNXOS_CMDIF) {
+            /* dont allow overidding cache replacement in mellanox OS env */
             return MFE_OCR_NOT_SUPPORTED;
         }
         rc = seventh_gen_init_direct_access(mfl, flash_params);
@@ -2515,24 +2307,20 @@ int seven_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 
 int six_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
+    int      rc = 0;
     u_int8_t needs_cache_replacement = 0;
 
     rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
+    if (needs_cache_replacement) {
+        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD) {
             rc = icmd_init(mfl);
             CHECK_RC(rc);
         }
         rc = flash_init_fw_access(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         rc = sixth_gen_init_direct_access(mfl, flash_params);
         CHECK_RC(rc);
     }
@@ -2541,33 +2329,26 @@ int six_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 
 int fifth_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
+    int      rc = 0;
     u_int8_t needs_cache_replacement = 0;
 
-    if (mfl->mf->gb_info.is_gb_mngr)
-    {
+    if (mfl->mf->gb_info.is_gb_mngr) {
         /* need to update GW offsets before calling to the check_cache_replacement_guard */
         flash_update_amos_gearbox_gw(mfl);
-    }
-    else if (mfl->mf->gb_info.is_gearbox)
-    {
+    } else if (mfl->mf->gb_info.is_gearbox) {
         return MFE_OCR_NOT_SUPPORTED; /* Accessing flash GW of GB that's not manager is not possible */
     }
     rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
+    if (needs_cache_replacement) {
+        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD) {
             rc = icmd_init(mfl);
             CHECK_RC(rc);
         }
         rc = flash_init_fw_access(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         rc = fifth_gen_init_direct_access(mfl, flash_params);
         CHECK_RC(rc);
     }
@@ -2579,8 +2360,7 @@ int cntx_flash_init(mflash* mfl, flash_params_t* flash_params)
     int rc = 0;
 
     if ((mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_TOOLS_CMDIF) && (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0) &&
-        mfl->opts[MFO_CX3_FW_ACCESS_EN])
-    {
+        mfl->opts[MFO_CX3_FW_ACCESS_EN]) {
 #ifdef UEFI_BUILD
         /* tools CMDIF not supported in UEFI */
         rc = ME_NOT_IMPLEMENTED;
@@ -2588,22 +2368,18 @@ int cntx_flash_init(mflash* mfl, flash_params_t* flash_params)
         rc = tcif_cr_mbox_supported(mfl->mf);
 #endif
         /* init with direct access if not supported */
-        if ((rc == ME_NOT_IMPLEMENTED) || (rc == ME_CMDIF_NOT_SUPP))
-        {
+        if ((rc == ME_NOT_IMPLEMENTED) || (rc == ME_CMDIF_NOT_SUPP)) {
             mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_NO;
             return cntx_flash_init_direct_access(mfl, flash_params);
         }
-        if ((rc == ME_SEM_LOCKED) && !mfl->opts[MFO_IGNORE_SEM_LOCK])
-        {
+        if ((rc == ME_SEM_LOCKED) && !mfl->opts[MFO_IGNORE_SEM_LOCK]) {
             return MFE_SEM_LOCKED;
         }
         rc = tools_cmdif_init(mfl);
         CHECK_RC(rc);
         rc = flash_init_fw_access(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_NO;
         rc = cntx_flash_init_direct_access(mfl, flash_params);
         CHECK_RC(rc);
@@ -2628,8 +2404,7 @@ int mf_read(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data, bool ver
     u_int32_t size = mfl->attr.size;
 
     if (((mfl->dm_dev_id == DeviceConnectX4LX) || (mfl->dm_dev_id == DeviceConnectX5)) &&
-        (mfl->attr.vendor == FV_GD25QXXX))
-    {
+        (mfl->attr.vendor == FV_GD25QXXX)) {
         size = 1 << FD_128; /* 16MB */
     }
     /* printf("size = %#x, addr = %#x, len = %d\n", size, addr, len); */
@@ -2643,8 +2418,7 @@ int mf_write(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
     u_int32_t size = mfl->attr.size;
 
     if (((mfl->dm_dev_id == DeviceConnectX4LX) || (mfl->dm_dev_id == DeviceConnectX5)) &&
-        (mfl->attr.vendor == FV_GD25QXXX))
-    {
+        (mfl->attr.vendor == FV_GD25QXXX)) {
         size = 1 << FD_128; /* 16MB */
     }
     CHECK_OUT_OF_RANGE(addr, len, size);
@@ -2663,12 +2437,11 @@ void mf_set_cpu_utilization(mflash* mfl, int cpuPercent)
 
 static int erase_com(mflash* mfl, u_int32_t addr, unsigned int sector_size, int erase_cmd)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int32_t backup_sector_size = 0;
-    int backup_erase_command = 0;
+    int       backup_erase_command = 0;
 
-    if (addr >= mfl->attr.size)
-    {
+    if (addr >= mfl->attr.size) {
         return MFE_OUT_OF_RANGE;
     }
     /* Locking semaphore for the entire existence of the mflash obj for write and erase only. */
@@ -2692,8 +2465,7 @@ int mf_erase(mflash* mfl, u_int32_t addr)
 
 int mf_erase_64k_sector(mflash* mfl, u_int32_t addr)
 {
-    if (!mfl->attr.support_sub_and_sector)
-    {
+    if (!mfl->attr.support_sub_and_sector) {
         return MFE_UNSUPPORTED_ERASE_OPERATION;
     }
     return erase_com(mfl, addr, FSS_64KB, mfl->attr.access_commands.sfc_sector_erase);
@@ -2701,8 +2473,7 @@ int mf_erase_64k_sector(mflash* mfl, u_int32_t addr)
 
 int mf_erase_4k_sector(mflash* mfl, u_int32_t addr)
 {
-    if (!mfl->attr.support_sub_and_sector)
-    {
+    if (!mfl->attr.support_sub_and_sector) {
         return MFE_UNSUPPORTED_ERASE_OPERATION;
     }
     return erase_com(mfl, addr, FSS_4KB, mfl->attr.access_commands.sfc_subsector_erase);
@@ -2726,17 +2497,12 @@ BinIdT get_bin_id(mflash* mfl, u_int32_t hw_dev_id)
 {
     u_int32_t dword = 0;
 
-    if (hw_dev_id == CX5_HW_ID)
-    {
-        if (mread4(mfl->mf, CX5_EFUSE_ADDR, &dword) == 4)
-        {
+    if (hw_dev_id == CX5_HW_ID) {
+        if (mread4(mfl->mf, CX5_EFUSE_ADDR, &dword) == 4) {
             u_int8_t bin_speed = EXTRACT(dword, 30, 2);
-            if (bin_speed == 0)
-            {
+            if (bin_speed == 0) {
                 return CX5_LOW_BIN;
-            }
-            else if (bin_speed == 1)
-            {
+            } else if (bin_speed == 1) {
                 return CX5_HIGH_BIN;
             }
         }
@@ -2748,7 +2514,7 @@ int get_dev_info(mflash* mfl)
 {
     u_int32_t dev_flags = 0;
     u_int32_t access_type = 0;
-    int rc = 0;
+    int       rc = 0;
     u_int32_t dev_id = 0;
 
     mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_NO;
@@ -2758,42 +2524,34 @@ int get_dev_info(mflash* mfl)
     CHECK_RC(rc);
 
     MfError status;
-    int icmdif_supported = is_icmdif_supported(mfl, &status);
+    int     icmdif_supported = is_icmdif_supported(mfl, &status);
 
-    if (status != MFE_OK)
-    {
+    if (status != MFE_OK) {
         return status;
     }
 
     mfl->attr.bin_id = UNKNOWN_BIN;
     /* get hw id */
     /* Special case for MLNX OS getting dev_id using REG MGIR */
-    if (dev_flags & MDEVS_MLNX_OS)
-    {
+    if (dev_flags & MDEVS_MLNX_OS) {
 #ifndef UEFI_BUILD
-        reg_access_status_t rc;
+        reg_access_status_t            rc;
         struct reg_access_hca_mgir_ext mgir;
         memset(&mgir, 0, sizeof(mgir));
         rc = reg_access_mgir(mfl->mf, REG_ACCESS_METHOD_GET, &mgir);
         /* printf("-D- RC[%s] -- REVID: %d -- DEVID: %d hw_dev_id: %d\n", m_err2str(rc), mgir.HWInfo.REVID, */
         /* mgir.HWInfo.DEVID, mgir.HWInfo.hw_dev_id); */
-        if (rc)
-        {
+        if (rc) {
             dev_id = DeviceSwitchIB_HwId;
             mfl->attr.rev_id = 0;
             mfl->attr.hw_dev_id = DeviceSwitchIB_HwId;
-        }
-        else
-        {
+        } else {
             dev_id = mgir.hw_info.hw_dev_id;
-            if (dev_id == 0)
-            {
+            if (dev_id == 0) {
                 dev_id = DeviceSwitchIB_HwId;
                 mfl->attr.hw_dev_id = DeviceSwitchIB_HwId;
                 mfl->attr.rev_id = mgir.hw_info.device_hw_revision & 0xf;
-            }
-            else
-            {
+            } else {
                 mfl->attr.hw_dev_id = dev_id;
                 mfl->attr.rev_id = 0; /* WA: MGIR should have also hw_rev_id and then we can use it. */
             }
@@ -2803,49 +2561,34 @@ int get_dev_info(mflash* mfl)
         /* we should never reach here */
         return MFE_UNKOWN_ACCESS_TYPE;
 #endif
-    }
-    else
-    {
+    } else {
         MREAD4(HW_DEV_ID, &dev_id);
-        if (dev_id == CR_LOCK_HW_ID)
-        {
+        if (dev_id == CR_LOCK_HW_ID) {
             return MFE_LOCKED_CRSPACE;
         }
         mfl->attr.rev_id = (dev_id & 0xff0000) >> 16;
         mfl->attr.hw_dev_id = dev_id & 0xffff;
         mfl->attr.bin_id = get_bin_id(mfl, mfl->attr.hw_dev_id);
 
-        if (icmdif_supported)
-        {
+        if (icmdif_supported) {
             int mode = 0;
-            if (!mf_get_secure_host(mfl, &mode) && mode)
-            {
+            if (!mf_get_secure_host(mfl, &mode) && mode) {
                 return MFE_LOCKED_CRSPACE;
             }
         }
     }
 
-    if (dev_flags & MDEVS_MLNX_OS)
-    {
+    if (dev_flags & MDEVS_MLNX_OS) {
         mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_MLNXOS_CMDIF;
-    }
-    else if (dev_flags & MDEVS_IB)
-    {
+    } else if (dev_flags & MDEVS_IB) {
         mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_INBAND;
-    }
-    else
-    { /* not mlnxOS or IB device - check HW ID to determine Access type */
-        if (icmdif_supported)
-        {
-            if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
-            {
+    } else { /* not mlnxOS or IB device - check HW ID to determine Access type */
+        if (icmdif_supported) {
+            if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0) {
                 mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_ICMD;
             }
-        }
-        else if (HAS_TOOLS_CMDIF(mfl->attr.hw_dev_id) && (IS_PCI_DEV(access_type)))
-        {
-            if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
-            {
+        } else if (HAS_TOOLS_CMDIF(mfl->attr.hw_dev_id) && (IS_PCI_DEV(access_type))) {
+            if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0) {
                 mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] = ATBM_TOOLS_CMDIF;
             }
         }
@@ -2886,8 +2629,7 @@ bool toggle_flash_io3_gpio_cx6(mfile* mf, gpio_toggle_conf_cx6 conf)
 {
     FLASH_DPRINTF(("toggle_flash_io3_gpio_cx6\n"));
     /* Enable lock */
-    if (mwrite4(mf, conf.lock_addr, 0xd42f) != 4)
-    {
+    if (mwrite4(mf, conf.lock_addr, 0xd42f) != 4) {
         printf("-E- failed to enable GPIO lock\n");
         return MFE_CR_ERROR;
     }
@@ -2896,28 +2638,24 @@ bool toggle_flash_io3_gpio_cx6(mfile* mf, gpio_toggle_conf_cx6 conf)
     /* Enable functional_enable0 */
     u_int32_t functional_enable0 = 0;
 
-    if (mread4(mf, conf.functional_enable0_addr, &functional_enable0) != 4)
-    {
+    if (mread4(mf, conf.functional_enable0_addr, &functional_enable0) != 4) {
         printf("-E- failed to read functional_enable0\n");
         return MFE_CR_ERROR;
     }
     functional_enable0 = functional_enable0 & 0xdfffffff;
-    if (mwrite4(mf, conf.functional_enable0_addr, functional_enable0) != 4)
-    {
+    if (mwrite4(mf, conf.functional_enable0_addr, functional_enable0) != 4) {
         printf("-E- failed to enable GPIO functional_enable0\n");
         return MFE_CR_ERROR;
     }
     /* Enable functional_enable1 */
     u_int32_t functional_enable1 = 0;
 
-    if (mread4(mf, conf.functional_enable1_addr, &functional_enable1) != 4)
-    {
+    if (mread4(mf, conf.functional_enable1_addr, &functional_enable1) != 4) {
         printf("-E- failed to read functional_enable1\n");
         return MFE_CR_ERROR;
     }
     functional_enable1 = functional_enable1 & 0xdfffffff;
-    if (mwrite4(mf, conf.functional_enable1_addr, functional_enable1) != 4)
-    {
+    if (mwrite4(mf, conf.functional_enable1_addr, functional_enable1) != 4) {
         printf("-E- failed to enable GPIO functional_enable1\n");
         return MFE_CR_ERROR;
     }
@@ -2925,14 +2663,12 @@ bool toggle_flash_io3_gpio_cx6(mfile* mf, gpio_toggle_conf_cx6 conf)
     /* Write to mode1_set */
     u_int32_t mode1_set = 0;
 
-    if (mread4(mf, conf.mode1_set_addr, &mode1_set) != 4)
-    {
+    if (mread4(mf, conf.mode1_set_addr, &mode1_set) != 4) {
         printf("-E- failed to read mode1_set\n");
         return MFE_CR_ERROR;
     }
     mode1_set = mode1_set | 0x20000000;
-    if (mwrite4(mf, conf.mode1_set_addr, mode1_set) != 4)
-    {
+    if (mwrite4(mf, conf.mode1_set_addr, mode1_set) != 4) {
         printf("-E- failed to write to mode1_set\n");
         return MFE_CR_ERROR;
     }
@@ -2941,21 +2677,18 @@ bool toggle_flash_io3_gpio_cx6(mfile* mf, gpio_toggle_conf_cx6 conf)
     /* Write to mode0_set */
     u_int32_t mode0_set = 0;
 
-    if (mread4(mf, conf.mode0_set_addr, &mode0_set) != 4)
-    {
+    if (mread4(mf, conf.mode0_set_addr, &mode0_set) != 4) {
         printf("-E- failed to read mode0_set\n");
         return MFE_CR_ERROR;
     }
     mode0_set = mode0_set | 0x20000000;
-    if (mwrite4(mf, conf.mode0_set_addr, mode0_set) != 4)
-    {
+    if (mwrite4(mf, conf.mode0_set_addr, mode0_set) != 4) {
         printf("-E- failed to write to mode0_set\n");
         return MFE_CR_ERROR;
     }
 
     /* Write to dataset */
-    if (mwrite4(mf, conf.dataset_addr, 0x20000000) != 4)
-    {
+    if (mwrite4(mf, conf.dataset_addr, 0x20000000) != 4) {
         printf("-E- failed to write to dataset\n");
         return MFE_CR_ERROR;
     }
@@ -2969,14 +2702,12 @@ bool toggle_flash_io3_gpio_cx7(mfile* mf, gpio_toggle_conf_cx7 conf)
     /* write 0x0 to select_synced_data_out.16:1 */
     u_int32_t select_synced_data_out = 0;
 
-    if (mread4(mf, conf.select_synced_data_out_addr, &select_synced_data_out) != 4)
-    {
+    if (mread4(mf, conf.select_synced_data_out_addr, &select_synced_data_out) != 4) {
         printf("-E- failed to read select_synced_data_out\n");
         return MFE_CR_ERROR;
     }
     select_synced_data_out = select_synced_data_out & 0xfffeffff;
-    if (mwrite4(mf, conf.select_synced_data_out_addr, select_synced_data_out) != 4)
-    {
+    if (mwrite4(mf, conf.select_synced_data_out_addr, select_synced_data_out) != 4) {
         printf("-E- failed to write 0x0 to select_synced_data_out.16:1\n");
         return MFE_CR_ERROR;
     }
@@ -2984,14 +2715,12 @@ bool toggle_flash_io3_gpio_cx7(mfile* mf, gpio_toggle_conf_cx7 conf)
     /* write 0x3 to fw_control_set.28:2 */
     u_int32_t fw_control_set = 0;
 
-    if (mread4(mf, conf.fw_control_set_addr, &fw_control_set) != 4)
-    {
+    if (mread4(mf, conf.fw_control_set_addr, &fw_control_set) != 4) {
         printf("-E- failed to read fw_control_set\n");
         return MFE_CR_ERROR;
     }
     fw_control_set = fw_control_set | 0x30000000;
-    if (mwrite4(mf, conf.fw_control_set_addr, fw_control_set) != 4)
-    {
+    if (mwrite4(mf, conf.fw_control_set_addr, fw_control_set) != 4) {
         printf("-E- failed to write 0x3 to fw_control_set.28:2\n");
         return MFE_CR_ERROR;
     }
@@ -2999,14 +2728,12 @@ bool toggle_flash_io3_gpio_cx7(mfile* mf, gpio_toggle_conf_cx7 conf)
     /* write 0x3 to hw_data_in.4:2 */
     u_int32_t hw_data_in = 0;
 
-    if (mread4(mf, conf.hw_data_in_addr, &hw_data_in) != 4)
-    {
+    if (mread4(mf, conf.hw_data_in_addr, &hw_data_in) != 4) {
         printf("-E- failed to read hw_data_in\n");
         return MFE_CR_ERROR;
     }
     hw_data_in = hw_data_in | 0x00000030;
-    if (mwrite4(mf, conf.hw_data_in_addr, hw_data_in) != 4)
-    {
+    if (mwrite4(mf, conf.hw_data_in_addr, hw_data_in) != 4) {
         printf("-E- failed to write 0x3 to hw_data_in.4:2\n");
         return MFE_CR_ERROR;
     }
@@ -3014,14 +2741,12 @@ bool toggle_flash_io3_gpio_cx7(mfile* mf, gpio_toggle_conf_cx7 conf)
     /* write 0x3 to fw_output_enable_set.28:2 */
     u_int32_t fw_output_enable_set = 0;
 
-    if (mread4(mf, conf.fw_output_enable_set_addr, &fw_output_enable_set) != 4)
-    {
+    if (mread4(mf, conf.fw_output_enable_set_addr, &fw_output_enable_set) != 4) {
         printf("-E- failed to read fw_output_enable_set\n");
         return MFE_CR_ERROR;
     }
     fw_output_enable_set = fw_output_enable_set | 0x30000000;
-    if (mwrite4(mf, conf.fw_output_enable_set_addr, fw_output_enable_set) != 4)
-    {
+    if (mwrite4(mf, conf.fw_output_enable_set_addr, fw_output_enable_set) != 4) {
         printf("-E- failed to write 0x3 to fw_output_enable_set.28:2\n");
         return MFE_CR_ERROR;
     }
@@ -3029,14 +2754,12 @@ bool toggle_flash_io3_gpio_cx7(mfile* mf, gpio_toggle_conf_cx7 conf)
     /* write 0x3 to fw_data_out_set.28:2 */
     u_int32_t fw_data_out_set = 0;
 
-    if (mread4(mf, conf.fw_data_out_set_addr, &fw_data_out_set) != 4)
-    {
+    if (mread4(mf, conf.fw_data_out_set_addr, &fw_data_out_set) != 4) {
         printf("-E- failed to read fw_data_out_set\n");
         return MFE_CR_ERROR;
     }
     fw_data_out_set = fw_data_out_set | 0x30000000;
-    if (mwrite4(mf, conf.fw_data_out_set_addr, fw_data_out_set) != 4)
-    {
+    if (mwrite4(mf, conf.fw_data_out_set_addr, fw_data_out_set) != 4) {
         printf("-E- failed to write 0x3 to fw_data_out_set.28:2\n");
         return MFE_CR_ERROR;
     }
@@ -3048,38 +2771,36 @@ bool force_flash_out_of_hold_state(mflash* mfl)
 {
     bool res = true;
 
-    if ((getenv("FORCE_GPIO_TOGGLE") != NULL) || dm_is_livefish_mode(mfl->mf))
-    {
-        switch (mfl->dm_dev_id)
+    if ((getenv("FORCE_GPIO_TOGGLE") != NULL) || dm_is_livefish_mode(mfl->mf)) {
+        switch (mfl->dm_dev_id) {
+        case DeviceConnectX6:
+        case DeviceConnectX6DX:
         {
-            case DeviceConnectX6:
-            case DeviceConnectX6DX:
-            {
-                gpio_toggle_conf_cx6 gpio_toggle_conf = {0};
-                set_gpio_toggle_conf_cx6(&gpio_toggle_conf);
-                res = toggle_flash_io3_gpio_cx6(mfl->mf, gpio_toggle_conf);
-                break;
-            }
+            gpio_toggle_conf_cx6 gpio_toggle_conf = {0};
+            set_gpio_toggle_conf_cx6(&gpio_toggle_conf);
+            res = toggle_flash_io3_gpio_cx6(mfl->mf, gpio_toggle_conf);
+            break;
+        }
 
-            case DeviceBlueField2:
-            {
-                gpio_toggle_conf_cx6 gpio_toggle_conf = {0};
-                set_gpio_toggle_conf_bf2(&gpio_toggle_conf);
-                res = toggle_flash_io3_gpio_cx6(mfl->mf, gpio_toggle_conf);
-                break;
-            }
+        case DeviceBlueField2:
+        {
+            gpio_toggle_conf_cx6 gpio_toggle_conf = {0};
+            set_gpio_toggle_conf_bf2(&gpio_toggle_conf);
+            res = toggle_flash_io3_gpio_cx6(mfl->mf, gpio_toggle_conf);
+            break;
+        }
 
-            case DeviceConnectX7:
-            case DeviceBlueField3:
-            {
-                gpio_toggle_conf_cx7 gpio_toggle_conf = {0};
-                set_gpio_toggle_conf_cx7(&gpio_toggle_conf);
-                res = toggle_flash_io3_gpio_cx7(mfl->mf, gpio_toggle_conf);
-                break;
-            }
+        case DeviceConnectX7:
+        case DeviceBlueField3:
+        {
+            gpio_toggle_conf_cx7 gpio_toggle_conf = {0};
+            set_gpio_toggle_conf_cx7(&gpio_toggle_conf);
+            res = toggle_flash_io3_gpio_cx7(mfl->mf, gpio_toggle_conf);
+            break;
+        }
 
-            default:
-                break;
+        default:
+            break;
         }
     }
 
@@ -3091,8 +2812,7 @@ int mf_open_fw(mflash* mfl, flash_params_t* flash_params, int num_of_banks)
 {
     int rc = 0;
 
-    if (!mfl)
-    {
+    if (!mfl) {
         return MFE_BAD_PARAMS;
     }
     rc = set_bank_int(mfl, -1);
@@ -3101,19 +2821,17 @@ int mf_open_fw(mflash* mfl, flash_params_t* flash_params, int num_of_banks)
     mfl->gw_cmd_register_addr = HCR_FLASH_CMD;
     mfl->gw_addr_field_addr = HCR_FLASH_ADDR;
     mfl->cache_repacement_en_addr = HCR_CACHE_REPLACEMNT_EN_ADDR;
-    mfl->gcm_en_addr = 0xffffffff; // Relevant to devices with new flash GW only
+    mfl->gcm_en_addr = 0xffffffff; /* Relevant to devices with new flash GW only */
     mfl->cache_rep_offset_field_addr = HCR_FLASH_CACHE_REPLACEMENT_OFFSET;
     mfl->cache_rep_cmd_field_addr = HCR_FLASH_CACHE_REPLACEMENT_CMD;
-    if (mfl->access_type == MFAT_MFILE)
-    {
+    if (mfl->access_type == MFAT_MFILE) {
         rc = get_dev_info(mfl);
         CHECK_RC(rc);
 
 #ifndef UEFI_BUILD
         trm_sts trm_rc;
         trm_rc = trm_create(&(mfl->trm), mfl->mf);
-        if (trm_rc)
-        {
+        if (trm_rc) {
             return trm2mfe_err(trm_rc);
         }
 #endif
@@ -3127,74 +2845,54 @@ int mf_open_fw(mflash* mfl, flash_params_t* flash_params, int num_of_banks)
         rc = force_flash_out_of_hold_state(mfl);
 
         MfError status;
-        int icmdif_supported = is_icmdif_supported(mfl, &status);
-        if (status != MFE_OK)
-        {
+        int     icmdif_supported = is_icmdif_supported(mfl, &status);
+        if (status != MFE_OK) {
             return status;
         }
-        if (IS_CONNECTX_4TH_GEN_FAMILY(mfl->attr.hw_dev_id))
-        {
+        if (IS_CONNECTX_4TH_GEN_FAMILY(mfl->attr.hw_dev_id)) {
             rc = cntx_flash_init(mfl, flash_params);
-        }
-        else if (icmdif_supported)
-        {
+        } else if (icmdif_supported) {
             FlashGen flash_gen = get_flash_gen(mfl);
-            if (flash_gen == LEGACY_FLASH)
-            {
+            if (flash_gen == LEGACY_FLASH) {
                 rc = fifth_gen_flash_init(mfl, flash_params);
-            }
-            else if (flash_gen == SIX_GEN_FLASH)
-            {
+            } else if (flash_gen == SIX_GEN_FLASH) {
                 rc = six_gen_flash_init(mfl, flash_params);
-            }
-            else if (flash_gen == SEVEN_GEN_FLASH)
-            {
+            } else if (flash_gen == SEVEN_GEN_FLASH) {
                 rc = seven_gen_flash_init(mfl, flash_params);
-            }
-            else
-            {
+            } else {
                 rc = MFE_ERROR;
             }
-        }
-        else if (mfl->attr.hw_dev_id == 0xffff)
-        {
+        } else if (mfl->attr.hw_dev_id == 0xffff) {
             rc = MFE_HW_DEVID_ERROR;
-        }
-        else
-        {
+        } else {
             rc = MFE_UNSUPPORTED_DEVICE;
         }
         CHECK_RC(rc);
-    }
-    else if (mfl->access_type == MFAT_UEFI)
-    {
+    } else if (mfl->access_type == MFAT_UEFI) {
         mfl->opts[MFO_NUM_OF_BANKS] =
-          1; /* We have only one flash in ConnectIB and ConnectX-3 - Need to specify it better! */
+            1; /* We have only one flash in ConnectIB and ConnectX-3 - Need to specify it better! */
         rc = uefi_flash_init(mfl, flash_params);
         CHECK_RC(rc);
-    }
-    else
-    {
+    } else {
         return MFE_UNKOWN_ACCESS_TYPE;
     }
     mfl->f_set_bank(mfl, 0);
     return MFE_OK;
 }
 
-int mf_opend_int(mflash** pmfl,
-                 void* access_dev,
-                 int num_of_banks,
+int mf_opend_int(mflash       ** pmfl,
+                 void          * access_dev,
+                 int             num_of_banks,
                  flash_params_t* flash_params,
-                 int ignore_cache_rep_guard,
-                 u_int8_t access_type,
-                 void* dev_extra,
-                 int cx3_fw_access)
+                 int             ignore_cache_rep_guard,
+                 u_int8_t        access_type,
+                 void          * dev_extra,
+                 int             cx3_fw_access)
 {
     int rc = 0;
 
     *pmfl = (mflash*)malloc(sizeof(mflash));
-    if (!*pmfl)
-    {
+    if (!*pmfl) {
         return MFE_NOMEM;
     }
 
@@ -3203,21 +2901,17 @@ int mf_opend_int(mflash** pmfl,
     (*pmfl)->opts[MFO_IGNORE_CASHE_REP_GUARD] = ignore_cache_rep_guard;
     (*pmfl)->opts[MFO_CX3_FW_ACCESS_EN] = cx3_fw_access;
     (*pmfl)->access_type = access_type;
-    if (access_type == MFAT_MFILE)
-    {
+    if (access_type == MFAT_MFILE) {
         (*pmfl)->mf = (mfile*)access_dev;
         u_int32_t dev_id;
         u_int32_t chip_rev;
         rc = dm_get_device_id((*pmfl)->mf, &((*pmfl)->dm_dev_id), &dev_id, &chip_rev);
         CHECK_RC(rc);
-    }
-    else if (access_type == MFAT_UEFI)
-    {
+    } else if (access_type == MFAT_UEFI) {
         /* open mfile as uefi */
         if (!((*pmfl)->mf =
-                mopen_fw_ctx(access_dev, ((uefi_dev_extra_t*)dev_extra)->fw_cmd_func,
-                             ((uefi_dev_extra_t*)dev_extra)->dma_func, &((uefi_dev_extra_t*)dev_extra)->dev_info)))
-        {
+                  mopen_fw_ctx(access_dev, ((uefi_dev_extra_t*)dev_extra)->fw_cmd_func,
+                               ((uefi_dev_extra_t*)dev_extra)->dma_func, &((uefi_dev_extra_t*)dev_extra)->dev_info))) {
             return MFE_NOMEM;
         }
         /* fill some device information */
@@ -3235,34 +2929,29 @@ int mf_open_uefi(mflash** pmfl, uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_dev
     return mf_opend_int(pmfl, (void*)uefi_dev, 4, (flash_params_t*)NULL, 0, MFAT_UEFI, (void*)uefi_dev_extra, 0);
 }
 
-int mf_open_int(mflash** pmfl,
-                const char* dev,
-                int num_of_banks,
+int mf_open_int(mflash       ** pmfl,
+                const char    * dev,
+                int             num_of_banks,
                 flash_params_t* flash_params,
-                int ignore_cache_rep_guard,
-                int cx3_fw_access)
+                int             ignore_cache_rep_guard,
+                int             cx3_fw_access)
 {
     mfile* mf;
-    int rc = MFE_OK;
+    int    rc = MFE_OK;
 
-    if (!dev)
-    {
+    if (!dev) {
         return MFE_BAD_PARAMS;
     }
 
     mf = mopen(dev);
 
-    if (!mf)
-    {
+    if (!mf) {
         return MFE_CR_ERROR;
     }
 
-    if (ignore_cache_rep_guard)
-    { /* relevant only if working with -ocr flag */
-        if (mf->gb_info.is_gb_mngr == 1)
-        {
-            if (mf_check_spi_channel(mf) != 1)
-            {
+    if (ignore_cache_rep_guard) { /* relevant only if working with -ocr flag */
+        if (mf->gb_info.is_gb_mngr == 1) {
+            if (mf_check_spi_channel(mf) != 1) {
                 mclose(mf);
                 printf("-E- Can not continue - SPI channel is not OK.\n");
                 return MFE_CR_ERROR;
@@ -3271,23 +2960,20 @@ int mf_open_int(mflash** pmfl,
     }
     rc = mf_opend_int(pmfl, (struct mfile_t*)mf, num_of_banks, flash_params, ignore_cache_rep_guard, MFAT_MFILE, NULL,
                       cx3_fw_access);
-    if ((*pmfl))
-    {
+    if ((*pmfl)) {
         (*pmfl)->opts[MFO_CLOSE_MF_ON_EXIT] = 1;
-    }
-    else
-    {
+    } else {
         mclose(mf);
     }
     return rc;
 }
 
-int mf_open_adv(mflash** pmfl,
-                const char* dev,
-                int num_of_banks,
+int mf_open_adv(mflash       ** pmfl,
+                const char    * dev,
+                int             num_of_banks,
                 flash_params_t* flash_params,
-                int ignore_cache_rep_guard,
-                int cx3_fw_access)
+                int             ignore_cache_rep_guard,
+                int             cx3_fw_access)
 {
     return mf_open_int(pmfl, dev, num_of_banks, flash_params, ignore_cache_rep_guard, cx3_fw_access);
 }
@@ -3299,31 +2985,26 @@ int mf_open(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* fl
 
 void mf_close(mflash* mfl)
 {
-    if (!mfl)
-    {
+    if (!mfl) {
         return;
     }
 
-    if (mfl->f_reset)
-    {
+    if (mfl->f_reset) {
         mfl->f_reset(mfl);
     }
 
-    if (mfl->f_set_bank)
-    {
+    if (mfl->f_set_bank) {
         (void)set_bank(mfl, 0);
     }
     mfl->unlock_flash_prog_allowed = 1;
     /* we release if we have writer_lock or not doesnt matter on close ... */
     release_semaphore(mfl, 1);
 
-    if (mfl->mf && (mfl)->opts[MFO_CLOSE_MF_ON_EXIT])
-    {
+    if (mfl->mf && (mfl)->opts[MFO_CLOSE_MF_ON_EXIT]) {
         mclose(mfl->mf);
     }
 #ifndef UEFI_BUILD
-    if (mfl->trm)
-    {
+    if (mfl->trm) {
         trm_destroy(mfl->trm);
         mfl->trm = (trm_ctx)NULL;
     }
@@ -3340,241 +3021,238 @@ int mf_get_attr(mflash* mfl, flash_attr* attr)
 
 const char* mf_err2str(int err_code)
 {
-    switch (err_code)
-    {
-        case MFE_OK:
-            return "MFE_OK";
+    switch (err_code) {
+    case MFE_OK:
+        return "MFE_OK";
 
-        case MFE_ERROR:
-            return "MFE_GENERAL_ERROR";
+    case MFE_ERROR:
+        return "MFE_GENERAL_ERROR";
 
-        case MFE_BAD_PARAMS:
-            return "MFE_BAD_PARAMS";
+    case MFE_BAD_PARAMS:
+        return "MFE_BAD_PARAMS";
 
-        case MFE_CR_ERROR:
-            return "MFE_CR_ERROR";
+    case MFE_CR_ERROR:
+        return "MFE_CR_ERROR";
 
-        case MFE_HW_DEVID_ERROR:
-            return "Read a corrupted device id (0xffff). Probably HW/PCI access problem.";
+    case MFE_HW_DEVID_ERROR:
+        return "Read a corrupted device id (0xffff). Probably HW/PCI access problem.";
 
-        case MFE_INVAL:
-            return "MFE_INVAL";
+    case MFE_INVAL:
+        return "MFE_INVAL";
 
-        case MFE_NOT_IMPLEMENTED:
-            return "MFE_NOT_IMPLEMENTED";
+    case MFE_NOT_IMPLEMENTED:
+        return "MFE_NOT_IMPLEMENTED";
 
-        case MFE_UNSUPPORTED_FLASH_TOPOLOGY:
-            return "MFE_UNSUPPORTED_FLASH_TOPOLOGY";
+    case MFE_UNSUPPORTED_FLASH_TOPOLOGY:
+        return "MFE_UNSUPPORTED_FLASH_TOPOLOGY";
 
-        case MFE_UNSUPPORTED_FLASH_TYPE:
-            return "MFE_UNSUPPORTED_FLASH_TYPE";
+    case MFE_UNSUPPORTED_FLASH_TYPE:
+        return "MFE_UNSUPPORTED_FLASH_TYPE";
 
-        case MFE_CFI_FAILED:
-            return "MFE_CFI_FAILED";
+    case MFE_CFI_FAILED:
+        return "MFE_CFI_FAILED";
 
-        case MFE_TIMEOUT:
-            return "MFE_TIMEOUT";
+    case MFE_TIMEOUT:
+        return "MFE_TIMEOUT";
 
-        case MFE_ERASE_TIMEOUT:
-            return "MFE_ERASE_TIMEOUT";
+    case MFE_ERASE_TIMEOUT:
+        return "MFE_ERASE_TIMEOUT";
 
-        case MFE_WRITE_TIMEOUT:
-            return "MFE_WRITE_TIMEOUT";
+    case MFE_WRITE_TIMEOUT:
+        return "MFE_WRITE_TIMEOUT";
 
-        case MFE_ERASE_ERROR:
-            return "MFE_ERASE_ERROR";
+    case MFE_ERASE_ERROR:
+        return "MFE_ERASE_ERROR";
 
-        case MFE_WRITE_ERROR:
-            return "MFE_WRITE_ERROR";
+    case MFE_WRITE_ERROR:
+        return "MFE_WRITE_ERROR";
 
-        case MFE_BAD_ALIGN:
-            return "MFE_BAD_ALIGN";
+    case MFE_BAD_ALIGN:
+        return "MFE_BAD_ALIGN";
 
-        case MFE_SEM_LOCKED:
-            return "MFE_SEM_LOCKED";
+    case MFE_SEM_LOCKED:
+        return "MFE_SEM_LOCKED";
 
-        case MFE_VERIFY_ERROR:
-            return "MFE_VERIFY_ERROR";
+    case MFE_VERIFY_ERROR:
+        return "MFE_VERIFY_ERROR";
 
-        case MFE_NOMEM:
-            return "MFE_NOMEM";
+    case MFE_NOMEM:
+        return "MFE_NOMEM";
 
-        case MFE_OUT_OF_RANGE:
-            return "MFE_OUT_OF_RANGE";
+    case MFE_OUT_OF_RANGE:
+        return "MFE_OUT_OF_RANGE";
 
-        case MFE_CMD_SUPPORTED_INBAND_ONLY:
-            return "Command supported over IB interface only.";
+    case MFE_CMD_SUPPORTED_INBAND_ONLY:
+        return "Command supported over IB interface only.";
 
-        case MFE_NO_FLASH_DETECTED:
-            return "MFE_NO_FLASH_DETECTED";
+    case MFE_NO_FLASH_DETECTED:
+        return "MFE_NO_FLASH_DETECTED";
 
-        case MFE_LOCKED_CRSPACE:
-            return "MFE_HW_ACCESS_DISABLED";
+    case MFE_LOCKED_CRSPACE:
+        return "MFE_HW_ACCESS_DISABLED";
 
-        case MFE_CMDIF_BAD_STATUS_ERR:
-            return "MFE_CMDIF_BAD_STATUS_ERR";
+    case MFE_CMDIF_BAD_STATUS_ERR:
+        return "MFE_CMDIF_BAD_STATUS_ERR";
 
-        case MFE_CMDIF_TIMEOUT_ERR:
-            return "MFE_CMDIF_TIMEOUT_ERR";
+    case MFE_CMDIF_TIMEOUT_ERR:
+        return "MFE_CMDIF_TIMEOUT_ERR";
 
-        case MFE_CMDIF_NOT_READY:
-            return "MFE_CMDIF_NOT_READY";
+    case MFE_CMDIF_NOT_READY:
+        return "MFE_CMDIF_NOT_READY";
 
-        case MFE_CMDIF_BAD_OP:
-            return "MFE_CMDIF_BAD_OP";
+    case MFE_CMDIF_BAD_OP:
+        return "MFE_CMDIF_BAD_OP";
 
-        case MFE_MISSING_KEY:
-            return "No key was set";
+    case MFE_MISSING_KEY:
+        return "No key was set";
 
-        case MFE_MISMATCH_KEY:
-            return "The given key is incorrect";
+    case MFE_MISMATCH_KEY:
+        return "The given key is incorrect";
 
-        case MFE_UNKNOWN_REG:
-            return "MFE_UNKNOWN_REG";
+    case MFE_UNKNOWN_REG:
+        return "MFE_UNKNOWN_REG";
 
-        case MFE_DIRECT_FW_ACCESS_DISABLED:
-            return "MFE_DIRECT_FW_ACCESS_DISABLED";
+    case MFE_DIRECT_FW_ACCESS_DISABLED:
+        return "MFE_DIRECT_FW_ACCESS_DISABLED";
 
-        case MFE_MANAGED_SWITCH_NOT_SUPPORTED:
-            return "MFE_MANAGED_SWITCH_NOT_SUPPORTED";
+    case MFE_MANAGED_SWITCH_NOT_SUPPORTED:
+        return "MFE_MANAGED_SWITCH_NOT_SUPPORTED";
 
-        case MFE_NOT_SUPPORTED_OPERATION:
-            return "MFE_NOT_SUPPORTED_OPERATION";
+    case MFE_NOT_SUPPORTED_OPERATION:
+        return "MFE_NOT_SUPPORTED_OPERATION";
 
-        case MFE_FLASH_NOT_EXIST:
-            return "MFE_FLASH_NOT_EXIST";
+    case MFE_FLASH_NOT_EXIST:
+        return "MFE_FLASH_NOT_EXIST";
 
-        case MFE_MISMATCH_PARAM:
-            return "MFE_MISMATCH_PARAM";
+    case MFE_MISMATCH_PARAM:
+        return "MFE_MISMATCH_PARAM";
 
-        case MFE_EXCEED_SUBSECTORS_MAX_NUM:
-            return "MFE_EXCEED_SUBSECTORS_MAX_NUM";
+    case MFE_EXCEED_SUBSECTORS_MAX_NUM:
+        return "MFE_EXCEED_SUBSECTORS_MAX_NUM";
 
-        case MFE_EXCEED_SECTORS_MAX_NUM:
-            return "MFE_EXCEED_SECTORS_MAX_NUM";
+    case MFE_EXCEED_SECTORS_MAX_NUM:
+        return "MFE_EXCEED_SECTORS_MAX_NUM";
 
-        case MFE_SECTORS_NUM_NOT_POWER_OF_TWO:
-            return "MFE_SECTORS_NUM_NOT_POWER_OF_TWO";
+    case MFE_SECTORS_NUM_NOT_POWER_OF_TWO:
+        return "MFE_SECTORS_NUM_NOT_POWER_OF_TWO";
 
-        case MFE_SECTORS_NUM_MORE_THEN_0_LESS_THEN_4:
-            return "Can not protect 1 or 2 blocks in this flash. Minimum is 4.";
+    case MFE_SECTORS_NUM_MORE_THEN_0_LESS_THEN_4:
+        return "Can not protect 1 or 2 blocks in this flash. Minimum is 4.";
 
-        case MFE_UNKOWN_ACCESS_TYPE:
-            return "MFE_UNKOWN_ACCESS_TYPE";
+    case MFE_UNKOWN_ACCESS_TYPE:
+        return "MFE_UNKOWN_ACCESS_TYPE";
 
-        case MFE_UNSUPPORTED_DEVICE:
-            return "MFE_UNSUPPORTED_DEVICE";
+    case MFE_UNSUPPORTED_DEVICE:
+        return "MFE_UNSUPPORTED_DEVICE";
 
-        case MFE_UNSUPPORTED_ERASE_OPERATION:
-            return "MFE_UNSUPPORTED_ERASE_OPERATION";
+    case MFE_UNSUPPORTED_ERASE_OPERATION:
+        return "MFE_UNSUPPORTED_ERASE_OPERATION";
 
-        case MFE_OLD_DEVICE_TYPE:
-            return "MFE_OLD_DEVICE_TYPE";
+    case MFE_OLD_DEVICE_TYPE:
+        return "MFE_OLD_DEVICE_TYPE";
 
-        case MFE_ICMD_INIT_FAILED:
-            return "MFE_ICMD_INIT_FAILED";
+    case MFE_ICMD_INIT_FAILED:
+        return "MFE_ICMD_INIT_FAILED";
 
-        case MFE_ICMD_NOT_SUPPORTED:
-            return "MFE_ICMD_NOT_SUPPORTED";
+    case MFE_ICMD_NOT_SUPPORTED:
+        return "MFE_ICMD_NOT_SUPPORTED";
 
-        case MFE_HW_ACCESS_NOT_SUPP:
-            return "Secure host mode is not enabled in this FW.";
+    case MFE_HW_ACCESS_NOT_SUPP:
+        return "Secure host mode is not enabled in this FW.";
 
-        case MFE_MAD_SEND_ERR:
-            return "MFE_MAD_SEND_ERR";
+    case MFE_MAD_SEND_ERR:
+        return "MFE_MAD_SEND_ERR";
 
-        case MFE_ICMD_BAD_PARAM:
-            return "MFE_ICMD_BAD_PARAM";
+    case MFE_ICMD_BAD_PARAM:
+        return "MFE_ICMD_BAD_PARAM";
 
-        case MFE_ICMD_INVALID_OPCODE:
-            return "MFE_ICMD_INVALID_OPCODE";
+    case MFE_ICMD_INVALID_OPCODE:
+        return "MFE_ICMD_INVALID_OPCODE";
 
-        case MFE_ICMD_INVALID_CMD:
-            return "MFE_ICMD_INVALID_CMD";
+    case MFE_ICMD_INVALID_CMD:
+        return "MFE_ICMD_INVALID_CMD";
 
-        case MFE_ICMD_OPERATIONAL_ERROR:
-            return "MFE_ICMD_OPERATIONAL_ERROR";
+    case MFE_ICMD_OPERATIONAL_ERROR:
+        return "MFE_ICMD_OPERATIONAL_ERROR";
 
-        case MFE_DATA_IS_OTP:
-            return "The data you are trying to write is OTP and have already been programmed.";
+    case MFE_DATA_IS_OTP:
+        return "The data you are trying to write is OTP and have already been programmed.";
 
-        case MFE_REG_ACCESS_BAD_METHOD:
-            return "MFE_REG_ACCESS_BAD_METHOD";
+    case MFE_REG_ACCESS_BAD_METHOD:
+        return "MFE_REG_ACCESS_BAD_METHOD";
 
-        case MFE_REG_ACCESS_NOT_SUPPORTED:
-            return "MFE_REG_ACCESS_NOT_SUPPORTED";
+    case MFE_REG_ACCESS_NOT_SUPPORTED:
+        return "MFE_REG_ACCESS_NOT_SUPPORTED";
 
-        case MFE_REG_ACCESS_DEV_BUSY:
-            return "MFE_REG_ACCESS_DEV_BUSY";
+    case MFE_REG_ACCESS_DEV_BUSY:
+        return "MFE_REG_ACCESS_DEV_BUSY";
 
-        case MFE_REG_ACCESS_VER_NOT_SUPP:
-            return "MFE_REG_ACCESS_VER_NOT_SUPP";
+    case MFE_REG_ACCESS_VER_NOT_SUPP:
+        return "MFE_REG_ACCESS_VER_NOT_SUPP";
 
-        case MFE_REG_ACCESS_UNKNOWN_TLV:
-            return "MFE_REG_ACCESS_UNKNOWN_TLV";
+    case MFE_REG_ACCESS_UNKNOWN_TLV:
+        return "MFE_REG_ACCESS_UNKNOWN_TLV";
 
-        case MFE_REG_ACCESS_REG_NOT_SUPP:
-            return "MFE_REG_ACCESS_REG_NOT_SUPP";
+    case MFE_REG_ACCESS_REG_NOT_SUPP:
+        return "MFE_REG_ACCESS_REG_NOT_SUPP";
 
-        case MFE_REG_ACCESS_CLASS_NOT_SUPP:
-            return "MFE_REG_ACCESS_CLASS_NOT_SUPP";
+    case MFE_REG_ACCESS_CLASS_NOT_SUPP:
+        return "MFE_REG_ACCESS_CLASS_NOT_SUPP";
 
-        case MFE_REG_ACCESS_METHOD_NOT_SUPP:
-            return "MFE_REG_ACCESS_METHOD_NOT_SUPP";
+    case MFE_REG_ACCESS_METHOD_NOT_SUPP:
+        return "MFE_REG_ACCESS_METHOD_NOT_SUPP";
 
-        case MFE_REG_ACCESS_BAD_PARAM:
-            return "MFE_REG_ACCESS_BAD_PARAM";
+    case MFE_REG_ACCESS_BAD_PARAM:
+        return "MFE_REG_ACCESS_BAD_PARAM";
 
-        case MFE_REG_ACCESS_RES_NOT_AVLBL:
-            return "MFE_REG_ACCESS_RESOURCE_NOT_AVAILABLE";
+    case MFE_REG_ACCESS_RES_NOT_AVLBL:
+        return "MFE_REG_ACCESS_RESOURCE_NOT_AVAILABLE";
 
-        case MFE_REG_ACCESS_MSG_RECPT_ACK:
-            return "MFE_REG_ACCESS_MSG_RECPT_ACK";
+    case MFE_REG_ACCESS_MSG_RECPT_ACK:
+        return "MFE_REG_ACCESS_MSG_RECPT_ACK";
 
-        case MFE_REG_ACCESS_UNKNOWN_ERR:
-            return "MFE_REG_ACCESS_UNKNOWN_ERR";
+    case MFE_REG_ACCESS_UNKNOWN_ERR:
+        return "MFE_REG_ACCESS_UNKNOWN_ERR";
 
-        case MFE_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
-            return "MFE_REG_ACCESS_SIZE_EXCCEEDS_LIMIT";
+    case MFE_REG_ACCESS_SIZE_EXCCEEDS_LIMIT:
+        return "MFE_REG_ACCESS_SIZE_EXCCEEDS_LIMIT";
 
-        case MFE_PCICONF:
-            return "Access to device should be through configuration cycles.";
+    case MFE_PCICONF:
+        return "Access to device should be through configuration cycles.";
 
-        case MFE_ILLEGAL_BANK_NUM:
-            return "MFE_ILLEGAL_BANK_NUM";
+    case MFE_ILLEGAL_BANK_NUM:
+        return "MFE_ILLEGAL_BANK_NUM";
 
-        case MFE_OCR_NOT_SUPPORTED:
-            return "Direct flash access is not supported.";
+    case MFE_OCR_NOT_SUPPORTED:
+        return "Direct flash access is not supported.";
 
-        default:
-            return "Unknown error";
+    default:
+        return "Unknown error";
     }
 }
 
 #ifndef UEFI_BUILD
 int trm2mfe_err(trm_sts rc)
 {
-    switch (rc)
-    {
-        case TRM_STS_DEV_NOT_SUPPORTED:
-            return MFE_UNSUPPORTED_DEVICE;
+    switch (rc) {
+    case TRM_STS_DEV_NOT_SUPPORTED:
+        return MFE_UNSUPPORTED_DEVICE;
 
-        case TRM_STS_CR_ACCESS_ERR:
-            return MFE_CR_ERROR;
+    case TRM_STS_CR_ACCESS_ERR:
+        return MFE_CR_ERROR;
 
-        case TRM_STS_MEM_ERROR:
-            return MFE_NOMEM;
+    case TRM_STS_MEM_ERROR:
+        return MFE_NOMEM;
 
-        default:
-            return MFE_ERROR;
+    default:
+        return MFE_ERROR;
     }
 }
 #endif
 
 int mf_set_opt(mflash* mfl, MfOpt opt, int val)
 {
-    if (((int)opt < 0) || (opt >= MFO_LAST))
-    {
+    if (((int)opt < 0) || (opt >= MFO_LAST)) {
         return MFE_BAD_PARAMS;
     }
     mfl->opts[opt] = val;
@@ -3583,8 +3261,7 @@ int mf_set_opt(mflash* mfl, MfOpt opt, int val)
 
 int mf_get_opt(mflash* mfl, MfOpt opt, int* val)
 {
-    if (((int)opt < 0) || (opt >= MFO_LAST))
-    {
+    if (((int)opt < 0) || (opt >= MFO_LAST)) {
         return MFE_BAD_PARAMS;
     }
     *val = mfl->opts[opt];
@@ -3593,8 +3270,7 @@ int mf_get_opt(mflash* mfl, MfOpt opt, int* val)
 
 int mf_cr_read(mflash* mfl, u_int32_t cr_addr, u_int32_t* data)
 {
-    if (mread4(mfl->mf, cr_addr, data) != 4)
-    {
+    if (mread4(mfl->mf, cr_addr, data) != 4) {
         return MFE_CR_ERROR;
     }
     return MFE_OK;
@@ -3602,8 +3278,7 @@ int mf_cr_read(mflash* mfl, u_int32_t cr_addr, u_int32_t* data)
 
 int mf_cr_write(mflash* mfl, u_int32_t cr_addr, u_int32_t data)
 {
-    if (mwrite4(mfl->mf, cr_addr, data) != 4)
-    {
+    if (mwrite4(mfl->mf, cr_addr, data) != 4) {
         return MFE_CR_ERROR;
     }
     return MFE_OK;
@@ -3611,52 +3286,51 @@ int mf_cr_write(mflash* mfl, u_int32_t cr_addr, u_int32_t data)
 
 int mf_set_reset_flash_on_warm_reboot(mflash* mfl)
 {
-    int rc;
+    int       rc;
     u_int32_t set_reset_bit_dword_addr = 0;
-    int set_reset_bit_offset;
+    int       set_reset_bit_offset;
     u_int32_t set_reset_bit_dword = 0;
 
-    switch (mfl->dm_dev_id)
-    {
-        case DeviceConnectX3:
-        case DeviceConnectX3Pro:
-        case DeviceConnectIB:
-        case DeviceSwitchIB:
-        case DeviceSwitchIB2:
-        case DeviceQuantum:
-        case DeviceQuantum2:
-        case DeviceQuantum3:
-        case DeviceConnectX7:
-        case DeviceBlueField3:
-        case DeviceConnectX8:
-        case DeviceBlueField4:
-        case DeviceSpectrum4:
-        case DeviceAbirGearBox:
-            return MFE_OK;
+    switch (mfl->dm_dev_id) {
+    case DeviceConnectX3:
+    case DeviceConnectX3Pro:
+    case DeviceConnectIB:
+    case DeviceSwitchIB:
+    case DeviceSwitchIB2:
+    case DeviceQuantum:
+    case DeviceQuantum2:
+    case DeviceQuantum3:
+    case DeviceConnectX7:
+    case DeviceBlueField3:
+    case DeviceConnectX8:
+    case DeviceBlueField4:
+    case DeviceSpectrum4:
+    case DeviceAbirGearBox:
+        return MFE_OK;
 
-        case DeviceSpectrum:
-        case DeviceConnectX4:
-        case DeviceConnectX4LX:
-        case DeviceConnectX5:
-        case DeviceBlueField:
-            set_reset_bit_dword_addr = 0xf0204;
-            set_reset_bit_offset = 1;
-            break;
+    case DeviceSpectrum:
+    case DeviceConnectX4:
+    case DeviceConnectX4LX:
+    case DeviceConnectX5:
+    case DeviceBlueField:
+        set_reset_bit_dword_addr = 0xf0204;
+        set_reset_bit_offset = 1;
+        break;
 
-        case DeviceConnectX6:
-        case DeviceConnectX6DX:
-        case DeviceConnectX6LX:
-        case DeviceBlueField2:
-        case DeviceSpectrum2:
-        case DeviceSpectrum3:
-        case DeviceGearBox:
-        case DeviceGearBoxManager:
-            set_reset_bit_dword_addr = 0xf0c28;
-            set_reset_bit_offset = 2;
-            break;
+    case DeviceConnectX6:
+    case DeviceConnectX6DX:
+    case DeviceConnectX6LX:
+    case DeviceBlueField2:
+    case DeviceSpectrum2:
+    case DeviceSpectrum3:
+    case DeviceGearBox:
+    case DeviceGearBoxManager:
+        set_reset_bit_dword_addr = 0xf0c28;
+        set_reset_bit_offset = 2;
+        break;
 
-        default:
-            return MFE_UNSUPPORTED_DEVICE;
+    default:
+        return MFE_UNSUPPORTED_DEVICE;
     }
     FLASH_DPRINTF(("mflash::mf_set_reset_flash_on_warm_reboot setting power_boot_partial_reset at addr 0x%x.%d\n",
                    set_reset_bit_dword_addr, set_reset_bit_offset));
@@ -3668,114 +3342,114 @@ int mf_set_reset_flash_on_warm_reboot(mflash* mfl)
 
 int mf_update_boot_addr(mflash* mfl, u_int32_t boot_addr)
 {
-    int rc;
+    int       rc;
     u_int32_t boot_cr_space_address;
-    int offset_in_address;
+    int       offset_in_address;
 
-    switch (mfl->dm_dev_id)
-    {
-        case DeviceConnectX3:
-        case DeviceConnectX3Pro:
-        case DeviceConnectIB:
-        case DeviceSwitchIB:
-        case DeviceSpectrum:
-        case DeviceConnectX4:
-        case DeviceConnectX4LX:
-        case DeviceSwitchIB2:
-            boot_cr_space_address = 0xf0000;
-            offset_in_address = 8;
-            break;
+    switch (mfl->dm_dev_id) {
+    case DeviceConnectX3:
+    case DeviceConnectX3Pro:
+    case DeviceConnectIB:
+    case DeviceSwitchIB:
+    case DeviceSpectrum:
+    case DeviceConnectX4:
+    case DeviceConnectX4LX:
+    case DeviceSwitchIB2:
+        boot_cr_space_address = 0xf0000;
+        offset_in_address = 8;
+        break;
 
-        case DeviceConnectX5:
-        case DeviceBlueField:
-            boot_cr_space_address = 0xf00c0;
-            offset_in_address = 0;
-            break;
+    case DeviceConnectX5:
+    case DeviceBlueField:
+        boot_cr_space_address = 0xf00c0;
+        offset_in_address = 0;
+        break;
 
-        case DeviceConnectX6:
-        case DeviceConnectX6DX:
-        case DeviceConnectX6LX:
-        case DeviceQuantum:
-        case DeviceBlueField2:
-        case DeviceSpectrum2:
-        case DeviceSpectrum3:
-        case DeviceGearBox:
-        case DeviceGearBoxManager:
-            boot_cr_space_address = 0xf0080;
-            offset_in_address = 0;
-            break;
+    case DeviceConnectX6:
+    case DeviceConnectX6DX:
+    case DeviceConnectX6LX:
+    case DeviceQuantum:
+    case DeviceBlueField2:
+    case DeviceSpectrum2:
+    case DeviceSpectrum3:
+    case DeviceGearBox:
+    case DeviceGearBoxManager:
+        boot_cr_space_address = 0xf0080;
+        offset_in_address = 0;
+        break;
 
-        case DeviceAbirGearBox:
-            boot_cr_space_address = 0xf1400;
-            offset_in_address = 0;
-            break;
+    case DeviceAbirGearBox:
+        boot_cr_space_address = 0xf1400;
+        offset_in_address = 0;
+        break;
 
-        case DeviceQuantum2:
-            boot_cr_space_address = 0xf1000;
-            offset_in_address = 0;
-            break;
-        case DeviceConnectX7:
-        case DeviceBlueField3:
-            boot_cr_space_address = 0xf2000;
-            offset_in_address = 0;
-            break;
-        case DeviceQuantum3:
-        case DeviceQuantum4:
-            boot_cr_space_address = 0xfc000;
-            offset_in_address = 0;
-            break;
-        case DeviceConnectX8:
-        case DeviceConnectX9:
-        case DeviceBlueField4:
-            boot_cr_space_address = 0xf8008;
-            offset_in_address = 0;
-            break;
-        case DeviceSpectrum4:
-        case DeviceSpectrum5:
-        case DeviceSpectrum6:
-        case DeviceSpectrum6IB:
-            boot_cr_space_address = 0xf1800;
-            offset_in_address = 0;
-            break;
-        default:
-            return MFE_UNSUPPORTED_DEVICE;
+    case DeviceQuantum2:
+        boot_cr_space_address = 0xf1000;
+        offset_in_address = 0;
+        break;
+
+    case DeviceConnectX7:
+    case DeviceBlueField3:
+        boot_cr_space_address = 0xf2000;
+        offset_in_address = 0;
+        break;
+
+    case DeviceQuantum3:
+    case DeviceQuantum4:
+        boot_cr_space_address = 0xfc000;
+        offset_in_address = 0;
+        break;
+
+    case DeviceConnectX8:
+    case DeviceConnectX9:
+    case DeviceBlueField4:
+        boot_cr_space_address = 0xf8008;
+        offset_in_address = 0;
+        break;
+
+    case DeviceSpectrum4:
+    case DeviceSpectrum5:
+    case DeviceSpectrum6:
+    case DeviceSpectrum6IB:
+        boot_cr_space_address = 0xf1800;
+        offset_in_address = 0;
+        break;
+
+    default:
+        return MFE_UNSUPPORTED_DEVICE;
     }
 
-    if ((mfl->access_type != MFAT_UEFI) && (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_MLNXOS_CMDIF))
-    {
+    if ((mfl->access_type != MFAT_UEFI) && (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] != ATBM_MLNXOS_CMDIF)) {
         /* the boot addr will be updated directly via cr-space */
         FLASH_DPRINTF(("mflash::mf_update_boot_addr setting boot_start_address at addr 0x%x to 0x%x\n",
                        boot_cr_space_address, boot_addr << offset_in_address));
         rc = mf_cr_write(mfl, boot_cr_space_address, boot_addr << offset_in_address);
         CHECK_RC(rc);
         return mf_set_reset_flash_on_warm_reboot(mfl);
-    }
-    else
-    {
+    } else {
         /* the boot addr will be updated via reg */
         return mf_update_boot_addr_by_type(mfl, boot_addr);
     }
 }
 
-int mf_read_modify_status_winbond(mflash* mfl,
+int mf_read_modify_status_winbond(mflash * mfl,
                                   u_int8_t bank_num,
                                   u_int8_t is_first_status_reg,
                                   u_int8_t param,
                                   u_int8_t offset,
                                   u_int8_t size)
 {
-    u_int8_t status1 = 0, status2 = 0, use_rdsr2 = 0;
+    u_int8_t  status1 = 0, status2 = 0, use_rdsr2 = 0;
     u_int32_t status = 0;
-    u_int8_t bytes_to_write = 1;
-    int rc = 0;
+    u_int8_t  bytes_to_write = 1;
+    int       rc = 0;
 
     rc = set_bank_int(mfl, bank_num);
     CHECK_RC(rc);
     if (((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND)) ||
         ((mfl->attr.vendor == FV_S25FLXXXX) &&
          ((mfl->attr.type == FMT_S25FL116K) || (mfl->attr.type == FMT_S25FLXXXL))) ||
-        ((mfl->attr.vendor == FV_MX25K16XXX) && (mfl->attr.type == FMT_MX25K16XXX)))
-    {
+        ((mfl->attr.vendor == FV_MX25K16XXX) && (mfl->attr.type == FMT_MX25K16XXX))) {
         /*
          * if we have 2 status registers, winbond are allowing us to write both of them
          * in a single command WRSR  status_reg1 located in MSB, status_reg2 after status_reg1
@@ -3786,15 +3460,11 @@ int mf_read_modify_status_winbond(mflash* mfl,
     /* Read register status */
     rc = mfl->f_spi_status(mfl, SFC_RDSR, &status1);
     CHECK_RC(rc);
-    if (use_rdsr2)
-    {
-        if (mfl->attr.vendor == FV_MX25K16XXX)
-        {
+    if (use_rdsr2) {
+        if (mfl->attr.vendor == FV_MX25K16XXX) {
             rc = mfl->f_spi_status(mfl, SFC_RDCR, &status2);
             CHECK_RC(rc);
-        }
-        else
-        {
+        } else {
             rc = mfl->f_spi_status(mfl, SFC_RDSR2, &status2);
             CHECK_RC(rc);
         }
@@ -3806,17 +3476,13 @@ int mf_read_modify_status_winbond(mflash* mfl,
     /* Modify the status according to the function arguments */
     status = MERGE(status, param, offset + is_first_status_reg * 8, size);
     /* fix status register in case we dont need to write status register 2 */
-    if (bytes_to_write == 1)
-    {
+    if (bytes_to_write == 1) {
         status = status >> 8;
     }
     /* Write register status */
-    if (mfl->attr.vendor == FV_GD25QXXX)
-    {
+    if (mfl->attr.vendor == FV_GD25QXXX) {
         rc = mfl->f_spi_write_status_reg(mfl, status, SFC_WRSR_GIGA, bytes_to_write);
-    }
-    else
-    {
+    } else {
         rc = mfl->f_spi_write_status_reg(mfl, status, SFC_WRSR, bytes_to_write);
     }
 
@@ -3826,10 +3492,8 @@ int mf_read_modify_status_winbond(mflash* mfl,
 
 u_int32_t mf_change_status_endianness(mflash* mfl, u_int32_t status, u_int8_t bytes_num)
 {
-    if (mfl->attr.vendor == FV_ST)
-    {
-        if (bytes_num == 2)
-        {
+    if (mfl->attr.vendor == FV_ST) {
+        if (bytes_num == 2) {
             status = ___my_swab16(status);
         }
     }
@@ -3841,7 +3505,7 @@ u_int32_t mf_change_status_endianness(mflash* mfl, u_int32_t status, u_int8_t by
 /* offset - destination bit offset */
 /* size - bit length */
 /* bytes_num - status register size in bytes */
-int mf_read_modify_status_new(mflash* mfl,
+int mf_read_modify_status_new(mflash * mfl,
                               u_int8_t bank_num,
                               u_int8_t read_cmd,
                               u_int8_t write_cmd,
@@ -3850,7 +3514,7 @@ int mf_read_modify_status_new(mflash* mfl,
                               u_int8_t size,
                               u_int8_t bytes_num)
 {
-    int rc = 0;
+    int       rc = 0;
     u_int32_t status = 0;
 
     rc = set_bank_int(mfl, bank_num);
@@ -3865,19 +3529,18 @@ int mf_read_modify_status_new(mflash* mfl,
     return MFE_OK;
 }
 
-int mf_get_param_int(mflash* mfl,
+int mf_get_param_int(mflash  * mfl,
                      u_int8_t* param_p,
-                     u_int8_t cmd,
-                     u_int8_t offset,
-                     u_int8_t bit_size,
-                     u_int8_t bytes_num,
-                     u_int8_t enabled_val)
+                     u_int8_t  cmd,
+                     u_int8_t  offset,
+                     u_int8_t  bit_size,
+                     u_int8_t  bytes_num,
+                     u_int8_t  enabled_val)
 {
     u_int32_t status = 0, is_first = 1, bank = 0;
-    int rc = 0;
+    int       rc = 0;
 
-    for (bank = 0; bank < mfl->attr.banks_num; bank++)
-    {
+    for (bank = 0; bank < mfl->attr.banks_num; bank++) {
         u_int8_t curr_val;
         rc = set_bank_int(mfl, bank);
         CHECK_RC(rc);
@@ -3885,20 +3548,15 @@ int mf_get_param_int(mflash* mfl,
         CHECK_RC(rc);
         status = mf_change_status_endianness(mfl, status, bytes_num);
         curr_val = EXTRACT(status, offset, bit_size);
-        if (bit_size == 1)
-        {
+        if (bit_size == 1) {
             curr_val = (curr_val == enabled_val);
         }
 
-        if (is_first)
-        {
+        if (is_first) {
             *param_p = curr_val;
             is_first = 0;
-        }
-        else
-        {
-            if (*param_p != curr_val)
-            {
+        } else {
+            if (*param_p != curr_val) {
                 return MFE_MISMATCH_PARAM;
             }
         }
@@ -3908,18 +3566,15 @@ int mf_get_param_int(mflash* mfl,
 
 int mf_set_dummy_cycles_direct_access(mflash* mfl, u_int8_t num_of_cycles)
 {
-    if (!mfl || (num_of_cycles < 1) || (num_of_cycles > 15))
-    {
+    if (!mfl || (num_of_cycles < 1) || (num_of_cycles > 15)) {
         return MFE_BAD_PARAMS;
     }
     int bank = 0, rc = 0;
 
-    if (!(mfl->attr.dummy_cycles_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.dummy_cycles_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
-    for (bank = 0; bank < mfl->attr.banks_num; bank++)
-    {
+    for (bank = 0; bank < mfl->attr.banks_num; bank++) {
         rc = mf_read_modify_status_new(mfl, bank, SFC_RDNVR, SFC_WRNVR, num_of_cycles, DUMMY_CYCLES_OFFSET_ST, 4, 2);
         CHECK_RC(rc);
     }
@@ -3928,12 +3583,10 @@ int mf_set_dummy_cycles_direct_access(mflash* mfl, u_int8_t num_of_cycles)
 
 int mf_get_dummy_cycles_direct_access(mflash* mfl, u_int8_t* dummy_cycles_p)
 {
-    if (!mfl || !dummy_cycles_p)
-    {
+    if (!mfl || !dummy_cycles_p) {
         return MFE_BAD_PARAMS;
     }
-    if (!(mfl->attr.dummy_cycles_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.dummy_cycles_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
     return mf_get_param_int(mfl, dummy_cycles_p, SFC_RDNVR, DUMMY_CYCLES_OFFSET_ST, 4, 2, 0);
@@ -3941,57 +3594,45 @@ int mf_get_dummy_cycles_direct_access(mflash* mfl, u_int8_t* dummy_cycles_p)
 
 int mf_set_driver_strength_direct_access(mflash* mfl, u_int8_t driver_strength)
 {
-    if (!mfl)
-    {
+    if (!mfl) {
         return MFE_BAD_PARAMS;
     }
-    if (!(mfl->attr.driver_strength_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.driver_strength_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
     int bank = 0, rc = MFE_OK;
 
-    for (; bank < mfl->attr.banks_num; bank++)
-    {
-        if (mfl->attr.vendor == FV_WINBOND)
-        {
+    for (; bank < mfl->attr.banks_num; bank++) {
+        if (mfl->attr.vendor == FV_WINBOND) {
             rc = mf_read_modify_status_new(
-              mfl, bank, SFC_RDSR3_WINBOND,        /* mflash, bank num, status-register-3 read cmd */
-              SFC_WRSR3_WINBOND, driver_strength,  /* status-register-3 write cmd, driver-strength new val */
-              DRIVER_STRENGTH_OFFSET_WINBOND,      /* driver-strength bit offset */
-              DRIVER_STRENGTH_BIT_LEN_WINBOND, 1); /* driver-strength bit length, status-register byte len */
+                mfl, bank, SFC_RDSR3_WINBOND,      /* mflash, bank num, status-register-3 read cmd */
+                SFC_WRSR3_WINBOND, driver_strength, /* status-register-3 write cmd, driver-strength new val */
+                DRIVER_STRENGTH_OFFSET_WINBOND,    /* driver-strength bit offset */
+                DRIVER_STRENGTH_BIT_LEN_WINBOND, 1); /* driver-strength bit length, status-register byte len */
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_ST) // micron
-        {
+        } else if (mfl->attr.vendor == FV_ST) { /* micron */
             rc = mf_read_modify_status_new(
-              mfl, bank, SFC_RDNVR,          // mflash, bank num, nonvolatile-configuration-register read cmd
-              SFC_WRNVR, driver_strength,    // nonvolatile-configuration-register write cmd, driver-strength new val
-              DRIVER_STRENGTH_OFFSET_MICRON, // driver-strength bit offset
-              DRIVER_STRENGTH_BIT_LEN_MICRON, 2); // driver-strength bit length, status-register byte len
+                mfl, bank, SFC_RDNVR,        /* mflash, bank num, nonvolatile-configuration-register read cmd */
+                SFC_WRNVR, driver_strength,  /* nonvolatile-configuration-register write cmd, driver-strength new val */
+                DRIVER_STRENGTH_OFFSET_MICRON, /* driver-strength bit offset */
+                DRIVER_STRENGTH_BIT_LEN_MICRON, 2); /* driver-strength bit length, status-register byte len */
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_MX25K16XXX)
-        {
+        } else if (mfl->attr.vendor == FV_MX25K16XXX) {
             rc = mf_read_modify_status_new(
-              mfl, bank, SFC_RDSR3_MICRON_MX25K16XXX, // mflash, bank num, nonvolatile-configuration-register read cmd
-              SFC_WRSR3_MICRON_MX25K16XXX,
-              driver_strength, // nonvolatile-configuration-register write cmd, driver-strength new val
-              DRIVER_STRENGTH_OFFSET_MICRON_MX25K16XXX,      // driver-strength bit offset
-              DRIVER_STRENGTH_BIT_LEN_MICRON_MX25K16XXX, 1); // driver-strength bit length, status-register byte len
+                mfl, bank, SFC_RDSR3_MICRON_MX25K16XXX, /* mflash, bank num, nonvolatile-configuration-register read cmd */
+                SFC_WRSR3_MICRON_MX25K16XXX,
+                driver_strength, /* nonvolatile-configuration-register write cmd, driver-strength new val */
+                DRIVER_STRENGTH_OFFSET_MICRON_MX25K16XXX,    /* driver-strength bit offset */
+                DRIVER_STRENGTH_BIT_LEN_MICRON_MX25K16XXX, 1); /* driver-strength bit length, status-register byte len */
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_IS25LPXXX) // issi
-        {
+        } else if (mfl->attr.vendor == FV_IS25LPXXX) { /* issi */
             rc = mf_read_modify_status_new(
-              mfl, bank, SFC_RDERP_ISSI,        // mflash, bank num, nonvolatile-configuration-register read cmd
-              SFC_SERPNV_ISSI, driver_strength, // nonvolatile-configuration-register write cmd, driver-strength new val
-              DRIVER_STRENGTH_OFFSET_ISSI,      // driver-strength bit offset
-              DRIVER_STRENGTH_BIT_LEN_ISSI, 1); // driver-strength bit length, status-register byte len
+                mfl, bank, SFC_RDERP_ISSI,      /* mflash, bank num, nonvolatile-configuration-register read cmd */
+                SFC_SERPNV_ISSI, driver_strength, /* nonvolatile-configuration-register write cmd, driver-strength new val */
+                DRIVER_STRENGTH_OFFSET_ISSI,    /* driver-strength bit offset */
+                DRIVER_STRENGTH_BIT_LEN_ISSI, 1); /* driver-strength bit length, status-register byte len */
             CHECK_RC(rc);
-        }
-        else
-        {
+        } else {
             return MFE_NOT_IMPLEMENTED;
         }
     }
@@ -4000,51 +3641,40 @@ int mf_set_driver_strength_direct_access(mflash* mfl, u_int8_t driver_strength)
 
 int mf_get_driver_strength_direct_access(mflash* mfl, u_int8_t* driver_strength_p)
 {
-    if (!mfl || !driver_strength_p)
-    {
+    if (!mfl || !driver_strength_p) {
         return MFE_BAD_PARAMS;
     }
-    if (!(mfl->attr.driver_strength_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.driver_strength_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
 
     int rc = MFE_OK;
 
-    if (mfl->attr.vendor == FV_WINBOND)
-    {
+    if (mfl->attr.vendor == FV_WINBOND) {
         rc = mf_get_param_int(mfl, driver_strength_p,
                               SFC_RDSR3_WINBOND,               /* mflash, output pointer, status-register-3 read cmd */
                               DRIVER_STRENGTH_OFFSET_WINBOND,  /* driver-strength bit offset */
                               DRIVER_STRENGTH_BIT_LEN_WINBOND, /* driver-strength bit length */
                               1, 0);                           /* status-register byte len, don't-care */
-    }
-    else if (mfl->attr.vendor == FV_ST) // micron
-    {
-        rc = mf_get_param_int(mfl, driver_strength_p,         // mflash, output pointer,
-                              SFC_RDNVR,                      // nonvolatile-configuration-register read cmd
-                              DRIVER_STRENGTH_OFFSET_MICRON,  // driver-strength bit offset
-                              DRIVER_STRENGTH_BIT_LEN_MICRON, // driver-strength bit length
-                              2, 0);                          // status-register byte len, don't-care
-    }
-    else if (mfl->attr.vendor == FV_MX25K16XXX) // micron
-    {
-        rc = mf_get_param_int(mfl, driver_strength_p,                    // mflash, output pointer,
-                              SFC_RDSR3_MICRON_MX25K16XXX,               // nonvolatile-configuration-register read cmd
-                              DRIVER_STRENGTH_OFFSET_MICRON_MX25K16XXX,  // driver-strength bit offset
-                              DRIVER_STRENGTH_BIT_LEN_MICRON_MX25K16XXX, // driver-strength bit length
-                              1, 0);                                     // status-register byte len, don't-care
-    }
-    else if (mfl->attr.vendor == FV_IS25LPXXX) // issi
-    {
-        rc = mf_get_param_int(mfl, driver_strength_p,         // mflash, output pointer,
-                              SFC_RDERP_ISSI,                 // nonvolatile-configuration-register read cmd
-                              DRIVER_STRENGTH_OFFSET_ISSI,    // driver-strength bit offset
-                              DRIVER_STRENGTH_BIT_LEN_MICRON, // driver-strength bit length
-                              1, 0);                          // status-register byte len, don't-care
-    }
-    else
-    {
+    } else if (mfl->attr.vendor == FV_ST) { /* micron */
+        rc = mf_get_param_int(mfl, driver_strength_p,         /* mflash, output pointer, */
+                              SFC_RDNVR,                      /* nonvolatile-configuration-register read cmd */
+                              DRIVER_STRENGTH_OFFSET_MICRON,  /* driver-strength bit offset */
+                              DRIVER_STRENGTH_BIT_LEN_MICRON, /* driver-strength bit length */
+                              2, 0);                          /* status-register byte len, don't-care */
+    } else if (mfl->attr.vendor == FV_MX25K16XXX) { /* micron */
+        rc = mf_get_param_int(mfl, driver_strength_p,                    /* mflash, output pointer, */
+                              SFC_RDSR3_MICRON_MX25K16XXX,               /* nonvolatile-configuration-register read cmd */
+                              DRIVER_STRENGTH_OFFSET_MICRON_MX25K16XXX,  /* driver-strength bit offset */
+                              DRIVER_STRENGTH_BIT_LEN_MICRON_MX25K16XXX, /* driver-strength bit length */
+                              1, 0);                                     /* status-register byte len, don't-care */
+    } else if (mfl->attr.vendor == FV_IS25LPXXX) { /* issi */
+        rc = mf_get_param_int(mfl, driver_strength_p,         /* mflash, output pointer, */
+                              SFC_RDERP_ISSI,                 /* nonvolatile-configuration-register read cmd */
+                              DRIVER_STRENGTH_OFFSET_ISSI,    /* driver-strength bit offset */
+                              DRIVER_STRENGTH_BIT_LEN_MICRON, /* driver-strength bit length */
+                              1, 0);                          /* status-register byte len, don't-care */
+    } else {
         rc = MFE_NOT_IMPLEMENTED;
     }
 
@@ -4053,48 +3683,41 @@ int mf_get_driver_strength_direct_access(mflash* mfl, u_int8_t* driver_strength_
 
 int mf_set_quad_en_direct_access(mflash* mfl, u_int8_t quad_en)
 {
-    if (!mfl)
-    {
+    if (!mfl) {
         return MFE_BAD_PARAMS;
     }
     int bank = 0, rc = 0;
 
-    if (!(mfl->attr.quad_en_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.quad_en_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
-    for (bank = 0; bank < mfl->attr.banks_num; bank++)
-    {
-        if (mfl->attr.vendor == FV_WINBOND &&
-            (mfl->attr.type == FMT_WINBOND_3V || mfl->attr.type == FMT_WINBOND_IQ ||
-             mfl->attr.type == FMT_WINBOND_IM))
-        {
+    for (bank = 0; bank < mfl->attr.banks_num; bank++) {
+        if ((mfl->attr.vendor == FV_WINBOND) &&
+            ((mfl->attr.type == FMT_WINBOND_3V) || (mfl->attr.type == FMT_WINBOND_IQ) ||
+             (mfl->attr.type == FMT_WINBOND_IM))) {
             rc =
-              mf_read_modify_status_new(mfl, bank, SFC_RDSR2, SFC_WRSR2, quad_en, QUAD_EN_OFFSET_WINBOND_CYPRESS, 1, 1);
+                mf_read_modify_status_new(mfl,
+                                          bank,
+                                          SFC_RDSR2,
+                                          SFC_WRSR2,
+                                          quad_en,
+                                          QUAD_EN_OFFSET_WINBOND_CYPRESS,
+                                          1,
+                                          1);
             CHECK_RC(rc);
-        }
-        else if ((mfl->attr.vendor == FV_WINBOND) || (mfl->attr.vendor == FV_S25FLXXXX))
-        {
+        } else if ((mfl->attr.vendor == FV_WINBOND) || (mfl->attr.vendor == FV_S25FLXXXX)) {
             rc = mf_read_modify_status_winbond(mfl, bank, 0, quad_en, QUAD_EN_OFFSET_WINBOND_CYPRESS, 1);
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_ST)
-        {
+        } else if (mfl->attr.vendor == FV_ST) {
             rc = mf_read_modify_status_new(mfl, bank, SFC_RDNVR, SFC_WRNVR, !quad_en, QUAD_EN_OFFSET_MICRON, 1, 2);
             CHECK_RC(rc);
-        }
-        else if ((mfl->attr.vendor == FV_IS25LPXXX) || (mfl->attr.vendor == FV_MX25K16XXX))
-        {
+        } else if ((mfl->attr.vendor == FV_IS25LPXXX) || (mfl->attr.vendor == FV_MX25K16XXX)) {
             rc = mf_read_modify_status_winbond(mfl, bank, 1, quad_en, QUAD_EN_OFFSET_ISSI_MACRONIX, 1);
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_GD25QXXX)
-        {
+        } else if (mfl->attr.vendor == FV_GD25QXXX) {
             rc = mf_read_modify_status_winbond(mfl, bank, 1, quad_en, QUAD_EN_OFFSET_GIGABYTE, 1);
             CHECK_RC(rc);
-        }
-        else
-        {
+        } else {
             return MFE_NOT_IMPLEMENTED;
         }
     }
@@ -4103,28 +3726,19 @@ int mf_set_quad_en_direct_access(mflash* mfl, u_int8_t quad_en)
 
 int mf_get_quad_en_direct_access(mflash* mfl, u_int8_t* quad_en_p)
 {
-    if (!mfl || !quad_en_p)
-    {
+    if (!mfl || !quad_en_p) {
         return MFE_BAD_PARAMS;
     }
-    if (!(mfl->attr.quad_en_support && mfl->supp_sr_mod))
-    {
+    if (!(mfl->attr.quad_en_support && mfl->supp_sr_mod)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
-    if ((mfl->attr.vendor == FV_WINBOND) || (mfl->attr.vendor == FV_S25FLXXXX))
-    {
+    if ((mfl->attr.vendor == FV_WINBOND) || (mfl->attr.vendor == FV_S25FLXXXX)) {
         return mf_get_param_int(mfl, quad_en_p, SFC_RDSR2, QUAD_EN_OFFSET_WINBOND_CYPRESS, 1, 1, 1);
-    }
-    else if (mfl->attr.vendor == FV_ST)
-    {
+    } else if (mfl->attr.vendor == FV_ST) {
         return mf_get_param_int(mfl, quad_en_p, SFC_RDNVR, QUAD_EN_OFFSET_MICRON, 1, 2, 0);
-    }
-    else if ((mfl->attr.vendor == FV_IS25LPXXX) || (mfl->attr.vendor == FV_MX25K16XXX))
-    {
+    } else if ((mfl->attr.vendor == FV_IS25LPXXX) || (mfl->attr.vendor == FV_MX25K16XXX)) {
         return mf_get_param_int(mfl, quad_en_p, SFC_RDSR, QUAD_EN_OFFSET_ISSI_MACRONIX, 1, 1, 1);
-    }
-    else if (mfl->attr.vendor == FV_GD25QXXX)
-    {
+    } else if (mfl->attr.vendor == FV_GD25QXXX) {
         return mf_get_param_int(mfl, quad_en_p, SFC_RDSR2, QUAD_EN_OFFSET_GIGABYTE, 1, 2, 1);
     }
     return MFE_NOT_SUPPORTED_OPERATION;
@@ -4132,9 +3746,9 @@ int mf_get_quad_en_direct_access(mflash* mfl, u_int8_t* quad_en_p)
 
 int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_protect_info_t* protect_info)
 {
-    u_int32_t protect_mask = 0, log2_sect_num;
-    u_int32_t sectors_num = protect_info->sectors_num;
-    int rc;
+    u_int32_t            protect_mask = 0, log2_sect_num;
+    u_int32_t            sectors_num = protect_info->sectors_num;
+    int                  rc;
     write_protect_info_t cur_protect_info;
 
     memset(&cur_protect_info, 0x0, sizeof(cur_protect_info));
@@ -4143,57 +3757,44 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
     /*       protect_info->is_subsector, protect_info->is_bottom, protect_info->sectors_num); */
 
     WRITE_PROTECT_CHECKS(mfl, bank_num);
-    if (((protect_info->sectors_num - 1) & protect_info->sectors_num) != 0)
-    {
+    if (((protect_info->sectors_num - 1) & protect_info->sectors_num) != 0) {
         return MFE_SECTORS_NUM_NOT_POWER_OF_TWO;
     }
-    if (protect_info->sectors_num > MAX_SECTORS_NUM)
-    {
+    if (protect_info->sectors_num > MAX_SECTORS_NUM) {
         return MFE_EXCEED_SECTORS_MAX_NUM;
     }
     if (((mfl->attr.vendor == FV_S25FLXXXX) && (mfl->attr.type == FMT_S25FLXXXL) &&
          (mfl->attr.log2_bank_size == FD_128)) ||
-        ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) && (mfl->attr.log2_bank_size == FD_128)))
-    {
-        if (!protect_info->is_subsector && ((protect_info->sectors_num == 1) || (protect_info->sectors_num == 2)))
-        {
+        ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) &&
+         (mfl->attr.log2_bank_size == FD_128))) {
+        if (!protect_info->is_subsector && ((protect_info->sectors_num == 1) || (protect_info->sectors_num == 2))) {
             return MFE_SECTORS_NUM_MORE_THEN_0_LESS_THEN_4;
         }
     }
-    if (protect_info->is_subsector && !mfl->attr.protect_sub_and_sector)
-    {
+    if (protect_info->is_subsector && !mfl->attr.protect_sub_and_sector) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
-    if (mfl->attr.protect_sub_and_sector && protect_info->is_subsector)
-    {
-        if (protect_info->sectors_num > MAX_SUBSECTOR_NUM)
-        {
+    if (mfl->attr.protect_sub_and_sector && protect_info->is_subsector) {
+        if (protect_info->sectors_num > MAX_SUBSECTOR_NUM) {
             return MFE_EXCEED_SUBSECTORS_MAX_NUM;
         }
     }
-    if ((mfl->attr.vendor == FV_MX25K16XXX) || (mfl->attr.vendor == FV_IS25LPXXX))
-    {
+    if ((mfl->attr.vendor == FV_MX25K16XXX) || (mfl->attr.vendor == FV_IS25LPXXX)) {
         rc = mf_get_write_protect(mfl, bank_num, &cur_protect_info);
         CHECK_RC(rc);
-        if (cur_protect_info.is_bottom && !protect_info->is_bottom)
-        {
-            if (protect_info->sectors_num)
-            {
+        if (cur_protect_info.is_bottom && !protect_info->is_bottom) {
+            if (protect_info->sectors_num) {
                 return MFE_DATA_IS_OTP;
-            }
-            else
-            {
+            } else {
                 protect_info->is_bottom =
-                  cur_protect_info.is_bottom; /* write protect is disabled, so we don't really */
-                                              /* care about top/bottom bit. */
+                    cur_protect_info.is_bottom; /* write protect is disabled, so we don't really */
+                                                /* care about top/bottom bit. */
             }
         }
     }
 
-    for (log2_sect_num = 0; log2_sect_num < 8; log2_sect_num++)
-    {
-        if (sectors_num == 0)
-        {
+    for (log2_sect_num = 0; log2_sect_num < 8; log2_sect_num++) {
+        if (sectors_num == 0) {
             break;
         }
         sectors_num >>= 1;
@@ -4206,45 +3807,38 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
         (((mfl->attr.vendor == FV_S25FLXXXX) && (mfl->attr.type == FMT_S25FLXXXL) &&
           (mfl->attr.log2_bank_size == FD_128)) ||
          ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) &&
-          (mfl->attr.log2_bank_size == FD_128))))
-    {
+          (mfl->attr.log2_bank_size == FD_128)))) {
         log2_sect_num -= 2; /* spec alignment */
     }
 
-    if ((mfl->attr.vendor == FV_ST) && (mfl->attr.type == FMT_N25QXXX))
-    {
+    if ((mfl->attr.vendor == FV_ST) && (mfl->attr.type == FMT_N25QXXX)) {
         protect_mask = MERGE(protect_mask, log2_sect_num & 0x7, 0, BP_SIZE);
         protect_mask = MERGE(protect_mask, protect_info->is_bottom, BP_SIZE, 1);
         protect_mask = MERGE(protect_mask, (log2_sect_num & 0x8) >> 3, BP_SIZE + 1, 1);
         return mf_read_modify_status_winbond(mfl, bank_num, 1, protect_mask, BP_OFFSET, PROTECT_BITS_SIZE);
-    }
-    else if ((mfl->attr.vendor == FV_MX25K16XXX) || (mfl->attr.vendor == FV_IS25LPXXX) ||
-             ((mfl->attr.vendor == FV_S25FLXXXX) && (mfl->attr.type == FMT_S25FLXXXL) &&
-              (mfl->attr.log2_bank_size == FD_256)) ||
-             ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) &&
-              (mfl->attr.log2_bank_size == FD_256)))
-    {
-        if (mfl->attr.vendor == FV_MX25K16XXX)
-        {
+    } else if ((mfl->attr.vendor == FV_MX25K16XXX) || (mfl->attr.vendor == FV_IS25LPXXX) ||
+               ((mfl->attr.vendor == FV_S25FLXXXX) && (mfl->attr.type == FMT_S25FLXXXL) &&
+                (mfl->attr.log2_bank_size == FD_256)) ||
+               ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) &&
+                (mfl->attr.log2_bank_size == FD_256))) {
+        if (mfl->attr.vendor == FV_MX25K16XXX) {
             rc = mf_read_modify_status_winbond(mfl, bank_num, 0, protect_info->is_bottom, TB_OFFSET_MACRONIX, 1);
             CHECK_RC(rc);
-        }
-        else if (mfl->attr.vendor == FV_IS25LPXXX)
-        {
+        } else if (mfl->attr.vendor == FV_IS25LPXXX) {
             rc = mf_read_modify_status_new(mfl, bank_num, SFC_RDFR, SFC_WRFR, protect_info->is_bottom, TB_OFFSET_ISSI,
                                            1, 1);
             CHECK_RC(rc);
-        }
-        else
-        { /* vendor == FV_S25FLXXXX or vendor == FV_WINBOND */
-            rc = mf_read_modify_status_winbond(mfl, bank_num, 1, protect_info->is_bottom, TB_OFFSET_CYPRESS_WINBOND_256,
+        } else { /* vendor == FV_S25FLXXXX or vendor == FV_WINBOND */
+            rc = mf_read_modify_status_winbond(mfl,
+                                               bank_num,
+                                               1,
+                                               protect_info->is_bottom,
+                                               TB_OFFSET_CYPRESS_WINBOND_256,
                                                1);
             CHECK_RC(rc);
         }
         return mf_read_modify_status_winbond(mfl, bank_num, 1, log2_sect_num, BP_OFFSET, 4);
-    }
-    else
-    {
+    } else {
         u_int8_t modify_size = 0;
 
         protect_mask = MERGE(protect_mask, log2_sect_num, 0, BP_SIZE);
@@ -4252,8 +3846,7 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
 
         protect_mask = MERGE(protect_mask, protect_info->is_bottom, BP_SIZE, 1);
         modify_size += 1;
-        if (mfl->attr.protect_sub_and_sector)
-        {
+        if (mfl->attr.protect_sub_and_sector) {
             protect_mask = MERGE(protect_mask, protect_info->is_subsector, BP_SIZE + 1, 1);
             modify_size += 1;
         }
@@ -4263,60 +3856,50 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
 
 int mf_get_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_protect_info_t* protect_info)
 {
-    int rc = 0;
+    int      rc = 0;
     u_int8_t status = 0;
     u_int8_t tb_offset = TB_OFFSET;
-    int spec_alignment_factor;
+    int      spec_alignment_factor;
 
     WRITE_PROTECT_CHECKS(mfl, bank_num);
     rc = set_bank_int(mfl, bank_num);
     CHECK_RC(rc);
     protect_info->is_subsector = 0; /* Defaultly no support for subsector protection */
-    if (mfl->attr.vendor == FV_MX25K16XXX)
-    {
+    if (mfl->attr.vendor == FV_MX25K16XXX) {
         rc = mfl->f_spi_status(mfl, SFC_RDCR, &status);
         CHECK_RC(rc);
         protect_info->is_bottom = EXTRACT(status, TB_OFFSET_MACRONIX, 1);
-    }
-    else if (mfl->attr.vendor == FV_IS25LPXXX)
-    {
+    } else if (mfl->attr.vendor == FV_IS25LPXXX) {
         rc = mfl->f_spi_status(mfl, SFC_RDFR, &status);
         CHECK_RC(rc);
         protect_info->is_bottom = EXTRACT(status, TB_OFFSET_ISSI, 1);
-    }
-    else
-    {
+    } else {
         if (((mfl->attr.vendor == FV_S25FLXXXX) && (mfl->attr.type == FMT_S25FLXXXL) &&
              (mfl->attr.log2_bank_size == FD_256)) ||
             ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) &&
-             (mfl->attr.log2_bank_size == FD_256)))
-        {
+             (mfl->attr.log2_bank_size == FD_256))) {
             tb_offset = TB_OFFSET_CYPRESS_WINBOND_256;
         }
         rc = mfl->f_spi_status(mfl, SFC_RDSR, &status);
         CHECK_RC(rc);
         protect_info->is_bottom = EXTRACT(status, tb_offset, 1);
-        if (mfl->attr.protect_sub_and_sector)
-        {
+        if (mfl->attr.protect_sub_and_sector) {
             protect_info->is_subsector = EXTRACT(status, SEC_OFFSET, 1);
-        }
-        else
-        {
+        } else {
             protect_info->is_subsector = 0;
         }
     }
     rc = mfl->f_spi_status(mfl, SFC_RDSR, &status);
     CHECK_RC(rc);
-    if (EXTRACT(status, BP_OFFSET, BP_SIZE) == 0)
-    {
+    if (EXTRACT(status, BP_OFFSET, BP_SIZE) == 0) {
         protect_info->sectors_num = 0;
-    }
-    else
-    {
+    } else {
         spec_alignment_factor =
-          ((mfl->attr.vendor == FV_S25FLXXXX && mfl->attr.type == FMT_S25FLXXXL && mfl->attr.log2_bank_size == FD_128) ||
-           (mfl->attr.vendor == FV_WINBOND && mfl->attr.type == FMT_WINBOND_3V && mfl->attr.log2_bank_size == FD_128)) &&
-              !protect_info->is_subsector ?
+            ((mfl->attr.vendor == FV_S25FLXXXX && mfl->attr.type == FMT_S25FLXXXL &&
+              mfl->attr.log2_bank_size == FD_128) ||
+             (mfl->attr.vendor == FV_WINBOND && mfl->attr.type == FMT_WINBOND_3V &&
+              mfl->attr.log2_bank_size == FD_128)) &&
+            !protect_info->is_subsector ?
             1 :
             -1;
         protect_info->sectors_num = 1 << (EXTRACT(status, BP_OFFSET, BP_SIZE) + spec_alignment_factor);
@@ -4328,10 +3911,10 @@ int mf_get_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
 int mf_is_fifth_gen(mflash* mfl)
 {
     MfError status;
-    int is7NmSuppported = 0;
-    int icmdif_supported = is_icmdif_supported(mfl, &status);
-    if (status != MFE_OK)
-    {
+    int     is7NmSuppported = 0;
+    int     icmdif_supported = is_icmdif_supported(mfl, &status);
+
+    if (status != MFE_OK) {
         return status;
     }
     return icmdif_supported;
@@ -4341,12 +3924,9 @@ int mf_enable_hw_access(mflash* mfl, u_int64_t key)
 {
 #ifndef UEFI_BUILD
     int rc = 0;
-    if (mf_is_fifth_gen(mfl))
-    {
+    if (mf_is_fifth_gen(mfl)) {
         return mf_secure_host_op(mfl, key, 0);
-    }
-    else
-    {
+    } else {
         rc = tcif_hw_access(mfl->mf, key, 0 /* Unlock */);
         return (rc == ME_CMDIF_UNKN_TLV) ? MFE_MISMATCH_KEY : MError2MfError((MError)rc);
     }
@@ -4370,27 +3950,23 @@ int mf_secure_host_op(mflash* mfl, u_int64_t key, int op)
     mlock.key = key;
     int rc = ME_OK;
 
-    if (IS_CONNECT_IB(mfl->attr.hw_dev_id))
-    {
+    if (IS_CONNECT_IB(mfl->attr.hw_dev_id)) {
         rc = ME_REG_ACCESS_REG_NOT_SUPP;
-    }
-    else
-    {
+    } else {
         rc = (int)reg_access_secure_host(mfl->mf, REG_ACCESS_METHOD_SET, &mlock);
     }
-    switch (rc)
-    {
-        case ME_REG_ACCESS_REG_NOT_SUPP:
-            rc = MFE_NOT_SUPPORTED_OPERATION;
-            break;
+    switch (rc) {
+    case ME_REG_ACCESS_REG_NOT_SUPP:
+        rc = MFE_NOT_SUPPORTED_OPERATION;
+        break;
 
-        case ME_REG_ACCESS_BAD_PARAM:
-            rc = MFE_MISMATCH_KEY;
-            break;
+    case ME_REG_ACCESS_BAD_PARAM:
+        rc = MFE_MISMATCH_KEY;
+        break;
 
-        default:
-            rc = MError2MfError((MError)rc);
-            break;
+    default:
+        rc = MError2MfError((MError)rc);
+        break;
     }
     return rc;
 }
@@ -4418,19 +3994,18 @@ int mf_disable_hw_access(mflash* mfl)
 
     rc = tcif_hw_access(mfl->mf, 0, 1 /* Lock */);
     /* translate to operation specific errors */
-    switch (rc)
-    {
-        case ME_CMDIF_UNKN_TLV:
-            rc = MFE_MISMATCH_KEY;
-            break;
+    switch (rc) {
+    case ME_CMDIF_UNKN_TLV:
+        rc = MFE_MISMATCH_KEY;
+        break;
 
-        case ME_CMDIF_BAD_OP:
-            rc = MFE_MISSING_KEY;
-            break;
+    case ME_CMDIF_BAD_OP:
+        rc = MFE_MISSING_KEY;
+        break;
 
-        default:
-            rc = MError2MfError((MError)rc);
-            break;
+    default:
+        rc = MError2MfError((MError)rc);
+        break;
     }
     return rc;
 #else
@@ -4441,8 +4016,7 @@ int mf_disable_hw_access(mflash* mfl)
 
 int mf_disable_hw_access_with_key(mflash* mfl, u_int64_t key)
 {
-    if (!mf_is_fifth_gen(mfl))
-    {
+    if (!mf_is_fifth_gen(mfl)) {
         return MFE_NOT_SUPPORTED_OPERATION;
     }
     return mf_secure_host_op(mfl, key, 1);
@@ -4465,23 +4039,20 @@ int mf_get_jedec_id(mflash* mfl, u_int32_t* jedec_id)
 
 int mf_set_quad_en(mflash* mfl, u_int8_t quad_en)
 {
-    if ((quad_en == 0) && (getenv("FORCE_RESET_QUAD_EN") == NULL))
-    {
+    if ((quad_en == 0) && (getenv("FORCE_RESET_QUAD_EN") == NULL)) {
         /* If flash HOLD state issue is relevant for given device, we'll block disabling Quad mode */
-        if (mfl->attr.vendor == FV_WINBOND)
-        {
-            switch (mfl->dm_dev_id)
-            {
-                case DeviceConnectX6:
-                case DeviceConnectX6DX:
-                case DeviceBlueField2:
-                case DeviceConnectX7:
-                case DeviceBlueField3:
-                    printf("-E- Disable QuadEn for given device is not allowed.\n");
-                    return MFE_ERROR;
+        if (mfl->attr.vendor == FV_WINBOND) {
+            switch (mfl->dm_dev_id) {
+            case DeviceConnectX6:
+            case DeviceConnectX6DX:
+            case DeviceBlueField2:
+            case DeviceConnectX7:
+            case DeviceBlueField3:
+                printf("-E- Disable QuadEn for given device is not allowed.\n");
+                return MFE_ERROR;
 
-                default:
-                    break;
+            default:
+                break;
             }
         }
     }
@@ -4495,90 +4066,97 @@ int mf_get_quad_en(mflash* mfl, u_int8_t* quad_en)
 
 int mf_to_vendor_driver_strength(u_int8_t vendor, u_int8_t value, u_int8_t* driver_strength)
 {
-    if (vendor == FV_ST)
-    {
-        switch (value)
-        {
-            case 100:
-                *driver_strength = DRIVER_STRENGTH_VAL_20_MICRON;
-                break;
-            case 66:
-                *driver_strength = DRIVER_STRENGTH_VAL_30_MICRON;
-                break;
-            case 44:
-                *driver_strength = DRIVER_STRENGTH_VAL_45_MICRON;
-                break;
-            case 22:
-                *driver_strength = DRIVER_STRENGTH_VAL_90_MICRON;
-                break;
-            default:
-                return MFE_BAD_PARAMS;
+    if (vendor == FV_ST) {
+        switch (value) {
+        case 100:
+            *driver_strength = DRIVER_STRENGTH_VAL_20_MICRON;
+            break;
+
+        case 66:
+            *driver_strength = DRIVER_STRENGTH_VAL_30_MICRON;
+            break;
+
+        case 44:
+            *driver_strength = DRIVER_STRENGTH_VAL_45_MICRON;
+            break;
+
+        case 22:
+            *driver_strength = DRIVER_STRENGTH_VAL_90_MICRON;
+            break;
+
+        default:
+            return MFE_BAD_PARAMS;
         }
-    }
-    else if (vendor == FV_MX25K16XXX)
-    {
-        switch (value)
-        {
-            case 100:
-                *driver_strength = DRIVER_STRENGTH_VAL_120_MICRON_MX25K16XXX;
-                break;
-            case 83:
-                *driver_strength = DRIVER_STRENGTH_VAL_100_MICRON_MX25K16XXX;
-                break;
-            case 70:
-                *driver_strength = DRIVER_STRENGTH_VAL_85_MICRON_MX25K16XXX;
-                break;
-            case 41:
-                *driver_strength = DRIVER_STRENGTH_VAL_50_MICRON_MX25K16XXX;
-                break;
-            default:
-                return MFE_BAD_PARAMS;
+    } else if (vendor == FV_MX25K16XXX) {
+        switch (value) {
+        case 100:
+            *driver_strength = DRIVER_STRENGTH_VAL_120_MICRON_MX25K16XXX;
+            break;
+
+        case 83:
+            *driver_strength = DRIVER_STRENGTH_VAL_100_MICRON_MX25K16XXX;
+            break;
+
+        case 70:
+            *driver_strength = DRIVER_STRENGTH_VAL_85_MICRON_MX25K16XXX;
+            break;
+
+        case 41:
+            *driver_strength = DRIVER_STRENGTH_VAL_50_MICRON_MX25K16XXX;
+            break;
+
+        default:
+            return MFE_BAD_PARAMS;
         }
-    }
-    else if (vendor == FV_IS25LPXXX)
-    {
-        switch (value)
-        {
-            case 100:
-                *driver_strength = DRIVER_STRENGTH_VAL_15_ISSI;
-                break;
-            case 75:
-                *driver_strength = DRIVER_STRENGTH_VAL_20_ISSI;
-                break;
-            case 50:
-                *driver_strength = DRIVER_STRENGTH_VAL_30_ISSI;
-                break;
-            case 33:
-                *driver_strength = DRIVER_STRENGTH_VAL_45_ISSI;
-                break;
-            case 25:
-                *driver_strength = DRIVER_STRENGTH_VAL_60_ISSI;
-                break;
-            case 16:
-                *driver_strength = DRIVER_STRENGTH_VAL_90_ISSI;
-                break;
-            default:
-                return MFE_BAD_PARAMS;
+    } else if (vendor == FV_IS25LPXXX) {
+        switch (value) {
+        case 100:
+            *driver_strength = DRIVER_STRENGTH_VAL_15_ISSI;
+            break;
+
+        case 75:
+            *driver_strength = DRIVER_STRENGTH_VAL_20_ISSI;
+            break;
+
+        case 50:
+            *driver_strength = DRIVER_STRENGTH_VAL_30_ISSI;
+            break;
+
+        case 33:
+            *driver_strength = DRIVER_STRENGTH_VAL_45_ISSI;
+            break;
+
+        case 25:
+            *driver_strength = DRIVER_STRENGTH_VAL_60_ISSI;
+            break;
+
+        case 16:
+            *driver_strength = DRIVER_STRENGTH_VAL_90_ISSI;
+            break;
+
+        default:
+            return MFE_BAD_PARAMS;
         }
-    }
-    else
-    {
-        switch (value)
-        {
-            case 25:
-                *driver_strength = DRIVER_STRENGTH_VAL_25_WINBOND;
-                break;
-            case 50:
-                *driver_strength = DRIVER_STRENGTH_VAL_50_WINBOND;
-                break;
-            case 75:
-                *driver_strength = DRIVER_STRENGTH_VAL_75_WINBOND;
-                break;
-            case 100:
-                *driver_strength = DRIVER_STRENGTH_VAL_100_WINBOND;
-                break;
-            default:
-                return MFE_BAD_PARAMS;
+    } else {
+        switch (value) {
+        case 25:
+            *driver_strength = DRIVER_STRENGTH_VAL_25_WINBOND;
+            break;
+
+        case 50:
+            *driver_strength = DRIVER_STRENGTH_VAL_50_WINBOND;
+            break;
+
+        case 75:
+            *driver_strength = DRIVER_STRENGTH_VAL_75_WINBOND;
+            break;
+
+        case 100:
+            *driver_strength = DRIVER_STRENGTH_VAL_100_WINBOND;
+            break;
+
+        default:
+            return MFE_BAD_PARAMS;
         }
     }
     return MFE_OK;
@@ -4586,98 +4164,103 @@ int mf_to_vendor_driver_strength(u_int8_t vendor, u_int8_t value, u_int8_t* driv
 
 int mf_from_vendor_driver_strength(u_int8_t vendor, u_int8_t vendor_driver_strength, u_int8_t* value)
 {
-    if (vendor == FV_ST)
-    {
-        switch (vendor_driver_strength)
-        {
-            case DRIVER_STRENGTH_VAL_20_MICRON:
-                *value = 20;
-                break;
-            case DRIVER_STRENGTH_VAL_30_MICRON:
-                *value = 30;
-                break;
-            case DRIVER_STRENGTH_VAL_45_MICRON:
-                *value = 45;
-                break;
-            case DRIVER_STRENGTH_VAL_90_MICRON:
-                *value = 90;
-                break;
-            default:
-                *value = 0xff;
+    if (vendor == FV_ST) {
+        switch (vendor_driver_strength) {
+        case DRIVER_STRENGTH_VAL_20_MICRON:
+            *value = 20;
+            break;
+
+        case DRIVER_STRENGTH_VAL_30_MICRON:
+            *value = 30;
+            break;
+
+        case DRIVER_STRENGTH_VAL_45_MICRON:
+            *value = 45;
+            break;
+
+        case DRIVER_STRENGTH_VAL_90_MICRON:
+            *value = 90;
+            break;
+
+        default:
+            *value = 0xff;
         }
-        if (*value != 0xff)
-        {
+        if (*value != 0xff) {
             *value = (20 * 100) / *value;
         }
-    }
-    else if (vendor == FV_IS25LPXXX)
-    {
-        switch (vendor_driver_strength)
-        {
-            case DRIVER_STRENGTH_VAL_15_ISSI:
-                *value = 15;
-                break;
-            case DRIVER_STRENGTH_VAL_20_ISSI:
-                *value = 20;
-                break;
-            case DRIVER_STRENGTH_VAL_30_ISSI:
-                *value = 30;
-                break;
-            case DRIVER_STRENGTH_VAL_45_ISSI:
-                *value = 45;
-                break;
-            case DRIVER_STRENGTH_VAL_60_ISSI:
-                *value = 60;
-                break;
-            case DRIVER_STRENGTH_VAL_90_ISSI:
-                *value = 90;
-                break;
-            default:
-                *value = 0xff;
+    } else if (vendor == FV_IS25LPXXX) {
+        switch (vendor_driver_strength) {
+        case DRIVER_STRENGTH_VAL_15_ISSI:
+            *value = 15;
+            break;
+
+        case DRIVER_STRENGTH_VAL_20_ISSI:
+            *value = 20;
+            break;
+
+        case DRIVER_STRENGTH_VAL_30_ISSI:
+            *value = 30;
+            break;
+
+        case DRIVER_STRENGTH_VAL_45_ISSI:
+            *value = 45;
+            break;
+
+        case DRIVER_STRENGTH_VAL_60_ISSI:
+            *value = 60;
+            break;
+
+        case DRIVER_STRENGTH_VAL_90_ISSI:
+            *value = 90;
+            break;
+
+        default:
+            *value = 0xff;
         }
-        if (*value != 0xff)
-        {
+        if (*value != 0xff) {
             *value = (15 * 100) / *value;
         }
-    }
-    else if (vendor == FV_MX25K16XXX)
-    {
-        switch (vendor_driver_strength)
-        {
-            case DRIVER_STRENGTH_VAL_120_MICRON_MX25K16XXX:
-                *value = 100;
-                break;
-            case DRIVER_STRENGTH_VAL_100_MICRON_MX25K16XXX:
-                *value = 83;
-                break;
-            case DRIVER_STRENGTH_VAL_85_MICRON_MX25K16XXX:
-                *value = 70;
-                break;
-            case DRIVER_STRENGTH_VAL_50_MICRON_MX25K16XXX:
-                *value = 41;
-                break;
-            default:
-                return MFE_BAD_PARAMS;
+    } else if (vendor == FV_MX25K16XXX) {
+        switch (vendor_driver_strength) {
+        case DRIVER_STRENGTH_VAL_120_MICRON_MX25K16XXX:
+            *value = 100;
+            break;
+
+        case DRIVER_STRENGTH_VAL_100_MICRON_MX25K16XXX:
+            *value = 83;
+            break;
+
+        case DRIVER_STRENGTH_VAL_85_MICRON_MX25K16XXX:
+            *value = 70;
+            break;
+
+        case DRIVER_STRENGTH_VAL_50_MICRON_MX25K16XXX:
+            *value = 41;
+            break;
+
+        default:
+            return MFE_BAD_PARAMS;
         }
-    }
-    else
-    {
-        switch (vendor_driver_strength)
-        {
-            case DRIVER_STRENGTH_VAL_25_WINBOND:
-                *value = 25;
-                break;
-            case DRIVER_STRENGTH_VAL_50_WINBOND:
-                *value = 50;
-                break;
-            case DRIVER_STRENGTH_VAL_75_WINBOND:
-                *value = 75;
-                break;
-            case DRIVER_STRENGTH_VAL_100_WINBOND:
-                *value = 100;
-                break;
-            default:
-                *value = 0xff;
+    } else {
+        switch (vendor_driver_strength) {
+        case DRIVER_STRENGTH_VAL_25_WINBOND:
+            *value = 25;
+            break;
+
+        case DRIVER_STRENGTH_VAL_50_WINBOND:
+            *value = 50;
+            break;
+
+        case DRIVER_STRENGTH_VAL_75_WINBOND:
+            *value = 75;
+            break;
+
+        case DRIVER_STRENGTH_VAL_100_WINBOND:
+            *value = 100;
+            break;
+
+        default:
+            *value = 0xff;
         }
     }
     return MFE_OK;
@@ -4686,7 +4269,8 @@ int mf_from_vendor_driver_strength(u_int8_t vendor, u_int8_t vendor_driver_stren
 int mf_set_driver_strength(mflash* mfl, u_int8_t driver_strength)
 {
     u_int8_t vendor_driver_strength = 0;
-    int rc = mf_to_vendor_driver_strength(mfl->attr.vendor, driver_strength, &vendor_driver_strength);
+    int      rc = mf_to_vendor_driver_strength(mfl->attr.vendor, driver_strength, &vendor_driver_strength);
+
     CHECK_RC(rc);
     return mfl->f_set_driver_strength(mfl, vendor_driver_strength);
 }
@@ -4694,7 +4278,8 @@ int mf_set_driver_strength(mflash* mfl, u_int8_t driver_strength)
 int mf_get_driver_strength(mflash* mfl, u_int8_t* driver_strength)
 {
     u_int8_t value = 0;
-    int rc = mfl->f_get_driver_strength(mfl, &value);
+    int      rc = mfl->f_get_driver_strength(mfl, &value);
+
     CHECK_RC(rc);
     rc = mf_from_vendor_driver_strength(mfl->attr.vendor, value, driver_strength);
     return rc;

--- a/mflash/mflash_pack_layer.h
+++ b/mflash/mflash_pack_layer.h
@@ -53,13 +53,13 @@
 typedef void* trm_ctx;
 #endif
 
-// TODO: use: (int)log2((float)num)
-#define NEAREST_POW2(num)                                                                                    \
-    (num) < (256) ?                                                                                          \
-      ((num) < (128) ?                                                                                       \
-         ((num) < (64) ? ((num) < (32) ? ((num) < (16) ? ((num) < (8) ? (4) : (8)) : (16)) : (32)) : (64)) : \
-         (128)) :                                                                                            \
-      (256)
+/* TODO: use: (int)log2((float)num) */
+#define NEAREST_POW2(num)                                                                                \
+    (num) < (256) ?                                                                                      \
+    ((num) < (128) ?                                                                                     \
+     ((num) < (64) ? ((num) < (32) ? ((num) < (16) ? ((num) < (8) ? (4) : (8)) : (16)) : (32)) : (64)) : \
+     (128)) :                                                                                            \
+    (256)
 
 #ifndef CHECK_RC
 #define CHECK_RC(rc)   \
@@ -82,30 +82,30 @@ typedef void* trm_ctx;
 #define MFLASH_ERR_STR_SIZE 4
 #endif
 
-#define CX3_PRO_HW_ID 0x1F7
-#define CX3_HW_ID 0x1F5
-#define CX4_HW_ID 0x209
-#define CX4LX_HW_ID 0x20b
-#define CX5_HW_ID 0x20d
-#define CX6_HW_ID 0x20f
-#define CX7_HW_ID 0x218
-#define CX8_HW_ID 0x21e
-#define CX6DX_HW_ID 0x212
-#define CX6LX_HW_ID 0x216
-#define BLUEFIELD_HW_ID 0x211
-#define BLUEFIELD2_HW_ID 0x214
-#define BLUEFIELD3_HW_ID 0x21c
-#define BLUEFIELD4_HW_ID 0x220
-#define CONNECT_IB_HW_ID 0x1FF
-#define SWITCH_IB_HW_ID 0x247
-#define SPECTRUM_HW_ID 0x249
-#define SWITCH_IB2_HW_ID 0x24b
-#define QUANTUM_HW_ID 0x24d
-#define SPECTRUM2_HW_ID 0x24e
-#define SPECTRUM3_HW_ID 0x250
-#define QUANTUM2_HW_ID 0x257
-#define QUANTUM3_HW_ID 0x25b
-#define SPECTRUM4_HW_ID 0x254
+#define CX3_PRO_HW_ID       0x1F7
+#define CX3_HW_ID           0x1F5
+#define CX4_HW_ID           0x209
+#define CX4LX_HW_ID         0x20b
+#define CX5_HW_ID           0x20d
+#define CX6_HW_ID           0x20f
+#define CX7_HW_ID           0x218
+#define CX8_HW_ID           0x21e
+#define CX6DX_HW_ID         0x212
+#define CX6LX_HW_ID         0x216
+#define BLUEFIELD_HW_ID     0x211
+#define BLUEFIELD2_HW_ID    0x214
+#define BLUEFIELD3_HW_ID    0x21c
+#define BLUEFIELD4_HW_ID    0x220
+#define CONNECT_IB_HW_ID    0x1FF
+#define SWITCH_IB_HW_ID     0x247
+#define SPECTRUM_HW_ID      0x249
+#define SWITCH_IB2_HW_ID    0x24b
+#define QUANTUM_HW_ID       0x24d
+#define SPECTRUM2_HW_ID     0x24e
+#define SPECTRUM3_HW_ID     0x250
+#define QUANTUM2_HW_ID      0x257
+#define QUANTUM3_HW_ID      0x25b
+#define SPECTRUM4_HW_ID     0x254
 #define INBAND_MAX_REG_SIZE 44
 
 #define VSC_RECOVERY_SPACE_FLASH_GW_BASE_ADDRESS 0x10
@@ -114,29 +114,29 @@ typedef void* trm_ctx;
  * Device IDs Macros:
  */
 #define IS_CONNECTX_4TH_GEN_FAMILY(dev_id) (((dev_id) == CX3_HW_ID) || ((dev_id) == CX3_PRO_HW_ID))
-#define IS_SIB(dev_id) ((dev_id) == SWITCH_IB_HW_ID)
-#define IS_SIB2(dev_id) ((dev_id) == SWITCH_IB2_HW_ID)
-#define IS_SEN(dev_id) ((dev_id) == SPECTRUM_HW_ID)
-#define IS_SPECTRUM2(dev_id) ((dev_id) == SPECTRUM2_HW_ID)
-#define IS_CONNECT_IB(dev_id) ((dev_id) == CONNECT_IB_HW_ID)
-#define IS_CONNECTX4(dev_id) ((dev_id) == CX4_HW_ID)
-#define IS_CONNECTX4LX(dev_id) ((dev_id) == CX4LX_HW_ID)
-#define IS_CONNECTX5(dev_id) ((dev_id) == CX5_HW_ID)
-#define IS_CONNECTX7(dev_id) ((dev_id) == CX7_HW_ID)
-#define IS_CONNECTX8(dev_id) ((dev_id) == CX8_HW_ID)
-#define IS_CONNECTX6(dev_id) ((dev_id) == CX6_HW_ID)
-#define IS_CONNECTX6DX(dev_id) ((dev_id) == CX6DX_HW_ID)
-#define IS_CONNECTX6LX(dev_id) ((dev_id) == CX6LX_HW_ID)
-#define IS_BLUEFIELD(dev_id) ((dev_id) == BLUEFIELD_HW_ID)
-#define IS_QUANTUM(dev_id) ((dev_id) == QUANTUM_HW_ID)
-#define IS_SPECTRUM(dev_id) ((dev_id) == SPECTRUM_HW_ID)
-#define IS_BLUEFEILD(dev_id) ((dev_id) == BLUEFIELD_HW_ID)
-#define IS_BLUEFEILD2(dev_id) ((dev_id) == BLUEFIELD2_HW_ID)
-#define IS_BLUEFEILD3(dev_id) ((dev_id) == BLUEFIELD3_HW_ID)
-#define IS_BLUEFEILD4(dev_id) ((dev_id) == BLUEFIELD4_HW_ID)
-#define IS_QUANTUM2(dev_id) ((dev_id) == QUANTUM2_HW_ID)
-#define IS_QUANTUM3(dev_id) ((dev_id) == QUANTUM3_HW_ID)
-#define IS_SPECTRUM4(dev_id) ((dev_id) == SPECTRUM4_HW_ID)
+#define IS_SIB(dev_id)                     ((dev_id) == SWITCH_IB_HW_ID)
+#define IS_SIB2(dev_id)                    ((dev_id) == SWITCH_IB2_HW_ID)
+#define IS_SEN(dev_id)                     ((dev_id) == SPECTRUM_HW_ID)
+#define IS_SPECTRUM2(dev_id)               ((dev_id) == SPECTRUM2_HW_ID)
+#define IS_CONNECT_IB(dev_id)              ((dev_id) == CONNECT_IB_HW_ID)
+#define IS_CONNECTX4(dev_id)               ((dev_id) == CX4_HW_ID)
+#define IS_CONNECTX4LX(dev_id)             ((dev_id) == CX4LX_HW_ID)
+#define IS_CONNECTX5(dev_id)               ((dev_id) == CX5_HW_ID)
+#define IS_CONNECTX7(dev_id)               ((dev_id) == CX7_HW_ID)
+#define IS_CONNECTX8(dev_id)               ((dev_id) == CX8_HW_ID)
+#define IS_CONNECTX6(dev_id)               ((dev_id) == CX6_HW_ID)
+#define IS_CONNECTX6DX(dev_id)             ((dev_id) == CX6DX_HW_ID)
+#define IS_CONNECTX6LX(dev_id)             ((dev_id) == CX6LX_HW_ID)
+#define IS_BLUEFIELD(dev_id)               ((dev_id) == BLUEFIELD_HW_ID)
+#define IS_QUANTUM(dev_id)                 ((dev_id) == QUANTUM_HW_ID)
+#define IS_SPECTRUM(dev_id)                ((dev_id) == SPECTRUM_HW_ID)
+#define IS_BLUEFEILD(dev_id)               ((dev_id) == BLUEFIELD_HW_ID)
+#define IS_BLUEFEILD2(dev_id)              ((dev_id) == BLUEFIELD2_HW_ID)
+#define IS_BLUEFEILD3(dev_id)              ((dev_id) == BLUEFIELD3_HW_ID)
+#define IS_BLUEFEILD4(dev_id)              ((dev_id) == BLUEFIELD4_HW_ID)
+#define IS_QUANTUM2(dev_id)                ((dev_id) == QUANTUM2_HW_ID)
+#define IS_QUANTUM3(dev_id)                ((dev_id) == QUANTUM3_HW_ID)
+#define IS_SPECTRUM4(dev_id)               ((dev_id) == SPECTRUM4_HW_ID)
 
 #define HAS_TOOLS_CMDIF(dev_id) ((((dev_id) == CX3_HW_ID) || ((dev_id) == CX3_PRO_HW_ID)))
 
@@ -169,102 +169,100 @@ typedef int (*f_mf_set_dummy_cycles)(mflash* mfl, u_int8_t num_of_cycles);
 
 typedef int (*f_cntx_st_spi_erase_sect)(mflash* mfl, u_int32_t addr);
 typedef int (*f_cntx_int_spi_get_status_data)(mflash* mfl, u_int8_t op_type, u_int32_t* status, u_int8_t data_num);
-typedef int (*f_cntx_st_spi_block_write_ex)(mflash* mfl,
+typedef int (*f_cntx_st_spi_block_write_ex)(mflash  * mfl,
                                             u_int32_t blk_addr,
                                             u_int32_t blk_size,
                                             u_int8_t* data,
-                                            u_int8_t is_first,
-                                            u_int8_t is_last,
+                                            u_int8_t  is_first,
+                                            u_int8_t  is_last,
                                             u_int32_t total_size);
 typedef int (*f_cntx_sst_spi_block_write_ex)(mflash* mfl, u_int32_t blk_addr, u_int32_t blk_size, u_int8_t* data);
-typedef int (*f_cntx_st_spi_block_read_ex)(mflash* mfl,
+typedef int (*f_cntx_st_spi_block_read_ex)(mflash  * mfl,
                                            u_int32_t blk_addr,
                                            u_int32_t blk_size,
                                            u_int8_t* data,
-                                           u_int8_t is_first,
-                                           u_int8_t is_last,
-                                           bool verbose);
+                                           u_int8_t  is_first,
+                                           u_int8_t  is_last,
+                                           bool      verbose);
 typedef int (*f_cntx_spi_write_status_reg)(mflash* mfl, u_int32_t status_reg, u_int8_t write_cmd, u_int8_t bytes_num);
 
-typedef enum FlashGen
-{
+typedef enum FlashGen {
     LEGACY_FLASH = 0,
     SIX_GEN_FLASH,
     SEVEN_GEN_FLASH
 } FlashGen;
 
-/////////////////////////////////////////////
-//
-// MFlash struct
-//
-/////////////////////////////////////////////
-struct mflash
-{
+/*/////////////////////////////////////////// */
+/* */
+/* MFlash struct */
+/* */
+/*/////////////////////////////////////////// */
+struct mflash {
 #ifndef IRISC
     mfile* mf;
 #endif
 
-    // Functions:
+    /* Functions: */
     f_mf_lock f_lock;
 
-    f_mf_set_bank f_set_bank;
-    f_mf_get_info f_get_info;
+    f_mf_set_bank     f_set_bank;
+    f_mf_get_info     f_get_info;
     f_mf_get_jedec_id f_get_jedec_id;
 
-    f_mf_read f_read;
-    f_mf_write f_write;
-    f_mf_write f_write_blk; // write and write_block have the same signateure, but theyr'e not the same func !
-    f_mf_read f_read_blk;   // read  and read_block have the same signateure, but theyr'e not the same func !
+    f_mf_read       f_read;
+    f_mf_write      f_write;
+    f_mf_write      f_write_blk; /* write and write_block have the same signateure, but theyr'e not the same func ! */
+    f_mf_read       f_read_blk; /* read  and read_block have the same signateure, but theyr'e not the same func ! */
     f_mf_erase_sect f_erase_sect;
-    f_mf_reset f_reset;
+    f_mf_reset      f_reset;
 
-    f_mf_get_quad_en f_get_quad_en;
-    f_mf_set_quad_en f_set_quad_en;
+    f_mf_get_quad_en         f_get_quad_en;
+    f_mf_set_quad_en         f_set_quad_en;
     f_mf_get_driver_strength f_get_driver_strength;
     f_mf_set_driver_strength f_set_driver_strength;
-    f_mf_get_write_protect f_get_write_protect;
-    f_mf_set_write_protect f_set_write_protect;
-    f_mf_get_dummy_cycles f_get_dummy_cycles;
-    f_mf_set_dummy_cycles f_set_dummy_cycles;
+    f_mf_get_write_protect   f_get_write_protect;
+    f_mf_set_write_protect   f_set_write_protect;
+    f_mf_get_dummy_cycles    f_get_dummy_cycles;
+    f_mf_set_dummy_cycles    f_set_dummy_cycles;
 
-    // Relevant for SPI flash (InfiniHostIIILx, ConnectX) only
+    /* Relevant for SPI flash (InfiniHostIIILx, ConnectX) only */
     f_st_spi_status f_spi_status;
 
-    f_cntx_st_spi_erase_sect f_st_spi_erase_sect;
+    f_cntx_st_spi_erase_sect       f_st_spi_erase_sect;
     f_cntx_int_spi_get_status_data f_int_spi_get_status_data;
-    f_cntx_st_spi_block_write_ex f_st_spi_block_write_ex;
-    f_cntx_sst_spi_block_write_ex f_sst_spi_block_write_ex;
-    f_cntx_st_spi_block_read_ex f_st_spi_block_read_ex;
-    f_cntx_spi_write_status_reg f_spi_write_status_reg;
+    f_cntx_st_spi_block_write_ex   f_st_spi_block_write_ex;
+    f_cntx_sst_spi_block_write_ex  f_sst_spi_block_write_ex;
+    f_cntx_st_spi_block_read_ex    f_st_spi_block_read_ex;
+    f_cntx_spi_write_status_reg    f_spi_write_status_reg;
 
-    // when set(1) we support modification of the flash status register
+    /* when set(1) we support modification of the flash status register */
     u_int8_t supp_sr_mod;
 
     int curr_bank;
     int is_locked;
     int flash_prog_locked;
     int unlock_flash_prog_allowed;
-    // if writer_lock is set, semaphore should be freed only in mf_close()/disable_hw_access()
+    /* if writer_lock is set, semaphore should be freed only in mf_close()/disable_hw_access() */
     int writer_lock;
 
     flash_attr attr;
 
-    int opts[MFO_LAST];
+    int  opts[MFO_LAST];
     char last_err_str[MFLASH_ERR_STR_SIZE];
 
-    u_int8_t access_type; // 0 = mfile , 1 = uefi
-    trm_ctx trm;
+    u_int8_t    access_type; /* 0 = mfile , 1 = uefi */
+    trm_ctx     trm;
     dm_dev_id_t dm_dev_id;
-    int cputUtilizationApplied;
-    int cpuPercent;
-    u_int32_t cache_repacement_en_addr;
-    u_int32_t gcm_en_addr;
-    u_int32_t gw_addr_field_addr;
-    u_int32_t gw_data_field_addr;
-    u_int32_t gw_cmd_register_addr;
-    u_int32_t cache_rep_offset_field_addr;
-    u_int32_t cache_rep_cmd_field_addr;
-    // Below fields are initialized and used for mflash_new_gw.c only
+    int         cputUtilizationApplied;
+    int         cpuPercent;
+    u_int32_t   cache_repacement_en_addr;
+    u_int32_t   gcm_en_addr;
+    u_int32_t   gw_addr_field_addr;
+    u_int32_t   gw_data_field_addr;
+    u_int32_t   gw_cmd_register_addr;
+    u_int32_t   cache_rep_offset_field_addr;
+    u_int32_t   cache_rep_cmd_field_addr;
+    /* Below fields are initialized and used for mflash_new_gw.c only */
     u_int32_t gw_rw_bit_offset;
     u_int32_t gw_cmd_phase_bit_offset;
     u_int32_t gw_addr_phase_bit_offset;
@@ -277,33 +275,31 @@ struct mflash
     u_int32_t gw_cmd_bit_offset;
     u_int32_t gw_cmd_bit_len;
     u_int32_t gw_busy_bit_offset;
-    u_int32_t gw_data_size_register_addr; // Relevant to 7th gen flash GW
+    u_int32_t gw_data_size_register_addr; /* Relevant to 7th gen flash GW */
 
-    // Frequency related fields relevant for CX7 and BF3
-    bool is_freq_handle_required;
-    bool is_freq_changed;
+    /* Frequency related fields relevant for CX7 and BF3 */
+    bool      is_freq_handle_required;
+    bool      is_freq_changed;
     u_int32_t core_clocks_per_usec_addr;
     u_int32_t flash_div_addr;
-    u_int32_t orig_flash_div_reg; // Whole register, not flash_div field only
+    u_int32_t orig_flash_div_reg; /* Whole register, not flash_div field only */
     u_int32_t core_clocks_per_usec;
 };
 
-typedef struct mfpa_command_args
-{
-    u_int8_t flash_bank;                 // IN
-    u_int32_t boot_address;              // IN/OUT
-    int num_of_banks;                    // OUT
-    u_int32_t jedec_id;                  // OUT
-    u_int32_t fw_flash_sector_sz;        // OUT
-    u_int8_t supp_sub_and_sector_erase;  // OUT
-    u_int8_t supp_sector_write_prot;     // OUT
-    u_int8_t supp_sub_sector_write_prot; // OUT
-    u_int8_t supp_quad_en;               // OUT
-    u_int8_t supp_dummy_cycles;          // OUT
+typedef struct mfpa_command_args {
+    u_int8_t  flash_bank;                /* IN */
+    u_int32_t boot_address;              /* IN/OUT */
+    int       num_of_banks;              /* OUT */
+    u_int32_t jedec_id;                  /* OUT */
+    u_int32_t fw_flash_sector_sz;        /* OUT */
+    u_int8_t  supp_sub_and_sector_erase; /* OUT */
+    u_int8_t  supp_sector_write_prot;    /* OUT */
+    u_int8_t  supp_sub_sector_write_prot; /* OUT */
+    u_int8_t  supp_quad_en;              /* OUT */
+    u_int8_t  supp_dummy_cycles;         /* OUT */
 } mfpa_command_args;
 
-enum AccessTypeByMfile
-{
+enum AccessTypeByMfile {
     ATBM_NO = 0,
     ATBM_INBAND,
     ATBM_MLNXOS_CMDIF,
@@ -311,85 +307,85 @@ enum AccessTypeByMfile
     ATBM_TOOLS_CMDIF,
 };
 
-enum CntxCrConstants
-{
-    HCR_FLASH_CMD = 0xf0400,
-    HCR_FLASH_ADDR = 0xf0404,
+enum CntxCrConstants {
+    HCR_FLASH_CMD                      = 0xf0400,
+    HCR_FLASH_ADDR                     = 0xf0404,
     HCR_FLASH_CACHE_REPLACEMENT_OFFSET = 0xf0408,
-    HCR_FLASH_CACHE_REPLACEMENT_CMD = 0xf040c,
-    HCR_FLASH_DATA = 0xf0410,
-    HCR_CACHE_REPLACEMNT_EN_ADDR = 0xf0420,
-    // Gearbox flash GW registers addresses
-    HCR_FLASH_GEARBOX_CMD = 0x2000,
-    HCR_FLASH_GEARBOX_ADDR = 0x2004,
-    HCR_FLASH_GEARBOX_CACHE_REPLACEMENT_OFFSET = 0x2008,
-    HCR_FLASH_GEARBOX_DATA = 0x2010,
-    HCR_FLASH_GEARBOX_CACHE_REPLACEMENT_CMD = 0x200c,
+    HCR_FLASH_CACHE_REPLACEMENT_CMD    = 0xf040c,
+    HCR_FLASH_DATA                     = 0xf0410,
+    HCR_CACHE_REPLACEMNT_EN_ADDR       = 0xf0420,
+    /* Gearbox flash GW registers addresses */
+    HCR_FLASH_GEARBOX_CMD                       = 0x2000,
+    HCR_FLASH_GEARBOX_ADDR                      = 0x2004,
+    HCR_FLASH_GEARBOX_CACHE_REPLACEMENT_OFFSET  = 0x2008,
+    HCR_FLASH_GEARBOX_DATA                      = 0x2010,
+    HCR_FLASH_GEARBOX_CACHE_REPLACEMENT_CMD     = 0x200c,
     HCR_FLASH_GEARBOX_CACHE_REPLACEMENT_EN_ADDR = 0x2020,
-    // 6th gen flash GW registers addresses
-    HCR_NEW_GW_FLASH_ADDR = 0xf0420,
+    /* 6th gen flash GW registers addresses */
+    HCR_6GEN_FLASH_GW_BASE_ADDR         = 0xf0420,
+    HCR_NEW_GW_FLASH_ADDR               = HCR_6GEN_FLASH_GW_BASE_ADDR,
     HCR_NEW_GW_CACHE_REPLACEMNT_EN_ADDR = 0xf0480,
-    HCR_NEW_GW_GCM_EN_ADDR = 0xf0440,
-    // 7th gen flash GW registers addresses
-    // QTM3:
+    HCR_NEW_GW_GCM_EN_ADDR              = 0xf0440,
+    /* 7th gen flash GW registers addresses */
+    /* QTM3: */
     HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR = 0x101000,
-    HCR_7GEN_QTM3_FLASH_CMD = HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR,
-    HCR_7GEN_QTM3_FLASH_DATA = 0x101010,
-    HCR_7GEN_QTM3_GCM_EN_ADDR = 0x101028,
-    HCR_7GEN_QTM3_FLASH_ADDR = 0x10103c,
-    HCR_7GEN_QTM3_FLASH_DATA_SIZE = 0x101044,
-    // ARCUSE:
-    HCR_7GEN_ARCUSE_FLASH_CMD = 0x101000,
-    HCR_7GEN_ARCUSE_FLASH_DATA = 0x101010,
-    HCR_7GEN_ARCUSE_GCM_EN_ADDR = 0x101028,
-    HCR_7GEN_ARCUSE_FLASH_ADDR = 0x10103c,
+    HCR_7GEN_QTM3_FLASH_CMD          = HCR_7GEN_QTM3_FLASH_GW_BASE_ADDR,
+    HCR_7GEN_QTM3_FLASH_DATA         = 0x101010,
+    HCR_7GEN_QTM3_GCM_EN_ADDR        = 0x101028,
+    HCR_7GEN_QTM3_FLASH_ADDR         = 0x10103c,
+    HCR_7GEN_QTM3_FLASH_DATA_SIZE    = 0x101044,
+    /* ARCUSE: */
+    HCR_7GEN_ARCUSE_FLASH_CMD       = 0x101000,
+    HCR_7GEN_ARCUSE_FLASH_DATA      = 0x101010,
+    HCR_7GEN_ARCUSE_GCM_EN_ADDR     = 0x101028,
+    HCR_7GEN_ARCUSE_FLASH_ADDR      = 0x10103c,
     HCR_7GEN_ARCUSE_FLASH_DATA_SIZE = 0x101044,
-    // CX8:
+    /* CX8: */
     HCR_7GEN_CX8_FLASH_GW_BASE_ADDR = 0x8a1000,
-    HCR_7GEN_CX8_FLASH_CMD = HCR_7GEN_CX8_FLASH_GW_BASE_ADDR,
-    HCR_7GEN_CX8_FLASH_DATA = 0x8a1010,
-    HCR_7GEN_CX8_GCM_EN_ADDR = 0x8a1028,
-    HCR_7GEN_CX8_FLASH_ADDR = 0x8a103c,
-    HCR_7GEN_CX8_FLASH_DATA_SIZE = 0x8a1044,
+    HCR_7GEN_CX8_FLASH_CMD          = HCR_7GEN_CX8_FLASH_GW_BASE_ADDR,
+    HCR_7GEN_CX8_FLASH_DATA         = 0x8a1010,
+    HCR_7GEN_CX8_GCM_EN_ADDR        = 0x8a1028,
+    HCR_7GEN_CX8_FLASH_ADDR         = 0x8a103c,
+    HCR_7GEN_CX8_FLASH_DATA_SIZE    = 0x8a1044,
 
-    // Flash GW fields offsets and lengths
-    HBO_READ_OP = 0,
-    HBO_CMD_PHASE = 2,
-    HBO_ADDR_PHASE = 3,
-    HBS_DATA_SIZE = 3,
-    HBO_DATA_PHASE = 4,
-    HBO_DATA_SIZE = 8,
-    HBO_CS_HOLD = 5,
-    HBO_CHIP_SELECT = 11,
-    HBO_FLASH_ENABLE = 13, // In old devices
-    HBO_ADDR_SIZE = 14,
-    HBO_CMD = 16,
-    HBS_CMD = 8,
-    HBO_BUSY = 30,
-    HBO_LOCK = 31,
-    // 6th gen flash GW fields offsets and lengths
-    HBS_NEW_GW_DATA_SIZE = 5,
+    /* Flash GW fields offsets and lengths */
+    HBO_READ_OP      = 0,
+    HBO_CMD_PHASE    = 2,
+    HBO_ADDR_PHASE   = 3,
+    HBS_DATA_SIZE    = 3,
+    HBO_DATA_PHASE   = 4,
+    HBO_DATA_SIZE    = 8,
+    HBO_CS_HOLD      = 5,
+    HBO_CHIP_SELECT  = 11,
+    HBO_FLASH_ENABLE = 13, /* In old devices */
+    HBO_ADDR_SIZE    = 14,
+    HBO_CMD          = 16,
+    HBS_CMD          = 8,
+    HBO_BUSY         = 30,
+    HBO_LOCK         = 31,
+    /* 6th gen flash GW fields offsets and lengths */
+    HBS_NEW_GW_DATA_SIZE   = 5,
     HBO_NEW_GW_CHIP_SELECT = 13,
-    HBO_NEW_GW_ADDR_SIZE = 15,
-    // 7th gen flash GW fields offsets and lengths
-    HBO_7GEN_RW = 5,
-    HBO_7GEN_CMD_PHASE = 7,
-    HBO_7GEN_ADDR_PHASE = 8,
-    HBO_7GEN_DATA_PHASE = 9,
-    HBO_7GEN_CS_HOLD = 10,
+    HBO_NEW_GW_ADDR_SIZE   = 15,
+    /* 7th gen flash GW fields offsets and lengths */
+    HBO_7GEN_RW          = 5,
+    HBO_7GEN_CMD_PHASE   = 7,
+    HBO_7GEN_ADDR_PHASE  = 8,
+    HBO_7GEN_DATA_PHASE  = 9,
+    HBO_7GEN_CS_HOLD     = 10,
     HBO_7GEN_CHIP_SELECT = 13,
-    HBO_7GEN_ADDR_SIZE = 15,
-    HBO_7GEN_CMD = 16,
-    HBS_7GEN_CMD = 8,
-    HBO_7GEN_BUSY = 30,
+    HBO_7GEN_ADDR_SIZE   = 15,
+    HBO_7GEN_CMD         = 16,
+    HBS_7GEN_CMD         = 8,
+    HBO_7GEN_BUSY        = 30,
 
-    // GPIOs
-    HCR_GPIO_LOCK = 0xf0048,
+    /* GPIOs */
+    HCR_GPIO_LOCK     = 0xf0048,
     HCR_GPIO_LOCK_VAL = 0xd42f,
 
     HCR_GPIO_DATA_OUT = 0xf0040,
-    HCR_GPIO_MODE0 = 0xf0050,
-    HCR_GPIO_MODE1 = 0xf004c,
+    HCR_GPIO_MODE0    = 0xf0050,
+    HCR_GPIO_MODE1    = 0xf004c,
 
     HBO_GPIO_CS = 25,
     HBS_GPIO_CS = 4
@@ -415,17 +411,17 @@ enum CntxCrConstants
         }                                 \
     }
 
-//////////////////////////////////// SX FLASH functions ////////////////////////////////////
+/*////////////////////////////////// SX FLASH functions //////////////////////////////////// */
 
 typedef u_int32_t (*f_reg_pack)(void* data_to_pack, u_int8_t* packed_buffer);
 typedef void (*f_reg_unpack)(void* unpacked_data, u_int8_t* buffer_to_unpack);
 typedef void (*f_reg_dump)(void* data_to_print, FILE* out_port);
 
-int sx_st_block_access(mfile* mf,
-                       u_int32_t flash_addr,
-                       u_int8_t bank,
-                       u_int32_t size,
-                       u_int8_t* data,
+int sx_st_block_access(mfile             * mf,
+                       u_int32_t           flash_addr,
+                       u_int8_t            bank,
+                       u_int32_t           size,
+                       u_int8_t          * data,
                        reg_access_method_t method);
 
 int common_erase_sector(mfile* mf, u_int32_t addr, u_int8_t flash_bank, u_int32_t erase_size);


### PR DESCRIPTION
Description: in ZF mode, recovery is done via the "recovery" address_space in VSC and not the "crspace" address_space. base address of flash GW is 0x10 in VSC recovery address_space, so when reading/writing: address should be base_flash_gw + <relative address of component>

Tested OS:n/a
Tested devices:n/a
Tested flows:n/a

Known gaps (with RM ticket):n/a

Issue:4231024