### PR TITLE
Feature #4295538: ByteDance: BFB FW bundle query

### DIFF
--- a/flint/cmd_line_parser.cpp
+++ b/flint/cmd_line_parser.cpp
@@ -126,6 +126,7 @@ SubCmdMetaData::SubCmdMetaData()
     _sCmds.push_back(new SubCmd("", "rsa_sign", SC_RSA_Sign));
     _sCmds.push_back(new SubCmd("", "export_public_key", SC_Export_Public_Key));
     _sCmds.push_back(new SubCmd("qc", "query_components", SC_Query_Components));
+    _sCmds.push_back(new SubCmd("qbfb", "query_bfb_components", SC_Query_Bfb_Components));
 }
 
 SubCmdMetaData::~SubCmdMetaData()
@@ -245,7 +246,7 @@ FlagMetaData::FlagMetaData()
     _flags.push_back(new Flag("", "user_password", 1));
     _flags.push_back(new Flag("", "cert_chain_index", 1));
     _flags.push_back(new Flag("", "component_type", 1));
-    _flags.push_back(new Flag("", "image_size_only", 0));
+    _flags.push_back(new Flag("", "pending", 0));
     _flags.push_back(new Flag("", "skip_if_same", 0));
 }
 
@@ -667,6 +668,12 @@ void Flint::initCmdParser()
                "",
                "When specified, only flashed fw version is fetched\n"
                "Commands affected: query");
+
+    AddOptions("pending",
+               ' ',
+               "",
+               "When specified, shows the versions of the pending BFB components\n"
+               "Commands affected: query_bfb_components");
 
     AddOptions("nofs", ' ', "", "Burn image in a non failsafe manner.");
 
@@ -1404,6 +1411,10 @@ ParseStatus Flint::HandleOption(string name, string value)
     else if (name == "image_size_only")
     {
         _flintParams.imageSizeOnly = true;
+    }
+    else if (name == "pending")
+    {
+        _flintParams.pending = true;
     }
     else
     {

--- a/flint/flint.cpp
+++ b/flint/flint.cpp
@@ -154,6 +154,7 @@ map_sub_cmd_t_to_subcommand Flint::initSubcommandMap()
     cmdMap[SC_Qrom] = new RomQuerySubCommand();
     cmdMap[SC_Bb] = new BbSubCommand();
     cmdMap[SC_Sg] = new SgSubCommand();
+    cmdMap[SC_Query_Bfb_Components] = new QueryBfbComponentsSubCommand();
 #ifndef EXTERNAL
     cmdMap[SC_Smg] = new SmgSubCommand();
     cmdMap[SC_Set_Vpd] = new SetVpdSubCommand();

--- a/flint/flint_params.cpp
+++ b/flint/flint_params.cpp
@@ -118,6 +118,7 @@ FlintParams::FlintParams()
     imageSizeOnly = false;
     cert_uuid = "";
     skip_if_same = false;
+    pending = false;
 }
 
 FlintParams::~FlintParams() {}

--- a/flint/flint_params.h
+++ b/flint/flint_params.h
@@ -92,7 +92,8 @@ typedef enum
     SC_RSA_Sign,
     SC_Binary_Compare,
     SC_Export_Public_Key,
-    SC_Query_Components
+    SC_Query_Components,
+    SC_Query_Bfb_Components
 } sub_cmd_t;
 
 class FlintParams
@@ -200,6 +201,7 @@ public:
     bool imageSizeOnly;
     string cert_uuid;
     bool skip_if_same;
+    bool pending;
 };
 
 #endif

--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -8470,3 +8470,114 @@ FlintStatus ExportPublicSubCommand::executeCommand()
     return FLINT_SUCCESS;
 }
 #endif
+
+
+/***********************
+ * Class: QueryBfbComponentsSubCommand
+ ***********************/
+QueryBfbComponentsSubCommand::QueryBfbComponentsSubCommand()
+{
+    _name = "query_bfb_components";
+    _desc = "Query BFB components version";
+    _extendedDesc = "Query and display information about BFB components in the device";
+    _flagLong = "query_bfb_components";
+    _flagShort = "qbfb";
+    _param = "";
+    _paramExp = "";
+    _example = FLINT_NAME " -d " MST_DEV_EXAMPLE1 " query_bfb_components";
+    _v = Wtv_Dev;
+    _maxCmdParamNum = 0;
+    _cmdType = SC_Query_Bfb_Components;
+    _mccSupported = true;
+    _pending = false;
+};
+
+QueryBfbComponentsSubCommand::~QueryBfbComponentsSubCommand() {}
+
+FlintStatus QueryBfbComponentsSubCommand::executeCommand()
+{
+    if (preFwOps() == FLINT_FAILED)
+    {
+        return FLINT_FAILED;
+    }
+
+    if (!_fwOps->getBFBComponentsVersions(_name_to_version, _pending))
+    {
+        return FLINT_FAILED;
+    }
+
+    printComponents();
+    return FLINT_SUCCESS;
+}
+
+bool QueryBfbComponentsSubCommand::verifyParams()
+{
+    _pending = _flintParams.pending;
+
+    if (!_flintParams.device_specified)
+    {
+        reportErr(true, FLINT_NO_DEVICE_ERROR);
+        return false;
+    }
+
+    if (!_flintParams.cmd_params.empty())
+    {
+        reportErr(true, FLINT_CMD_ARGS_ERROR, _name.c_str(), 0, (int)_flintParams.cmd_params.size());
+        return false;
+    }
+
+    return isDeviceSupported();
+}
+
+bool QueryBfbComponentsSubCommand::isDeviceSupported()
+{
+    mfile* mf = mopen(_flintParams.device.c_str());
+    if (!mf)
+    {
+        reportErr(true, "Failed to open device: %s\n", _flintParams.device.c_str());
+        return false;
+    }
+
+    dm_dev_id_t devid_type = DeviceUnknown;
+    u_int32_t devid = 0, revid = 0;
+    int rc = dm_get_device_id(mf, &devid_type, &devid, &revid);
+    mclose(mf);
+
+    if (rc != 0)
+    {
+        reportErr(true, "Can't get device ID.\n");
+        return false;
+    }
+
+    if (devid_type != DeviceBlueField3)
+    {
+        reportErr(true, "query_bfb_components sub-command is supported for BlueField3 only. Device provided: %s\n",
+                  dm_dev_type2str(devid_type));
+        return false;
+    }
+
+    return true;
+}
+
+void QueryBfbComponentsSubCommand::printComponents()
+{
+    printf("{\n\n");
+    printf(
+      "    \"//\": \"This JSON represents a Redfish Software Inventory collection containing multiple software components.\",\n\n");
+    printf("    \"Name\": \"BFB File Content\",\n\n");
+    printf("    \"Members\": [\n");
+
+    size_t id = 1;
+    for (const auto& name_version_pair : _name_to_version)
+    {
+        printf("        {\n");
+        printf("            \"Id\": \"%zu\",\n", id++);
+        printf("            \"Name\": \"%s\",\n", name_version_pair.first.c_str());
+        printf("            \"Version\": \"%s\",\n", name_version_pair.second.c_str());
+        printf("        }%s\n", (id <= _name_to_version.size()) ? "," : "");
+    }
+
+    printf("    ],\n\n");
+    printf("    \"Members@odata.count\": %zu\n", _name_to_version.size());
+    printf("}\n");
+}

--- a/flint/subcommands.h
+++ b/flint/subcommands.h
@@ -44,6 +44,7 @@
 
 #include <string>
 #include <memory>
+#include <map>
 
 #include <tools_layouts/tools_open_layouts.h>
 #include "tools_layouts/image_layout_layouts.h"
@@ -330,6 +331,23 @@ public:
     FlintStatus QueryCertStatus();
 private:
     FwComponent::comps_ids_t _comp;
+};
+
+
+class QueryBfbComponentsSubCommand : public SubCommand
+{
+public:
+    QueryBfbComponentsSubCommand();
+    ~QueryBfbComponentsSubCommand();
+    bool verifyParams() override;
+    FlintStatus executeCommand() override;
+
+private:
+    bool _pending;
+    std::map<std::string, std::string> _name_to_version;
+
+    bool isDeviceSupported();
+    void printComponents();
 };
 
 class Extract4MBImageSubCommand : public SubCommand

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -2543,3 +2543,72 @@ fw_comps_error_t FwCompsMgr::mccErrTrans(u_int8_t err)
         return FWCOMPS_GENERAL_ERR;
     }
 }
+
+
+bool FwCompsMgr::runMISOC(reg_access_hca_misoc_reg_ext* bfb_component, u_int32_t type, u_int32_t query_pending)
+{
+    // check via MCAM if MISOC supported
+    int misoc_reg_supported = 0;
+    reg_access_hca_mcam_reg_ext mcam;
+    memset(&mcam, 0, sizeof(mcam));
+    mcam.access_reg_group = 0; // group 0 for IDs 0x9001 to 0x907F
+    reg_access_status_t rc = reg_access_mcam(_mf, REG_ACCESS_METHOD_GET, &mcam);
+    if (rc == ME_OK)
+    {
+        // MISOC is bit 38s
+        // DWORD select logic: 3 - (38 / 32)
+        // bit select logic: 38 % 32
+        misoc_reg_supported = EXTRACT(mcam.mng_access_reg_cap_mask[3 - 1], 6, 1);
+    }
+    DPRINTF(("misoc_reg_supported = %d\n", misoc_reg_supported));
+    if (!misoc_reg_supported)
+    {
+        _lastError = FWCOMPS_REG_ACCESS_REG_NOT_SUPP;
+        return false;
+    }
+
+    bool ret = true;
+    mft_signal_set_handling(1);
+    bfb_component->type = EXTRACT(type, 0, 4);
+    bfb_component->query_pending = EXTRACT(query_pending, 0, 1);
+
+    DPRINTF(("-D- MISOC: type %u query_pending %u"
+             "\n",
+             type, query_pending));
+    rc = reg_access_misoc(_mf, REG_ACCESS_METHOD_GET, bfb_component);
+    deal_with_signal();
+    if (rc)
+    {
+        _lastError = regErrTrans(rc);
+        setLastRegisterAccessStatus(rc);
+        ret = false;
+    }
+
+    return ret;
+}
+
+bool FwCompsMgr::queryMISOC(std::string& version, u_int32_t type, u_int32_t query_pending)
+{
+    struct reg_access_hca_misoc_reg_ext bfb_component;
+    memset(&bfb_component, 0, sizeof(bfb_component));
+
+    if (!runMISOC(&bfb_component, type, query_pending))
+    {
+        DPRINTF(("Error in reading MISOC register.\n"));
+        return false;
+    }
+
+    if (bfb_component.query_not_available)
+    {
+        version = "Info not available";
+    }
+    else
+    {
+        char version_str[257];
+        memset(version_str, 0, sizeof(version_str));
+        memcpy(version_str, bfb_component.version, 256);
+        version = version_str;
+    }
+
+    return true;
+}

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -43,6 +43,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 #include "reg_access/reg_access.h"
 #include "mlxfwops/uefi_c/mft_uefi_common.h"
 #include "mlxfwops/lib/mlxfwops_com.h"
@@ -447,6 +448,8 @@ public:
                     u_int32_t lp_msb = 0);
     u_int8_t GetSecureHostState() { return _secureHostState; }
     bool IsDevicePresent(FwComponent::comps_ids_t compType);
+    bool queryMISOC(std::string& version, u_int32_t type, u_int32_t query_pending);
+    bool runMISOC(reg_access_hca_misoc_reg_ext* bfb_component, u_int32_t type, u_int32_t query_pending);
 
 private:
     typedef enum

--- a/mlxfwops/lib/fsctrl_ops.h
+++ b/mlxfwops/lib/fsctrl_ops.h
@@ -133,6 +133,7 @@ public:
     virtual bool GetSecureHostState(u_int8_t& state);
     virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
     virtual bool IsComponentSupported(FwComponent::comps_ids_t component);
+    bool getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending);
 
 
 private:

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -3136,3 +3136,8 @@ u_int32_t CRSpaceRegisters::getRegister(u_int32_t address)
 
     return crSpaceReg;
 }
+
+bool FwOperations::getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending)
+{
+    return errmsg("getBFBComponentsVersions is not supported");
+}

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -301,6 +301,7 @@ public:
     virtual bool GetSecureHostState(u_int8_t& state);
     virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
     virtual bool IsComponentSupported(FwComponent::comps_ids_t component);
+    virtual bool getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending);
     
 #ifndef UEFI_BUILD
     static bool CheckPemKeySize(const string privPemFileStr, u_int32_t& keySize);

--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -113,6 +113,7 @@
 #define REG_ID_MROQ  0x902F
 #define REG_ID_MPIR  0x9059
 #define REG_ID_MRSV  0x9164
+#define REG_ID_MISOC 0x9026
 
 /* For mstdump oob feature: */
 #define REG_ID_ICAM 0x387F
@@ -840,6 +841,14 @@ reg_access_status_t reg_access_mpir(mfile* mf, reg_access_method_t method, struc
 reg_access_status_t reg_access_mrsv(mfile* mf, reg_access_method_t method, struct reg_access_hca_MRSV_ext* mrsv)
 {
     REG_ACCCESS(mf, method, REG_ID_MRSV, mrsv, MRSV_ext, reg_access_hca);
+}
+
+/************************************
+ * Function: reg_access_misoc
+ ************************************/
+reg_access_status_t reg_access_misoc(mfile* mf, reg_access_method_t method, struct reg_access_hca_misoc_reg_ext* misoc)
+{
+    REG_ACCCESS(mf, method, REG_ID_MISOC, misoc, misoc_reg_ext, reg_access_hca);
 }
 
 reg_access_status_t getIndexOfRegGroup(unsigned int reg_id, int* idx)

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -284,6 +284,10 @@ reg_access_status_t reg_access_mpir(mfile* mf, reg_access_method_t method, struc
 struct reg_access_hca_MRSV_ext;
 reg_access_status_t reg_access_mrsv(mfile* mf, reg_access_method_t method, struct reg_access_hca_MRSV_ext* mrsv);
 
+struct reg_access_hca_misoc_reg_ext;
+    reg_access_status_t
+      reg_access_misoc(mfile* mf, reg_access_method_t method, struct reg_access_hca_misoc_reg_ext* misoc);
+
 /* MCAM - functions and constants to extract valid bit in a more generic way */
 static const unsigned int REG_ACCESS_BASE_GROUP_0_ID = 0x9000;
 static const unsigned int REG_ACCESS_BASE_GROUP_1_ID = 0x9080;


### PR DESCRIPTION
Feature #4295538: ByteDance: BFB FW bundle query

Description: HLD link below:
https://confluence.nvidia.com/pages/viewpage.action?pageId=3910474820
add support to query BFB components

Tested OS: linux
Tested devices: BF3
Tested flows:
/swgwork/ssela/workspace/MFT/mft/user/flint/flint_oem -d /dev/mst/mt41692_pciconf0 query_bfb_components /swgwork/ssela/workspace/MFT/mft/user/flint/flint_oem -d /dev/mst/mt41692_pciconf0 --pending query_bfb_components

Known gaps (with RM ticket): latest FW does not support MISOC types 0x2 and 0x3
Issue: 4295538, 4462147