### PR TITLE
[CX8] When device is in LF Relay, mstflint query fails to run

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -1403,6 +1403,10 @@ bool Fs4Operations::IsSecurityVersionAccessible(chip_type_t chip_type)
             case CT_BLUEFIELD2:
             case CT_CONNECTX6DX:
             case CT_CONNECTX6LX:
+            case CT_QUANTUM3:
+            case CT_CONNECTX8:
+            case CT_CONNECTX9:
+            case CT_ARCUSE:
                 res = false;
                 break;
             default:


### PR DESCRIPTION
Description: missing definitions for security version accessibility

MSTFlint port needed: yes
Tested OS: linux
Tested devices: cx8
Tested flows: mstflint -d <dev> -ocr q full

Known gaps (with RM ticket): N/A

Issue: 4361666