### PR TITLE
pldmlib: include <sys/types.h> for musl compatibility

### DIFF
--- a/pldmlib/pldm_utils.h
+++ b/pldmlib/pldm_utils.h
@@ -13,6 +13,7 @@
 #ifndef PLDM_UTILS_H_
 #define PLDM_UTILS_H_
 
+#include <sys/types.h>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Currently, the following errors occur when attempting to compile the latest `mstflint` release using the `musl` toolchain:

```
In file included from pldm_utils.cpp:21:
pldm_utils.h:63:22: error: 'u_int32_t' was not declared in this scope; did you mean 'uint32_t'?
   63 | std::string NumToStr(u_int32_t num);
      |                      ^~~~~~~~~
      |                      uint32_t
pldm_utils.h:66:80: error: 'u_int16_t' has not been declared
   66 | void ComponentIdentifierToStringValue(ComponentIdentifier componentIdentifier, u_int16_t field, std::string& value);
      |                                                                                ^~~~~~~~~
pldm_utils.h:67:74: error: 'u_int16_t' has not been declared
   67 | void ComponentIdentifierToValue(ComponentIdentifier componentIdentifier, u_int16_t field, u_int16_t& value);
      |                                                                          ^~~~~~~~~
pldm_utils.h:67:91: error: 'u_int16_t' has not been declared
   67 | void ComponentIdentifierToValue(ComponentIdentifier componentIdentifier, u_int16_t field, u_int16_t& value);
      |                                                                                           ^~~~~~~~~
pldm_utils.h:70:7: error: 'u_int8_t' does not name a type; did you mean 'uint8_t'?
   70 | const u_int8_t expectedHeaderIdentifier[16] = {0xf0, 0x18, 0x87, 0x8c, 0xcb, 0x7d, 0x49, 0x43,
      |       ^~~~~~~~
      |       uint8_t
pldm_utils.cpp:64:8: error: redefinition of 'std::string NumToStr'
   64 | string NumToStr(u_int32_t num)
      |        ^~~~~~~~
pldm_utils.h:63:13: note: 'std::string NumToStr' previously declared here
   63 | std::string NumToStr(u_int32_t num);
      |             ^~~~~~~~
pldm_utils.cpp:64:17: error: 'u_int32_t' was not declared in this scope; did you mean 'uint32_t'?
   64 | string NumToStr(u_int32_t num)
      |                 ^~~~~~~~~
      |                 uint32_t
pldm_utils.cpp:89:80: error: 'u_int16_t' has not been declared
   89 | void ComponentIdentifierToStringValue(ComponentIdentifier componentIdentifier, u_int16_t field, string& value)
      |                                                                                ^~~~~~~~~
pldm_utils.cpp:108:74: error: 'u_int16_t' has not been declared
  108 | void ComponentIdentifierToValue(ComponentIdentifier componentIdentifier, u_int16_t field, u_int16_t& value)
      |                                                                          ^~~~~~~~~
pldm_utils.cpp:108:91: error: 'u_int16_t' has not been declared
  108 | void ComponentIdentifierToValue(ComponentIdentifier componentIdentifier, u_int16_t field, u_int16_t& value)
      |                                                                                           ^~~~~~~~~
make[5]: *** [Makefile:507: pldm_utils.lo] Error 1
```
<br>

This issue arises because `musl`'s `stdlib.h` does not include `<sys/types.h>`, unlike the `glibc` toolchain. This patch manually includes `<sys/types.h>` to resolve the problem.