### PR TITLE
mstfwreset | vfio device failure

### DIFF
--- a/small_utils/mlxfwresetlib/mlxfwreset_utils.py
+++ b/small_utils/mlxfwresetlib/mlxfwreset_utils.py
@@ -129,6 +129,8 @@ def getDevDBDF(device, logger=None):
             raise RuntimeError("Unexpected device name format")
         return device[3:]
     elif (operatingSys == "Linux"):
+        if device.startswith("vfio-"):
+            device = device[5:]
         cmd = "mdevices_info -vv"
         (rc, out, _) = cmdExec(cmd)
         if rc != 0:


### PR DESCRIPTION
Description: we get a "Failed to get device PCI Address" error since the device name has "vfio-" that is not handled.

Issue: 4578529