### PR TITLE
[Design] - [META] [GB200/300] mstreg failure doesn't print FW syndrome

### DIFF
--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -163,6 +163,7 @@ struct mfile_t {
     int                     is_zombiefish;
     int                     vsc_recovery_space_flash_control_vld;
     void*                   nvml_device; /* libnvml device object. */
+    u_int32_t               syndrome; /* syndrome from last access register */
 };
 
 #endif /* ifndef __MTCR_MF__ */

--- a/mlxreg/mlxreg_lib/mlxreg_lib.cpp
+++ b/mlxreg/mlxreg_lib/mlxreg_lib.cpp
@@ -240,8 +240,18 @@ MlxRegLibStatus MlxRegLib::sendRegister(string regName, int method, std::vector<
     u_int16_t regId = (u_int16_t)_regAccessMap.find(regName)->second;
     int rc;
     rc = sendMaccessReg(regId, method, data);
-    if (rc) {
-        throw MlxRegException("Failed to send access register: %s", m_err2str((MError)rc));
+    if (rc)
+    {
+        char error_msg[200];
+        snprintf(error_msg, sizeof(error_msg), "Failed to send access register: %s", m_err2str((MError)rc));
+        if (_mf->icmd.syndrome)
+        {
+            snprintf(error_msg + strlen(error_msg),
+                     sizeof(error_msg) - strlen(error_msg),
+                     " and the syndrome number is: 0x%X",
+                     (_mf->icmd.syndrome));
+        }
+        throw MlxRegException(error_msg);
     }
     return MRLS_SUCCESS;
 }
@@ -255,7 +265,16 @@ MlxRegLibStatus MlxRegLib::sendRegister(u_int16_t regId, int method, std::vector
     rc = sendMaccessReg(regId, method, data);
     if (rc)
     {
-        throw MlxRegException("Failed send access register: %s", m_err2str((MError)rc));
+        char error_msg[200];
+        snprintf(error_msg, sizeof(error_msg), "Failed to send access register: %s", m_err2str((MError)rc));
+        if (_mf->icmd.syndrome)
+        {
+            snprintf(error_msg + strlen(error_msg),
+                     sizeof(error_msg) - strlen(error_msg),
+                     " and the syndrome number is: 0x%X",
+                     (_mf->icmd.syndrome));
+        }
+        throw MlxRegException(error_msg);
     }
     return MRLS_SUCCESS;
 }

--- a/mtcr_ul/fwctrl.c
+++ b/mtcr_ul/fwctrl.c
@@ -186,8 +186,10 @@ int fwctl_control_access_register(int    fd,
 
     cmd_status = MLX5_GET(access_register_out, out, status);
     if (cmd_status) {
+        u_int32_t syndrome = MLX5_GET(access_register_out, out, syndrome);
+        mf->syndrome = syndrome;
         FWCTL_DEBUG_PRINT(mf, "FWCTL_IOCTL_CMD_RPC returned error from FW: reg_id=0x%x, method=0x%x, cmd_status=0x%x, syndrome=0x%x\n",
-                          reg_id, method, cmd_status, MLX5_GET(access_register_out, out, syndrome));
+                          reg_id, method, cmd_status, syndrome);
 
         if (reg_id == mnvda_reg_id) {
             *reg_status = translate_cmd_status_to_reg_status(cmd_status);
@@ -197,6 +199,7 @@ int fwctl_control_access_register(int    fd,
         FWCTL_DEBUG_PRINT(mf, "Mapped FW cmd_status=0x%x to reg_status=0x%x (%s)\n", cmd_status, *reg_status, m_err2str(*reg_status));
     } else {
         *reg_status = 0;
+        mf->syndrome = 0;
         FWCTL_DEBUG_PRINT(mf, "FWCTL_IOCTL_CMD_RPC succeeded: reg_id=0x%x, method=0x%x\n", reg_id, method);
     }
 


### PR DESCRIPTION
Description: print the syndrome value in case it is set and access register has failed when running mstreg tool.

Issue:4598390