### PR TITLE
Remove names of unused parameter names

### DIFF
--- a/mlxfwops/lib/components/fs_comps_ops.cpp
+++ b/mlxfwops/lib/components/fs_comps_ops.cpp
@@ -79,7 +79,7 @@ bool FsCompsOperations::CheckFwVersion(ComponentFwVersion currentVersion, u_int8
     return true;
 }
 
-bool FsCompsOperations::FwQuery(fw_info_t* fwInfo, bool, bool, bool, bool, bool)
+bool FsCompsOperations::FwQuery(fw_info_t*, bool, bool, bool, bool, bool)
 {
     return Unsupported(__FUNCTION__);
 }
@@ -89,63 +89,63 @@ bool FsCompsOperations::SignForSecureBoot(const char*, const char*, const MlxSig
     return Unsupported(__FUNCTION__);
 }
 
-bool FsCompsOperations::FwVerify(VerifyCallBack verifyCallBackFunc, bool isStripedImage, bool showItoc, bool ignoreDToc)
+bool FsCompsOperations::FwVerify(VerifyCallBack, bool, bool, bool)
 {
     return Unsupported(__FUNCTION__);
 }
 
-bool FsCompsOperations::FwReadRom(std::vector<u_int8_t>& romSect)
+bool FsCompsOperations::FwReadRom(std::vector<u_int8_t>&)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwBurnRom(FImage* romImg,
-                                  bool ignoreProdIdCheck,
-                                  bool ignoreDevidCheck,
-                                  ProgressCallBack progressFunc)
+bool FsCompsOperations::FwBurnRom(FImage*,
+                                  bool,
+                                  bool,
+                                  ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwDeleteRom(bool ignoreProdIdCheck, ProgressCallBack progressFunc)
+bool FsCompsOperations::FwDeleteRom(bool, ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwBurn(FwOperations* imageOps, u_int8_t forceVersion, ProgressCallBack progressFunc)
+bool FsCompsOperations::FwBurn(FwOperations*, u_int8_t, ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwBurnAdvanced(FwOperations* imageOps, ExtBurnParams& burnParams)
+bool FsCompsOperations::FwBurnAdvanced(FwOperations*, ExtBurnParams&)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwBurnBlock(FwOperations* imageOps, ProgressCallBack progressFunc)
+bool FsCompsOperations::FwBurnBlock(FwOperations*, ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetGuids(sg_params_t& sgParam, PrintCallBack callBackFunc, ProgressCallBack progressFunc)
+bool FsCompsOperations::FwSetGuids(sg_params_t&, PrintCallBack, ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetMFG(fs3_uid_t baseGuid, PrintCallBack callBackFunc)
+bool FsCompsOperations::FwSetMFG(fs3_uid_t, PrintCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetMFG(guid_t baseGuid, PrintCallBack callBackFunc)
+bool FsCompsOperations::FwSetMFG(guid_t, PrintCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetVSD(char* vsdStr, ProgressCallBack progressFunc, PrintCallBack printFunc)
+bool FsCompsOperations::FwSetVSD(char*, ProgressCallBack, PrintCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetVPD(char* vpdFileStr, PrintCallBack callBackFunc)
+bool FsCompsOperations::FwSetVPD(char*, PrintCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwSetAccessKey(hw_key_t userKey, ProgressCallBack progressFunc)
+bool FsCompsOperations::FwSetAccessKey(hw_key_t, ProgressCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwGetSection(u_int32_t sectType, std::vector<u_int8_t>& sectInfo, bool stripedImage)
+bool FsCompsOperations::FwGetSection(u_int32_t, std::vector<u_int8_t>&, bool)
 {
     return Unsupported(__FUNCTION__);
 }
@@ -153,11 +153,11 @@ bool FsCompsOperations::FwResetNvData()
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwShiftDevData(PrintCallBack progressFunc)
+bool FsCompsOperations::FwShiftDevData(PrintCallBack)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsCompsOperations::FwCalcMD5(u_int8_t md5sum[16])
+bool FsCompsOperations::FwCalcMD5(u_int8_t[16])
 {
     return Unsupported(__FUNCTION__);
 }

--- a/mlxfwops/lib/components/fs_synce_ops.cpp
+++ b/mlxfwops/lib/components/fs_synce_ops.cpp
@@ -40,11 +40,11 @@ FsSyncEOperations::FsSyncEOperations(FImage* imageAccess) : FsCompsOperations(im
 }
 
 bool FsSyncEOperations::FwQuery(fw_info_t* fwInfo,
-                                bool readRom,
-                                bool isStripedImage,
-                                bool quickQuery,
-                                bool ignoreDToc,
-                                bool verbose)
+                                bool __attribute__ ((unused)) readRom,
+                                bool __attribute__ ((unused)) isStripedImage,
+                                bool __attribute__ ((unused)) quickQuery,
+                                bool __attribute__ ((unused)) ignoreDToc,
+                                bool __attribute__ ((unused)) verbose)
 {
     u_int8_t data[sizeof(_header)] = {0};
 

--- a/mlxfwops/lib/fs5_ops.cpp
+++ b/mlxfwops/lib/fs5_ops.cpp
@@ -234,7 +234,7 @@ bool Fs5Operations::CheckBoot2(bool fullRead, const char* pref, VerifyCallBack v
 }
 
 bool Fs5Operations::CheckBoot2(u_int32_t,
-                               u_int32_t offs,
+                               u_int32_t __attribute__ ((unused)) offs,
                                u_int32_t&,
                                bool fullRead,
                                const char* pref,

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -675,7 +675,7 @@ bool FsCtrlOperations::_createImageOps(unique_ptr<FwOperations>& imageOps)
     return true;
 }
 
-bool FsCtrlOperations::GetHashesTableSize(u_int32_t hashes_table_addr, u_int32_t& size)
+bool FsCtrlOperations::GetHashesTableSize(u_int32_t, u_int32_t& size)
 {
     u_int32_t htoc_size =
       IMAGE_LAYOUT_HTOC_HEADER_SIZE + MAX_HTOC_ENTRIES_NUM * (IMAGE_LAYOUT_HTOC_ENTRY_SIZE + HTOC_HASH_SIZE);

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2488,7 +2488,7 @@ bool FwOperations::burnEncryptedImage(FwOperations*, ExtBurnParams&)
     return errmsg("Burning encrypted image not supported");
 }
 
-bool FwOperations::FwExtract4MBImage(vector<u_int8_t>& img, bool, bool , bool, bool)
+bool FwOperations::FwExtract4MBImage(vector<u_int8_t>&, bool, bool , bool, bool)
 {
     return errmsg("FwExtract4MBImage not supported");
 }
@@ -2806,7 +2806,7 @@ bool FwOperations::VerifyBranchFormat(const char* vsdString)
     return false;
 }
 
-bool FwOperations::GetDtocAddress(u_int32_t& dTocAddress)
+bool FwOperations::GetDtocAddress(u_int32_t&)
 {
     return errmsg("GetDtocAddress not supported.");
 }
@@ -2830,12 +2830,12 @@ bool FwOperations::GetImageSize(u_int32_t*)
 {
     return errmsg("GetImageSize is not supported");
 }
-bool FwOperations::GetHashesTableData(vector<u_int8_t>& data)
+bool FwOperations::GetHashesTableData(vector<u_int8_t>&)
 {
     return errmsg("GetHashesTableData is not supported");
 }
 
-bool FwOperations::QueryComponentData(FwComponent::comps_ids_t comp, u_int32_t deviceIndex, vector<u_int8_t>& data)
+bool FwOperations::QueryComponentData(FwComponent::comps_ids_t, u_int32_t, vector<u_int8_t>&)
 {
     return errmsg("GetComponentData is not supported");
 }
@@ -2845,7 +2845,7 @@ bool FwOperations::ReadMccComponent(vector<u_int8_t>&, FwComponent::comps_ids_t,
     return errmsg("ReadMccComponent is not supported");
 }
 
-bool FwOperations::IsCompatibleToDevice(vector<u_int8_t>& data, u_int8_t forceVersion)
+bool FwOperations::IsCompatibleToDevice(vector<u_int8_t>&, u_int8_t)
 {
     return errmsg("IsCompatibleToDevice is not supported");
 }


### PR DESCRIPTION
Remove names of unused parameters, or mark them as unused.

Avoid a long series of warnings in case -Wunused-parameter is used or implied.