### PR TITLE
Add missing BuildRequires for enablefwmgr

### DIFF
--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -35,9 +35,15 @@ BuildRequires: pkgconfig
 %if 0%{?suse_version}
 %define openssl_devel_lib libopenssl-devel
 %define expat_devel_lib libexpat-devel
+%define libcurl_devel_lib libcurl-devel
+%define libxml2_devel_lib libxml2-devel
+%define liblzma_devel_lib liblzma-devel
 %else
 %define openssl_devel_lib openssl-devel
 %define expat_devel_lib expat-devel
+%define libcurl_devel_lib libcurl-devel
+%define libxml2_devel_lib libxml2-devel
+%define liblzma_devel_lib liblzma-devel
 %endif
 
 %if "%{nopenssl}" == "0"
@@ -47,6 +53,12 @@ BuildRequires: %{openssl_devel_lib}
 %if "%{enableadbgenerictools}" == "1"
 BuildRequires: %{expat_devel_lib}
 BuildRequires: xz-devel
+%endif
+
+%if "%{enablefwmgr}" == "1"
+BuildRequires: %{libcurl_devel_lib}
+BuildRequires: %{libxml2_devel_lib}
+BuildRequires: %{liblzma_devel_lib}
 %endif
 
 BuildRequires: zlib-devel %{ibmadlib}


### PR DESCRIPTION
Add missing BuildRequires for enablefwmgr

Description:
The mstfwmanager tool requires libcurl, libxml2, and liblzma libraries. These dependencies were not listed as BuildRequires in mstflint.spec.in, causing "missed libcurl headers" error during RPM build when using --define 'enablefwmgr 1'.

Added conditional BuildRequires for libcurl-devel, libxml2-devel, and liblzma-devel when enablefwmgr=1.

After this fix, RPM builds with enablefwmgr=1 should succeed:
- 'dnf builddep mstflint.spec' will install dependencies automatically
- 'rpmbuild -ba --define "enablefwmgr 1" mstflint.spec' will complete successfully

Issue:37727985