### PR TITLE
Compilation fails when building with dpa flag

### DIFF
--- a/mlxtokengenerator/Makefile.am
+++ b/mlxtokengenerator/Makefile.am
@@ -66,6 +66,7 @@ msttokengenerator_DEPENDENCIES = \
                                 $(top_builddir)/cmdif/libcmdif.la \
 							    $(top_builddir)/dev_mgt/libdev_mgt.la \
                                 $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
+                                $(top_builddir)/mlxdpa/libmstdpa.a \
                                 $(SQLITE_LIBS) \
                                 $(JSON_LIBS) \
                                 $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la


### PR DESCRIPTION
Description: Adding libmstdpa as a dependency

Issue: 4552233