### PR TITLE
Fixing GUID comparison between orig and current for query command

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -4168,7 +4168,8 @@ bool QuerySubCommand::displayFs3Uids(const fw_info_t& fwInfo)
     else if (fwInfo.fs3_info.fs3_uids_info.guid_format == MULTI_ASIC_GUIDS)
     {
         printFs4OrNewerUids(fwInfo.fs3_info.fs3_uids_info.multi_asic_guids.image_layout_uids.base_guid,
-                            fwInfo.fs3_info.fs3_uids_info.multi_asic_guids.image_layout_uids.base_guid, "GUID", false);
+                            fwInfo.fs3_info.orig_fs3_uids_info.multi_asic_guids.image_layout_uids.base_guid, "GUID",
+                            false);
         printFs4OrNewerUids(fwInfo.fs3_info.fs3_uids_info.multi_asic_guids.image_layout_uids.base_mac,
                             fwInfo.fs3_info.orig_fs3_uids_info.multi_asic_guids.image_layout_uids.base_mac, "MAC",
                             false);


### PR DESCRIPTION
Description: the comparison in printFs4OrNewerUids for GUID was on the same current objects, this has been fixed the comparison is between the current and the orig

MSTFlint port needed: Yes
Tested OS: linux
Tested devices: cx8
Tested flows: flint -d  /dev/mst/mt4131_pciconf0 query full

Known gaps (with RM ticket): NA

Issue: 4170267
Change-Id: Iedd2472bd9e8f68424d012146aa1f86d46f763d7