### PR TITLE
mlxlink | PCIE | bug fix for pci gen-6 showing as 'N/A'

### DIFF
--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -1185,7 +1185,11 @@ string getCableMedia(u_int32_t cableType)
 string pcieSpeedStr(u_int32_t linkSpeedActive)
 {
     string linkSpeedActiveStr;
-    if (linkSpeedActive & GEN5)
+    if (linkSpeedActive & GEN6)
+    {
+        linkSpeedActiveStr = "32G PAM-4 Gen6";
+    }
+    else if (linkSpeedActive & GEN5)
     {
         linkSpeedActiveStr = "32G-Gen 5";
     }


### PR DESCRIPTION
Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: