### PR TITLE
[Umbriel][CX7] NSM protection modes 2 does NOT block flint update

### DIFF
--- a/flint/subcommands_linkx.cpp
+++ b/flint/subcommands_linkx.cpp
@@ -199,7 +199,6 @@ FlintStatus QuerySubCommand::QueryLinkX(string deviceName, string outputFile, st
         return FLINT_FAILED;
     }
     FwComponent bootImageComponent;
-    std::vector<FwComponent> compsToBurn;
     for (unsigned int i = 0; i < deviceIds.size(); i++)
     {
         if (deviceIds[i] < 0)
@@ -349,7 +348,6 @@ FlintStatus BurnSubCommand::BurnLinkX(string deviceName,
     }
 
     bootImageComponent.init(binaryData, binaryData.size(), FwComponent::COMPID_LINKX);
-    compsToBurn.push_back(bootImageComponent);
     if (downloadTransferNeeded)
     {
         printf("-I- Downloading FW ...\n");
@@ -363,7 +361,7 @@ FlintStatus BurnSubCommand::BurnLinkX(string deviceName,
             }
         }
     }
-    if (!fwCompsAccess.burnComponents(compsToBurn, funcAdv))
+    if (!fwCompsAccess.burnComponents(bootImageComponent, funcAdv))
     {
         char* err_msg = (char*)fwCompsAccess.getLastErrMsg();
         bool IbError = (strcmp("Unknown MAD error", err_msg) == 0);

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -395,7 +395,7 @@ public:
     u_int32_t getFwSupport();
     mfile* getMfileObj() { return _mf; };
     bool fwReactivateImage();
-    bool burnComponents(std::vector<FwComponent>& comps,
+    bool burnComponents(FwComponent& comp,
                         ProgressCallBackAdvSt* progressFuncAdv = (ProgressCallBackAdvSt*)NULL);
     bool getFwComponents(std::vector<FwComponent>& comps, bool readEn = false);
     bool readComponent(FwComponent::comps_ids_t compType,

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -1835,7 +1835,6 @@ void GenericCommander::apply(const vector<u_int8_t>& buff)
     vector<TLVConf*> tlvs;
     vector<u_int32_t> dwBuff;
     FwCompsMgr fwCompsAccess(_mf);
-    vector<FwComponent> compsToBurn;
     FwComponent::comps_ids_t compsId = FwComponent::comps_ids_t::COMPID_UNKNOWN;
 
     size_t fingerPrintLength = strlen(BIN_FILE_FINGERPRINT);
@@ -1865,8 +1864,7 @@ void GenericCommander::apply(const vector<u_int8_t>& buff)
     }
 
     comp.init(buff, buff.size(), compsId);
-    compsToBurn.push_back(comp);
-    if (!fwCompsAccess.burnComponents(compsToBurn))
+    if (!fwCompsAccess.burnComponents(comp))
     {
         throw MlxcfgException("Error applying the component: %s", fwCompsAccess.getLastErrMsg());
     }

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -859,10 +859,8 @@ bool FsCtrlOperations::_Burn(std::vector<u_int8_t> imageOps4MData,
     progressCallBack.uefi_func
 #endif
     FwComponent bootImageComponent;
-    std::vector<FwComponent> compsToBurn;
 
     bootImageComponent.init(imageOps4MData, imageOps4MData.size(), ComponentId);
-    compsToBurn.push_back(bootImageComponent);
     if (!_fwCompsAccess->lock_flash_semaphore())
     {
         return errmsg(FwCompsErrToFwOpsErr(_fwCompsAccess->getLastError()), "%s", _fwCompsAccess->getLastErrMsg());
@@ -876,7 +874,7 @@ bool FsCtrlOperations::_Burn(std::vector<u_int8_t> imageOps4MData,
             DPRINTF(("-W- DMA access is not supported due to BME is unset (Bus primary Enable).\n"));
         }
     }
-    if (!_fwCompsAccess->burnComponents(compsToBurn, &progressCallBack))
+    if (!_fwCompsAccess->burnComponents(bootImageComponent, &progressCallBack))
     {
         _fwCompsAccess->unlock_flash_semaphore();
         return errmsg(FwCompsErrToFwOpsErr(_fwCompsAccess->getLastError()), "%s", _fwCompsAccess->getLastErrMsg());


### PR DESCRIPTION
Description: checking secure host state prior to locking MCC udpate handle