### PR TITLE
Fix build failure with Fedora 43

### DIFF
--- a/common/bit_slice.h
+++ b/common/bit_slice.h
@@ -33,7 +33,6 @@
 #ifndef BIT_SLICE_H
 #define BIT_SLICE_H
 
-// BIT Slicing macros
 #define ONES32(size) ((size) ? (0xffffffff >> (32 - (size))) : 0)
 #define MASK32(offset, size) (ONES32(size) << (offset))
 
@@ -57,14 +56,5 @@
 #define MERGE64(rsrc1, rsrc2, start, len) (((len) == 64) ? (rsrc2) : MERGE_C64(rsrc1, rsrc2, start, len))
 #define INSERTF64(src1, start1, src2, start2, len) MERGE64((src1), EXTRACT64((src2), (start2), (len)), (start1), (len))
 #define EXT64(src, end, start) EXTRACT64(src, start, end - start + 1)
-
-#ifndef __cplusplus
-enum cpp_bool
-{
-    false = 0,
-    true
-};
-typedef unsigned char bool;
-#endif
 
 #endif

--- a/mstdump/crd_main/mstdump.c
+++ b/mstdump/crd_main/mstdump.c
@@ -30,7 +30,8 @@
  * SOFTWARE.
  *
  */
-//#include <stdbool.h>
+#include <stdbool.h>
+
 #include <crdump.h>
 #include <dev_mgt/tools_dev_types.h>
 #include <common/tools_version.h>

--- a/mtcr_ul/mtcr_gpu.c
+++ b/mtcr_ul/mtcr_gpu.c
@@ -31,8 +31,8 @@
  *
  *
  */
+#include "mtcr_gpu.h"
 
-#include "common/compatibility.h"
 #include "dev_mgt/tools_dev_types.h"
 
 typedef struct pci_id_range_st {

--- a/mtcr_ul/mtcr_gpu.h
+++ b/mtcr_ul/mtcr_gpu.h
@@ -34,6 +34,11 @@
 #ifndef _MTCR_GPU /* guard */
 #define _MTCR_GPU
 
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "common/compatibility.h"
+
 int is_gpu_pci_device(u_int16_t pci_device_id);
 bool is_gpu_device(u_int16_t hw_dev_id);
 

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -31,13 +31,13 @@
  *
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
-#if !defined(_MSC_VER)
 #include <unistd.h>
-#endif
+
 #include "common/bit_slice.h"
 #include "common/tools_time.h"
 #include "mtcr_icmd_cif.h"

--- a/mvpd/mvpd.c
+++ b/mvpd/mvpd.c
@@ -30,23 +30,17 @@
  * SOFTWARE.
  */
 
+#include "mvpd.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <ctype.h>
-#include <tools_dev_types.h>
-
-#ifdef MST_UL
 #include <syslog.h>
-#endif
-#include "mvpd.h"
 
-#if defined(__MINGW32__) || defined(__MINGW64__) || defined(_MSC_VER) /* Windows */
-#define syslog(lvl, format, ...)
-#else
-#include <syslog.h>
-#endif
+#include "tools_dev_types.h"
 
 enum
 {

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -32,17 +32,20 @@
 
 #ifndef REG_ACCESS_H
 #define REG_ACCESS_H
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+#include <stdbool.h>
+
 /* #include <tools_layouts/reg_access_hca_layouts.h> */
 /* #include <tools_layouts/reg_access_switch_layouts.h> */
 #include "reg_access_common.h"
 #include "common/bit_slice.h"
-#define MCAM_REG_GROUPS_AMOUNT 4
 
+#define MCAM_REG_GROUPS_AMOUNT 4
 
 enum { /* header lengths in bytes */
     REG_ACCESS_MFBA_HEADER_LEN = 12,


### PR DESCRIPTION
../common/bit_slice.h:64:5: error: cannot use keyword 'false' as enumeration constant
   64 |     false = 0,
      |     ^~~~~
../common/bit_slice.h:64:5: note: 'false' is a keyword with '-std=c23' onwards
../common/bit_slice.h:67:23: error: 'bool' cannot be defined via 'typedef'
   67 | typedef unsigned char bool;
      |                       ^~~~
../common/bit_slice.h:67:23: note: 'bool' is a keyword with '-std=c23' onwards
../common/bit_slice.h:67:1: warning: useless type name in empty declaration
   67 | typedef unsigned char bool;
      | ^~~~~~~