### PR TITLE
Test return of ioremap with non-NULL

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -1502,7 +1502,7 @@ static int mst_ioctl(struct inode* inode, struct file* file, unsigned int opcode
 
         dev->hw_addr = ioremap(resource_start, MST_MEMORY_SIZE);
 
-        if (dev->hw_addr <= 0) {
+        if (!dev->hw_addr) {
             mst_err("could not map device memory\n");
             res = -EFAULT;
             goto fin;
@@ -1780,7 +1780,7 @@ static struct mst_dev_data* mst_device_create(enum dev_type type, struct pci_dev
         dev->data_reg = 0;     /* invalid */
         dev->bar = 0;
         dev->hw_addr = ioremap(pci_resource_start(pdev, dev->bar), MST_MEMORY_SIZE);
-        if (dev->hw_addr <= 0) {
+        if (!dev->hw_addr) {
             mst_err("could not map device memory, BAR: %x\n", dev->bar);
             goto out;
         }


### PR DESCRIPTION
Don't consider the result of ioremap a pointer that can include an errno (was that the rationale?).

Avoids an error of considering a pointer as an int.