### PR TITLE
mlxlink | add support for displaying multi port tables

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -202,6 +202,7 @@ void MlxlinkAmBerCollector::startCollector()
         _labelPort = it->labelPort;
         _splitPort = it->split;
         _secondSplit = it->secondSplit;
+        _isFnmPort = it->isFnm;
 
         init();
         collect();
@@ -434,7 +435,8 @@ vector < AmberField > MlxlinkAmBerCollector::getIndexesInfo()
         ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3))) {
         labelPortStr += "/" + to_string(_secondSplit);
     }
-    fields.push_back(AmberField("Port_Number", labelPortStr + "(" + to_string(_localPort) + ")", !_isPortPCIE));
+    fields.push_back(AmberField(
+      "Port_Number", labelPortStr + "(" + to_string(_localPort) + ")" + (_isFnmPort ? "(FNM)" : ""), !_isPortPCIE));
     fields.push_back(AmberField("depth", to_string(_depth), _isPortPCIE));
     fields.push_back(AmberField("pcie_index", to_string(_pcieIndex), _isPortPCIE));
     fields.push_back(AmberField("node", to_string(_node), _isPortPCIE));

--- a/mlxlink/modules/mlxlink_amBER_collector.h
+++ b/mlxlink/modules/mlxlink_amBER_collector.h
@@ -79,6 +79,7 @@ public:
     bool isGBValid();
     bool isMCMValid();
 
+    string getClRawBer();
     void startCollector();
 
     u_int32_t _pnat;
@@ -144,6 +145,7 @@ private:
     u_int32_t _labelPort;
     u_int32_t _splitPort;
     u_int32_t _secondSplit;
+    bool _isFnmPort;
     map<AMBER_SHEET, vector<AmberField>> _amberCollection;
     map<AMBER_SHEET, FIELDS_COUNT> _baseSheetsList;
 
@@ -166,7 +168,6 @@ protected:
     // Helper functions
     virtual string getBerAndErrorTitle(u_int32_t portType);
     virtual void getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params);
-    string getClRawBer();
     virtual void getModuleLinkUpInfoPage(vector<AmberField>& fields);
 
     // Callers

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -86,6 +86,7 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _speedBerCsv = 0;
     _fecActive = 0;
     _protoActive = 0;
+    _phyMngrFsmState = -1;
     _productTechnology = 0;
     _allUnhandledErrors = "";
     _mlxlinkMaps = MlxlinkMaps::getInstance();
@@ -95,6 +96,8 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _portInfo = NULL;
     _amberCollector = NULL;
     _groupOpcode = MONITOR_OPCODE;
+    _loopbackMode = 0;
+    _fomStr = "";
 }
 
 MlxlinkCommander::~MlxlinkCommander()
@@ -1774,14 +1777,12 @@ void MlxlinkCommander::operatingInfoPage()
 {
     try
     {
-        sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_OPERATIONAL_INFO_PAGE);
-        u_int32_t phyMngrFsmState = getFieldValue("phy_mngr_fsm_state");
-        int       loopbackMode = (phyMngrFsmState != PHY_MNGR_DISABLED) ? getFieldValue("loopback_mode") : -1;
+        getPddrOperInfo();
+        int loopbackMode = (_phyMngrFsmState != PHY_MNGR_DISABLED) ? _loopbackMode : -1;
         u_int32_t ethAnFsmState = getFieldValue("eth_an_fsm_state");
         u_int32_t ib_phy_fsm_state = getFieldValue("ib_phy_fsm_state");
         string    color =
-            MlxlinkRecord::state2Color(phyMngrFsmState ==
-                                       PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)phyMngrFsmState);
+            MlxlinkRecord::state2Color(_phyMngrFsmState == PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)_phyMngrFsmState);
         _protoActive = getFieldValue("proto_active");
         if (_protoActive == NVLINK) {
             _isNVLINK = true;
@@ -1789,15 +1790,15 @@ void MlxlinkCommander::operatingInfoPage()
         }
         _fecActive = getFieldValue("fec_mode_active");
 
-        _linkUP = (phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
-        _portPolling = phyMngrFsmState == PHY_MNGR_POLLING;
+        _linkUP = (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+        _portPolling = _phyMngrFsmState == PHY_MNGR_POLLING;
         _protoCapability = getFieldValue("cable_ext_eth_proto_cap");
 
         if (_protoActive == IB) {
             _protoCapability = getFieldValue("cable_link_speed_cap");
             _activeSpeed = getFieldValue("link_speed_active");
-            _protoAdmin = (phyMngrFsmState != 0) ? getFieldValue("core_to_phy_link_proto_enabled") :
-                          getFieldValue("phy_manager_link_proto_enabled");
+            _protoAdmin = (_phyMngrFsmState != 0) ? getFieldValue("core_to_phy_link_proto_enabled") :
+                                                    getFieldValue("phy_manager_link_proto_enabled");
         }
 
         getPtys();
@@ -1810,7 +1811,7 @@ void MlxlinkCommander::operatingInfoPage()
 
         setPrintTitle(_operatingInfoCmd, "Operational Info", PDDR_OPERATIONAL_INFO_LAST, !_prbsTestMode);
 
-        setPrintVal(_operatingInfoCmd, "State", getStrByValue(phyMngrFsmState, _mlxlinkMaps->_pmFsmState), color, true,
+        setPrintVal(_operatingInfoCmd, "State", getStrByValue(_phyMngrFsmState, _mlxlinkMaps->_pmFsmState), color, true,
                     !_prbsTestMode);
         setPrintVal(_operatingInfoCmd, "Physical state",
                     _protoActive == ETH ? getStrByValue(ethAnFsmState, _mlxlinkMaps->_ethANFsmState) :
@@ -1951,7 +1952,9 @@ void MlxlinkCommander::showPddr()
         runningVersion();
         if (_prbsTestMode) {
             showTestMode();
-        } else {
+        } 
+        else if (!_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
+        {
             std::cout << _operatingInfoCmd;
             std::cout << _supportedInfoCmd;
             std::cout << _troubInfoCmd;
@@ -1985,6 +1988,14 @@ void MlxlinkCommander::getPtys()
         u_int32_t val = _protoAdminEx ? _protoAdminEx : _protoAdmin;
         _speedForce = " - " + SupportedSpeeds2Str(_protoActive, val, (bool)_protoAdminEx);
     }
+}
+
+void MlxlinkCommander::getPddrOperInfo()
+{
+    sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_OPERATIONAL_INFO_PAGE);
+    _phyMngrFsmState = getFieldValue("phy_mngr_fsm_state");
+    _loopbackMode = getFieldValue("loopback_mode");
+    _fecActive = getFieldValue("fec_mode_active");
 }
 
 void MlxlinkCommander::showTestMode()
@@ -2339,22 +2350,22 @@ void MlxlinkCommander::prepare40_28_16nmEyeInfo(u_int32_t numOfLanes)
             } else {
                 phaseEONegStr = to_string(phaseEOPos + phaseEONeg);
             }
+
+            _fomStr += physicalGrades.back() + " ";
         }
         heightLengths.push_back(MlxlinkRecord::addSpaceForSlrg(offsetEONegStr));
         phaseWidths.push_back(MlxlinkRecord::addSpaceForSlrg(phaseEONegStr));
     }
 
-    setPrintVal(_eyeOpeningInfoCmd,
-                "Physical Grade",
-                getStringFromVector(physicalGrades),
-                ANSI_COLOR_RESET,
-                true,
-                true,
-                true);
-    setPrintVal(_eyeOpeningInfoCmd, "Height Eye Opening [mV]", getStringFromVector(heightLengths), ANSI_COLOR_RESET,
-                true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Phase  Eye Opening [psec]", getStringFromVector(phaseWidths), ANSI_COLOR_RESET,
-                true, true, true);
+    if (!_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
+    {
+        setPrintVal(_eyeOpeningInfoCmd, "Physical Grade", getStringFromVector(physicalGrades), ANSI_COLOR_RESET, true,
+                    true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Height Eye Opening [mV]", getStringFromVector(heightLengths), ANSI_COLOR_RESET,
+                    true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Phase  Eye Opening [psec]", getStringFromVector(phaseWidths), ANSI_COLOR_RESET,
+                    true, true, true);
+    }
 }
 
 void MlxlinkCommander::startSlrgPciScan(u_int32_t numOfLanesToUse)
@@ -2406,28 +2417,31 @@ void MlxlinkCommander::prepare7nmEyeInfo(u_int32_t numOfLanesToUse)
 
         status = getFieldValue("status");
         std::string initialFomStr = status ? getFieldStr("initial_fom", (u_int32_t)8) : "N/A";
-
         initialFom.push_back(MlxlinkRecord::addSpaceForSlrg(initialFomStr));
         lastFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("last_fom", (u_int32_t)8) : "N/A"));
         upperFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("upper_eye", (u_int32_t)8) : "N/A"));
         midFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("mid_eye", (u_int32_t)8) : "N/A"));
         lowerFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("lower_eye", (u_int32_t)8) : "N/A"));
-
+        
+        fillFomDataForTableView(initialFom, initialFomStr, _fomStr);
         legand.push_back(MlxlinkRecord::addSpaceForSlrg(to_string(lane)));
     }
 
-    string fomMode = status ? _mlxlinkMaps->_slrgFomMode[getFieldValue("fom_mode")] : "N/A";
-
-    setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Lane", status ? getStringFromVector(legand) : "N/A", ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", status ? getStringFromVector(initialFom) : "N/A", ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Last FOM", status ? getStringFromVector(lastFom) : "N/A", ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Upper Grades", getStringFromVector(upperFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_UPPER), true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Mid Grades", getStringFromVector(midFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_MIDDLE), true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Lower Grades", getStringFromVector(lowerFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_LOWER), true, true);
+    if (!_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
+    {
+        string fomMode = _mlxlinkMaps->_slrgFomMode[getFieldValue("fom_mode")];
+        setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Lane", getStringFromVector(legand), ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", getStringFromVector(initialFom), ANSI_COLOR_RESET, true, true,
+                    true);
+        setPrintVal(_eyeOpeningInfoCmd, "Last FOM", getStringFromVector(lastFom), ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Upper Grades", getStringFromVector(upperFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_UPPER), true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Mid Grades", getStringFromVector(midFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_MIDDLE), true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Lower Grades", getStringFromVector(lowerFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_LOWER), true, true);
+    }
 }
 
 void MlxlinkCommander::prepare5nmEyeInfo(u_int32_t numOfLanesToUse)
@@ -2466,30 +2480,31 @@ void MlxlinkCommander::prepare5nmEyeInfo(u_int32_t numOfLanesToUse)
 
         status = getFieldValue("status");
         std::string initialFomStr = status ? getFieldStr("initial_fom", (u_int32_t)16) : "N/A";
-
         initialFom.push_back(MlxlinkRecord::addSpaceForSlrg(initialFomStr));
         lastFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("last_fom", (u_int32_t)16) : "N/A"));
         upperFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("upper_eye", (u_int32_t)16) : "N/A"));
         midFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("mid_eye", (u_int32_t)16) : "N/A"));
         lowerFom.push_back(MlxlinkRecord::addSpaceForSlrg(status ? getFieldStr("lower_eye", (u_int32_t)16) : "N/A"));
-
+        
+        fillFomDataForTableView(initialFom, initialFomStr, _fomStr);
         legand.push_back(MlxlinkRecord::addSpaceForSlrg(to_string(lane)));
     }
 
-    string fomMode = status ? _mlxlinkMaps->_slrgFomMode5nm[getFieldValue("fom_mode")] : "N/A";
-    setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Lane", status ? getStringFromVector(legand) : "N/A", ANSI_COLOR_RESET, true,
-                true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", status ? getStringFromVector(initialFom) : "N/A",
-                ANSI_COLOR_RESET, true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Last FOM", status ? getStringFromVector(lastFom) : "N/A", ANSI_COLOR_RESET,
-                true, true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Upper Grades", getStringFromVector(upperFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_UPPER), true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Mid Grades", getStringFromVector(midFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_MIDDLE), true, true);
-    setPrintVal(_eyeOpeningInfoCmd, "Lower Grades", getStringFromVector(lowerFom), ANSI_COLOR_RESET,
-                (fomMeasurement & SLRG_EOM_LOWER), true, true);
+    if (!_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
+    {
+        string fomMode = _mlxlinkMaps->_slrgFomMode5nm[getFieldValue("fom_mode")];
+        setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Lane", getStringFromVector(legand), ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Initial FOM", getStringFromVector(initialFom), ANSI_COLOR_RESET, true, true,
+                    true);
+        setPrintVal(_eyeOpeningInfoCmd, "Last FOM", getStringFromVector(lastFom), ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Upper Grades", getStringFromVector(upperFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_UPPER), true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Mid Grades", getStringFromVector(midFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_MIDDLE), true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Lower Grades", getStringFromVector(lowerFom), ANSI_COLOR_RESET,
+                    (fomMeasurement & SLRG_EOM_LOWER), true, true);
+    }
 }
 
 void MlxlinkCommander::showEye()
@@ -3018,7 +3033,7 @@ void MlxlinkCommander::collectAMBER()
                     _amberCollector->_localPorts.push_back(pg);
                 } else if (!dm_is_gpu(static_cast<dm_dev_id_t>(_devID))) {
                     /* collect all ports info if the port flag wasn't provided */
-                    u_int32_t numOfPorts = 0;
+                    u_int32_t numOfPorts = getNumberOfPorts();;
 
                     vector < string > labelPorts;
                     _ignorePortStatus = false;
@@ -3218,6 +3233,223 @@ void MlxlinkCommander::showTxGroupMapping()
                                       "following exception: ") +
                                string(exc.what()) + string("\n");
     }
+}
+
+string MlxlinkCommander::getLabelPortString(const PortGroup& portInfo)
+{
+    string labelPortStr = " " + to_string(portInfo.labelPort);
+    // Add split port information if applicable
+    bool shouldAddSplit = (portInfo.split && portInfo.split != 1) || (_devID == DeviceQuantum2) ||
+                          (_devID == DeviceQuantum3) || (_devID == DeviceQuantum4) ||
+                          dm_is_gpu(static_cast<dm_dev_id_t>(_devID));
+    if (shouldAddSplit)
+    {
+        labelPortStr += "/" + to_string(portInfo.split);
+    }
+    // Add second split information if applicable
+    bool shouldAddSecondSplit =
+      (portInfo.secondSplit && portInfo.secondSplit != 1) &&
+      ((_devID == DeviceQuantum2) || (_devID == DeviceQuantum3) || (_devID == DeviceQuantum4));
+    if (shouldAddSecondSplit)
+    {
+        labelPortStr += "/" + to_string(portInfo.secondSplit);
+    }
+    labelPortStr += "(" + to_string(portInfo.localPort) + ")";
+    // Add IB port information if applicable
+    if (_protoActive == IB && !_isHCA)
+    {
+        sendPrmReg(ACCESS_REG_PLIB, GET);
+        labelPortStr += " " + std::to_string(getFieldValue("ib_port"));
+    }
+    if (portInfo.isFnm)
+    {
+        labelPortStr += "(FNM)";
+    }
+    return labelPortStr;
+}
+
+void MlxlinkCommander::updatePortModuleInfo(vector<string>& tableData,
+                                            const PortGroup& portInfo,
+                                            u_int32_t& posToUpdateWidthInVector)
+{
+    // Update local port and get cable parameters
+    _localPort = portInfo.localPort;
+    if (!_isSwControled)
+    {
+        getCableParams();
+    }
+    // Get cable information strings
+    std::string cableLenStr = getCableLengthStr(_cableLen, _cmisCable) + "m";
+    std::string cableTypeStr = _isSwControled ? "sw cntrld" : _mlxlinkMaps->_cableTypeForTableDisplay[_cableMediaType];
+    // Get speed and color information
+    std::string speedStr = getSpeedStrForTableView();
+    string color =
+      MlxlinkRecord::state2Color(_phyMngrFsmState == PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)_phyMngrFsmState);
+    string resetColor = MlxlinkRecord::state2Color(RESET);
+    // Update table with cable information
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   _cableSN, _cableSN.length(), !_isSwControled);
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   _cablePN, _cablePN.length(), !_isSwControled);
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   cableLenStr, cableLenStr.length(), !_isSwControled);
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   cableTypeStr, cableTypeStr.length());
+    // Update table with port state and speed information
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   color + _mlxlinkMaps->_phyMgrStateForTableDisplay[_phyMngrFsmState] + resetColor,
+                                   _mlxlinkMaps->_phyMgrStateForTableDisplay[_phyMngrFsmState].length());
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   speedStr, speedStr.length());
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   _mlxlinkMaps->_fecModeActiveForTableDispaly[_fecActive],
+                                   _mlxlinkMaps->_fecModeActiveForTableDispaly[_fecActive].length(),
+                                   _phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    // Update table with BER information
+    std::string berStr = getBerString();
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   berStr, berStr.length());
+}
+
+
+void MlxlinkCommander::showMultiPortModuleInfo()
+{
+    // Set up table header with appropriate label
+    string label_port = (_protoActive == IB) ? "Label(Pport)IBport" : "Label(Pport)";
+    _mlxlinkMaps->_multiPortModuleInfoTableHeader.insert(_mlxlinkMaps->_multiPortModuleInfoTableHeader.begin(),
+                                                         std::make_pair(label_port, label_port.length()));
+    std::vector<std::string> tableData = {};
+    updateLocalPortGroup();
+    // Process each port group
+    for (const auto& portInfo : _localPortsPerGroup)
+    {
+        u_int32_t posToUpdateWidthInVector = 0;
+        // Get and update label port string
+        string labelPortStr = getLabelPortString(portInfo);
+        updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortModuleInfoTableHeader, posToUpdateWidthInVector++,
+                                       tableData, labelPortStr, labelPortStr.length());
+        // Update port information in table
+        updatePortModuleInfo(tableData, portInfo, posToUpdateWidthInVector);
+    }
+    // Print the final table
+    printMlxlinkTable(tableData, _mlxlinkMaps->_multiPortModuleInfoTableHeader);
+}
+
+void MlxlinkCommander::updatePortInfo(vector<string>& tableData,
+                                      const PortGroup& portInfo,
+                                      u_int32_t& posToUpdateWidthInVector)
+{
+    _localPort = portInfo.localPort;
+    _fomStr = "";
+    string labelPortStr = getLabelPortString(portInfo);
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   labelPortStr, labelPortStr.length());
+    std::string speedStr = getSpeedStrForTableView();
+    getPddrOperInfo();
+    string color =
+      MlxlinkRecord::state2Color(_phyMngrFsmState == PHY_MNGR_RX_DISABLE ? YELLOW : (STATUS_COLOR)_phyMngrFsmState);
+    string resetColor = MlxlinkRecord::state2Color(RESET);
+    // Update state and speed info
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   color + _mlxlinkMaps->_phyMgrStateForTableDisplay[_phyMngrFsmState] + resetColor,
+                                   _mlxlinkMaps->_phyMgrStateForTableDisplay[_phyMngrFsmState].length());
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   speedStr, speedStr.length());
+    // Update FEC info
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   _mlxlinkMaps->_fecModeActiveForTableDispaly[_fecActive],
+                                   _mlxlinkMaps->_fecModeActiveForTableDispaly[_fecActive].length(),
+                                   _phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+
+    // Update cable info
+    if (!_isSwControled)
+    {
+        getCableParams();
+    }
+    std::string cableInfoStr = _isSwControled ? "sw cntrld" :
+                                                _mlxlinkMaps->_cableTypeForTableDisplay[_cableMediaType] + "/" +
+                                                  getCableLengthStr(_cableLen, _cmisCable) + "m";
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   cableInfoStr, cableInfoStr.length(), _cableMediaType == UNPLUGGED);
+    // Update time to link up info
+    sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_MODULE_LINK_UP_INFO_PAGE);
+    std::stringstream ss;
+    ss << std::fixed << std::setprecision(3) << ((float)getFieldValue("time_to_link_up") / 1000) << " sec";
+    string ttluStr = ss.str();
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   ttluStr, ttluStr.length(), _phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    // Update statistical info
+    updatePortStatisticalInfo(tableData, posToUpdateWidthInVector);
+    // Update eye info
+    if (_productTechnology <= PRODUCT_16NM)
+    {
+        prepare40_28_16nmEyeInfo(_numOfLanes);
+    }
+    else if (_productTechnology == PRODUCT_7NM)
+    {
+        prepare7nmEyeInfo(_numOfLanes);
+    }
+    else if (_productTechnology == PRODUCT_5NM)
+    {
+        prepare5nmEyeInfo(_numOfLanes);
+    }
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   _fomStr, _fomStr.length());
+    // Update BER info
+    std::string berStr = getBerString();
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   color + berStr + resetColor, berStr.length());
+    // Update link down and FC zero info
+    sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_PHY_GROUP);
+    std::string linkDownStr = getFieldStr("link_down_events");
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   linkDownStr, linkDownStr.length(), _phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
+    std::string fcZeroHist = to_string(getFieldValue("fc_zero_hist"));
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   fcZeroHist, fcZeroHist.length(), _phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+}
+
+
+void MlxlinkCommander::updatePortStatisticalInfo(vector<string>& tableData, u_int32_t& posToUpdateWidthInVector)
+{
+    sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_PHY_GROUP);
+    char buff[64];
+    double val =
+      (double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low")) /
+      60000.0;
+    sprintf(buff, "%.01f min", val);
+    sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
+    double rawBerCoef = getFieldValue("raw_ber_coef");
+    double rawBerMag = getFieldValue("raw_ber_magnitude");
+    double rawBer = rawBerCoef * std::pow(10, -rawBerMag);
+    double timeSinceLinkUp =
+      ((double)add32BitTo64(getFieldValue("time_since_last_clear_high"), getFieldValue("time_since_last_clear_low"))) /
+      1000.0;
+    double activeRate =
+      _protoActive == IB ? _mlxlinkMaps->_IBSpeed2gNum[_activeSpeed] : _mlxlinkMaps->_EthExtSpeed2gNum[_activeSpeed];
+    double rateBerLane = (activeRate / _numOfLanes) * pow(10.0, 9);
+    double clBer = 0;
+    char clBerStr[128];
+    if (activeRate)
+    {
+        clBer = 1 - exp(-1 * rateBerLane * timeSinceLinkUp * rawBer);
+    }
+    sprintf(clBerStr, "%s/%.1E%%", buff, clBer);
+    updateColumnWidthPopulateTable(_mlxlinkMaps->_multiPortInfoTableHeader, posToUpdateWidthInVector++, tableData,
+                                   clBerStr, strlen(clBerStr));
+}
+
+void MlxlinkCommander::showMultiPortInfo()
+{
+    std::vector<std::string> tableData = {};
+    updateLocalPortGroup();
+    for (const auto& portInfo : _localPortsPerGroup)
+    {
+        u_int32_t posToUpdateWidthInVector = 0;
+        updatePortInfo(tableData, portInfo, posToUpdateWidthInVector);
+    }
+    printMlxlinkTable(tableData, _mlxlinkMaps->_multiPortInfoTableHeader);
 }
 
 std::map < string, string > MlxlinkCommander::getRawEffectiveErrorsinTestMode()
@@ -5233,4 +5465,88 @@ void MlxlinkCommander::showPlr()
         throw MlxRegException("PLR is not supported for the current device!");
     }
     cout << _plrInfoCmd;
+}
+
+u_int32_t MlxlinkCommander::getNumberOfPorts()
+{
+    int numOfPorts = 0;
+    if (dm_is_gpu(static_cast<dm_dev_id_t>(_devID)) || _devID == DeviceSpectrum3 || _devID == DeviceQuantum3 || _isHCA)
+    {
+        sendPrmReg(ACCESS_REG_MGIR, GET);
+        numOfPorts = getFieldValue("num_ports");
+    }
+    else
+    {
+        sendPrmReg(ACCESS_REG_MGPIR, GET);
+        numOfPorts = getFieldValue("num_of_modules");
+    }
+    return numOfPorts;
+}
+
+string MlxlinkCommander::getBerString()
+{
+    string berString = "";
+    if (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP)
+    {
+        sendPrmReg(ACCESS_REG_PPCNT, GET, "grp=%d", PPCNT_STATISTICAL_GROUP);
+        string symBer = (_protoActive == ETH) ? "N/A" : 
+            (getFieldStr("symbol_ber_coef") + "E-" + getFieldStr("symbol_ber_magnitude"));
+        std::stringstream ss;
+        ss << symBer << "/"
+           << getFieldValue("effective_ber_coef") << "E-"
+           << getFieldValue("effective_ber_magnitude") << "/"
+           << getFieldValue("raw_ber_coef") << "E-"
+           << getFieldValue("raw_ber_magnitude");
+        
+        berString = ss.str();
+    }
+    return berString;
+}
+
+void MlxlinkCommander::updateLocalPortGroup()
+{
+    u_int32_t numOfPorts = getNumberOfPorts();
+    vector<string> localPorts;
+    localPorts.reserve(numOfPorts); // Reserve memory to size 'numOfPorts'
+    for (u_int32_t localPort = 1; localPort <= numOfPorts; localPort++)
+    {
+        localPorts.push_back(to_string(localPort));
+    }
+    if (_isHCA)
+    {
+        // NICs have only one port
+        _localPortsPerGroup.push_back(PortGroup(1, 1, 0, 0));
+    }
+    else
+    {
+        handleLabelPorts(localPorts, true);
+    }
+}
+
+std::string MlxlinkCommander::getSpeedStrForTableView()
+{
+    std::string speedStr = "";
+    if (_protoActive == IB)
+    {
+        getPddrOperInfo(); // fsm_state + fec
+        _activeSpeed = getFieldValue("link_speed_active");
+    }
+    else
+    {
+        getPtys(); // get port speed
+        _activeSpeed =
+          _productTechnology >= PRODUCT_16NM ? getFieldValue("ext_eth_proto_oper") : getFieldValue("eth_proto_oper");
+        getPddrOperInfo(); // fsm_state + fec
+    }
+    _linkUP = (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    bool extended = _activeSpeedEx && _protoAdminEx;
+    _linkSpeed = extended ? _activeSpeedEx : _activeSpeed;
+    _isPam4Speed = isPAM4Speed(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive, extended);
+    _speedStrG = activeSpeed2Str(_linkSpeed, extended);
+    getActualNumOfLanes(_linkSpeed, extended);
+    if (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP)
+    {
+        speedStr = _speedStrG + "_" + std::to_string(_numOfLanes);
+    }
+    return speedStr;
 }

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -104,6 +104,14 @@
 #define PEPC_SHOW_FLAG_SHORT ' '
 #define PLR_INFO_FLAG "show_plr"
 #define PLR_INFO_FLAG_SHORT ' '
+#define MULTI_PORT_MODULE_INFO_FLAG "show_multi_port_module_info"
+#define MULTI_PORT_MODULE_INFO_FLAG_SHORT ' '
+#define MULTI_PORT_MODULE_INFO_ACRONYM_FLAG "smpmi"
+#define MULTI_PORT_MODULE_INFO_ACRONYM_FLAG_SHORT ' '
+#define MULTI_PORT_INFO_FLAG "show_multi_port_info"
+#define MULTI_PORT_INFO_FLAG_SHORT ' '
+#define MULTI_PORT_INFO_ACRONYM_FLAG "smpi"
+#define MULTI_PORT_INFO_ACRONYM_FLAG_SHORT ' '
 
 //------------------------------------------------------------
 //        Mlxlink COMMANDS Flags
@@ -332,6 +340,8 @@ enum OPTION_TYPE
     SLRG_TEST,
     PCIE_ERROR_INJ,
     SHOW_PLR,
+    SHOW_MULTI_PORT_INFO,
+    SHOW_MULTI_PORT_MODULE_INFO,
 
     // Any new function's index should be added before FUNCTION_LAST in this enum
     FUNCTION_LAST
@@ -429,6 +439,7 @@ public:
     void collectBER();
     void showTxGroupMapping();
     void showPlr();
+    void getPddrOperInfo();
 
     // Query helper functions
     string getCableTechnologyStr(u_int32_t cableTechnology);
@@ -455,6 +466,7 @@ public:
     string fecMaskToStr(u_int32_t mask);
     void updateSwControlStatus();
     bool checkDPNvSupport();
+    u_int32_t getNumberOfPorts();
 
     void showTestMode();
     void showTestModeBer();
@@ -591,6 +603,11 @@ public:
     void checkSltpParamsSize();
     bool isMpeinjSupported();
     u_int32_t getRateFromPptt();
+    void showMultiPortInfo();
+    void showMultiPortModuleInfo();
+    string getBerString();
+    void updateLocalPortGroup();
+    std::string getSpeedStrForTableView();
 
     // Mlxlink params
     UserInput _userInput;
@@ -602,6 +619,7 @@ public:
     u_int32_t _cableMediaType;
     u_int32_t _fecActive;
     u_int32_t _protoActive;
+    int _phyMngrFsmState;
     u_int32_t _anDisable;
     u_int32_t _speedBerCsv;
     u_int32_t _cableIdentifier;
@@ -620,6 +638,7 @@ public:
     u_int32_t _slotIndex;
     u_int32_t _linkSpeed;
     u_int32_t _groupOpcode;
+    u_int32_t _loopbackMode;
     string _extAdbFile;
     string _fwVersion;
     string _speedStrG;
@@ -655,9 +674,16 @@ public:
     MlxlinkErrInjCommander* _errInjector;
     MlxlinkPortInfo* _portInfo;
     MlxlinkAmBerCollector* _amberCollector;
+    string _fomStr;
 
 protected:
     vector<AmberField> _ppcntFields;
+
+    // New helper functions for port info display
+    string getLabelPortString(const PortGroup& portInfo);
+    void updatePortModuleInfo(vector<string>& tableData, const PortGroup& portInfo, u_int32_t& posToUpdateWidthInVector);
+    void updatePortInfo(vector<string>& tableData, const PortGroup& portInfo, u_int32_t& posToUpdateWidthInVector);
+    void updatePortStatisticalInfo(vector<string>& tableData, u_int32_t& posToUpdateWidthInVector);
 };
 
 #endif /* MLXLINK_COMMANDER_H */

--- a/mlxlink/modules/mlxlink_enums.h
+++ b/mlxlink/modules/mlxlink_enums.h
@@ -116,6 +116,11 @@
 #define SHIFT_13 13
 #define SHIFT_14 14
 #define SHIFT_15 15
+#define SHIFT_16 16
+#define SHIFT_17 17
+#define SHIFT_18 18
+#define SHIFT_19 19
+#define SHIFT_20 20
 /*
  * QSFP Paging, Page 0 Low
  */

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -67,6 +67,21 @@ void MlxlinkMaps::initPortStateMapping()
     _pmFsmState[PHY_MNGR_TRAINING] = "Training";
     _pmFsmState[PHY_MNGR_SUB_FSM_ACTIVE] = "SubFSM active";
 
+    _phyMgrStateForTableDisplay[PHY_MNGR_DISABLED] = "DIS";
+    _phyMgrStateForTableDisplay[PHY_MNGR_OPEN_PORT] = "OPEN";
+    _phyMgrStateForTableDisplay[PHY_MNGR_POLLING] = "POL";
+    _phyMgrStateForTableDisplay[PHY_MNGR_ACTIVE_LINKUP] = "ACT";
+    _phyMgrStateForTableDisplay[PHY_MNGR_CLOSE_PORT] = "CLOSE";
+    _phyMgrStateForTableDisplay[PHY_MNGR_PHYSICAL_LINKUP] = "PHY_UP";
+    _phyMgrStateForTableDisplay[PHY_MNGR_SLEEP] = "SLEEP";
+    _phyMgrStateForTableDisplay[PHY_MNGR_RX_DISABLE] = "RX_DISABLE";
+    _phyMgrStateForTableDisplay[PHY_MNGR_SIGNAL_DETECT] = "SIGNAL_DETECT";
+    _phyMgrStateForTableDisplay[PHY_MNGR_RECEIVER_DETECT] = "RECEIVER_DETECT";
+    _phyMgrStateForTableDisplay[PHY_MNGR_SYNC_PEER] = "SYNC_PEER";
+    _phyMgrStateForTableDisplay[PHY_MNGR_NEGOTIATION] = "NEGOTIATION";
+    _phyMgrStateForTableDisplay[PHY_MNGR_TRAINING] = "TRAINING";
+    _phyMgrStateForTableDisplay[PHY_MNGR_SUB_FSM_ACTIVE] = "SUBFSM_ACTIVE";
+
     _networkProtocols[IB] = "InfiniBand";
     _networkProtocols[ETH] = "Ethernet";
     _networkProtocols[NVLINK] = "NVLink";
@@ -166,6 +181,22 @@ void MlxlinkMaps::initFecAndLoopbackMapping()
     _fecModeActive[FEC_MODE_RS_FEC_PLR_272_257] = "Ethernet_Consortium_LL_50G_RS_FEC_PLR -(272,257+1)";
     _fecModeActive[FEC_MODE_INTERLEAVED_RS_FEC_PLR_272_257] =
       "Interleaved_Ethernet_Consortium_LL_50G_RS_FEC_PLR - (272,257+1)";
+
+    _fecModeActiveForTableDispaly[FEC_MODE_NO_FEC] = "NO_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_FIRECODE_FEC] = "FC_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_STANDARD_RS_FEC_528_514] = "KR4_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_STANDARD_LL_FEC_271_257] = "LL_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_INTERLEAVED_QUAD_RS_FEC_544_514] = "Quad_KP4_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_INTERLEAVED_STANDARD_RS_FEC_544_514] = "Int_KP4_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_STANDARD_RS_FEC_544_514] = "KP4_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_ZERO_LATENCY_FEC] = "ZL_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_RS_FEC_272_257] = "ELL_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_INTERLEAVED_RS_FEC_272_257] = "Int_ELL_FEC";
+    _fecModeActiveForTableDispaly[FEC_MODE_INTERLEAVED_RS_FEC_544_514_PLR] = "Int_KP4_FEC_PLR";
+    _fecModeActiveForTableDispaly[FEC_MODE_RS_FEC_544_514_PLR] = "Int_KP4_FEC_PLR";
+    _fecModeActiveForTableDispaly[FEC_MODE_RS_FEC_271_257_PLR] = "Int_KP4_FEC_PLR";
+    _fecModeActiveForTableDispaly[FEC_MODE_RS_FEC_PLR_272_257] = "ELL_FEC_PLR";
+    _fecModeActiveForTableDispaly[FEC_MODE_INTERLEAVED_RS_FEC_PLR_272_257] = "Int_ELL_FEC_PLR";
 
     _fecModeMask[FEC_MODE_MASK_AU] = make_pair("Auto-FEC", "AU");
     _fecModeMask[FEC_MODE_MASK_NF] = make_pair("No-FEC", "NF");
@@ -1551,6 +1582,39 @@ void MlxlinkMaps::initPlrRejectModeMapping()
     _plrRejectMode[PLR_REJECT_MODE_CS] = "rejection based on CS";
 }
 
+void MlxlinkMaps::initCableTypeForTableView()
+{
+    _cableTypeForTableDisplay[UNIDENTIFIED] = "UNIDENT";
+    _cableTypeForTableDisplay[ACTIVE] = "AOC/ACC";
+    _cableTypeForTableDisplay[OPTICAL_MODULE] = "AOM";
+    _cableTypeForTableDisplay[PASSIVE] = "DAC";
+    _cableTypeForTableDisplay[UNPLUGGED] = "UNPLUGD";
+}
+
+void MlxlinkMaps::initTableHeaders()
+{
+    _multiPortInfoTableHeader = {{"port", SHIFT_8},
+                                 {"State", SHIFT_8},
+                                 {"Speed", SHIFT_8},
+                                 {"FEC", SHIFT_15},
+                                 {"Cable Type/LEN", SHIFT_20},
+                                 {"TTLU", SHIFT_15},
+                                 {"Time Since Clear/CL", SHIFT_20},
+                                 {"FOM", SHIFT_20},
+                                 {"Net BER", SHIFT_20},
+                                 {"Link Down", SHIFT_10},
+                                 {"F. C. Zero Hist", SHIFT_20}};
+    // Need to add here localPort string, done when used in mlxlinkCommander
+    _multiPortModuleInfoTableHeader = { {"Cable S/N", SHIFT_15},
+                                        {"Cable P/N", SHIFT_20},
+                                        {"Cable Len", SHIFT_15},
+                                        {"Cable Type", SHIFT_15},
+                                        {"State", SHIFT_15},
+                                        {"Speed", SHIFT_8},
+                                        {"FEC", SHIFT_15},
+                                        {"Net BER", SHIFT_20}};
+}
+
 MlxlinkMaps::MlxlinkMaps()
 {
     initPublicStrings();
@@ -1564,6 +1628,7 @@ MlxlinkMaps::MlxlinkMaps()
     initSltpStatusMapping();
     initCableComplianceMapping();
     initCableTechnologyMapping();
+    initCableTypeForTableView();
     initCablePowerClassMapping();
     initEnhancedDebugMapping();
     phyHstFsmHdrStateMapping();
@@ -1571,6 +1636,7 @@ MlxlinkMaps::MlxlinkMaps()
     initPpttParamsMapping();
     initPpttSpeedMapping();
     initPlrRejectModeMapping();
+    initTableHeaders();
 }
 
 MlxlinkMaps::~MlxlinkMaps() {}

--- a/mlxlink/modules/mlxlink_maps.h
+++ b/mlxlink/modules/mlxlink_maps.h
@@ -58,6 +58,7 @@ struct PortGroup
         groupId = 0;
         split = 0;
         secondSplit = 0;
+        isFnm = false;
     }
     PortGroup(u_int32_t _localPort, u_int32_t _labelPort, u_int32_t _groupId, u_int32_t _split)
     {
@@ -66,6 +67,7 @@ struct PortGroup
         groupId = _groupId;
         split = _split;
         secondSplit = 0;
+        isFnm = false;
     }
     PortGroup(u_int32_t _localPort, u_int32_t _labelPort, u_int32_t _groupId, u_int32_t _split, u_int32_t _secondSplit)
     {
@@ -74,12 +76,28 @@ struct PortGroup
         groupId = _groupId;
         split = _split;
         secondSplit = _secondSplit;
+        isFnm = false;
+    }
+    PortGroup(u_int32_t _localPort,
+              u_int32_t _labelPort,
+              u_int32_t _groupId,
+              u_int32_t _split,
+              u_int32_t _secondSplit,
+              bool _isFnm)
+    {
+        localPort = _localPort;
+        labelPort = _labelPort;
+        groupId = _groupId;
+        split = _split;
+        secondSplit = _secondSplit;
+        isFnm = _isFnm;
     }
     u_int32_t localPort;
     u_int32_t labelPort;
     u_int32_t groupId;
     u_int32_t split;
     u_int32_t secondSplit;
+    bool isFnm;
 };
 
 struct CAP_VALUE
@@ -197,6 +215,8 @@ private:
     void initPpttParamsMapping();
     void initPpttSpeedMapping();
     void initPlrRejectModeMapping();
+    void initCableTypeForTableView();
+    void initTableHeaders();
 
 public:
     static MlxlinkMaps* getInstance();
@@ -324,6 +344,12 @@ public:
     std::map<u_int32_t, u_int32_t> _ppcntGroups;
     std::map<u_int32_t, PRM_FIELD> _ppttParams;
     std::map<u_int32_t, u_int32_t> _ppttSpeedMapping;
+    std::map<u_int32_t, std::string> _fecModeActiveForTableDispaly;
+    std::map<u_int32_t, std::string> _cableTypeForTableDisplay;
+    std::map<u_int32_t, std::string> _phyMgrStateForTableDisplay;
+    // Vectors
+    std::vector<std::pair<std::string, u_int32_t>> _multiPortInfoTableHeader;
+    std::vector<std::pair<std::string, u_int32_t>> _multiPortModuleInfoTableHeader;
 
     string _sltpHeader;
     string _showErrorsTitle;

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -84,7 +84,8 @@ void MlxlinkUi::initRegAccessLib()
 
 void MlxlinkUi::initPortInfo()
 {
-    if (!_userInput._portSpecified && _userInput._csvBer != "")
+    if ((!_userInput._portSpecified && _userInput._csvBer != "") ||
+        (_userInput._showMultiPortInfo || _userInput._showMultiPortModuleInfo))
     {
         _mlxlinkCommander->findFirstValidPort();
     }
@@ -168,6 +169,12 @@ void MlxlinkUi::printSynopsisQueries()
                                  "Show BER Monitor Info (not supported for HCA)");
     MlxlinkRecord::printFlagLine(PEPC_SHOW_FLAG_SHORT, PEPC_SHOW_FLAG, "",
                                  "Show External PHY Info (for Ethernet switches only)");
+    MlxlinkRecord::printFlagLineWithAcronym(MULTI_PORT_INFO_FLAG_SHORT, MULTI_PORT_INFO_FLAG,
+                                            MULTI_PORT_INFO_ACRONYM_FLAG_SHORT, MULTI_PORT_INFO_ACRONYM_FLAG, "",
+                                            "Show Multi Port Info Table");
+    MlxlinkRecord::printFlagLineWithAcronym(
+      MULTI_PORT_MODULE_INFO_FLAG_SHORT, MULTI_PORT_MODULE_INFO_FLAG, MULTI_PORT_MODULE_INFO_ACRONYM_FLAG_SHORT,
+      MULTI_PORT_MODULE_INFO_ACRONYM_FLAG, "", "Show Multi Port Module Info Table");
 }
 
 void MlxlinkUi::printSynopsisCommands()
@@ -997,6 +1004,11 @@ void MlxlinkUi::initCmdParser()
     AddOptions(PEPC_SHOW_FLAG, PEPC_SHOW_FLAG_SHORT, "", "Show External PHY Info");
     AddOptions(PRINT_JSON_OUTPUT_FLAG, PRINT_JSON_OUTPUT_FLAG_SHORT, "", "Print the output in json format");
     AddOptions(PLR_INFO_FLAG, PLR_INFO_FLAG_SHORT, "", "Show PLR Info");
+    AddOptions(MULTI_PORT_INFO_FLAG, MULTI_PORT_INFO_FLAG_SHORT, "", "Show multi ports info table");
+    AddOptions(MULTI_PORT_INFO_ACRONYM_FLAG, MULTI_PORT_INFO_ACRONYM_FLAG_SHORT, "", "Show multi port info table");
+    AddOptions(MULTI_PORT_MODULE_INFO_FLAG, MULTI_PORT_MODULE_INFO_FLAG_SHORT, "", "Show multi port module info table");
+    AddOptions(MULTI_PORT_MODULE_INFO_ACRONYM_FLAG, MULTI_PORT_MODULE_INFO_ACRONYM_FLAG_SHORT, "",
+               "Show multi port module info table");
 
     AddOptions(FEC_DATA_FLAG, FEC_DATA_FLAG_SHORT, "", "FEC Data");
     AddOptions(PAOS_FLAG, PAOS_FLAG_SHORT, "PAOS", "Send PAOS");
@@ -1200,6 +1212,12 @@ void MlxlinkUi::commandsCaller()
                 break;
             case SHOW_PLR:
                 _mlxlinkCommander->showPlr();
+                break;
+            case SHOW_MULTI_PORT_INFO:
+                _mlxlinkCommander->showMultiPortInfo();
+                break;
+            case SHOW_MULTI_PORT_MODULE_INFO:
+                _mlxlinkCommander->showMultiPortModuleInfo();
                 break;
             default:
                 break;
@@ -1780,6 +1798,18 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     else if (name == MPEINJ_DBDF_FLAG)
     {
         _userInput.dbdf = value;
+        return PARSE_OK;
+    }
+    else if (name == MULTI_PORT_INFO_ACRONYM_FLAG || name == MULTI_PORT_INFO_FLAG)
+    {
+        addCmd(SHOW_MULTI_PORT_INFO);
+        _userInput._showMultiPortInfo = true;
+        return PARSE_OK;
+    }
+    else if (name == MULTI_PORT_MODULE_INFO_ACRONYM_FLAG || name == MULTI_PORT_MODULE_INFO_FLAG)
+    {
+        addCmd(SHOW_MULTI_PORT_MODULE_INFO);
+        _userInput._showMultiPortModuleInfo = true;
         return PARSE_OK;
     }
     return PARSE_ERROR;

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -86,6 +86,8 @@ UserInput::UserInput()
     _write = false;
     _read = false;
     _showPlr = false;
+    _showMultiPortInfo = false;
+    _showMultiPortModuleInfo = false;
 
     _device = "";
     _extAdbFile = "";

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -96,6 +96,8 @@ public:
     bool gradeScanPerLane;
     bool autoCsvName;
     bool _showPlr;
+    bool _showMultiPortInfo;
+    bool _showMultiPortModuleInfo;
 
     string _device;
     string _extAdbFile;

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -1596,3 +1596,123 @@ bool askUser(const char* question, bool force)
 
     return ret;
 }
+
+std::string centerString(const std::string& str, int width, char fillChar)
+{
+    int strLen = getStringLengthWOColorCodes(str);
+    if (width <= strLen)
+    {
+        return str;
+    }
+    int padding = (width - strLen) / 2;
+    int remainingPadding = width - strLen - padding;
+    std::string leftPadding(padding, fillChar);
+    std::string rightPadding(remainingPadding, fillChar);
+    return leftPadding + str + rightPadding;
+}
+
+std::string generateTableRow(const std::vector<std::pair<std::string, u_int32_t>>& columns,
+                             const std::string& delimiter)
+{
+    std::stringstream tableRow("");
+    if (columns.empty())
+    {
+        return "";
+    }
+    for (const auto& column : columns)
+    {
+        tableRow << delimiter << centerString(column.first, column.second);
+    }
+    tableRow << delimiter;
+    return tableRow.str();
+}
+
+void fillFomDataForTableView(std::vector<string>& initialFom, const std::string& initialFomStr, std::string& fomStr)
+{
+    initialFom.push_back(MlxlinkRecord::addSpaceForSlrg(initialFomStr));
+    fomStr.clear();
+    fomStr = initialFomStr;
+}
+
+int getStringLengthWOColorCodes(const std::string& s)
+{
+    int length = 0;
+    size_t i = 0;
+    while (i < s.size())
+    {
+        if (s[i] == '\033' && i + 1 < s.size() && s[i + 1] == '[')
+        {
+            // Skip the escape sequence until 'm' is found
+            size_t j = i + 2;
+            while (j < s.size() && s[j] != 'm')
+            {
+                j++;
+            }
+            if (j < s.size())
+            {
+                i = j + 1; // Skip the entire escape sequence including 'm'
+            }
+            else
+            {
+                // If 'm' is not found, length is the rest of the string.
+                length += (s.size() - i);
+                break;
+            }
+        }
+        else
+        {
+            length++;
+            i++;
+        }
+    }
+    return length;
+}
+
+
+void printMlxlinkTable(const std::vector<std::string>& tableData,
+                       const std::vector<std::pair<std::string, u_int32_t>>& tableHeader)
+{
+    u_int32_t numCols = tableHeader.size();
+    std::string tableHeaderRow = generateTableRow(tableHeader, "|");
+    std::cout << tableHeaderRow << std::endl;
+    std::string underscoreRow(tableHeaderRow.length() - 2, '_');
+    std::cout << "|" << underscoreRow << "|" << std::endl;
+    for (u_int32_t i = 0; i < tableData.size() / numCols; i++)
+    {
+        std::vector<std::pair<std::string, u_int32_t>> rowData = {};
+        for (u_int32_t j = 0; j < numCols; j++)
+        {
+            rowData.push_back(std::make_pair(tableData[i * numCols + j], tableHeader[j].second));
+        }
+        std::cout << generateTableRow(rowData, "|") << std::endl;
+    }
+}
+
+void updateColumnWidthPopulateTable(std::vector<std::pair<std::string, u_int32_t>>& vectorToAmend,
+                                    const u_int32_t locationInVector,
+                                    std::vector<std::string>& tableData,
+                                    const std::string& valToAdd,
+                                    u_int32_t unformattedStrLen,
+                                    bool isActive)
+{
+    if (locationInVector < vectorToAmend.size())
+    {
+        if (unformattedStrLen > vectorToAmend[locationInVector].second)
+        {
+            vectorToAmend[locationInVector].second = unformattedStrLen;
+        }
+    }
+    else
+    {
+        throw std::out_of_range(
+          string("Showing Multi Port Info Table raised the following exception: Location in vector is out of bounds"));
+    }
+    if (isActive && valToAdd != "N/A")
+    {
+        tableData.push_back(valToAdd);
+    }
+    else
+    {
+        tableData.push_back("");
+    }
+}

--- a/mlxlink/modules/mlxlink_utils.h
+++ b/mlxlink/modules/mlxlink_utils.h
@@ -158,4 +158,17 @@ string getStrByMaskFromPair(u_int32_t bitmask,
                             map<u_int32_t, pair<string, string>> maskMap,
                             const string& fieldSeparator = ",",
                             u_int32_t pairIndex = 0);
+std::string centerString(const std::string& str, int width, char fillChar = ' ');
+std::string generateTableRow(const std::vector<std::pair<std::string, u_int32_t>>& columns,
+                             const std::string& delimiter);
+int getStringLengthWOColorCodes(const std::string& s);
+void printMlxlinkTable(const std::vector<std::string>& tableData,
+                       const std::vector<std::pair<std::string, u_int32_t>>& tableHeader);
+void updateColumnWidthPopulateTable(std::vector<std::pair<std::string, u_int32_t>>& vectorToAmend,
+                                    const u_int32_t locationInVector,
+                                    std::vector<std::string>& tableData,
+                                    const std::string& valToAdd,
+                                    u_int32_t unformattedStrLen,
+                                    bool isActive = true);
+void fillFomDataForTableView(std::vector<string>& initialFom, const std::string& initialFomStr, std::string& fomStr);
 #endif

--- a/mlxlink/modules/printutil/mlxlink_record.cpp
+++ b/mlxlink/modules/printutil/mlxlink_record.cpp
@@ -221,6 +221,39 @@ void MlxlinkRecord::printFlagLine(const char flag_s,
     printf(IDENT3 ": %-30s\n", desc.c_str());
 }
 
+
+void MlxlinkRecord::printFlagLineWithAcronym(const char flag_s,
+                                             const std::string& flag_l,
+                                             const char flag_acr_s,
+                                             const std::string& flag_acr_l,
+                                             const std::string& param,
+                                             const std::string& desc)
+{
+    std::string sflags_s(1, flag_s);
+    std::string sflags_acr_s(1, flag_acr_s);
+    if (sflags_s != " " || sflags_acr_s != " ")
+    {
+        printf(IDENT2 "-%-2s|-%-2s|--%-10s|--%-10s",
+               sflags_s.c_str(),
+               sflags_acr_s.c_str(),
+               flag_l.c_str(),
+               flag_acr_l.c_str());
+    }
+    else
+    {
+        printf(IDENT2 "--%s |--%-10s", flag_l.c_str(), flag_acr_l.c_str());
+    }
+    if (param.length())
+    {
+        printf(" <%s>", param.c_str());
+    }
+    else
+    {
+        printf("\t");
+    }
+    printf(IDENT3 ": %-30s\n", desc.c_str());
+}
+
 std::string MlxlinkRecord::addSpace(const std::string& str, u_int32_t size, bool right)
 {
     if (MlxlinkRecord::jsonFormat)

--- a/mlxlink/modules/printutil/mlxlink_record.h
+++ b/mlxlink/modules/printutil/mlxlink_record.h
@@ -141,6 +141,12 @@ public:
     static short unsigned int getWinColor(const std::string& color);
     static void
       printFlagLine(const char sflag_s, const std::string& flag_l, const std::string& param, const std::string& desc);
+    static void printFlagLineWithAcronym(const char flag_s,
+                                        const std::string& flag_l,
+                                        const char flag_acr_s,
+                                        const std::string& flag_acr_l,
+                                        const std::string& param,
+                                        const std::string& desc);
     static std::string addSpace(const std::string& str, u_int32_t size, bool right = true);
     static std::string addSpaceForDDM(const std::string& str);
     static std::string addSpaceForSlrg(const std::string& str);


### PR DESCRIPTION
Description:
support querying available ports in one table:
added support to view multi port info.
added support to view multi port module info.
new flags:
--smpi or --show-multi-port-info
--smpmi or --show-multi-port-module-info

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: