### PR TITLE
[mstflint] build fails at make when we install it with option --disab…

### DIFF
--- a/mlxtokengenerator/Makefile.am
+++ b/mlxtokengenerator/Makefile.am
@@ -73,6 +73,11 @@ msttokengenerator_DEPENDENCIES = \
 
 msttokengenerator_LDFLAGS = -static
 
+if ENABLE_OPENSSL
+else
+AM_CXXFLAGS += -DNO_OPEN_SSL
+endif
+
 if ENABLE_FWMGR
 msttokengenerator_DEPENDENCIES += \
     $(top_builddir)/ext_libs/minixz/libminixz.la


### PR DESCRIPTION
…le-openssl while openssl is removed

Description: support disabled openssl build in msttokengenerator

Tested flows: configure with --disable-openssl -> make

Issue: 4412895