### PR TITLE
Align april

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -794,6 +794,12 @@ bool FwCompsMgr::runMCQI(u_int32_t componentIndex,
     }
     if (data && dataSize) {
         if (!rc) {
+            if (_currCompInfo.info_size > reg_access_hca_mcqi_reg_data_auto_ext_size())
+            {
+                DPRINTF(("-E- got unexpected info size from MCQI: %u\n", _currCompInfo.info_size));
+                _lastError = FWCOMPS_REG_ACCESS_SIZE_EXCCEEDS_LIMIT;
+                return false;
+            }
             memcpy(data, &_currCompInfo.data, _currCompInfo.info_size);
         }
     }

--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -108,6 +108,8 @@ static struct pci_device_id supported_pci_devices[] = {
     {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 4125)}, /* MT2892 Family [ConnectX-6DX] */
     {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 4127)}, /* MT2894 Family [ConnectX-6LX] */
     {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 4129)}, /* MT2910 Family [ConnectX-7] */
+    {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 4131)}, /* [ConnectX-8] */
+    {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 6525)}, /* [ConnectX-8 PCIe bridge] */
     {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 41682)}, /* MT416842 Family BlueField integrated ConnectX-5 network controller */
     {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, 41686)}, /* MT42822 Family BlueField2 integrated ConnectX-6 DX network controller
                                                    */

--- a/mft_utils/mft_sig_handler.c
+++ b/mft_utils/mft_sig_handler.c
@@ -42,7 +42,7 @@ static char* s_interrupt_message = NULL;
 #ifdef __WIN__
 static int signals_array[] = {SIGINT};
 #else
-static int signals_array[] = {SIGINT, SIGQUIT, SIGTERM, SIGUSR1};
+static int signals_array[] = {SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGHUP};
 #endif
 
 static void (*prev_handlers[sizeof(signals_array) / sizeof(signals_array[0])])(int sig);

--- a/mlxconfig/mlxcfg_param.h
+++ b/mlxconfig/mlxcfg_param.h
@@ -65,6 +65,7 @@ public:
     virtual void unpack(u_int8_t* buff, u_int32_t offset) = 0;
     virtual u_int32_t getIntVal();
     virtual void parseValue(string, u_int32_t&, string&);
+    bool isEmpty;
 
     virtual ~ParamValue(){};
 

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -1498,6 +1498,7 @@ const FwOperations::HwDevData FwOperations::hwDevData[] = {
   {"ConnectX-6LX", CX6LX_HW_ID, CT_CONNECTX6LX, CFT_HCA, 0, {4127, 0}, {{UNKNOWN_BIN, {0}}}},
   {"ConnectX-7", CX7_HW_ID, CT_CONNECTX7, CFT_HCA, 0, {4129, 0}, {{UNKNOWN_BIN, {0}}}},
   {"ConnectX-8", CX8_HW_ID, CT_CONNECTX8, CFT_HCA, 0, {4131, 0}, {{UNKNOWN_BIN, {0}}}},
+  {"ConnectX-8 PCIe Bridge", CX8_HW_ID, CT_CONNECTX8, CFT_HCA, 0, {6525, 0}, {{UNKNOWN_BIN, {0}}}},
   {"ConnectX-9", CX9_HW_ID, CT_CONNECTX9, CFT_HCA, 0, {4133, 0}, {{UNKNOWN_BIN, {0}}}},
   {"BlueField", BF_HW_ID, CT_BLUEFIELD, CFT_HCA, 0, {41680, 41681, 41682, 0}, {{UNKNOWN_BIN, {0}}}},
   {"BlueField2", BF2_HW_ID, CT_BLUEFIELD2, CFT_HCA, 0, {41684, 41685, 41686, 0}, {{UNKNOWN_BIN, {0}}}},

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -2657,6 +2657,7 @@ static long supported_dev_ids[] = {0x1003, /* Connect-X3 */
                                    0x101f, /* Connect-X6LX */
                                    0x1021, /* Connect-X7 */
                                    0x1023, /* Connect-X8 */
+                                   0x197d, /* Connect-X8 PCIe bridge */
                                    0xcb20, /* Switch-IB */
                                    0xcb84, /* Spectrum */
                                    0xcf08, /* Switch-IB2 */


### PR DESCRIPTION
added the following commits that are present in MFT's mft_4_32_0_oberon branch but missing in the mstflint branch:

83a2446a5434d028e61986f4c8ca5530e9032391 - [ConnectX-8] add support to PCIe Switch
22610ac970c306deb8dc1475e276478b3b974737 - [mlxtokengenerator] Badly formed XML
cfb89c86f94c9d801e1a064e3143079384d5cf85 - Fix Customer bug for handle sighup
568ca1479e05034a5b91eb725041020a0fcdde81 - [mlxfwmanager][flint] Validate out of range info size for MCQI