### PR TITLE
mlxfwreset | default level not picked in some flows

### DIFF
--- a/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
@@ -190,7 +190,10 @@ class CmdRegMfrl():
     def query_text(self, is_any_sync_supported=None):
         'return the text for the query operation in mlxfwreset'
         # Reset levels
-        default_reset_level = self.default_reset_level()
+        skip_pci_reset = False
+        if is_any_sync_supported is None:
+            skip_pci_reset = True
+        default_reset_level = self.default_reset_level(is_any_sync_supported, skip_pci_reset)
         result = "Reset-levels:\n"
         for reset_level_ii in self._reset_levels:
             level = reset_level_ii['level']
@@ -246,9 +249,11 @@ class CmdRegMfrl():
         else:
             return False
 
-    def default_reset_level(self):
+    def default_reset_level(self, is_any_sync_supported, skip_pci_reset):
         'Return the default reset-level (minimal supported reset-level)'
         for reset_level_ii, is_default in CmdRegMfrl.reset_levels_default():
+            if reset_level_ii == CmdRegMfrl.PCI_RESET and not skip_pci_reset and not is_any_sync_supported:
+                continue
             if self.is_reset_level_supported(reset_level_ii) and is_default:
                 return reset_level_ii
         raise CmdNotSupported("There is no supported reset-level")

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -2159,8 +2159,13 @@ def reset_flow_host(device, args, command):
             print(mrsi.query_text(is_bluefield))
 
     elif command == "reset":
-        reset_level = mfrl.default_reset_level(
-        ) if args.reset_level is None else args.reset_level
+        if mroq.mroq_is_supported():
+            is_any_sync_supported = mroq.is_any_sync_supported(tool_owner_support)
+            skip_pci_reset = False
+        else:
+            is_any_sync_supported = None
+            skip_pci_reset = True
+        reset_level = mfrl.default_reset_level(is_any_sync_supported, skip_pci_reset) if args.reset_level is None else args.reset_level
 
         reset_sync = SyncOwner.TOOL
         if reset_level is CmdRegMfrl.PCI_RESET:


### PR DESCRIPTION
Description: when no sync is supported, there is also no support for PCI_RESET, this was not reflected in the reset_level list maintained in the code, where PCI_RESET was set as supported according to MFRL only. Added necessary update of PCI_RESET based on MROQ

Issue: 4515809