### PR TITLE
fwctrl, dev_mgmt: fix build errors

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -48,6 +48,7 @@
 #include <tools_layouts/reg_access_hca_layouts.h>
 #include "tools_dev_types.h"
 #include "mflash/mflash_types.h"
+#include "mtcr_ul/mtcr_ul_com.h"
 
 enum dm_dev_type {
     DM_UNKNOWN = -1,

--- a/mtcr_ul/fwctrl.c
+++ b/mtcr_ul/fwctrl.c
@@ -194,7 +194,7 @@ int fwctl_control_access_register(int    fd,
     }
 
     FWCTL_DEBUG_PRINT(mf, "register id = 0x%x, command status = 0x%x, reg status code: 0x%x, reg status: %s\n",
-                      reg_id, cmd_status, *reg_status, m_err2str(status));
+                      reg_id, cmd_status, *reg_status, m_err2str(*reg_status));
 out:
     free(out);
     free(in);

--- a/mtcr_ul/fwctrl.c
+++ b/mtcr_ul/fwctrl.c
@@ -40,7 +40,9 @@
 #include <errno.h>
 #include <string.h>
 #include <stddef.h>
+#include "mtcr.h"
 #include "mtcr_mf.h"
+#include "mtcr_ul_com.h"
 #include "fwctrl.h"
 #include "fwctrl_ioctl.h"
 

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -165,6 +165,8 @@ int mclear_pci_semaphore_ul(const char* name);
 
 int mvpd_read4_ul(mfile* mf, unsigned int offset, u_int8_t value[4]);
 
+int return_by_reg_status(int reg_status);
+
 int space_to_cap_offset(int space);
 
 int get_dma_pages(mfile* mf, struct mtcr_page_info* page_info, int page_amount);


### PR DESCRIPTION
This PR fixes various errors that occurred for me while trying to build the `mstflint` tools on the `master_devel` branch.
I used the following configure arguments: `--enable-fw-mgr --disable-inband --enable-adb-generic-tools`.