### PR TITLE
[mlxreg] Does not exit on bad flag

### DIFF
--- a/mlxreg/mlxreg_ui.cpp
+++ b/mlxreg/mlxreg_ui.cpp
@@ -624,7 +624,7 @@ void MlxRegUi::run(int argc, char** argv)
     {
         return;
     }
-    else if (rc == PARSE_ERROR)
+    else if (rc != PARSE_OK)
     {
         cout << _cmdParser.GetUsage();
         throw MlxRegException("failed to parse arguments. %s", _cmdParser.GetErrDesc());


### PR DESCRIPTION
Description:
In case of bad parsing mlxreg will now:
1) report the error
2) print the show usage massage
3) exit the program