### PR TITLE
[mstflint][livefish][CX8] Unable to verify device

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -1269,6 +1269,18 @@ bool Fs4Operations::ParseDevData(bool quickQuery, bool verbose, VerifyCallBack v
     }
     if (dtocExists)
     {
+        if (!InitHwPtrs())
+        {
+            DPRINTF(("Fs4Operations::encryptedFwQuery HW pointers not found"));
+            return false;
+        }
+
+        if (!ParseImageInfoFromEncryptedImage())
+        {
+            DPRINTF(("Fs4Operations::GetEncryptedImageSizeFromImageInfo Failed to read IMAGE_INFO section"));
+            return false;
+        }
+
         // We have a DTOC to parse
         _ioAccess->set_address_convertor(0, 0);
         // Parse DTOC header:


### PR DESCRIPTION
Description: added init for verify flow

MSTFlint port needed: no
Tested OS: linux
Tested devices: CX8 encrypted
Tested flows: mstflint -d <dev> v

Known gaps (with RM ticket): N/A

Issue: 4424563