### PR TITLE
ICMD semaphore62 lock fix

### DIFF
--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -175,7 +175,7 @@ const char* m_err2str(MError status);
 int mread_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
 int mwrite_buffer(mfile* mf, unsigned int offset, u_int8_t* data, int byte_len);
 
-int mget_vsec_supp(mfile* mf);
+int is_gw_access(mfile* mf);
 
 int mget_addr_space(mfile* mf);
 int mset_addr_space(mfile* mf, int space);

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -205,6 +205,7 @@ typedef enum MError {
     ME_ICMD_ICM_NOT_AVAIL,
     ME_ICMD_WRITE_PROTECT,
     ME_ICMD_SIZE_EXCEEDS_LIMIT,
+    ME_ICMD_UNABLE_TO_TAKE_SEMAOHORE,
 
     /* errors regarding Tools CMDIF */
     ME_CMDIF_BUSY = 0x300,

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -2514,8 +2514,12 @@ int mset_cr_access(mfile* mf, int access)
     return -1;
 }
 
-int mget_vsec_supp(mfile* mf)
+int is_gw_access(mfile* mf)
 {
+    if (mf->tp == MST_BAR0_GW_PCI)
+    {
+        return 1;
+    }
     return mf->functional_vsec_supp;
 }
 

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -272,8 +272,12 @@ int supports_reg_access_gmp(mfile* mf, maccess_reg_method_t reg_method)
     return supports_reg_access_gmp_ul(mf, reg_method);
 }
 
-int mget_vsec_supp(mfile* mf)
+int is_gw_access(mfile* mf)
 {
+    if (mf->tp == MST_BAR0_GW_PCI)
+    {
+        return 1;
+    }
     return mf->functional_vsec_supp;
 }
 

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -54,6 +54,8 @@
 #define ICMD_QUERY_CAP_CMD_ID        0x8400
 #define ICMD_QUERY_CAP_CMD_SZ        0x8
 #define ICMD_QUERY_CAP_EXMB_ICMD_OFF 0x8
+#define SEMAPHORE_62_LOCKED_INDICATOR 0x1
+
 
 /* _DEBUG_MODE   // un-comment this to enable debug prints */
 
@@ -266,8 +268,10 @@ int MREAD4_SEMAPHORE(mfile* mf, int offset, u_int32_t* ptr)
     }
     RESTORE_SPACE(mf);
 
-    /* icmd semaphore lock in non-vsec cr-space is only the last bit in the DWORD. */
-    if (!mf->functional_vsec_supp) {
+    // When accessing directly to the device configuration space, the semaphore lock is the last bit in the DWORD.
+    // When accessing via VSC GW or BAR0 GW, the semaphore lock is the whole dword.
+    if (!is_gw_access(mf))
+    {
         *ptr = EXTRACT(*ptr, 31, 1);
     }
 
@@ -641,12 +645,28 @@ static int icmd_take_semaphore_com(mfile* mf, u_int32_t expected_read_val)
         } else
 #endif
         {
-            if (mf->functional_vsec_supp) {
-                /* write expected val before reading it */
-                MWRITE4_SEMAPHORE(mf, mf->icmd.semaphore_addr, expected_read_val);
+            if (mf->functional_vsec_supp)
+            {
+                DBG_PRINTF("ICMD_SEMAPHORE: Writing expected_read_val=0x%x to semaphore\n", expected_read_val);
+                MWRITE4_SEMAPHORE(mf, mf->icmd.semaphore_addr,
+                                  expected_read_val); // Attempt to take the semaphore by writing the PID
             }
             MREAD4_SEMAPHORE(mf, mf->icmd.semaphore_addr, &read_val);
-            if (read_val == expected_read_val) {
+            DBG_PRINTF("ICMD_SEMAPHORE: read_val=0x%x expected_read_val=0x%x\n", read_val, expected_read_val);
+            if (read_val == expected_read_val) // Semaphore was free (PID if VSC, 0 if non-VSC)
+            {
+                if (!is_gw_access(mf))
+                {
+                    // Verify HW has set the semaphore to locked state
+                    MREAD4_SEMAPHORE(mf, mf->icmd.semaphore_addr, &read_val);
+                    if (read_val != SEMAPHORE_62_LOCKED_INDICATOR)
+                    {
+                        printf("Failed to take ICMD semaphore (semaphore 62). "
+                               "Semaphore was free (0) but HW failed to set it to locked state when we took it."
+                               "This might indicate a FW or HW issue.\n");
+                        return ME_ICMD_UNABLE_TO_TAKE_SEMAOHORE;
+                    }
+                }
                 break;
             }
         }

--- a/small_utils/mtserver.c
+++ b/small_utils/mtserver.c
@@ -500,7 +500,7 @@ void get_devices_list(int con)
         }
     }
 }
-int mget_vsec_supp(mfile* mf)
+int is_gw_access(mfile* mf)
 {
     TOOLS_UNUSED(mf);
     return 0;
@@ -937,7 +937,7 @@ int main(int ac, char* av[])
 #endif
                             // write Recv buffer
                             char res_buf[16];
-                            snprintf(res_buf, 16, "O %d", mget_vsec_supp(mf));
+                            snprintf(res_buf, 16, "O %d", is_gw_access(mf));
                             writes_deb(con, res_buf);
                         }
                         else

--- a/tools_res_mgmt/tools_res_mgmt.c
+++ b/tools_res_mgmt/tools_res_mgmt.c
@@ -561,7 +561,7 @@ trm_sts trm_lock(trm_ctx trm, trm_resourse res, unsigned int max_retries)
     switch ((int)res)
     {
         case TRM_RES_ICMD:
-            if (trm->dev_sem_info->vsec_sem_supported && mget_vsec_supp(trm->mf))
+            if (trm->dev_sem_info->vsec_sem_supported && is_gw_access(trm->mf))
             {
                 return lock_icommand_gateway_semaphore(trm->mf, g_vsec_sem_addr[TRM_RES_ICMD], max_retries);
 #if !defined(__FreeBSD__) && !defined(UEFI_BUILD)
@@ -579,7 +579,7 @@ trm_sts trm_lock(trm_ctx trm, trm_resourse res, unsigned int max_retries)
             break;
 
         case TRM_RES_FLASH_PROGRAMING:
-            if (trm->dev_sem_info->vsec_sem_supported && mget_vsec_supp(trm->mf))
+            if (trm->dev_sem_info->vsec_sem_supported && is_gw_access(trm->mf))
             {
                 return lock_icommand_gateway_semaphore(trm->mf, g_vsec_sem_addr[TRM_RES_FLASH_PROGRAMING], max_retries);
 #if !defined(__FreeBSD__) && !defined(UEFI_BUILD)
@@ -637,7 +637,7 @@ trm_sts trm_unlock(trm_ctx trm, trm_resourse res)
     switch ((int)res)
     {
         case TRM_RES_ICMD:
-            if (trm->dev_sem_info->vsec_sem_supported && mget_vsec_supp(trm->mf))
+            if (trm->dev_sem_info->vsec_sem_supported && is_gw_access(trm->mf))
             {
                 return unlock_icommand_gateway_semaphore(trm->mf, g_vsec_sem_addr[TRM_RES_ICMD]);
 #if !defined(__FreeBSD__) && !defined(UEFI_BUILD)
@@ -655,7 +655,7 @@ trm_sts trm_unlock(trm_ctx trm, trm_resourse res)
             break;
 
         case TRM_RES_FLASH_PROGRAMING:
-            if (trm->dev_sem_info->vsec_sem_supported && mget_vsec_supp(trm->mf))
+            if (trm->dev_sem_info->vsec_sem_supported && is_gw_access(trm->mf))
             {
                 return unlock_icommand_gateway_semaphore(trm->mf, g_vsec_sem_addr[TRM_RES_FLASH_PROGRAMING]);
 #if !defined(__FreeBSD__) && !defined(UEFI_BUILD)


### PR DESCRIPTION
Description: when accessing the device configuration space via GW (either VSC GW or PCI BAR0 GW), we address the ICMD semaphore as a whole DWORD.
This is in contrast to direct access to the device configuration space (MST_PCI) where the ICMD semaphore is 1 bit long.

Issue:4436228