### PR TITLE
Aligning mstflint_4_31_0_gb200 to MFT's mft_4_31_0_release branch

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -2019,15 +2019,35 @@ bool BinaryCompareSubCommand::CompareEncryptedFwOpsViaMCC(bool& res)
 
     std::vector<u_int8_t> deviceBuff;
     std::vector<u_int8_t> imgBuff;
-    if (!_fwOps->GetHashesTableData(deviceBuff))
+   if (_imgOps->FwType() == FIT_FS5)
     {
-        return false;
+        //* Compare Ncore
+        if (!_fwOps->GetNcoreData(deviceBuff))
+        {
+            reportErr(true, _fwOps->err());
+            return false;
+        }
+        if (!_imgOps->GetNcoreData(imgBuff))
+        {
+            reportErr(true, _imgOps->err());
+            return false;
+        }
     }
-    if (!_imgOps->GetHashesTableData(imgBuff))
+    else
     {
-        return false;
+        //* Compare hashes table
+        if (!_fwOps->GetHashesTableData(deviceBuff))
+        {
+            reportErr(true, _fwOps->err());
+            return false;
+        }
+        if (!_imgOps->GetHashesTableData(imgBuff))
+        {
+            reportErr(true, _imgOps->err());
+            return false;
+        }
     }
-
+    
     if (deviceBuff == imgBuff)
     {
         res = true;

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -788,8 +788,16 @@ bool FwCompsMgr::runMCQI(u_int32_t componentIndex,
         setLastRegisterAccessStatus(rc);
         ret = false;
     }
-    if (data && dataSize) {
-        if (!rc) {
+    if (data && dataSize)
+    {
+        if (!rc)
+        {
+            if (_currCompInfo.info_size > reg_access_hca_mcqi_reg_data_auto_ext_size())
+            {
+                DPRINTF(("-E- got unexpected info size from MCQI: %u\n", _currCompInfo.info_size));
+                _lastError = FWCOMPS_REG_ACCESS_SIZE_EXCCEEDS_LIMIT;
+                return false;
+            }
             memcpy(data, &_currCompInfo.data, _currCompInfo.info_size);
         }
     }

--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -511,9 +511,8 @@ int get_log2size_by_vendor_type_density(u_int8_t vendor, u_int8_t type, u_int8_t
     if ((type == FMT_SST_25) && (vendor == FV_SST)) {
         return cntx_sst_get_log2size(density, log2size);
     }
-    if (((((type == FMT_WINBOND) || (type == FMT_WINBOND_3V)) && (vendor == FV_WINBOND)) ||
-         ((type == FMT_N25QXXX) && (vendor == FV_ST)) || ((type == FMT_IS25WPXXX) && (vendor == FV_IS25LPXXX))) &&
-        (density == 0x20)) {
+    // In some flashes, the value is 20, but the correct value should be 0x1A. It cannot be 0x20 because 2^20 would overflow an integer.
+    if(density == 0x20) {
         *log2size = 0x1a;
     } else {
         *log2size = density;

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -948,7 +948,7 @@ const char* GenericCommander::loadConfigurationGetStr()
 
     if (dm_is_5th_gen_hca(deviceId))
     {
-        // send warm boot (bit 6)
+        // send warm boot (bit 6 + bit 3)
         mfrl.reset_trigger = 1 << 6;
         mft_signal_set_handling(1);
         rc = reg_access_mfrl(_mf, REG_ACCESS_METHOD_SET, &mfrl);

--- a/mlxfwops/lib/fs3_ops.cpp
+++ b/mlxfwops/lib/fs3_ops.cpp
@@ -4104,7 +4104,7 @@ bool Fs3Operations::Fs3IsfuActivateImage(u_int32_t newImageStart)
     rc = reg_access_mfai(mf, REG_ACCESS_METHOD_SET, &mfai);
     if (!rc)
     {
-        /* send warm boot (bit 6) */
+        // send warm boot (bit 6)
         mfrl.reset_trigger = 1 << 6;
         rc = reg_access_mfrl(mf, REG_ACCESS_METHOD_SET, &mfrl);
         /* ignore ME_REG_ACCESS_BAD_PARAM error for old FW */

--- a/mlxfwops/lib/fs5_ops.cpp
+++ b/mlxfwops/lib/fs5_ops.cpp
@@ -416,9 +416,36 @@ bool Fs5Operations::FsVerifyAux(VerifyCallBack verifyCallBackFunc,
     return true;
 }
 
+bool Fs5Operations::IsExtracted()
+{
+    u_int32_t image_size;
+    // Calculate the size from the start to the end of the iTOCs.
+    if (!GetImageSize(&image_size))
+    {
+        return errmsg("Can't get image size.\n");
+    }
+    u_int32_t readbleSize = _ioAccess->get_size();
+    if (readbleSize < image_size)
+    {
+        return errmsg("-E- iTOCs size smaller than the image (image problem).\n");
+    }
+    u_int32_t gapSize = readbleSize - image_size;
+    // If the image contains an encapsulation header, this will represent the gap (equal to the encapsulation header
+    // size, which matches the BCH size).
+    if (gapSize == 0 || gapSize == BCH_SIZE_IN_BYTES)
+    {
+        return true;
+    }
+    return false;
+}
+
 bool Fs5Operations::FwQuery(fw_info_t* fwInfo, bool, bool, bool quickQuery, bool ignoreDToc, bool verbose)
 {
     DPRINTF(("Fs5Operations::FwQuery\n"));
+    if (IsExtracted())
+    {
+        ignoreDToc = true;
+    }
     if (!encryptedFwQuery(fwInfo, quickQuery, ignoreDToc, verbose))
     {
         return errmsg("%s", err());
@@ -470,7 +497,15 @@ bool Fs5Operations::FwExtract4MBImage(vector<u_int8_t>& img,
                                       bool ignoreImageStart,
                                       bool imageSizeOnly)
 {
-    bool res = Fs4Operations::FwExtract4MBImage(img, maskMagicPatternAndDevToc, verbose, ignoreImageStart);
+     bool res;
+     if (IsExtracted())
+    {
+        res = FwExtractEncryptedImage(img, maskMagicPatternAndDevToc, verbose, ignoreImageStart);
+    }
+    else
+    {
+        res = Fs4Operations::FwExtract4MBImage(img, maskMagicPatternAndDevToc, verbose, ignoreImageStart);
+    }
 
     if (res && !imageSizeOnly)
     {

--- a/mlxfwops/lib/fs5_ops.cpp
+++ b/mlxfwops/lib/fs5_ops.cpp
@@ -150,6 +150,26 @@ bool Fs5Operations::GetImageSize(u_int32_t* image_size)
     return true;
 }
 
+bool Fs5Operations::GetNcoreData(vector<u_int8_t>& imgBuff)
+{
+    fs5_image_layout_boot_component_header bchComponent;
+    vector<u_int8_t> bchRawData(FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE);
+    if (!_ioAccess->read(_ncore_bch_ptr, bchRawData.data(), FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE))
+    {
+        return errmsg("%s - read error can not read bch\n", _ioAccess->err());
+    }
+    TOCPUn(bchRawData.data(), BCH_SIZE_IN_BYTES / 4);
+    fs5_image_layout_boot_component_header_unpack(&bchComponent, bchRawData.data());
+  
+    u_int32_t payloadSize = bchComponent.stage1_components[0].u32_binary_len;
+    imgBuff.resize(payloadSize);
+    if (!_ioAccess->read(_ncore_bch_ptr + FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE, imgBuff.data(), payloadSize))
+    {
+        return errmsg("%s - read error can not read bch\n", _ioAccess->err());
+    }
+    return true;
+}
+
 bool Fs5Operations::GetHashesTableSize(u_int32_t& size)
 {
     bool image_encrypted = false;

--- a/mlxfwops/lib/fs5_ops.h
+++ b/mlxfwops/lib/fs5_ops.h
@@ -79,6 +79,7 @@ private:
                      bool verbose = false) override;
     bool IsSecureFwUpdateSigned(bool& isSigned);
     bool NCoreQuery(fw_info_t* fwInfo);
+    bool GetNcoreData(vector<u_int8_t>& imgBuff) override;
     bool GetHashesTableSize(u_int32_t& size) override;
 
     static const u_int32_t BCH_SIZE_IN_BYTES;               

--- a/mlxfwops/lib/fs5_ops.h
+++ b/mlxfwops/lib/fs5_ops.h
@@ -65,6 +65,7 @@ protected:
     bool GetDtocAddress(u_int32_t& dTocAddress) override;
     bool GetMfgInfo(u_int8_t* buff) override;
     bool CheckAndDealWithChunkSizes(u_int32_t cntxLog2ChunkSize, u_int32_t imageCntxLog2ChunkSize) override;
+    bool IsExtracted();
     u_int32_t _ncore_bch_ptr;
 
 private:

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -675,6 +675,72 @@ bool FsCtrlOperations::_createImageOps(unique_ptr<FwOperations>& imageOps)
     return true;
 }
 
+
+bool FsCtrlOperations::GetNcoreData(vector<u_int8_t>& ncoreData)
+{
+    u_int32_t ncoreBchAddr = 0;
+    if (!GetNcoreBCHAddr(ncoreBchAddr))
+    {
+        return errmsg("%s", err());
+    }
+
+    u_int32_t ncoreSize = 0;
+    if (!GetNcoreSize(ncoreBchAddr, ncoreSize))
+    {
+        return errmsg("%s", err());
+    }
+
+    u_int32_t ncoreAddr = ncoreBchAddr + FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE;
+    if (!FwReadBlock(ncoreAddr, ncoreSize, ncoreData))
+    {
+        return errmsg("%s", err());
+    }
+
+    return true;
+}
+
+bool FsCtrlOperations::GetNcoreBCHAddr(u_int32_t& ncoreBchAddr)
+{
+    struct fs5_image_layout_hw_pointers_gilboa cx8_hw_pointers;
+    if (!GetFS5HWPointers(cx8_hw_pointers))
+    {
+        return false;
+    }
+    ncoreBchAddr = cx8_hw_pointers.ncore_bch_pointer.ptr;
+    return true;
+}
+
+bool FsCtrlOperations::GetNcoreSize(u_int32_t ncoreBchAddr, u_int32_t& size)
+{
+    vector<u_int8_t> bch(FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE);
+    if (!FwReadBlock(ncoreBchAddr, bch.size(), bch))
+    {
+        return errmsg("Failed to read BCH NCORE from flash");
+    }
+    struct fs5_image_layout_boot_component_header ncoreBCH;
+    memset(&ncoreBCH, 0, sizeof(ncoreBCH));
+
+    TOCPUn(bch.data(), FS5_IMAGE_LAYOUT_BOOT_COMPONENT_HEADER_SIZE / 4);
+    fs5_image_layout_boot_component_header_unpack(&ncoreBCH, bch.data());
+    size = ncoreBCH.stage1_components[0].u32_binary_len;
+    return true;
+}
+
+bool FsCtrlOperations::GetFS5HWPointers(fs5_image_layout_hw_pointers_gilboa& hw_pointers)
+{
+    if (FwType() != FIT_FS5)
+    {
+        return errmsg("Failed. GetFS5HWPointers supported only for FS5 images/devices.");
+    }
+    vector<u_int8_t> buff(FS5_IMAGE_LAYOUT_HW_POINTERS_GILBOA_SIZE);
+    if (!FwReadBlock(FS4_HW_PTR_START, buff.size(), buff))
+    {
+        return errmsg("Failed to read HW pointers from flash");
+    }
+    fs5_image_layout_hw_pointers_gilboa_unpack(&hw_pointers, buff.data());
+    return true;
+}
+
 bool FsCtrlOperations::GetHashesTableSize(u_int32_t hashes_table_addr, u_int32_t& size)
 {
     u_int32_t htoc_size =

--- a/mlxfwops/lib/fsctrl_ops.h
+++ b/mlxfwops/lib/fsctrl_ops.h
@@ -35,6 +35,7 @@
 #include "aux_tlv_ops.h"
 #include "fw_comps_mgr/fw_comps_mgr.h"
 #include "fw_comps_mgr/fw_comps_mgr_dma_access.h"
+#include "tools_layouts/fs5_image_layout_layouts.h"
 
 class FsCtrlOperations : public FwOperations
 {
@@ -148,6 +149,11 @@ private:
     bool CheckITOCSignature(u_int8_t* signature);
     bool GetHashesTableAddr(u_int32_t& addr);
     bool GetHashesTableSize(u_int32_t hashes_table_addr, u_int32_t& size);
+    bool GetNcoreData(vector<u_int8_t>& ncoreData);
+    bool GetFS5HWPointers(fs5_image_layout_hw_pointers_gilboa& hw_pointers);
+    bool GetNcoreBCHAddr(u_int32_t& ncoreBchAddr);
+    bool GetNcoreSize(u_int32_t ncoreBchAddr, u_int32_t& size);
+
 
     fs3_info_t _fsCtrlImgInfo;
     FwCompsMgr* _fwCompsAccess;

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -2850,6 +2850,21 @@ bool FwOperations::IsCompatibleToDevice(vector<u_int8_t>& data, u_int8_t forceVe
     return errmsg("IsCompatibleToDevice is not supported");
 }
 
+bool FwOperations::GetSecureHostState(u_int8_t&)
+{
+    return errmsg("GetSecureHostState is not supported");
+}
+
+bool FwOperations::ChangeSecureHostState(bool, u_int64_t)
+{
+    return errmsg("ChangeSecureHostState is not supported");
+}
+
+bool FwOperations::GetNcoreData(vector<u_int8_t>&)
+{
+    return errmsg("GetNcoreData is not supported");
+}
+
 bool FwOperations::IsExtendedGuidNumSupported()
 {
     bool isSupported = false;

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -293,6 +293,9 @@ public:
     virtual bool ReadMccComponent(vector<u_int8_t>& componentRawData,
                                   FwComponent::comps_ids_t component,
                                   ProgressCallBackAdvSt* stProgressFunc = NULL);
+    virtual bool GetNcoreData(vector<u_int8_t>& ncoreData);
+    virtual bool GetSecureHostState(u_int8_t& state);
+    virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
 
 #ifndef UEFI_BUILD
     static bool CheckPemKeySize(const string privPemFileStr, u_int32_t& keySize);

--- a/mlxfwupdate/image_access.cpp
+++ b/mlxfwupdate/image_access.cpp
@@ -249,13 +249,13 @@ int ImageAccess::queryPsid(const string&  fname,
             imgv.setVersion("FW", 3, img_query.fw_info.fw_ver, img_query.fw_info.branch_ver);
             ri.imgVers.push_back(imgv);
         } else {
-            u_int16_t fwVer[4];
+            u_int16_t fwVer[3];
             fwVer[0] = img_query.fw_info.fw_ver[0];
             fwVer[1] = img_query.fw_info.fw_ver[1];
-            fwVer[2] = img_query.fw_info.fw_ver[2] / 100;
-            fwVer[3] = img_query.fw_info.fw_ver[2] % 100;
+            fwVer[2] = img_query.fw_info.fw_ver[2];
+
             ImgVersion imgv;
-            imgv.setVersion("FW", 4, fwVer);
+            imgv.setVersion("FW", 3, fwVer);
             ri.imgVers.push_back(imgv);
         }
         for (int i = 0; i < img_query.fw_info.roms_info.num_of_exp_rom; i++) {

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -544,7 +544,7 @@ public:
     void checkPrbsPolCap(const string& prbsReg);
     void checkPprtPptt();
     void checkPplrCap();
-    void sendPrbsPpaos(bool);
+    void sendPrbsPpaos(bool testMode, bool dc_cpl_allow = false);
     void startTuning();
     void prbsConfiguration(const string& prbsReg,
                            bool enable,


### PR DESCRIPTION
Added the following commits that were missing:
 
f189a2523734d516d3c8671918cbd813273010de - [flint] Binary Compare for CX8
530cd3c7d422d1b95155d06e3e293a0612804f2f - Revert "[flint] Set pci-link-disable bit when sending MFRL after FW update"
c38c970015bf66fbe8a74ab1e522254447d16bca - [flint][mflash] Flash Vendor Size Issue
c09515bddfe58d81fe78afacdbd5d672970b4d5c - [flint]Added support for burning extracted image
e007a66e67a8deffa9b2f0b97dfc6a901e7162ad - [mlxfwmanager][flint] Validate out of range info size for MCQI
04b60377e651d2c1df0e7b2cc9d1d140ea3ce1bd - [AWS-NVL][GB200] mlxfwmanager query with old firmware returns incorrect available version