### PR TITLE
cmdparser | bug fix for out-of-range access to options array

### DIFF
--- a/cmdparser/cmdparser.cpp
+++ b/cmdparser/cmdparser.cpp
@@ -608,7 +608,7 @@ ParseStatus CommandLineParser::ParseOptions(int argc,
 
     ParseStatus curr_result;
     while ((option_type =
-              tools_getopt_long_only(argc, internal_argv, options_str.c_str(), options_arr, &option_index)) != -1)
+              tools_getopt_long_only(argc, internal_argv, options_str.c_str(), options_arr, &option_index, i)) != -1)
     {
         // printf("option_type=\'%c\'\n", option_type);
 

--- a/cmdparser/my_getopt.c
+++ b/cmdparser/my_getopt.c
@@ -510,7 +510,8 @@ int _getopt_internal(int argc,
                      const char* optstring,
                      const struct option* longopts,
                      int* longind,
-                     int long_only)
+                     int long_only,
+                     int longOptSize)
 {
     tools_optarg = NULL;
 
@@ -661,7 +662,8 @@ int _getopt_internal(int argc,
 
         /* Test all long options for either exact match
            or abbreviated matches.  */
-        for (p = longopts, option_index = 0; p->name; p++, option_index++)
+           for (p = longopts, option_index = 0;
+            (longOptSize != LONG_OPTS_SIZE_DEFAULT && option_index < longOptSize) && p->name; p++, option_index++)
             if (!strncmp(p->name, nextchar, nameend - nextchar))
             {
                 if ((unsigned int)(nameend - nextchar) == (unsigned int)strlen(p->name))
@@ -1015,21 +1017,22 @@ int _getopt_internal(int argc,
 
 int tools_getopt(int argc, char* const* argv, const char* optstring)
 {
-    return _getopt_internal(argc, argv, optstring, (const struct option*)0, (int*)0, 0);
+    return _getopt_internal(argc, argv, optstring, (const struct option*)0, (int*)0, 0, LONG_OPTS_SIZE_DEFAULT);
 }
 
 int tools_getopt_long(int argc, char* const* argv, const char* optstring, const struct option* longopts, int* longindex)
 {
-    return _getopt_internal(argc, argv, optstring, longopts, longindex, 0);
+    return _getopt_internal(argc, argv, optstring, longopts, longindex, 0, LONG_OPTS_SIZE_DEFAULT);
 }
 
 int tools_getopt_long_only(int argc,
                            char* const* argv,
                            const char* optstring,
                            const struct option* longopts,
-                           int* longindex)
+                           int* longindex,
+                           int longOptSize)
 {
-    return _getopt_internal(argc, argv, optstring, longopts, longindex, 1);
+    return _getopt_internal(argc, argv, optstring, longopts, longindex, 1, longOptSize);
 }
 
 #ifdef TEST

--- a/cmdparser/my_getopt.h
+++ b/cmdparser/my_getopt.h
@@ -20,6 +20,8 @@
 #ifndef _TOOLS_GETOPT_H
 #define _TOOLS_GETOPT_H
 
+#define LONG_OPTS_SIZE_DEFAULT -1
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -106,7 +108,8 @@ extern "C"
                                char* const* argv,
                                const char* shortopts,
                                const struct option* longopts,
-                               int* longind);
+                               int* longind,
+                               int longOptSize);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: