### PR TITLE
mtcr_ul: Avoid assignment in parentheses

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -1751,7 +1751,8 @@ static int mtcr_pciconf_open(mfile* mf, const char* name, u_int32_t adv_opt)
 
     mf->tp = MST_PCICONF;
 
-    if (mf->vsec_addr = pci_find_capability(mf, CAP_ID)) {
+    mf->vsec_addr = pci_find_capability(mf, CAP_ID);
+    if (mf->vsec_addr) {
         READ4_PCI(mf, &vsec_type, mf->vsec_addr, "read vsc type", return ME_PCI_READ_ERROR);
         mf->vsec_type = EXTRACT(vsec_type, MLX_VSC_TYPE_OFFSET, MLX_VSC_TYPE_LEN);
         DBG_PRINTF("in mtcr_pciconf_open function. mf->vsec_type: %d\n", mf->vsec_type);


### PR DESCRIPTION
Avoids the warning:
suggest parentheses around assignment used as truth value [-Wparentheses]