### PR TITLE
[flint][hw set/query][SRWD]add support for SRWD bit

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -6709,6 +6709,33 @@ FlintStatus HwSubCommand::printAttr(const ext_flash_attr_t& attr)
         }
     }
 
+    // SRWD query
+    if (attr.srwd_support && attr.write_protect_support)
+    {
+        switch (attr.mf_get_srwd_rc)
+        {
+            case MFE_OK:
+                printf("  " SRWD_PARAM "                    %d\n", attr.srwd);
+                break;
+
+            case MFE_MISMATCH_PARAM:
+                printf("-E- There is a mismatch in the " SRWD_PARAM
+                       " attribute between the flashes attached to the device\n");
+                break;
+
+            case MFE_NOT_SUPPORTED_OPERATION:
+                printf(SRWD_PARAM " not supported operation.\n");
+                break;
+            case MFE_NOT_IMPLEMENTED:
+                printf(SRWD_PARAM "not implemented.\n");
+                break;
+            default:
+                printf("Failed to get " SRWD_PARAM " attribute: %s (%s)", errno == 0 ? "" : strerror(errno),
+                       mf_err2str(attr.mf_get_srwd_rc));
+                return FLINT_FAILED;
+        }
+    }
+
     return FLINT_SUCCESS;
 }
 

--- a/mflash/mflash.h
+++ b/mflash/mflash.h
@@ -229,6 +229,9 @@ int mf_get_jedec_id(mflash* mfl, u_int32_t* jedec_id);
 int mf_set_quad_en(mflash* mfl, u_int8_t quad_en);
 int mf_get_quad_en(mflash* mfl, u_int8_t* quad_en);
 
+int mf_set_srwd(mflash* mfl, u_int8_t srwd);
+int mf_get_srwd(mflash* mfl, u_int8_t* srwd);
+
 int mf_set_driver_strength(mflash* mfl, u_int8_t driver_strength);
 int mf_get_driver_strength(mflash* mfl, u_int8_t* driver_strength);
 

--- a/mflash/mflash_access_layer.h
+++ b/mflash/mflash_access_layer.h
@@ -142,6 +142,7 @@ enum FlashConstant
     TB_OFFSET_CYPRESS_WINBOND_256 = 6,
     BP_OFFSET = 2,
     BP_4TH_BIT_OFFSET_MICRON = 6,
+    SRWD_OFFSET_ISSI = 7,
     BP_SIZE = 3,
     PROTECT_BITS_SIZE = 5
 };

--- a/mflash/mflash_common_structs.h
+++ b/mflash/mflash_common_structs.h
@@ -189,6 +189,7 @@ typedef struct flash_attr
 
     u_int8_t banks_num;
     u_int8_t quad_en_support;
+    u_int8_t srwd_support;
     u_int8_t driver_strength_support;
     u_int8_t dummy_cycles_support;
     u_int8_t write_protect_support;

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -917,12 +917,18 @@ bool Flash::get_attr(ext_flash_attr_t& attr)
     attr.block_write = _attr.block_write;
     attr.command_set = _attr.command_set;
     attr.quad_en_support = _attr.quad_en_support;
+    attr.srwd_support = _attr.srwd_support;
     attr.driver_strength_support = _attr.driver_strength_support;
     attr.dummy_cycles_support = _attr.dummy_cycles_support;
     // Quad EN query
     if (_attr.quad_en_support)
     {
         attr.mf_get_quad_en_rc = (MfError)mf_get_quad_en(_mfl, &attr.quad_en);
+    }
+    // SRWD query
+    if (_attr.srwd_support)
+    {
+        attr.mf_get_srwd_rc = (MfError)mf_get_srwd(_mfl, &attr.srwd);
     }
     // Drive-strength query
     if (_attr.driver_strength_support)
@@ -991,6 +997,21 @@ bool Flash::set_attr(char* param_name, char* param_val_str)
         if (rc != MFE_OK)
         {
             return errmsg("Setting " QUAD_EN_PARAM " failed: (%s)", mf_err2str(rc));
+        }
+    }
+    else if (!strcmp(param_name, SRWD_PARAM))
+    {
+        char* endp;
+        u_int8_t srwd_val;
+        srwd_val = strtoul(param_val_str, &endp, 0);
+        if (*endp != '\0' || srwd_val > 1)
+        {
+            return errmsg("Bad " SRWD_PARAM " value (%s), it can be 0 or 1\n", param_val_str);
+        }
+        rc = mf_set_srwd(_mfl, srwd_val);
+        if (rc != MFE_OK)
+        {
+            return errmsg("Setting " SRWD_PARAM " failed: (%s)", mf_err2str(rc));
         }
     }
     else if (!strcmp(param_name, DUMMY_CYCLES_PARAM))

--- a/mlxfwops/lib/flint_io.h
+++ b/mlxfwops/lib/flint_io.h
@@ -74,11 +74,15 @@ typedef struct ext_flash_attr
     int block_write;
     int command_set;
     u_int8_t quad_en_support;
+    u_int8_t srwd_support;
     u_int8_t driver_strength_support;
     u_int8_t dummy_cycles_support;
 
     u_int8_t quad_en;
     MfError mf_get_quad_en_rc;
+
+    u_int8_t srwd;
+    MfError mf_get_srwd_rc;
 
     u_int8_t driver_strength;
     MfError mf_get_driver_strength_rc;
@@ -471,6 +475,7 @@ public:
 
 // needed for printing flash status in flint hw query cmd
 #define QUAD_EN_PARAM "QuadEn"
+#define SRWD_PARAM "SRWD"
 #define DRIVER_STRENGTH_PARAM "DriverStrength"
 #define DUMMY_CYCLES_PARAM "DummyCycles"
 #define FLASH_NAME "Flash"


### PR DESCRIPTION
Description: for ISSI flash:
* flint hw query will display SRWD

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: CX-6, CX-8
Tested flows:
Used mcra commands to:
* get the value of SRWD and then make sure I get the same value in flint hw query

Known gaps (with RM ticket): N/A

Issue: 4103192