### PR TITLE
minixz: Mark implicit fallthrough

### DIFF
--- a/ext_libs/minixz/xz_dec_lzma2.c
+++ b/ext_libs/minixz/xz_dec_lzma2.c
@@ -1131,6 +1131,8 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2* s, struct xz_buf* b)
 
                 s->lzma2.sequence = SEQ_LZMA_PREPARE;
 
+                /* fallthrough */
+
             case SEQ_LZMA_PREPARE:
                 if (s->lzma2.compressed < RC_INIT_BYTES)
                     return XZ_DATA_ERROR;
@@ -1140,6 +1142,8 @@ XZ_EXTERN enum xz_ret xz_dec_lzma2_run(struct xz_dec_lzma2* s, struct xz_buf* b)
 
                 s->lzma2.compressed -= RC_INIT_BYTES;
                 s->lzma2.sequence = SEQ_LZMA_RUN;
+
+                /* fallthrough */
 
             case SEQ_LZMA_RUN:
                 /*

--- a/ext_libs/minixz/xz_dec_stream.c
+++ b/ext_libs/minixz/xz_dec_stream.c
@@ -618,6 +618,8 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
                 if (ret != XZ_OK)
                     return ret;
 
+                /* fallthrough */
+
             case SEQ_BLOCK_START:
                 /* We need one byte of input to continue. */
                 if (b->in_pos == b->in_size)
@@ -641,6 +643,8 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
                 s->temp.pos = 0;
                 s->sequence = SEQ_BLOCK_HEADER;
 
+                /* fallthrough */
+
             case SEQ_BLOCK_HEADER:
                 if (!fill_temp(s, b))
                     return XZ_OK;
@@ -651,12 +655,16 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
 
                 s->sequence = SEQ_BLOCK_UNCOMPRESS;
 
+                /* fallthrough */
+
             case SEQ_BLOCK_UNCOMPRESS:
                 ret = dec_block(s, b);
                 if (ret != XZ_STREAM_END)
                     return ret;
 
                 s->sequence = SEQ_BLOCK_PADDING;
+
+                /* fallthrough */
 
             case SEQ_BLOCK_PADDING:
                 /*
@@ -679,6 +687,8 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
 
                 s->sequence = SEQ_BLOCK_CHECK;
 
+                /* fallthrough */
+
             case SEQ_BLOCK_CHECK:
                 if (s->check_type == XZ_CHECK_CRC32)
                 {
@@ -696,12 +706,16 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
                 s->sequence = SEQ_BLOCK_START;
                 break;
 
+                /* fallthrough */
+
             case SEQ_INDEX:
                 ret = dec_index(s, b);
                 if (ret != XZ_STREAM_END)
                     return ret;
 
                 s->sequence = SEQ_INDEX_PADDING;
+
+                /* fallthrough */
 
             case SEQ_INDEX_PADDING:
                 while ((s->index.size + (b->in_pos - s->in_start)) & 3)
@@ -725,6 +739,8 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
 
                 s->sequence = SEQ_INDEX_CRC32;
 
+                /* fallthrough */
+
             case SEQ_INDEX_CRC32:
                 ret = crc32_validate(s, b);
                 if (ret != XZ_STREAM_END)
@@ -732,6 +748,8 @@ static enum xz_ret dec_main(struct xz_dec* s, struct xz_buf* b)
 
                 s->temp.size = STREAM_HEADER_SIZE;
                 s->sequence = SEQ_STREAM_FOOTER;
+
+                /* fallthrough */
 
             case SEQ_STREAM_FOOTER:
                 if (!fill_temp(s, b))


### PR DESCRIPTION
Only adds comments, no code change. But gets rid of warnings when building with -Wimplicit-fallthrough or anything that implies it.