### PR TITLE
[mlxlink][bug fix] PEMI register does not exist in mstflint should ma…

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -2606,7 +2606,7 @@ vector<AmberField> MlxlinkAmBerCollector::getExtModuleStatus()
     {
         if (!_isPortPCIE)
         {
-            sendPrmReg(ACCESS_REG_PEMI, GET, "local_port=%d,page_select=%d", _localPort, PEMI_GROUP_SEL_SNR_SAMPLES);
+            sendLocalPrmReg(ACCESS_REG_PEMI, GET, "local_port=%d,page_select=%d", _localPort, PEMI_GROUP_SEL_SNR_SAMPLES);
 
             u_int32_t groupCapMask = getLocalFieldValue("group_cap_mask");
 


### PR DESCRIPTION
…ke sure it ignores failures in reg access

Description: should call sendlocalprmreg function instead of sendprmreg