### PR TITLE
mstflint | mtcr.py can't be used on Python2 systems

### DIFF
--- a/mtcr_py/mtcr.py
+++ b/mtcr_py/mtcr.py
@@ -74,7 +74,7 @@ try:
         except BaseException:
             CMTCR = CDLL(os.path.join(os.path.dirname(os.path.realpath(__file__)), "cmtcr.so"), use_errno=True)
 except BaseException as e:
-    print(f"Error loading CMTCR: {e}")
+    print("Error loading CMTCR: {0}".format(e))
     CMTCR = None
 
 if CMTCR:


### PR DESCRIPTION
Description: fixed python3 string formatting which broke mtrc for python2 before:
>>> import mtcr.py
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mtcr.py", line 77
    print(f"Error loading CMTCR: {e}")
                                    ^
SyntaxError: invalid syntax
>>>

after:
>>> import mtcr
>>>

Issue: 4554842