### PR TITLE
mtserver: Fix build failure

### DIFF
--- a/small_utils/mtserver.c
+++ b/small_utils/mtserver.c
@@ -607,7 +607,7 @@ void usage(const char* s)
 }
 
 /* ////////////////////////////////////////////////////////////////////// */
-void mySignal()
+void mySignal(int s)
 {
     exit(0);
 }


### PR DESCRIPTION
Fix the following build failure:

mtserver.c: In function ‘main’:
mtserver.c:849:17: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
  849 |     PREP_SIGNAL(mySignal);
      |                 ^~~~~~~~
      |                 |
      |                 void (*)(void)
mtserver.c:116:53: note: in definition of macro ‘PREP_SIGNAL’
  116 | #define PREP_SIGNAL(signal_handler) signal(SIGPIPE, signal_handler);
      |                                                     ^~~~~~~~~~~~~~
In file included from mtserver.c:149:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
mtserver.c:610:6: note: ‘mySignal’ declared here
  610 | void mySignal()
      |      ^~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);