### PR TITLE
fix compilation issue

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -32,7 +32,7 @@
 
 noinst_LTLIBRARIES = libcommon.la
 
-AM_CPPFLAGS = $(JSON_CFLAGS)
+AM_CPPFLAGS = $(JSON_CFLAGS) -I$(top_srcdir)/include/mtcr_ul
 
 libcommon_la_SOURCES = \
     bit_slice.h \


### PR DESCRIPTION
fix compilation issue intriduced in "flint | CX8 Switch-Only Mode - Add Product Type Indicator"