### PR TITLE
Fix for mstflint query over I2C

### DIFF
--- a/mtcr_ul/mtcr_ul_com.h
+++ b/mtcr_ul/mtcr_ul_com.h
@@ -194,6 +194,8 @@ void set_force_i2c_address(int i2c_address);
 
 int mtcr_i2c_mread4(mfile* mf, unsigned int offset, u_int32_t* value);
 int mtcr_i2c_mwrite4(mfile* mf, unsigned int offset, u_int32_t value);
+int mtcr_i2c_mread_chunks(mfile* mf, unsigned int offset, void* data, int length);
+int mtcr_i2c_mwrite_chunks(mfile* mf, unsigned int offset, void* data, int length);
 int mread_i2c_chunk(mfile* mf, unsigned int offset, void* data, int length);
 int mwrite_i2c_chunk(mfile* mf, unsigned int offset, void* data, int length);
 int mread_i2cblock(mfile* mf,


### PR DESCRIPTION
Fix for mstflint query over I2C

Description: fixed the hierarchy of the writing functions.

1. mtcr_i2c_mwrite_chunks:
Splits the data into 32-byte chunks, calls mwrite_i2c_chunk for each chunk.
Returns total bytes written or error.

2. mwrite_i2c_chunk:
Handles a single chunk of data (32 bytes). Converts endianness, sets up I2C addressing, and calls mwrite_i2cblock for the actual write.
Returns total bytes written or error.

mwrite_i2cblock:
Performs the I2C write ioctl.
Returns the ioctl rc in case of failure.

Adjusted the read functionality to be of the same format.

Tested OS: linux
Tested devices: Spectrum2 (appssw-15)
Tested flows:
./flint/mstflint -d /dev/i2c-2 q
./mstdump/crd_main/mstregdump /dev/i2c-2

Known gaps (with RM ticket): n/a

Issue: 36597033