### PR TITLE
[flint][modules][3rd party] module fw burn stops at 99%

### DIFF
--- a/cable_access/cdb_cable_commander.cpp
+++ b/cable_access/cdb_cable_commander.cpp
@@ -239,9 +239,9 @@ void FwManagementCdbCommander::DownloadFWImageData(CmisCdbAccess::PayloadMethod 
     {
         mft_signal_set_handling(1); // Ignoring signals during CMIS download flow
         SendFwChunk(payloadMethod, fwData, remainingImageData, blockAddress);
-        progressFunc(100);
         DealWithSignalDuringBurn();
     }
+    progressFunc(100);
 }
 
 void FwManagementCdbCommander::StartFWDownload(const vector<u_int8_t>& image, const vector<u_int8_t>& vendorData)


### PR DESCRIPTION
Description: fixed burn completion print

MSTFlint port needed: no
Tested OS: linux
Tested devices: 3rd party module
Tested flows: mstflint -d <module> -i <image> --activate burn

Known gaps (with RM ticket): N/A

Issue: 4644225