### PR TITLE
mlxlink | bug fix for FEC histogram reporting unsupported device when…

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -5254,11 +5254,9 @@ void MlxlinkCommander::handlePCIeErrInj()
 bool MlxlinkCommander::isPPHCRSupported()
 {
     bool supported = true;
-    int  pnat = _protoActive == ETH ? 0 : 1;
-
     try
     {
-        sendPrmReg(ACCESS_REG_PPHCR, GET, "pnat=%d", pnat);
+        sendPrmReg(ACCESS_REG_PPHCR, GET);
     }
     catch(MlxRegException & exc)
     {


### PR DESCRIPTION
… querying QM3 FNM port.

Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: