### PR TITLE
Remove unnecessary and duplicate defines

### DIFF
--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -100,9 +100,6 @@ typedef long long int64_t;
 #define SMP_SEMAPHOE_LOCK_CMD 0xff53
 #define ADDRESS_OUT_OF_RANGE  0x3 /* syndrome_code value */
 
-#define CX8_HW_ID 0x21e
-#define CX9_HW_ID 0x225
-
 /*
  * MST <--> MTCR API defines
  */


### PR DESCRIPTION
These two defines were added recently. They don't seem to be necessary for a build. They cause warnings about values being redefined in various places.

Note that those defines already seem to be duplicated in several places, according to the warnings.