### PR TITLE
coverity | memory leaks, overflow, infinite loop

### DIFF
--- a/pldmlib/pldm_dev_id_record.cpp
+++ b/pldmlib/pldm_dev_id_record.cpp
@@ -89,6 +89,7 @@ bool PldmDevIdRecord::unpack(PldmBuffer& buff)
         PldmRecordDescriptor* descriptor = new PldmRecordDescriptor();
         if (!descriptor->unpack(buff))
         {
+            delete descriptor;
             reset();
             return false;
         }

--- a/pldmlib/pldm_pkg.cpp
+++ b/pldmlib/pldm_pkg.cpp
@@ -84,12 +84,12 @@ bool PldmPkg::unpack(PldmBuffer& buff)
     }
     buff.read(deviceIDRecordCount);
     u_int8_t componentBitmapBitLength = packageHeader.getComponentBitmapBitLength();
-    u_int8_t i;
-    for (i = 0; i < deviceIDRecordCount; i++)
+    for (u_int8_t i = 0; i < deviceIDRecordCount; i++)
     {
         PldmDevIdRecord* deviceIDRecord = new PldmDevIdRecord(componentBitmapBitLength);
         if (!deviceIDRecord->unpack(buff))
         {
+            delete deviceIDRecord;
             reset();
             return false;
         }
@@ -98,7 +98,7 @@ bool PldmPkg::unpack(PldmBuffer& buff)
         psidComponentsMap[deviceIDRecord->getDevicePsid()] = deviceIDRecord->getComponentsIndexes();
     }
     buff.read(componentImageCount);
-    for (i = 0; i < componentImageCount; i++)
+    for (u_int8_t i = 0; i < componentImageCount; i++)
     {
         PldmComponenetImage* componentImage = new PldmComponenetImage();
         componentImage->unpack(buff);

--- a/pldmlib/pldm_record_descriptor.cpp
+++ b/pldmlib/pldm_record_descriptor.cpp
@@ -63,6 +63,8 @@ bool PldmRecordDescriptor::unpack(PldmBuffer& buff)
         if (!extractVendorDefined())
         {
             printf("unknown vendor defined descriptor\n");
+            delete[] descriptorData;
+            descriptorData = NULL;
             return false;
         }
     }


### PR DESCRIPTION
Description: fixed the following:
* pldm_dev_id_record.cpp, pldm_pkg.cpp: added missing frees in case of failure
* pldm_pkg.cpp: coverity thought the i variable could cause an infinite loop so declared a separate i variables for each loop