### PR TITLE
mstflint | DFA optimization I2C over USB

### DIFF
--- a/mflash/mflash.h
+++ b/mflash/mflash.h
@@ -277,6 +277,8 @@ int mf_enable_hw_access(mflash* mfl, u_int64_t key);
 int mf_disable_hw_access_with_key(mflash* mfl, u_int64_t key);
 int mf_disable_hw_access(mflash* mfl);
 int mf_release_semaphore(mflash* mfl);
+int mf_acquire_persistent_lock(mflash* mfl);
+int mf_release_persistent_lock(mflash* mfl);
 
 // get mfile object
 mfile* mf_get_mfile(mflash* mfl);

--- a/mflash/mflash_new_gw.c
+++ b/mflash/mflash_new_gw.c
@@ -99,7 +99,8 @@ static int set_gw_data_size(mflash* mfl, u_int32_t data_size, u_int32_t* gw_cmd)
 static int set_gw_data_size_wrapper(mflash* mfl, u_int32_t data_size, u_int32_t* gw_cmd, bool is_first)
 {
     int rc = 0;
-    if (!is_first && data_size == (u_int32_t)mfl->attr.block_write)
+    FlashGen flash_gen = get_flash_gen(mfl);
+    if (flash_gen == SEVEN_GEN_FLASH && !is_first && data_size == (u_int32_t)mfl->attr.block_write)
     {
         DPRINTF(("set_gw_data_size_wrapper: skip setting data size for non-first block\n"));
     }

--- a/mflash/mflash_new_gw.c
+++ b/mflash/mflash_new_gw.c
@@ -96,6 +96,20 @@ static int set_gw_data_size(mflash* mfl, u_int32_t data_size, u_int32_t* gw_cmd)
     return MFE_OK;
 }
 
+static int set_gw_data_size_wrapper(mflash* mfl, u_int32_t data_size, u_int32_t* gw_cmd, bool is_first)
+{
+    int rc = 0;
+    if (!is_first && data_size == (u_int32_t)mfl->attr.block_write)
+    {
+        DPRINTF(("set_gw_data_size_wrapper: skip setting data size for non-first block\n"));
+    }
+    else
+    {
+        rc = set_gw_data_size(mfl, data_size, gw_cmd);
+    }
+    return rc;
+}
+
 static int st_spi_wait_wip(mflash* mfl, u_int32_t init_delay_us, u_int32_t retry_delay_us, u_int32_t num_of_retries)
 {
     int rc = 0;
@@ -423,7 +437,7 @@ int new_gw_st_spi_block_write_ex(mflash* mfl,
     CHECK_RC(rc);
 
     gw_cmd = MERGE(gw_cmd, 1, mfl->gw_data_phase_bit_offset, 1);
-    rc = set_gw_data_size(mfl, blk_size, &gw_cmd);
+    rc = set_gw_data_size_wrapper(mfl, blk_size, &gw_cmd, is_first);
     CHECK_RC(rc);
 
     if (is_first)
@@ -458,7 +472,7 @@ int new_gw_st_spi_block_write_ex(mflash* mfl,
         DPRINTF(("word = 0x%08x\n", word));
     }
 
-    rc = new_gw_exec_cmd_set(mfl, gw_cmd, buff, (blk_size >> 2), &addr, "PP command");
+    rc = new_gw_exec_cmd_set(mfl, gw_cmd, buff, (blk_size >> 2), is_first ? &addr : NULL, "PP command");
     CHECK_RC(rc);
 
     //
@@ -561,7 +575,7 @@ int new_gw_st_spi_block_read_ex(mflash* mfl,
     // Read the data block
     gw_cmd = MERGE(gw_cmd, 1, mfl->gw_rw_bit_offset, 1);
     gw_cmd = MERGE(gw_cmd, 1, mfl->gw_data_phase_bit_offset, 1);
-    rc = set_gw_data_size(mfl, blk_size, &gw_cmd);
+    rc = set_gw_data_size_wrapper(mfl, blk_size, &gw_cmd, is_first);
     CHECK_RC(rc);
 
     rc = new_gw_exec_cmd_get(mfl, gw_cmd, (u_int32_t*)data, (blk_size >> 2), &addr, "Read");

--- a/mflash/mflash_pack_layer.h
+++ b/mflash/mflash_pack_layer.h
@@ -252,6 +252,7 @@ struct mflash {
 
     int curr_bank;
     int is_locked;
+    int unlock_blocked;
     int flash_prog_locked;
     int unlock_flash_prog_allowed;
     /* if writer_lock is set, semaphore should be freed only in mf_close()/disable_hw_access() */

--- a/mlxfwops/lib/flint_io.h
+++ b/mlxfwops/lib/flint_io.h
@@ -524,7 +524,7 @@ public:
     bool check_and_disable_flash_wp_if_required();
     bool backup_write_protect_info(write_protect_info_backup_t& protect_info_backup);
     bool restore_write_protect_info(write_protect_info_backup_t& protect_info_backup);
-    static void deal_with_signal();
+    static void deal_with_signal(mflash* mfl = nullptr);
 
     mfile* getMfileObj() { return mf_get_mfile(_mfl); }
     mflash* getMflashObj() { return _mfl; }


### PR DESCRIPTION
Description:
Prio 1:
1: Avoid polling on FlashGW busy bit when the flint interface is i2c. We can assume that FlashGW HW sends the SPI command much faster than it takes the next transaction on i2c bus. limitation: i2c

2: No need to repeat writing 0x10 to FlashGW data_size
limitation: none

3: No need to release and re-lock semaphore after each FlashGW operation. Lock once at the beginning of DFA session and release at the end.
limitation: LF.

Prio 2:
4: If FlashGW address doesn't change, no need to write it again limitation:  none