### PR TITLE
[flint][set_key] dosen't work on secure devices

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -1544,6 +1544,7 @@ const char* FwComponent::getCompIdStr(comps_ids_t compId)
 u_int32_t FwCompsMgr::getFwSupport()
 {
     u_int32_t devid = 0;
+    _secureHostState = 0x0;
 
     _isDmaSupported = false;
 #ifndef UEFI_BUILD
@@ -1604,20 +1605,20 @@ u_int32_t FwCompsMgr::getFwSupport()
         return 0;
     }
     _mircCaps = EXTRACT(mcam.mng_access_reg_cap_mask[3 - 3], 2, 1);
-    int mode = 0;
+
     struct tools_open_mlock mlock;
     memset(&mlock, 0, sizeof(mlock));
     rc = reg_access_secure_host(_mf, REG_ACCESS_METHOD_GET, &mlock);
     if (rc == ME_OK)
     {
-        mode = mlock.operation;
+        _secureHostState = mlock.operation;
     }
 
     DPRINTF((
       "getFwSupport _mircCaps = %d mcqsCap = %d mcqiCap = %d mccCap = %d mcdaCap = %d mqisCap = %d mcddCap = %d mgirCap = %d secure_host = %d\n",
-      _mircCaps, mcqsCap, mcqiCap, mccCap, mcdaCap, mqisCap, mcddCap, mgirCap, mode));
+      _mircCaps, mcqsCap, mcqiCap, mccCap, mcdaCap, mqisCap, mcddCap, mgirCap, _secureHostState));
 
-    if (mcqsCap && mcqiCap && mccCap && mcdaCap && mqisCap && mgirCap && mode == 0)
+    if (mcqsCap && mcqiCap && mccCap && mcdaCap && mqisCap && mgirCap && _secureHostState == 0)
     {
         return 1;
     }

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -441,6 +441,7 @@ public:
                     u_int32_t local_port = 0,
                     u_int8_t pnat = 0,
                     u_int32_t lp_msb = 0);
+    u_int8_t GetSecureHostState() { return _secureHostState; }
 
 private:
     typedef enum
@@ -611,5 +612,6 @@ private:
 #ifndef UEFI_BUILD
     trm_ctx _trm;
 #endif
+    u_int8_t _secureHostState;
 };
 #endif /* USER_MLXFWOPS_LIB_FW_COMPS_MGR_H_ */

--- a/mlxfwops/lib/fs3_ops.h
+++ b/mlxfwops/lib/fs3_ops.h
@@ -159,6 +159,7 @@ public:
                           PrintCallBack printFunc = (PrintCallBack)NULL);
     virtual bool FwSetVPD(char* vpdFileStr, PrintCallBack callBackFunc = (PrintCallBack)NULL);
     virtual bool FwSetAccessKey(hw_key_t userKey, ProgressCallBack progressFunc = (ProgressCallBack)NULL);
+    virtual bool GetSecureHostState(u_int8_t& state);
     virtual bool FwResetNvData();
     virtual bool FwShiftDevData(PrintCallBack progressFunc = (PrintCallBack)NULL);
     virtual const char* FwGetResetRecommandationStr();

--- a/mlxfwops/lib/fsctrl_ops.h
+++ b/mlxfwops/lib/fsctrl_ops.h
@@ -129,6 +129,8 @@ public:
     virtual bool ReadMccComponent(vector<u_int8_t>& componentRawData,
                                   FwComponent::comps_ids_t component,
                                   ProgressCallBackAdvSt* stProgressFunc = NULL);
+    virtual bool GetSecureHostState(u_int8_t& state);
+    virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
 
 private:
     virtual u_int32_t GetHwDevId() { return _hwDevId; }

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2850,6 +2850,16 @@ bool FwOperations::IsCompatibleToDevice(vector<u_int8_t>& data, u_int8_t forceVe
     return errmsg("IsCompatibleToDevice is not supported");
 }
 
+bool FwOperations::GetSecureHostState(u_int8_t&)
+{
+    return errmsg("GetSecureHostState is not supported");
+}
+
+bool FwOperations::ChangeSecureHostState(bool, u_int64_t)
+{
+    return errmsg("ChangeSecureHostState is not supported");
+}
+
 bool FwOperations::IsExtendedGuidNumSupported()
 {
     bool isSupported = false;

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -293,6 +293,8 @@ public:
     virtual bool ReadMccComponent(vector<u_int8_t>& componentRawData,
                                   FwComponent::comps_ids_t component,
                                   ProgressCallBackAdvSt* stProgressFunc = NULL);
+    virtual bool GetSecureHostState(u_int8_t& state);
+    virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
 
 #ifndef UEFI_BUILD
     static bool CheckPemKeySize(const string privPemFileStr, u_int32_t& keySize);


### PR DESCRIPTION
Description: added support for set_key and hw_access command on secured devices

MSTFlint port needed:
Tested OS: linux
Tested devices: Cx5 Cx7
Tested flows:
flint set_key
flint hw_access enable
flint hw_access disable

Known gaps (with RM ticket): N/A

Issue: 4382555