### PR TITLE
mtcr sync from master

### DIFF
--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -3110,8 +3110,9 @@ static int check_zf_through_vsc(mfile* mf)
 {
     int prev_address_space = mf->address_space;
 
-    /* If the device is in LF mode or the recovery space is not supported, the device is not in Zombiefish mode. */
-    if (is_livefish_device(mf) || (mset_addr_space(mf, AS_RECOVERY) == -1)) {
+    // If the device is in LF mode or the recovery space is not supported, the device is not in Zombiefish mode.
+    if (is_livefish_device_int(mf) || mset_addr_space(mf, AS_RECOVERY) == -1)
+    {
         return 0;
     }
 

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -1721,6 +1721,8 @@ int space_to_cap_offset(int space)
     case AS_PCI_GLOBAL_SEMAPHORE:
         return VCC_PCI_GLOBAL_SEMAPHORE_SPACE_SUPPORTED;
 
+    case AS_RECOVERY:
+            return VCC_RECOVERY_SPACE_SUPPORTED;
     default:
         return 0;
     }
@@ -4080,7 +4082,11 @@ static int check_zf_through_vsc(mfile* mf)
 {
     int prev_address_space = mf->address_space;
 
-    mset_addr_space(mf, AS_RECOVERY);
+    // If the device is in LF mode or the recovery space is not supported, the device is not in Zombiefish mode.
+    if (is_livefish_device(mf) || mset_addr_space(mf, AS_RECOVERY) == -1)
+    {
+        return 0;
+    }
 
     uint32_t first_dword = 0;
     int      rc = mread4(mf, INITIALIZING_BIT_OFFSET_IN_VSC_RECOVERY_SPACE, &first_dword);


### PR DESCRIPTION
[mtcr] - added a check whether recovery spcae in VSC is supported before attempting to read from it.

Description: when we determine whether a device is in ZF mode, before attempting to read from the recovery space in VSC, check whether FW supports this space. if FW does not support this space the device is not in ZF mode.