### PR TITLE
[Tarball] Production Burn Fails at 94% Core Dump over CX8

### DIFF
--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -2848,7 +2848,7 @@ bool Fs4Operations::BurnFs4Image(Fs4Operations& imageOps, ExtBurnParams& burnPar
                               burnParams.progressUserData,
                               burnParams.progressFunc,
                               toc_entry->flash_addr << 2,
-                              &(itoc_info_p->section_data[0]),
+                              itoc_info_p->section_data.data(),
                               itoc_info_p->section_data.size(),
                               true,
                               true,


### PR DESCRIPTION
Description: fixed syntax for passing a pointer to vector data

MSTFlint port needed: no
Tested OS: linux
Tested devices: CX8
Tested flows: mstflint -d <dev> -i <image> -ocr -nofs --ignore_dev_data -y b

Known gaps (with RM ticket): N/A

issue: 4539350