### PR TITLE
mlxlink | amber | bug fix for amber collect (inclusive - all ports) c…

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -418,6 +418,28 @@ void MlxlinkCommander::updateSwControlStatus()
     }
 }
 
+void MlxlinkCommander::findFirstValidPort()
+{
+    u_int32_t minLabelPort = 0;
+    for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
+    {
+        try
+        {
+            sendPrmReg(ACCESS_REG_PLLP, GET, "local_port=%d", localPort);
+        }
+        catch (...)
+        {
+            continue;
+        } // access register will fail if local port does not exist
+        u_int32_t currentLabelPort = getFieldValue("label_port");
+        if (minLabelPort == 0 || currentLabelPort < minLabelPort)
+        {
+            minLabelPort = currentLabelPort;
+        }
+    }
+    _userInput._labelPort = minLabelPort;
+}
+
 void MlxlinkCommander::labelToLocalPort()
 {
     _pnat = _userInput._pcie ? PNAT_PCIE : PNAT_LOCAL;

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -359,6 +359,7 @@ public:
     bool checkPortStatus(u_int32_t localPort);
     void checkAllPortsStatus();
     void handlePortStr(const string& portStr);
+    void findFirstValidPort();
     void labelToLocalPort();
     void labelToHCALocalPort();
     void labeltoDSlocalPort();

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -80,6 +80,7 @@ void MlxlinkUi::initRegAccessLib()
 
 void MlxlinkUi::initPortInfo()
 {
+    _mlxlinkCommander->findFirstValidPort();
     _mlxlinkCommander->labelToLocalPort();
     _mlxlinkCommander->validatePortType(_userInput._portType);
     _mlxlinkCommander->updateSwControlStatus();


### PR DESCRIPTION
…rashes when the first label port isn't 1

Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: