### PR TITLE
mlxlink | bug fix for missing clear counters msg | bug fix for missin…

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -3439,6 +3439,7 @@ void MlxlinkCommander::clearCounters()
 {
     try
     {
+        MlxlinkRecord::printCmdLine("Clearing Counters", _jsonRoot);
         if (_mf->tp != MST_IB)
         {
             sendPrmReg(ACCESS_REG_PPCNT, SET, "clr=%d,grp=%d", 1, PPCNT_ALL_GROUPS);
@@ -4343,27 +4344,33 @@ u_int32_t MlxlinkCommander::getLaneSpeed(u_int32_t lane)
 void MlxlinkCommander::validateNumOfParamsForNDRGen()
 {
     u_int32_t params;
-    string    errMsg = "Invalid set of Transmitter Parameters, ";
-
+    string errMsg = "Invalid set of Transmitter Parameters, ";
     errMsg += "valid parameters for the active speed are: ";
-    if ((!_activeSpeed && (_devID == DeviceSpectrum4)) ||
-        isSpeed100GPerLane((_protoActive == IB) ? _activeSpeed : _activeSpeedEx, _protoActive)) {
+    if ((!_linkSpeed && _devID == DeviceSpectrum4) ||
+        isSpeed100GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
+    {
         params = SLTP_NDR_LAST;
-        errMsg += "fir_pre3,fir_pre2,fir_pre1,fir_main,fir_post1";
-    } else if (isSpeed50GPerLane((_protoActive == IB) ? _activeSpeed : _activeSpeedEx, _protoActive)) {
-        params = SLTP_NDR_FIR_POST1;
-        errMsg += "fir_pre2,fir_pre1,fir_main,fir_post1";
-    } else {
-        params = SLTP_NDR_FIR_MAIN;
-        errMsg += "fir_pre1,fir_main,fir_post1";
+        errMsg += "fir_pre3,fir_pre2,fir_pre1,fir_main,fir_post1,drv_amp";
     }
-    if (_userInput._sltpParams.size() != params) {
+    else if (isSpeed50GPerLane(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive))
+    {
+        params = SLTP_NDR_DRV_AMP;
+        errMsg += "fir_pre2,fir_pre1,fir_main,fir_post1,drv_amp";
+    }
+    else
+    {
+        params = SLTP_NDR_FIR_POST1;
+        errMsg += "fir_pre1,fir_main,fir_post1,drv_amp";
+    }
+    if (_userInput._sltpParams.size() != params)
+    {
         throw MlxRegException(errMsg);
     }
-    for (map < u_int32_t, u_int32_t > ::iterator it = _userInput._sltpParams.begin();
-         it != _userInput._sltpParams.end();
-         it++) {
-        if ((((int)it->second) > MAX_SBYTE) || (((int)it->second) < MIN_SBYTE)) {
+    for (map<u_int32_t, u_int32_t>::iterator it = _userInput._sltpParams.begin(); it != _userInput._sltpParams.end();
+         it++)
+    {
+        if (((int)it->second) > MAX_SBYTE || ((int)it->second) < MIN_SBYTE)
+        {
             throw MlxRegException("Invalid Transmitter Parameters values");
         }
     }

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -698,6 +698,7 @@ void MlxlinkMaps::initSltpStatusMapping()
     _SltpNdrParams[SLTP_NDR_FIR_PRE1] = PRM_FIELD{"fir_pre1", "fir_pre1", FIELD_ACCESS_RW, true, LINK_SPEED_ALL};
     _SltpNdrParams[SLTP_NDR_FIR_MAIN] = PRM_FIELD{"fir_main", "fir_main", FIELD_ACCESS_RW, true, LINK_SPEED_ALL};
     _SltpNdrParams[SLTP_NDR_FIR_POST1] = PRM_FIELD{"fir_post1", "fir_post1", FIELD_ACCESS_RW, true, LINK_SPEED_ALL};
+    _SltpNdrParams[SLTP_NDR_DRV_AMP] = PRM_FIELD{"drv_amp", "drv_amp", FIELD_ACCESS_R, false, LINK_SPEED_ALL};
 
     _SltpXdrParams[SLTP_XDR_TAP0] = PRM_FIELD{"tap0", "fir_pre4", FIELD_ACCESS_RW, true, LINK_SPEED_200G_LANE};
     _SltpXdrParams[SLTP_XDR_TAP1] =


### PR DESCRIPTION
…g drv_amp field in show_serdes_tx

Description:

MSTFlint port needed:yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: