### PR TITLE
mlxfwreset | Incorrect detection of the PCIe switch when it acts as a…

### DIFF
--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -113,6 +113,8 @@
 #define REG_ID_MROQ  0x902F
 #define REG_ID_MPIR  0x9059
 #define REG_ID_MRSV  0x9164
+#define REG_ID_MPEIN 0x9050
+
 
 /* For mstdump oob feature: */
 #define REG_ID_ICAM 0x387F
@@ -840,4 +842,12 @@ reg_access_status_t reg_access_mpir(mfile* mf, reg_access_method_t method, struc
 reg_access_status_t reg_access_mrsv(mfile* mf, reg_access_method_t method, struct reg_access_hca_MRSV_ext* mrsv)
 {
     REG_ACCCESS(mf, method, REG_ID_MRSV, mrsv, MRSV_ext, reg_access_hca);
+}
+
+/************************************
+ * Function: reg_access_mpein
+ ************************************/
+reg_access_status_t reg_access_mpein(mfile* mf, reg_access_method_t method, struct reg_access_hca_mpein_reg_ext* mpein)
+{
+    REG_ACCCESS(mf, method, REG_ID_MPEIN, mpein, mpein_reg_ext, reg_access_hca);
 }

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -282,6 +282,10 @@ reg_access_status_t reg_access_mpir(mfile* mf, reg_access_method_t method, struc
 struct reg_access_hca_MRSV_ext;
 reg_access_status_t reg_access_mrsv(mfile* mf, reg_access_method_t method, struct reg_access_hca_MRSV_ext* mrsv);
 
+struct reg_access_hca_mpein_reg_ext;
+    reg_access_status_t
+      reg_access_mpein(mfile* mf, reg_access_method_t method, struct reg_access_hca_mpein_reg_ext* mpein);
+
 #ifdef __cplusplus
 }
 #endif

--- a/reg_access/regaccess.py
+++ b/reg_access/regaccess.py
@@ -115,6 +115,7 @@ if REG_ACCESS:
             self._reg_access_dtor = REG_ACCESS.reg_access_dtor
             self._reg_access_mrsi = REG_ACCESS.reg_access_mrsi
             self._reg_access_mpir = REG_ACCESS.reg_access_mpir
+            self._reg_access_mpein = REG_ACCESS.reg_access_mpein
 
         def _err2str(self, rc):
             err2str = REG_ACCESS.reg_access_err2str
@@ -345,6 +346,18 @@ if REG_ACCESS:
 
             return mpirRegisterP.contents.bus, mpirRegisterP.contents.device, mpirRegisterP.contents.sdm
 
+        ##########################
+        def sendMPEIN(self, depth, pcie_index, node):
+            mpeinRegisterP = pointer(MPEIN_REG_EXT())
+            mpeinRegisterP.contents.depth = depth
+            mpeinRegisterP.contents.pcie_index = pcie_index
+            mpeinRegisterP.contents.node = node
+            rc = self._reg_access_mpein(self._mstDev.mf, c_uint(REG_ACCESS_METHOD_GET), mpeinRegisterP)
+            if rc:
+                raise RegAccException("Failed to send Register MPEIN: %s (%d)" % (self._err2str(rc), rc))
+
+            return mpeinRegisterP.contents.port_type
+        
         ##########################
         def sendMROQ(self, reset_type):
             mroqRegisterP = pointer(MROQ_EXT())


### PR DESCRIPTION
… switch only

Description: Using MPIR to compare device bus to MPIR bus isn't working as a means of PCIe switch detcetion when device is SD or PCIe switch only. Instead using MPEIN to check if the port type is that of PCI_EXPRESS_UPSTREAM_PORT (meaning we should be in PCIe switch flow).

Issue: 4503900
Issue: 4517447