### PR TITLE
mlxlink | display per lane BER info

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -781,6 +781,23 @@ vector < AmberField > MlxlinkAmBerCollector::getLinkStatus()
             fields.push_back(
                 AmberField("successful_recovery_events", to_string(getFieldValue("successful_recovery_events"))));
 
+            resetLocalParser(ACCESS_REG_PPCNT);
+            updateField("local_port", _localPort);
+            updateField("grp", PPCNT_STATISTICAL_GROUP);
+            updateField("lp_gl", (u_int32_t)(_localPort == 255));
+            sendRegister(ACCESS_REG_PPCNT, MACCESS_REG_METHOD_GET);
+            string val = "";
+            for (u_int32_t lane = 0; lane < MAX_NETWORK_LANES; lane++)
+            {
+                val = "N/A";
+                if (lane < _numOfLanes)
+                {
+                    val = getFieldStr("raw_ber_coef_lane" + to_string(lane)) + "E-" +
+                          getFieldStr("raw_ber_magnitude_lane" + to_string(lane));
+                }
+                fields.push_back(AmberField("Raw_BER_lane" + to_string(lane), val));
+            }
+
             if (_isPortETH) {
                 resetLocalParser(ACCESS_REG_PPCNT);
                 updateField("local_port", _localPort);

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -2082,6 +2082,15 @@ void MlxlinkCommander::prepareBerInfo()
         setPrintVal(_berInfoCmd, "Link Error Recovery Counter", to_string(linkRecoveryCounter), ANSI_COLOR_RESET, true,
                     _linkUP);
     }
+    
+    if (_productTechnology >= PRODUCT_7NM && !dm_is_gpu((dm_dev_id_t)_devID))
+    {
+        sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
+        string rawBer = AmberField::getValueFromFields(_ppcntFields, "Raw_BER_lane", false);
+        findAndReplace(rawBer, "_", ",");
+        rawBer = getValuesOfActiveLanes(rawBer);
+        setPrintVal(_berInfoCmd, "Raw Physical BER Per Lane", rawBer, ANSI_COLOR_RESET, true, _linkUP, true);
+    }
 }
 
 void MlxlinkCommander::prepareBerInfoEDR()


### PR DESCRIPTION
Description:

MSTFlint port needed: yes
Tested OS: linux
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 4274650