### PR TITLE
[Mstflint] WB a full image on Device does not report status

### DIFF
--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -1336,7 +1336,9 @@ bool FwOperations::writeImageEx(ProgressCallBackEx progressFuncEx,
         // Report
         if (progressFunc != NULL || progressFuncEx != NULL)
         {
-            u_int32_t curr_percent = ((cnt - towrite + alreadyWrittenSz) * 100) / totalSz;
+            double written = cnt - towrite + alreadyWrittenSz;
+            double curr_percent_double = (written / totalSz) * 100;
+            u_int32_t curr_percent = (u_int32_t)curr_percent_double;
             if (last_percent != curr_percent)
             {
                 last_percent = curr_percent;


### PR DESCRIPTION
Description: fixed written bytes overflow

MSTFlint port needed: yes
Tested OS: linux
Tested devices: Cx8 in LF
Tested flows: mstflint -d <dev> -ocr wb <image> 0x0

Known gaps (with RM ticket): N/A

Issue: 4477144