### PR TITLE
resourcedump_lib: Fix build failure

### DIFF
--- a/resourcetools/resourcedump_lib/src/filters/include_exclude_segments_filter.h
+++ b/resourcetools/resourcedump_lib/src/filters/include_exclude_segments_filter.h
@@ -35,6 +35,7 @@
 
 #include "filter.h"
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <sstream>


### PR DESCRIPTION
Include cstdint to avoid the following build failure:

In file included from strip_control_segments_filter.h:36,
                 from strip_control_segments_filter.cpp:33:
include_exclude_segments_filter.h:52:52: error: 'uint16_t' was not declared in this scope
   52 |                                  const std::vector<uint16_t> selected_segment_ids,
      |                                                    ^~~~~~~~
include_exclude_segments_filter.h:41:1: note: 'uint16_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
   40 | #include <sstream>
  +++ |+#include <cstdint>
   41 |
include_exclude_segments_filter.h:52:60: error: template argument 1 is invalid
   52 |                                  const std::vector<uint16_t> selected_segment_ids,
      |                                                            ^
include_exclude_segments_filter.h:52:60: error: template argument 2 is invalid
include_exclude_segments_filter.h:60:23: error: 'uint16_t' was not declared in this scope
   60 |     const std::vector<uint16_t> _selected_segment_ids;