### PR TITLE
[Segmentation Fault][Mstfwmanager] Burning using mstfwmanager causes …

### DIFF
--- a/mlxfwupdate/mlnx_dev.cpp
+++ b/mlxfwupdate/mlnx_dev.cpp
@@ -904,7 +904,7 @@ bool MlnxDev::OpenDev()
         _devFwOps = NULL;
     }
     _devFwOps = FwOperations::FwOperationsCreate(_devFwParams);
-    delete[] _devFwParams.mstHndl;
+    
     if (_devFwOps == NULL)
     {
         _errMsg = _errBuff;


### PR DESCRIPTION
…segmentation fault

Description: removed unnecessary delete that causes double free
Issue: 4510340