### PR TITLE
[BugFix] Flash TBS,BP on Switches Issue

### DIFF
--- a/mflash/mflash_access_layer.h
+++ b/mflash/mflash_access_layer.h
@@ -165,6 +165,7 @@ int sx_set_driver_strength(mflash* mfl, u_int8_t driver_strength);
 int sx_get_driver_strength(mflash* mfl, u_int8_t* driver_strength);
 int sx_set_write_protect(mflash* mfl, u_int8_t bank_num, write_protect_info_t* protect_info);
 int sx_get_write_protect(mflash* mfl, u_int8_t bank_num, write_protect_info_t* protect_info);
+uint8_t sx_get_bp_val(mflash* mfl, write_protect_info_t* protect_info);
 int sx_set_dummy_cycles(mflash* mfl, u_int8_t num_of_cycles);
 int sx_get_dummy_cycles(mflash* mfl, u_int8_t* num_of_cycles);
 int gw_wait_ready(mflash* mfl, const char* msg);


### PR DESCRIPTION
Description: added the correct interpretation of BP bits when -ocr flag is not used during flint hw query

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: CX-6, Spectrum2
Tested flows: flint hw set Flash0.WriteProtected, flint -ocr hw set Flash0.WriteProtected, flint hw query, flint -ocr hw query

Known gaps (with RM ticket): None

Issue: 4376790
Change-Id: I3b77aebac25686dfac15c498e4a80e213115574d