### PR TITLE
[flint][BC] Supports binary comparison for FS5 in LF mode

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1986,7 +1986,7 @@ bool BinaryCompareSubCommand::ReadFwOpsImageData(vector<u_int8_t>& deviceBuff, v
     }
     deviceBuff.resize(imgSize);
     // on second call we fill it
-    if (!_fwOps->FwReadData((void*)(&deviceBuff[0]), &imgSize, _flintParams.silent == false))
+    if (!_fwOps->FwReadData((void*)(&deviceBuff[0]), &imgSize, _flintParams.silent == false, false, true))
     {
         reportErr(true, FLINT_IMAGE_READ_ERROR, _fwOps->err());
         return false;


### PR DESCRIPTION
Description: remove the encapsulation header from the comparison section

MSTFlint port needed: yes
Tested OS: linux
Tested devices: /dev/mst/mt542_pciconf0
Tested flows: flint -d /dev/mst/mt542_pciconf0 -i /mswg/projects/tool_vfn/bin_images_cache/10_06_2025/GILBOA/900-9X81E-00EX-ST0_Ax~MT_0000001167.bin -ocr v

Known gaps (with RM ticket): n/a

Issue: 4493174
Change-Id: I482ab3ae6bfe8c9ecd5e6a0ace7e4b0fff435bd2