### PR TITLE
fix for "[MSTFLINT] Bug SW #4410113: enable i2c flag not in mstflint

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -10,6 +10,7 @@
 %{!?enablexml2: %define enablexml2 0}
 %{!?enablefwmgr: %define enablefwmgr 0}
 %{!?enableadbgenerictools: %define enableadbgenerictools 1}
+%{!?enablei2c: %define enablei2c 0}
 %{!?CONF_DIR: %define CONF_DIR /etc/mstflint}
 
 %define mstflint_python_tools %{_libdir}/mstflint/python_tools
@@ -87,6 +88,10 @@ MSTFLINT_VERSION_STR="%{name} %{version}-%{release}"
 
 %if %{enableadbgenerictools}
     config_flags="$config_flags --enable-adb-generic-tools"
+%endif
+
+%if %{enablei2c}
+    config_flags="$config_flags --enable-i2c"
 %endif
 
 %if %{buildtype} == "ppc"


### PR DESCRIPTION
fix for "[MSTFLINT] Bug SW #4410113: enable i2c flag not in mstflint tarball"

Description: added a definition for the flag and the condition to include it in the spec file (to mstflint.spec.in).

Issue: 4410113