### PR TITLE
Add --enable-vfio configure flag to make VFIO library optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ LDFLAGS="$LDFLAGS -lstdc++"
 default_en_inband=""
 default_en_rdmem="no"
 default_en_nvml="no"
+default_en_vfio="no"
 default_en_i2c="no"
 OFED_VERSION_CHK=0
 KERNEL_BUILD_CHK=0
@@ -103,11 +104,6 @@ else
     fi
 fi
 
-if test "x$OS" = "xFreeBSD"; then
-    VFIO_DRIVER_DIR=""
-else
-    VFIO_DRIVER_DIR="vfio_driver_access"
-fi
 
 AC_SUBST(MTCR_CONF_DIR)
 AC_SUBST(VFIO_DRIVER_DIR)
@@ -431,6 +427,31 @@ AS_IF([test "x$enable_cables" = "xyes"],
         CABLE_ACCESS_DIR="cable_access"
     ]
 )
+
+# Enable VFIO:
+
+AC_MSG_CHECKING(--enable-vfio argument)
+AC_ARG_ENABLE(vfio,
+    AS_HELP_STRING([--enable-vfio], [enable VFIO driver access (Linux only), requires VFIO driver]),
+    [enable_vfio="$enableval"],
+    [enable_vfio="$default_en_vfio"]
+)
+AC_MSG_RESULT($enable_vfio)
+if test "x$enable_vfio" = "xyes"; then
+    CXXFLAGS="$CXXFLAGS -DENABLE_VFIO"
+    CFLAGS="$CFLAGS -DENABLE_VFIO"
+fi
+
+AM_CONDITIONAL(ENABLE_VFIO, [ test "x$enable_vfio" = "xyes" ])
+
+# Set VFIO_DRIVER_DIR based on enable_vfio flag
+if test "x$enable_vfio" = "xyes"; then
+    if test "x$OS" != "xFreeBSD"; then
+        VFIO_DRIVER_DIR="vfio_driver_access"
+    fi
+else
+    VFIO_DRIVER_DIR=""
+fi
 ##
 
 AC_MSG_CHECKING(--enable-rdmem argument)

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -278,7 +278,9 @@ typedef enum MType_t {
     MST_LINKX_CHIP  = 0x100000,
     MST_BAR0_GW_PCI = 0x200000,
     MST_NVML        = 0x400000,
+#ifdef ENABLE_VFIO
     MST_VFIO_DEVICE = 0x800000,
+#endif
     MST_DEFAULT     = 0xffffffff & ~MST_CABLE & ~MST_FPGA & ~MST_FPGA_ICMD & ~MST_FPGA_DRIVER & ~MST_LINKX_CHIP
 } MType;
 

--- a/mst_utils/mdevices_info.c
+++ b/mst_utils/mdevices_info.c
@@ -43,7 +43,9 @@
 #include "dev_mgt/tools_dev_types.h"
 #ifdef __linux__
 #include <linux/limits.h>
+#ifdef ENABLE_VFIO
 #include "vfio_driver_access/VFIODriverAccessWrapperC.h"
+#endif
 #endif
 #ifndef __FreeBSD__
 #include "mtcr_ul/mtcr_ul_com.h"
@@ -58,10 +60,12 @@ mfile* mopen_ul(const char* name)
     return 0;
 }
 
+#ifdef ENABLE_VFIO
 static inline bool CheckifVfioPciDriverIsLoaded(void)
 {
     return false;
 }
+#endif
 #endif
 
 int is_type_exist(dev_info* devs, int len, Mdevs type)
@@ -293,7 +297,7 @@ void print_pci_info(dev_info* dev, int domain_needed)
 
     /* Add NUMA node */
     printf("%-6s", dev->pci.numa_node);
-
+#ifdef ENABLE_VFIO
     if (CheckifVfioPciDriverIsLoaded())
     {
         printf("vfio-%-6s", dbdf);
@@ -302,6 +306,9 @@ void print_pci_info(dev_info* dev, int domain_needed)
     {
         printf(" ");
     }
+#else  
+    printf(" ");
+#endif
 
     printf("\n");
 }
@@ -411,7 +418,11 @@ int main(int argc, char** argv)
                            "RDMA",
                            "NET",
                            "NUMA",
+#ifdef ENABLE_VFIO
                            "VFIO");
+#else
+                           "");
+#endif
                 } else {
                     printf("%-24s%-30s%-16s%-16s%-40s%-6s%-16s\n",
                            "DEVICE_TYPE",
@@ -420,7 +431,11 @@ int main(int argc, char** argv)
                            "RDMA",
                            "NET",
                            "NUMA",
+#ifdef ENABLE_VFIO
                            "VFIO");
+#else
+                           "");
+#endif
                 }
                 /* printf("%-30s%-16s%-16s%-8s%-20s\n", "---", "-----------", "---", "----", "---"); */
             } else {
@@ -432,7 +447,11 @@ int main(int argc, char** argv)
                            "RDMA",
                            "NET",
                            "NUMA",
+#ifdef ENABLE_VFIO
                            "VFIO");
+#else
+                           "");
+#endif
                 } else {
                     printf("%-24s%-30s%-10s%-16s%-40s%-6s%-16s\n",
                            "DEVICE_TYPE",
@@ -441,7 +460,11 @@ int main(int argc, char** argv)
                            "RDMA",
                            "NET",
                            "NUMA",
+#ifdef ENABLE_VFIO
                            "VFIO");
+#else
+                           "");
+#endif
                 }
                 /* printf("%-30s%-16s%-10s%-8s%-20s\n", "---", "-----------", "---", "----", "---"); */
             }

--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -13,6 +13,7 @@
 %{!?enablecables: %define enablecables 0}
 %{!?enablei2c: %define enablei2c 0}
 %{!?enablenvml: %define enablenvml 0}
+%{!?enablevfio: %define enablevfio 0}
 %{!?CONF_DIR: %define CONF_DIR /etc/mstflint}
 
 %define mstflint_python_tools %{_libdir}/mstflint/python_tools
@@ -107,6 +108,10 @@ MSTFLINT_VERSION_STR="%{name} %{version}-%{release}"
 
 %if %{enablenvml}
     config_flags="$config_flags --enable-nvml"
+%endif
+
+%if %{enablevfio}
+    config_flags="$config_flags --enable-vfio"
 %endif
 
 %if %{enablecables}

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -47,12 +47,15 @@ libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
 			fwctrl.c fwctrl.h fwctrl_ioctl.h \
 			mtcr_gpu.c mtcr_gpu.h
 libmtcr_ul_la_CFLAGS = -W -Wall -g -MP -MD -fPIC -DMTCR_API="" -DMST_UL
+libmtcr_ul_la_DEPENDENCIES = 
 
 if ENABLE_INBAND
 libmtcr_ul_la_SOURCES += mtcr_ib_ofed.c
 endif
 
-libmtcr_ul_la_DEPENDENCIES = $(top_builddir)/vfio_driver_access/libvfio_access_driver.la
+if ENABLE_VFIO
+libmtcr_ul_la_DEPENDENCIES += $(top_builddir)/vfio_driver_access/libvfio_access_driver.la
+endif
 libmtcr_ul_la_LDFLAGS = -lstdc++
 
 if ENABLE_NVML


### PR DESCRIPTION
Add --enable-vfio configure flag to make VFIO library optional.

Tested flows:
build the project with and without --enable-vfio and then:
- nm /swgwork/ssela/workspace/mstflint2/mstflint/mtcr_ul/.libs/libmtcr_ul.a | grep -i vfio
- mdevices_info -v


Issue: 4648559
Change-Id: Ie24dfe2a5a0153155b1a534cc0a1b0aee2928e55