### PR TITLE
statify local functions

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -212,7 +212,7 @@ enum {
 #define VSEC_FULLY_SUPPORTED(dev) \
     (((dev)->functional_vsc_offset) && ((dev)->spaces_support_status == SS_ALL_SPACES_SUPPORTED))
 
-void swap_pci_address_space(int* address_space)
+static void swap_pci_address_space(int* address_space)
 {
     switch (*address_space) {
     case AS_ICMD_EXT:
@@ -263,7 +263,7 @@ void swap_pci_address_space(int* address_space)
 }
 
 
-int get_syndrome_code(struct mst_dev_data* dev, u_int8_t* syndrome_code)
+static int get_syndrome_code(struct mst_dev_data* dev, u_int8_t* syndrome_code)
 {
     /* In case syndrome is set, if syndrome_code is 0x3 (address_out_of_range), return the syndrome_code, so that the */
     /* ioctl will fail and then we'll retry with PCI space. */
@@ -618,7 +618,7 @@ static int read4_vsec(struct mst_dev_data* dev, int address_space, unsigned int 
     return 0; /* OPERATIONAL and LOGICAL success (PCI VSC address_spaces not supported) */
 }
 
-int pciconf_read4_legacy(struct mst_dev_data* dev, unsigned int offset, unsigned int* data)
+static int pciconf_read4_legacy(struct mst_dev_data* dev, unsigned int offset, unsigned int* data)
 {
     int          res = 0;
     unsigned int new_offset = offset;
@@ -646,7 +646,7 @@ int pciconf_read4_legacy(struct mst_dev_data* dev, unsigned int offset, unsigned
     return 0;
 }
 
-int pciconf_write4_legacy(struct mst_dev_data* dev, unsigned int offset, unsigned int data)
+static int pciconf_write4_legacy(struct mst_dev_data* dev, unsigned int offset, unsigned int data)
 {
     int res = 0;
 
@@ -753,7 +753,7 @@ static int get_space_support_status(struct mst_dev_data* dev)
 
 #define WO_REG_ADDR_DATA 0xbadacce5
 #define DEVID_OFFSET     0xf0014
-int is_wo_gw(struct pci_dev* pcidev, unsigned int addr_reg)
+static int is_wo_gw(struct pci_dev* pcidev, unsigned int addr_reg)
 {
     int          ret;
     unsigned int data = 0;


### PR DESCRIPTION
Declare functions that are not exported as local. Otherwise we get an error that they don't have a pre-declaration.