### PR TITLE
Porting MFT's legacy infrastructure for i2c interface.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,7 @@ LDL=""
 default_en_inband=""
 default_en_rdmem="no"
 default_en_nvml="no"
+default_en_i2c="no"
 OFED_VERSION_CHK=0
 KERNEL_BUILD_CHK=0
 
@@ -416,6 +417,21 @@ else
     CFLAGS="$CFLAGS -DNO_RDMEM"
 fi
 AM_CONDITIONAL(ENABLE_RDMEM, [ test "x$enable_rdmem" = "xyes" ])
+
+# Enable I2C:
+AC_MSG_CHECKING(--enable-i2c argument)
+AC_ARG_ENABLE(i2c,
+    AS_HELP_STRING([--enable-i2c], [enable i2c interface (supported in Linux only)]),
+    [enable_i2c="$enableval"],
+    [enable_i2c="$default_en_i2c"]
+)
+AC_MSG_RESULT($enable_i2c)
+if test "x$enable_i2c" = "xyes"; then
+    CXXFLAGS="$CXXFLAGS -DENABLE_MST_DEV_I2C"
+    CFLAGS="$CFLAGS -DENABLE_MST_DEV_I2C"
+fi
+AM_CONDITIONAL(ENABLE_MST_DEV_I2C, [ test "x$enable_i2c" = "xyes" ])
+##
 
 AC_MSG_CHECKING(--enable-cs argument)
 AC_ARG_ENABLE(cs,

--- a/flint/cmd_line_parser.cpp
+++ b/flint/cmd_line_parser.cpp
@@ -233,6 +233,7 @@ FlagMetaData::FlagMetaData()
     _flags.push_back(new Flag("", "activate_delay_sec", 1));
     _flags.push_back(new Flag("", "downstream_device_ids", 1));
     _flags.push_back(new Flag("", "download_transfer", 0));
+    _flags.push_back(new Flag("", "i2c_secondary", 1));
     _flags.push_back(new Flag("", "openssl_engine", 1));
     _flags.push_back(new Flag("", "openssl_key_id", 1));
     _flags.push_back(new Flag("", "cert_uuid", 1));
@@ -856,6 +857,9 @@ void Flint::initCmdParser()
                false,
                false,
                1);
+    AddOptions("i2c_secondary", ' ', "<i2c secondary address>", "Use this flag to specify I2C secondary address", false,
+               false, 1);
+
     AddOptions("openssl_engine", ' ', "<string>", "deprecated");
     AddOptions("openssl_key_id", ' ', "<string>", "deprecated");
     AddOptions("output_file", ' ', "<string>", "output file name for exporting the public key from PEM/BIN");
@@ -1348,6 +1352,20 @@ ParseStatus Flint::HandleOption(string name, string value)
         }
         _flintParams.cableDeviceSize = cableDeviceSize;
         _flintParams.cable_device_size_specified = true;
+    }
+    else if (name == "i2c_secondary")
+    {
+        int i2cSecondaryAddr = 0;
+        if (!strToInt(value, i2cSecondaryAddr))
+        {
+            return PARSE_ERROR;
+        }
+        if (i2cSecondaryAddr < 0)
+        {
+            printf("Invalid I2C secondary address.\n");
+            return PARSE_ERROR;
+        }
+        _flintParams.i2cSecondaryAddr = i2cSecondaryAddr;
     }
     else if (name == "cert_chain_index")
     {

--- a/flint/flint.cpp
+++ b/flint/flint.cpp
@@ -41,6 +41,7 @@
 #include <signal.h>
 
 #include "flint.h"
+#include "mtcr_ul/mtcr_ul_com.h"
 
 // Globals:
 Flint* gFlint = NULL;
@@ -274,6 +275,12 @@ FlintStatus Flint::run(int argc, char* argv[])
         printf("-E- FATAL: command object not found.\n");
         return FLINT_FAILED;
     }
+#ifdef ENABLE_MST_DEV_I2C
+    if (_flintParams.i2cSecondaryAddr != -1)
+    {
+        set_force_i2c_address(_flintParams.i2cSecondaryAddr);
+    }
+#endif
     _subcommands[_flintParams.cmd]->setParams(_flintParams);
     return _subcommands[_flintParams.cmd]->executeCommand();
 }

--- a/flint/flint_params.cpp
+++ b/flint/flint_params.cpp
@@ -113,6 +113,7 @@ FlintParams::FlintParams()
     download_transfer = false;
     // if no delay specified, use minimal delay to avoid disconnection in case of activating the connect port
     activate_delay_sec = 1;
+    i2cSecondaryAddr = -1;
     imageSizeOnly = false;
     cert_uuid = "";
 }

--- a/flint/flint_params.h
+++ b/flint/flint_params.h
@@ -192,6 +192,7 @@ public:
     bool downstream_device_ids_specified;
     std::vector<int> downstream_device_ids;
     bool download_transfer;
+    int i2cSecondaryAddr;
     u_int8_t activate_delay_sec;
     u_int32_t cert_chain_index;
     string component_type;

--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -123,7 +123,7 @@ int mclose(mfile* mf);
 
 void get_pci_dev_rdma(mfile* mf, char* buf);
 
-unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave);
+unsigned char mset_i2c_secondary(mfile* mf, unsigned char new_i2c_secondary);
 
 int mget_mdevs_flags(mfile* mf, u_int32_t* devs_flags);
 

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -123,6 +123,11 @@ typedef struct mib_private_t {
 /*#include "mtcr_ib_private.h" */
 /*#endif */
 
+
+#define MTCR_I2C_secondary_ADDRESS 0x48
+#define SLV_ADDRS_NUM 128
+
+
 typedef enum {
     SEM_LOCK_GET = 0x0,
     SEM_LOCK_SET = 0x1
@@ -501,7 +506,7 @@ typedef struct gearbox_info_t {
     gearbox_connection_t gb_conn_type;
     char                 gb_mngr_full_name[DEV_NAME_SZ];
     char                 gearbox_full_name[DEV_NAME_SZ];
-    unsigned char        i2c_slave;
+    unsigned char        i2c_secondary;
     u_int8_t             addr_width;
     char                 device_orig_name[DEV_NAME_SZ];
     char                 device_real_name[DEV_NAME_SZ];
@@ -512,6 +517,9 @@ typedef struct gearbox_info_t {
 typedef struct cables_info_t {
     int slave_addr_additional_offset;
 } cables_info;
+
+#define HW_ID_ADDR 0xf0014
+
 
 #define VSEC_MIN_SUPPORT_UL(mf)                                     \
     (((mf)->vsec_cap_mask & (1 << VCC_INITIALIZED)) &&              \

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -54,7 +54,7 @@ struct page_list_fbsd {
 #endif
 
 /*  All fields in follow structure are not supposed to be used */
-/*  or modified by user programs. Except i2c_slave that may be */
+/*  or modified by user programs. Except i2c_secondary that may be */
 /*  modified before each access to target I2C slave address */
 struct mfile_t {
     u_int16_t     hw_dev_id;
@@ -69,7 +69,7 @@ struct mfile_t {
     int           is_vm;  /*  if the machine is VM    */
     int           cr_access; /* If cr access is allowed in MLNXOS devices */
     cables_info   ext_info; /*keeps info for calculate the correct slave address (0x50 + offset) */
-    unsigned char i2c_slave;
+    unsigned char i2c_secondary;
     int           gpio_en;
     io_region   * iorw_regions; /* For LPC devices */
     int           regions_num;

--- a/mstdump/crd_main/mstdump.c
+++ b/mstdump/crd_main/mstdump.c
@@ -55,7 +55,7 @@ char correct_cmdline[] = "   Mellanox " MSTDUMP_NAME " utility, dumps device int
                          Note : be careful when using this flag, None safe addresses might be read.\n\
    -v | --version     :  Display version info\n\
    -h | --help        :  Print this help message\n\
-   i2c_slave          :   I2C slave [0-127]\n\
+   i2c_secondary          :   I2C slave [0-127]\n\
    Example :\n\
             " MSTDUMP_NAME " " DEV_EXAMPLE "\n";
 
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
     crd_ctxt_t* context = NULL;
     u_int32_t arr_size = 0;
     char* endptr;
-    u_int8_t new_i2c_slave = 0;
+    u_int8_t new_i2c_secondary = 0;
     char device[MAX_DEV_LEN] = {0};
 #if defined(__linux__) || defined(__FreeBSD__)
     if (geteuid() != 0)
@@ -166,14 +166,14 @@ int main(int argc, char* argv[])
     }
     if (i < argc)
     {
-        new_i2c_slave = (u_int8_t)strtoul(argv[i], &endptr, 0);
+        new_i2c_secondary = (u_int8_t)strtoul(argv[i], &endptr, 0);
         if (*endptr || !*argv[i])
         {
             fprintf(stderr, "Invalid i2c-slave %s\n", argv[i]);
             mclose(mf);
             return 1;
         }
-        mset_i2c_slave(mf, new_i2c_slave);
+        mset_i2c_secondary(mf, new_i2c_secondary);
         i++;
     }
     if (i < argc)

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -1443,6 +1443,12 @@ int mwrite_i2cblock(mfile       * mf,
     return 0;
 }
 
+int force_i2c_address = -1;
+void set_force_i2c_address(int i2c_address)
+{
+    (void)i2c_address;
+}
+
 /* TODO: Introduce a module to keep platform-independent routines like this one below */
 void mtcr_fix_endianness(u_int32_t* buf, int len)
 {
@@ -1492,23 +1498,23 @@ int mget_mdevs_type(mfile* mf, u_int32_t* mtype)
     return 0;
 }
 
-unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
+unsigned char mset_i2c_secondary(mfile* mf, unsigned char new_i2c_slave)
 {
     unsigned char ret;
 
     if (mf) {
-        ret = mf->i2c_slave;
-        mf->i2c_slave = new_i2c_slave;
+        ret = mf->i2c_secondary;
+        mf->i2c_secondary = new_i2c_slave;
     } else {
         ret = 0xff;
     }
     return ret;
 }
 
-int mget_i2c_slave(mfile* mf, unsigned char* new_i2c_slave_p)
+int mget_i2c_secondary(mfile* mf, unsigned char* new_i2c_slave_p)
 {
     if (mf) {
-        *new_i2c_slave_p = mf->i2c_slave;
+        *new_i2c_slave_p = mf->i2c_secondary;
         return 0;
     }
     return -1;

--- a/mtcr_ul/mtcr_ib_ofed.c
+++ b/mtcr_ul/mtcr_ib_ofed.c
@@ -286,7 +286,7 @@ struct __ibvsmad_hndl_t {
     ib_portid_t                 portid;
     int                         sock;
     int                         tp;
-    int                         i2c_slave;
+    int                         i2c_secondary;
     int                         use_smp;
     int                         use_class_a;
     u_int64_t                   mkey;

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -214,13 +214,6 @@ void get_pci_dev_rdma(mfile* mf, char* buf)
     }
 }
 
-unsigned char mset_i2c_slave(mfile* mf, unsigned char new_i2c_slave)
-{
-    (void)mf;
-    (void)new_i2c_slave; /* compiler warning */
-    fprintf(stderr, "Warning: libmtcr: mset_i2c_slave() is not implemented and has no effect.\n");
-    return 0;
-}
 
 int maccess_reg_mad(mfile* mf, u_int8_t* data)
 {

--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -180,6 +180,42 @@ void mtcr_fix_endianness(u_int32_t* buf, int len);
 int is_zombiefish_device(mfile* mf);
 
 int read_device_id(mfile* mf, u_int32_t* device_id);
+
+
+#ifdef ENABLE_MST_DEV_I2C
+void fix_endianness(u_int32_t* buf, int len, int be_mode);
+
+int mset_i2c_addr_width(mfile* mf, u_int8_t addr_width);
+int mget_i2c_addr_width(mfile* mf, u_int8_t* addr_width);
+unsigned char mget_i2c_secondary(mfile* mf);
+unsigned char mset_i2c_secondary(mfile* mf, unsigned char new_i2c_secondary);
+
+void set_force_i2c_address(int i2c_address);
+
+int mtcr_i2c_mread4(mfile* mf, unsigned int offset, u_int32_t* value);
+int mtcr_i2c_mwrite4(mfile* mf, unsigned int offset, u_int32_t value);
+int mread_i2c_chunk(mfile* mf, unsigned int offset, void* data, int length);
+int mwrite_i2c_chunk(mfile* mf, unsigned int offset, void* data, int length);
+int mread_i2cblock(mfile* mf,
+                            unsigned char i2c_secondary,
+                            u_int8_t addr_width,
+                            unsigned int offset,
+                            void* data,
+                            int length);
+int mwrite_i2cblock(mfile* mf,
+                             unsigned char i2c_secondary,
+                             u_int8_t addr_width,
+                             unsigned int offset,
+                             void* data,
+                             int length);
+
+int is_supported_device_id(u_int16_t dev_id);
+int is_secure_debug_access(u_int32_t dev_id);
+int try_to_read_secure_device(mfile* mf);
+int change_i2c_secondary_address(mfile* mf, DType dtype);
+#endif
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -65,6 +65,7 @@
 #define STAT_CFG_NOT_DONE_ADDR_CX5     0xb5e04
 #define STAT_CFG_NOT_DONE_ADDR_CX6     0xb5f04
 #define STAT_CFG_NOT_DONE_ADDR_CX7     0xb5f04
+#define STAT_CFG_NOT_DONE_ADDR_CX8     656132
 #define STAT_CFG_NOT_DONE_ADDR_GPU     0x3100010
 #define STAT_CFG_NOT_DONE_BITOFF_CIB   31
 #define STAT_CFG_NOT_DONE_BITOFF_CX4   31
@@ -80,6 +81,7 @@
 #define SEMAPHORE_ADDR_GB100           0xa52f8
 #define SEMAPHORE_ADDR_CX5             0xe74e0
 #define SEMAPHORE_ADDR_CX7             0xe5660
+#define SEMAPHORE_ADDR_CX8             358016
 #define SEMAPHORE_ADDR_GPU             0x308F4F8
 #define HCR_ADDR_CIB                   0x0
 #define HCR_ADDR_CX4                   HCR_ADDR_CIB
@@ -91,15 +93,18 @@
 #define ICMD_VERSION_BITOFF            24
 #define ICMD_VERSION_BITOFF_GPU        0
 #define ICMD_VERSION_BITLEN            8
+#define ICMD_VERSION_BITLEN_CX8        4
 #define CMD_PTR_ADDR_CIB               0x0
 #define CMD_PTR_ADDR_SW_IB             0x80000
 #define CMD_PTR_ADDR_QUANTUM           0x100000
 #define CMD_PTR_ADDR_CX4               CMD_PTR_ADDR_CIB
 #define CMD_PTR_ADDR_CX5               CMD_PTR_ADDR_CIB
 #define CMD_PTR_ADDR_CX7               CMD_PTR_ADDR_CIB
+#define CMD_PTR_ADDR_CX8               27262976
 #define CMD_PTR_ADDR_GPU               0x3100000
 #define CMD_PTR_BITOFF                 0
 #define CMD_PTR_BITLEN                 24
+#define CMD_PTR_BITLEN_CX8             28
 #define CMD_PTR_BITLEN_GPU             32
 #define CTRL_OFFSET                    0x3fc
 #define BUSY_BITOFF                    0
@@ -922,6 +927,7 @@ static int icmd_init_cr(mfile* mf)
 
     /* get device specific addresses */
     if (read_device_id(mf, &hw_id) != 4) {
+        DBG_PRINTF("icmd_init_cr: failed to read device ID.\n");
         return ME_ICMD_NOT_SUPPORTED;
     }
 
@@ -1015,13 +1021,23 @@ static int icmd_init_cr(mfile* mf)
 
     case (CX7_HW_ID):
     case (BF3_HW_ID):
-    case (CX8_HW_ID):
     case (BF4_HW_ID):
         cmd_ptr_addr = CMD_PTR_ADDR_CX7;
         hcr_address = HCR_ADDR_CX7;
         mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX7;
         mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX7;
         mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
+        break;
+
+    case (CX8_HW_ID):
+        cmd_ptr_addr = CMD_PTR_ADDR_CX8;
+        mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN_CX8;
+        mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX8;
+        mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX8;
+        mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
+        mf->icmd.version_bit_offset = CMD_PTR_BITLEN_CX8;
+        mf->icmd.version_bitlen = ICMD_VERSION_BITLEN_CX8;
+        hcr_address = CMD_PTR_ADDR_CX8; // hcr_address is "version address"
         break;
 
     case (AMOS_GBOX_HW_ID):
@@ -1261,6 +1277,13 @@ int icmd_open(mfile* mf)
     if (mf->functional_vsec_supp) {
         return icmd_init_vcr(mf);
     }
+
+#ifdef ENABLE_MST_DEV_I2C
+    if (mf->tp == MST_DEV_I2C) {
+        return icmd_init_cr(mf);
+    }
+#endif
+
     if ((mf->tp == MST_IB) || is_gpu_pci_device(mf->dinfo->pci.dev_id)) {
         return icmd_init_cr(mf);
     }

--- a/small_utils/mcra.c
+++ b/small_utils/mcra.c
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
     // Temp variable for using strtoul and then check if it's greater than UINT_MAX before assigning it to addr
     unsigned long int parsed_addr = 0;
     mfile* mf;
-    unsigned int i2c_slave = 0;
+    unsigned int i2c_secondary = 0;
     int c;
     int read_op = 0;
     int bit_offs = 0;
@@ -134,8 +134,8 @@ int main(int argc, char* argv[])
         switch (c)
         {
             case 's':
-                i2c_slave = strtoul(optarg, &endp, 0);
-                if (*endp || i2c_slave == 0 || i2c_slave > 0x7f)
+                i2c_secondary = strtoul(optarg, &endp, 0);
+                if (*endp || i2c_secondary == 0 || i2c_secondary > 0x7f)
                 {
                     fprintf(stderr, "-E- Bad slave address given (%s).Expecting a non-negative number\n", optarg);
                     exit(1);
@@ -322,9 +322,9 @@ int main(int argc, char* argv[])
         perror("mopen");
         return 1;
     }
-    if (i2c_slave)
+    if (i2c_secondary)
     {
-        mset_i2c_slave(mf, (u_int8_t)i2c_slave);
+        mset_i2c_secondary(mf, (u_int8_t)i2c_secondary);
     }
 
     if (path)

--- a/small_utils/mtserver.c
+++ b/small_utils/mtserver.c
@@ -258,10 +258,10 @@ int mi2c_detect(mfile* mf, u_int8_t slv_arr[SLV_ADDRS_NUM])
     TOOLS_UNUSED(slv_arr);
     return -1;
 }
-int mread_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mread_i2cblock(mfile* mf, unsigned char i2c_secondary, u_int8_t addr_width, unsigned int offset, void* data, int length)
 {
     TOOLS_UNUSED(mf);
-    TOOLS_UNUSED(i2c_slave);
+    TOOLS_UNUSED(i2c_secondary);
     TOOLS_UNUSED(addr_width);
     TOOLS_UNUSED(offset);
     TOOLS_UNUSED(data);
@@ -279,10 +279,10 @@ int mcables_remote_operation_server_side(mfile* mf, u_int32_t address, u_int32_t
     return 0;
 }
 
-int mwrite_i2cblock(mfile* mf, unsigned char i2c_slave, u_int8_t addr_width, unsigned int offset, void* data, int length)
+int mwrite_i2cblock(mfile* mf, unsigned char i2c_secondary, u_int8_t addr_width, unsigned int offset, void* data, int length)
 {
     TOOLS_UNUSED(mf);
-    TOOLS_UNUSED(i2c_slave);
+    TOOLS_UNUSED(i2c_secondary);
     TOOLS_UNUSED(addr_width);
     TOOLS_UNUSED(offset);
     TOOLS_UNUSED(data);


### PR DESCRIPTION
Description: Added the i2c interface infrastructure to support embedded i2c devices (/dev/i2c-X). For devices up until the secure generation - secondary address 0x48 is used both in livefish devices and functional devices. For devices of the secure generation (ConnectX7, Quantum2 and above) - secondary address 0x48 is used for livefish devices. 0x47 is for functional devices. Added to mstflint tool the option to set the desired secondary address from the command line.

Supported OSes: Linux.
Tested OS: linux
Tested devices: Spectrum3, Quantum2
Tested flows:
on secure and non-secure device (i.e. using 0x47 and 0x48). read:
mstflint/small_utils/mstmcra /dev/i2c-2 0xf0014
mstflint/small_utils/mstmcra /dev/i2c-2 0xf0014,16 write and check the value was indeed written:
mstflint/small_utils/mstmcra /dev/i2c-2 <icmd "command" address> 0 mstflint/small_utils/mstmcra /dev/i2c-2 <icmd "command" address>

Known gaps (with RM ticket): We do not have a B300 setup so this FR was tested only on the devices we have.

Issue:4317472