### PR TITLE
Feature Request #4438334: Customers| Meta | mstfwmanager --skip_if_same

### DIFF
--- a/flint/cmd_line_parser.cpp
+++ b/flint/cmd_line_parser.cpp
@@ -246,6 +246,7 @@ FlagMetaData::FlagMetaData()
     _flags.push_back(new Flag("", "cert_chain_index", 1));
     _flags.push_back(new Flag("", "component_type", 1));
     _flags.push_back(new Flag("", "image_size_only", 0));
+    _flags.push_back(new Flag("", "skip_if_same", 0));
 }
 
 FlagMetaData::~FlagMetaData()
@@ -735,6 +736,9 @@ void Flint::initCmdParser()
 
     AddOptions("no_fw_ctrl", ' ', "", "Do not attempt to work with the FW Ctrl update commands");
 
+    AddOptions("skip_if_same", ' ', "",
+               "Skip burning if the firmware version matches the current version on the device");
+
     AddOptions("use_dev_img_info",
                ' ',
                "",
@@ -1156,6 +1160,10 @@ ParseStatus Flint::HandleOption(string name, string value)
     else if (name == "no_fw_ctrl")
     {
         _flintParams.no_fw_ctrl = true;
+    }
+    else if (name == "skip_if_same")
+    {
+        _flintParams.skip_if_same = true;
     }
     else if (name == "dual_image")
     {

--- a/flint/flint_params.cpp
+++ b/flint/flint_params.cpp
@@ -117,6 +117,7 @@ FlintParams::FlintParams()
     i2cSecondaryAddr = -1;
     imageSizeOnly = false;
     cert_uuid = "";
+    skip_if_same = false;
 }
 
 FlintParams::~FlintParams() {}

--- a/flint/flint_params.h
+++ b/flint/flint_params.h
@@ -199,6 +199,7 @@ public:
     string component_type;
     bool imageSizeOnly;
     string cert_uuid;
+    bool skip_if_same;
 };
 
 #endif

--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -2684,6 +2684,13 @@ bool BurnSubCommand::checkFwVersion(bool CreateFromImgInfo, u_int16_t fw_ver0, u
             printf("\n    Note: The new FW version is %s the current FW"
                    " version on flash.\n",
                    current == new_version ? "the same as" : "older than");
+
+            if (current == new_version && _flintParams.skip_if_same)
+            {
+                printf("\n    Skipping burn because firmware versions match and --skip_if_same flag is set.\n");
+                return false;
+            }
+
             if (!askUser())
             {
                 return false;

--- a/mlxfwupdate/cmd_line_params.cpp
+++ b/mlxfwupdate/cmd_line_params.cpp
@@ -81,7 +81,7 @@ CmdLineParams::CmdLineParams()
     no_extract_list = false;
     numberOfRetrials = 5;
     component_type = "";
-
+    skip_if_same = false;
 #ifdef __WIN__
     char execName[1024];
     char certificatPath[1024];

--- a/mlxfwupdate/cmd_line_params.h
+++ b/mlxfwupdate/cmd_line_params.h
@@ -51,6 +51,7 @@ public:
     int update_fw;
     int use_mfa_file;
     int use_mfa_dir;
+    bool skip_if_same;
 
     string mfa_dir;
     string mfa_file;

--- a/mlxfwupdate/cmd_line_parser.cpp
+++ b/mlxfwupdate/cmd_line_parser.cpp
@@ -213,6 +213,9 @@ using namespace mft_utils;
 #define COMP_TYPE_L "component_type"
 #define COMP_TYPE_S ' '
 
+#define SKIP_IF_SAME_L "skip_if_same"
+#define SKIP_IF_SAME_S ' '
+
 string toolName = "";
 /************************************
  * Function: CmdLineParser
@@ -460,6 +463,8 @@ void CmdLineParser::initOptions()
                      true); // Hidden
     
     this->AddOptions(COMP_TYPE_L, COMP_TYPE_S, "componentName", "Specify the PLDM component type to extract");
+
+    this->AddOptions(SKIP_IF_SAME_L, SKIP_IF_SAME_S, "", "Skip firmware update if current and new versions match");
 }
 
 bool csvSplit(string str, vector<string>& strv)
@@ -821,6 +826,11 @@ ParseStatus CmdLineParser::HandleOption(string name, string value)
             cout << "-E- Negative value is not allowed " << value << "\n";
             return PARSE_ERROR;
         }
+        return PARSE_OK;
+    }
+    else if (name == SKIP_IF_SAME_L)
+    {
+        _cmdLineParams->skip_if_same = true;
         return PARSE_OK;
     }
     else

--- a/mlxfwupdate/mlxfwmanager.h
+++ b/mlxfwupdate/mlxfwmanager.h
@@ -140,7 +140,8 @@ void getUniqueMFAList(vector<MlnxDev*>& devs,
                       map<string, PsidQueryItem>& psidUpdateInfo,
                       int force_update,
                       vector<string>& mfa_list,
-                      vector<string>& mfa_base_name_list);
+                      vector<string>& mfa_base_name_list,
+                      bool skip_if_same);
 int queryMFAs(ServerRequest* srq,
               string& mfa_path,
               vector<string>& psid_list,
@@ -243,6 +244,7 @@ void filterFiles(vector<DownloadedFileProperties> files,
                  int family);
 
 int generateProductionName(string& targetFile, PsidQueryItem ri);
+bool isSameVersion(MlnxDev* dev, PsidQueryItem& psidUpdateInfo);
 
 int abort_request = 0;
 int CompareFFV = 0;


### PR DESCRIPTION
Feature Request #4438334: Customers| Meta | mstfwmanager --skip_if_same

Description:
when the user provides --skip_if_same and the FW version of the image in the .mfa provided is the same as the one already burned on the device the tool will print a message indicating they are the same and skip the update. -f flag behaviour stays as before. I.e. -f will override --skip_if_same

Tested OS:linux
Tested devices:cx8
Tested flows:
1. providing .mfa that has the same image already burned: with and without --force
/.autodirect/swgwork/ssela/workspace/fml/mft/user/mlxfwupdate/mlxfwmanager -d /dev/mst/mt4131_pciconf0 -u --skip_if_same -i /mswg/projects/tool_vfn/bin_images_cache/14_05_2025/MFAS/GILBOA.mfa Querying Mellanox devices firmware ...
Device /dev/mst/mt4131_pciconf0: Current firmware version matches target version. Skipping update.

/.autodirect/swgwork/ssela/workspace/fml/mft/user/mlxfwupdate/mlxfwmanager -d /dev/mst/mt4131_pciconf0 -u --skip_if_same -i
/mswg/projects/tool_vfn/bin_images_cache/14_05_2025/MFAS/GILBOA.mfa -f

2. providing .mfa with newer image to make sure fwupdate will happen: /.autodirect/swgwork/ssela/workspace/fml/mft/user/mlxfwupdate/mlxfwmanager -d /dev/mst/mt4131_pciconf0 -u --skip_if_same -i /mswg/tmp/cx8MFAs/cx8_new.mfa

3. providing .mfa with older image: /.autodirect/swgwork/ssela/workspace/fml/mft/user/mlxfwupdate/mlxfwmanager -d /dev/mst/mt4131_pciconf0 -u --skip_if_same -i /mswg/tmp/cx8MFAs/cx8_old.mfa

Known gaps (with RM ticket):n/a

Issue: 4438334