### PR TITLE
Add missing include cstdint for uint16_t

### DIFF
--- a/resourcetools/resourcedump_lib/src/filters/include_exclude_segments_filter.h
+++ b/resourcetools/resourcedump_lib/src/filters/include_exclude_segments_filter.h
@@ -38,6 +38,7 @@
 #include <memory>
 #include <vector>
 #include <sstream>
+#include <cstdint>
 
 namespace mft
 {


### PR DESCRIPTION
This missing header seems to break the build with GCC-15 on my system.