### PR TITLE
[flint] support CDB 100 for cable query

### DIFF
--- a/cable_access/cdb_cable_access.h
+++ b/cable_access/cdb_cable_access.h
@@ -195,7 +195,8 @@ public:
         CDB_COMPLETE_FW_DOWNLOAD = 0x0701,
         CDB_RUN_FW_IMAGE = 0x0901,
         CDB_COMMIT_FW_IMAGE = 0x0A01,
-        CDB_QUERY_STATUS = 0x0
+        CDB_QUERY_STATUS = 0x0,
+        CDB_GET_FW_INFO = 0x0001
     } FWManagedCdbCommand;
 
     struct FWMngFeatures

--- a/cable_access/cdb_cable_commander.h
+++ b/cable_access/cdb_cable_commander.h
@@ -38,11 +38,29 @@
 
 typedef int (*f_prog_func)(int completion);
 
+struct CmisFWVersion
+{
+    u_int8_t major;
+    u_int8_t minor;
+    u_int16_t build;
+    u_int8_t extraString[32];
+};
+
+struct FirmwareInfoReply
+{
+    u_int8_t firmwareStatus;
+    u_int8_t imageInformation;
+    CmisFWVersion imageAFwVersion;
+    CmisFWVersion imageBFwVersion;
+    CmisFWVersion factoryFwVersion;
+};
+
 class FwManagementCdbCommander
 {
 public:
     explicit FwManagementCdbCommander(string mstDevName, bool clearCompletionFlag = false);
 
+    string GetCmisFWIndicationStrings();
     void DownloadFWImage(const vector<u_int8_t>& image, const vector<u_int8_t>& vendorData, f_prog_func progressFunc);
     void SetPassword(string password);
     void SetCommandWaitingTime(string waitTime);
@@ -71,6 +89,8 @@ private:
         u_int8_t firmwareDownloadAllowed;
     };
 
+    FirmwareInfoReply GetCmisFWIndication();
+    string ParseCmisFWVersion(const CmisFWVersion& fwVersion, string fwImage);
     void QueryStatus();
     void EnterPassword();
     bool IsActivationNeeded();

--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -5101,6 +5101,26 @@ FlintStatus QuerySubCommand::queryMFA2()
     return FLINT_SUCCESS;
 }
 
+#if defined(CABLES_SUPPORT) && !defined(MST_CPU_armv7l_umbriel)
+FlintStatus QuerySubCommand::QueryCableAttributes()
+{
+    DPRINTF(("QuerySubCommand::QueryCableAttributes\n"));
+
+    try
+    {
+        FwManagementCdbCommander cableCommander(_flintParams.device.c_str());
+        cout << cableCommander.GetCmisFWIndicationStrings();
+    }
+    catch (const std::exception& e)
+    {
+        reportErr(true, "FW Info query failed, %s\n", e.what());
+        return FLINT_FAILED;
+    }
+
+    return FLINT_SUCCESS;
+}
+#endif
+
 FlintStatus QuerySubCommand::executeCommand()
 {
     DPRINTF(("QuerySubCommand::executeCommand\n"));
@@ -5118,6 +5138,18 @@ FlintStatus QuerySubCommand::executeCommand()
             return FLINT_FAILED;
         }
         return QueryLinkX(_flintParams.device, _flintParams.output_file, _flintParams.downstream_device_ids);
+    }
+    if (_flintParams.device.find("_cable") != string::npos && _flintParams.device.find("_rt") == string::npos)
+    {
+        FlintStatus rc = FLINT_SUCCESS;
+#if defined(CABLES_SUPPORT) && !defined(MST_CPU_armv7l_umbriel)
+        rc = QueryCableAttributes();
+#else
+        reportErr(true, "Query on cable devices is not supported.\n");
+        rc = FLINT_FAILED;
+#endif
+
+        return rc;
     }
     if (_flintParams.image_specified)
     {

--- a/flint/subcommands.h
+++ b/flint/subcommands.h
@@ -322,6 +322,7 @@ private:
                          char* delimeter,
                          bool isCSV);
     FlintStatus QueryLinkX(string deviceName, string outputFile, std::vector<int> deviceIds);
+    FlintStatus QueryCableAttributes();
     void PrintLifeCycle(const life_cycle_t& lifeCycle);
 
 public:


### PR DESCRIPTION
Description: flint query command on cable mst devices will perform CDB 100 and print FW information to the screen

MSTFlint port needed: no
Tested OS: linux x86_64
Tested devices: LinkX modules
Tested flows:
1) discover cables using mstcable_discovery
2) flint -d <cable dev> q

Known gaps (with RM ticket): N/A

Issue: 4549503