### PR TITLE
Signal handler needs to have an int parameter

### DIFF
--- a/small_utils/mtserver.c
+++ b/small_utils/mtserver.c
@@ -607,7 +607,11 @@ void usage(const char* s)
 }
 
 /* ////////////////////////////////////////////////////////////////////// */
+#ifdef __WIN__
 void mySignal()
+#else
+void mySignal(__attribute__ ((unused)) int signum)
+#endif
 {
     exit(0);
 }


### PR DESCRIPTION
This seems to break the build with GCC-15 on my system. I was not able to test this on Windows platforms but would not be completely surprised if the signal handler there gets the signal number as a parameter.