### PR TITLE
mstflint | mstflint crashes with assertion failure

### DIFF
--- a/mlxfwops/lib/fs3_ops.cpp
+++ b/mlxfwops/lib/fs3_ops.cpp
@@ -2121,6 +2121,7 @@ bool Fs3Operations::UpdateImageAfterInsert(struct toc_info* tocArr,
         u_int8_t sectType = currItoc->toc_entry.type;
         u_int32_t sectAddr = currItoc->toc_entry.flash_addr << 2;
         u_int32_t sectSize = currItoc->toc_entry.size * 4;
+        //struct toc_info* currItoc11 = currItoc->section_data;
         /* Some checks */
         if (sectAddr + sectSize > newImageSize)
         {
@@ -2136,13 +2137,13 @@ bool Fs3Operations::UpdateImageAfterInsert(struct toc_info* tocArr,
         if (!newImgData)
         {
             Fs3UpdateImgCache(currItoc->data, itocOffset, CIBFW_ITOC_ENTRY_SIZE);
-            Fs3UpdateImgCache(&currItoc->section_data[0], sectAddr, sectSize);
+            Fs3UpdateImgCache(currItoc->section_data.data(), sectAddr, sectSize); 
         }
         else
         {
             memcpy(&newImgData[itocOffset], currItoc->data, CIBFW_ITOC_ENTRY_SIZE);
 
-            memcpy(&newImgData[sectAddr], &currItoc->section_data[0], sectSize);
+            memcpy(&newImgData[sectAddr], currItoc->section_data.data(), sectSize);
         }
     }
     u_int32_t lastItocSect = _fs3ImgInfo.itocAddr + CIBFW_ITOC_HEADER_SIZE + numOfItocs * CIBFW_ITOC_ENTRY_SIZE;


### PR DESCRIPTION
Description:
mstflint -d 00:07.0 -i /mswg/projects/tool_vfn/bin_images_cache/04_07_2025/SHOMRON/MCX453A-FCA_Ax~MT_2160110021.bin   -uid d95fdf328b89619a --no_fw_ctrl -vsd ZABHUGWGLTPMFVFWWHSLJUQEQHIAHMTXCYKTSDSBIMRTGRDCQZCDTNYRKJIBYTEGKQBQMWQPWFDZOYYCZSJBSEBKJNSWXTAYJCGZDUOSVOJJZLYWTOKZJVII -y b
the above command results with assertion error in the following conditions:
* only for a cx-4 in the apps-16-05 setup (for apps-19 with similar cx-4 - no repro)
* only when installing mstflint via tarball. when compiling locally and running mstflint throuch compilation products - no repro

used gdb to discover that the assertion failure happens in Fs3Operations::UpdateImageAfterInsert function. Upon a closer look the reason to the failure is that this syntax leads to unexpected behaviour when the vector is empty: &currItoc->section_data[0]
-> replaced to a safer syntax that returns the same as the previous one for a non-empty vector, but for an empty vector - returns nullptr. This is the syntax: currItoc->section_data.data()

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: CX-4
Tested flows: the command mentioned in the description
* created a tarball from local fix and made sure the bug is resolved

Known gaps (with RM ticket): None

Issue: 4523725