### PR TITLE
feat(dev_mgt): Print a message for unsupported devices

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -635,6 +635,10 @@ int dm_get_device_id(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int32_t* ptr_hw_de
 {
     int return_value = 1;
 
+    if ((int32_t)(mf->bar_virtual_addr) == -1) {
+        printf("FATAL - mmap failed, unsupported/deprecated device?\n");
+        return GET_DEV_ID_ERROR;
+    }
     return_value = dm_get_device_id_inner(mf, ptr_dm_dev_id, ptr_hw_dev_id, ptr_hw_rev);
     if (return_value == CRSPACE_READ_ERROR) {
         printf("FATAL - crspace read (0x%x) failed: %s\n", DEVID_ADDR, strerror(errno));


### PR DESCRIPTION
Support for many devices was removed in commit 52eb6c0ebbe8. This can cause a segmentation fault when querying unsupported devices.

This change adds a check and prints a message indicating that the device may be unsupported or deprecated, preventing user frustration.

Fixes: #1157

I am not sure if it is compatible with other devices, but works with ConnectX3Pro.