### PR TITLE
[flint] Changing the reboot message to a generic reboot message

### DIFF
--- a/mlxfwops/lib/flint_base.h
+++ b/mlxfwops/lib/flint_base.h
@@ -482,11 +482,11 @@ struct GPH
 
 #define MAX_SECTION_SIZE 0x400000
 
-#define REBOOT_REQUIRED_STR "To load new FW run reboot machine."
+#define REBOOT_REQUIRED_STR "To load new FW, issue system-level reset."
 #ifndef MST_UL
-#define REBOOT_OR_FWRESET_REQUIRED_STR "To load new FW run mlxfwreset or reboot machine."
+#define REBOOT_OR_FWRESET_REQUIRED_STR "To load new FW, issue system-level reset or use mlxfwreset where applicable."
 #else
-#define REBOOT_OR_FWRESET_REQUIRED_STR "To load new FW run mstfwreset or reboot machine."
+#define REBOOT_OR_FWRESET_REQUIRED_STR "To load new FW, issue system-level reset or use mstfwreset where applicable."
 #endif
 
 void report(const char* format, ...);


### PR DESCRIPTION
Description: Changing the reboot message to a generic reboot message

MSTFlint port needed: Yes
Tested OS: linux
Tested devices: NA
Tested flows: NA

Known gaps (with RM ticket): NA

Issue: NA