### PR TITLE
Revert "mstfwreset | remove socket direct validation to identify pcie…

### DIFF
--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -1459,7 +1459,7 @@ def is_pcie_switch_device(devid, reg_access_obj=None, dbdf=None):
             else:
                 dev_dbdf_bus = int(dbdf.split(':')[1], 16)  # dbdf is a string variable in base 16
             logger.debug('MPIR bus: 0x{0:X}, dbdf: {1}, dev_dbdf_bus: 0x{2:X}, sdm: {3}'.format(bus, dbdf, dev_dbdf_bus, sdm))
-            if bus != dev_dbdf_bus:
+            if bus != dev_dbdf_bus and sdm == 0:
                 logger.debug("Found a PCIE switch device")
                 res = True
     except BaseException:


### PR DESCRIPTION
… switch"

This reverts commit 3ab06470dddf252b4f7904222bdb77ccaadd09bf.