### PR TITLE
FreeBSD | compilation issue

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -32,7 +32,7 @@
 
 noinst_LTLIBRARIES = libcommon.la
 
-AM_CPPFLAGS = $(JSON_CFLAGS)
+AM_CPPFLAGS = $(JSON_CFLAGS) -I$(top_srcdir) -I$(top_srcdir)/include/mtcr_ul
 
 libcommon_la_SOURCES = \
     bit_slice.h \
@@ -45,7 +45,7 @@ libcommon_la_SOURCES = \
     tools_time.h \
     tools_utils.h \
     tools_utils.h \
-    tools_version.h \ 
+    tools_version.h \
     mcam_capabilities.cpp \
     mcam_capabilities.h
 


### PR DESCRIPTION
Description: fixed this error:
In file included from mcam_capabilities.cpp:1:
In file included from ./mcam_capabilities.h:35:
In file included from ../reg_access/reg_access.h:45: In file included from ../reg_access/reg_access_common.h:41: /usr/include/mtcr.h:55:10: fatal error: 'mtcr_mf.h' file not found
   55 | #include "mtcr_mf.h"
      |          ^~~~~~~~~~~
1 error generated.
*** [mcam_capabilities.lo] Error code 1

make[2]: stopped in /tmp/mstflint/common
--- tools_filesystem.lo ---

Issue: 4516154