### PR TITLE
[msttokengenerator] --enable-i2c configure build flag not working

### DIFF
--- a/mlxtokengenerator/mlxtkngenerator.cpp
+++ b/mlxtokengenerator/mlxtkngenerator.cpp
@@ -46,6 +46,10 @@
 #include "mlxtkngenerator_utils.h"
 #include <tools_layouts/reg_access_switch_layouts.h>
 
+#ifdef ENABLE_MST_DEV_I2C
+#include "mtcr_ul/mtcr_ul_com.h"
+#endif
+
 #include <dirent.h>
 
 #define INDENT "    "


### PR DESCRIPTION
Description: missing include fixed

Issue: 4410103