### PR TITLE
Fix an uninitialized variable in GenericCommander::sign()

### DIFF
--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -1536,7 +1536,7 @@ void GenericCommander::sign(vector<u_int32_t>& buff,
 #if !defined(UEFI_BUILD) && !defined(NO_OPEN_SSL)
     vector<u_int32_t> encDigestDW;
     vector<u_int8_t> digest, encDigest, bytesBuff;
-    MlxSign::SHAType shaType;
+    MlxSign::SHAType shaType = MlxSign::INVALID_TYPE;
     unique_ptr<MlxSign::Signer> signer = nullptr;
 
     copyDwVectorToBytesVector(buff, bytesBuff);

--- a/mlxsign_lib/mlxsign_com_def.h
+++ b/mlxsign_lib/mlxsign_com_def.h
@@ -39,7 +39,8 @@ namespace MlxSign
 enum SHAType
 {
     SHA256,
-    SHA512
+    SHA512,
+    INVALID_TYPE
 };
 
 enum ErrorCode


### PR DESCRIPTION
Make sure initializing the variable with MlxSign::INVALID_TYPE before its first use and avoid a random behavior.