### PR TITLE
mlxlink | bug fix for show_eye crashing on GR100

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -2350,7 +2350,7 @@ void MlxlinkCommander::prepare5nmEyeInfo(u_int32_t numOfLanesToUse)
 
         // Temporary WA until GPUNet PRM is updated (typo in the word "measurement")!
         // TODO: remove this if in the future, and leave only the else branch.
-        if (_devID == DeviceGB100)
+        if (_devID == DeviceGB100 || _devID == DeviceGR100)
         {
             sendPrmReg(ACCESS_REG_SLRG, GET, "lane=%d,fom_measurment=%d", lane, fomMeasurement);
         }


### PR DESCRIPTION
Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: