### PR TITLE
Title:[Bug][MLXLINK] Page 0x2F is not printed in dump

### DIFF
--- a/mlxlink/modules/mlxlink_cables_commander.cpp
+++ b/mlxlink/modules/mlxlink_cables_commander.cpp
@@ -907,6 +907,8 @@ void MlxlinkCablesCommander::initValidPages()
                         p = page_t{page, UPPER_PAGE_OFFSET, I2C_ADDR_LOW};
                         _validPages.push_back(p);
                     }
+                    p = page_t{PAGE_2F, UPPER_PAGE_OFFSET, I2C_ADDR_LOW};
+                    _validPages.push_back(p);
                 }
 
                 /*


### PR DESCRIPTION
Description:Page 0x2F was missing from valid pages. Issue:4272664
Reviewed By:HarelK,MajdH
MSTFlint port needed: yes

Change-Id: I1f807eee0638dc9116d6e17a4679b0b0565ac935