### PR TITLE
mstflint crash during burn (software bug. uninitialized variables)

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr_abstract_access.h
+++ b/fw_comps_mgr/fw_comps_mgr_abstract_access.h
@@ -56,6 +56,7 @@ public:
         _mf = mf;
         _manager = manager;
         _lastFwError = FWCOMPS_SUCCESS;
+        _lastRegisterAccessStatus = ME_REG_ACCESS_OK;
     }
     virtual ~AbstractComponentAccess() {}
 

--- a/fw_comps_mgr/fw_comps_mgr_dma_access.h
+++ b/fw_comps_mgr/fw_comps_mgr_dma_access.h
@@ -75,8 +75,6 @@ private:
                            mtcr_page_addresses mailbox_page);
     bool readFromDataPage(mcddReg* accessData, mtcr_page_addresses page, u_int32_t* data, int data_size, int leftSize);
     std::vector<mtcr_page_addresses> _allocatedListVect;
-    fw_comps_error_t _lastFwError;
-    reg_access_status_t _lastRegisterAccessStatus;
     void setLastError(fw_comps_error_t error) { _lastFwError = error; }
 };
 #endif


### PR DESCRIPTION
Description: added initialization for members in AbstractComponentAccess class and removed unrequired members from derived class

MSTFlint port needed: no
Tested OS: linux
Tested devices: N/A
Tested flows: build

Known gaps (with RM ticket): N/A

Issue: 4620059