### PR TITLE
[flint][BC] Compilation issue

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1986,13 +1986,13 @@ bool BinaryCompareSubCommand::ReadFwOpsImageData(vector<u_int8_t>& deviceBuff, v
     }
     deviceBuff.resize(imgSize);
     // on second call we fill it
-    if (!_fwOps->FwReadData((void*)(&deviceBuff[0]), &imgSize, _flintParams.silent == false, false, true))
+    if (!_fwOps->FwReadData((void*)(&deviceBuff[0]), &imgSize, _flintParams.silent == false))
     {
         reportErr(true, FLINT_IMAGE_READ_ERROR, _fwOps->err());
         return false;
     }
 
-    if (!_imgOps->FwExtract4MBImage(imgBuff, false, (_flintParams.silent == false)))
+    if (!_imgOps->FwExtract4MBImage(imgBuff, false, (_flintParams.silent == false), false, true))
     {
         reportErr(true, FLINT_IMAGE_READ_ERROR, _imgOps->err());
         return false;


### PR DESCRIPTION
Description: Set the default value in the correct function.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: /dev/mst/mt542_pciconf0
Tested flows: flint -d /dev/mst/mt542_pciconf0 -i /mswg/projects/tool_vfn/bin_images_cache/10_06_2025/GILBOA/900-9X81E-00EX-ST0_Ax~MT_0000001167.bin -ocr v

Known gaps (with RM ticket): no

Issue: 4502257