### PR TITLE
FreeBSD | compilation issue

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -32,7 +32,7 @@
 
 noinst_LTLIBRARIES = libcommon.la
 
-AM_CPPFLAGS = $(JSON_CFLAGS) -I$(top_srcdir)/include/mtcr_ul
+AM_CPPFLAGS = $(JSON_CFLAGS) -I$(top_srcdir)/include/mtcr_ul -I$(top_srcdir)
 
 libcommon_la_SOURCES = \
     bit_slice.h \

--- a/resourcetools/resourcedump_lib/src/common/resource_dump_error_handling.cpp
+++ b/resourcetools/resourcedump_lib/src/common/resource_dump_error_handling.cpp
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
+#include "mtcr.h"
 #include "resource_dump_error_handling.h"
-#include "include/mtcr_ul/mtcr.h"
 #include <string>
 
 


### PR DESCRIPTION
Description: fixed this error:
In file included from mcam_capabilities.cpp:1:
In file included from ./mcam_capabilities.h:35:
In file included from ../reg_access/reg_access.h:45: In file included from ../reg_access/reg_access_common.h:41: /usr/include/mtcr.h:55:10: fatal error: 'mtcr_mf.h' file not found
   55 | #include "mtcr_mf.h"
      |          ^~~~~~~~~~~
1 error generated.
*** [mcam_capabilities.lo] Error code 1

make[2]: stopped in /tmp/mstflint/common
--- tools_filesystem.lo ---

Issue: 4516154