### PR TITLE
Add s390x support to mstflint spec files and configure flags

### DIFF
--- a/kernel/mstflint_kernel.spec
+++ b/kernel/mstflint_kernel.spec
@@ -165,7 +165,7 @@ find %{buildroot} -type f -name \*.ko -exec %{__strip} -p --strip-debug --discar
 %defattr(-,root,root,-)
 /lib/modules/%{KVERSION}/%{install_mod_dir}/
 %endif
-%if "%{cpu_arch}" == "ppc64" || "%{cpu_arch}" == "ppc64le"
+%if "%{cpu_arch}" == "ppc64" || "%{cpu_arch}" == "ppc64le" || "%{cpu_arch}" == "s390x"
 %if "%{KMP}" == "1"
 %files utils
 %defattr(-,root,root,-)

--- a/mstflint.spec.in
+++ b/mstflint.spec.in
@@ -144,6 +144,10 @@ MSTFLINT_VERSION_STR="%{name} %{version}-%{release}"
     config_flags="$config_flags --host arm"
 %endif
 
+%if %{buildtype} == "s390x"
+    config_flags="$config_flags --host=s390x-linux-gnu"
+%endif
+
 %configure ${config_flags} MSTFLINT_VERSION_STR="${MSTFLINT_VERSION_STR}"
 
 make


### PR DESCRIPTION
This PR adds support for building mstflint RPMs on IBM Z (s390x).
GH Issue: https://github.com/Mellanox/mstflint/issues/1428

**Changes made:**
- Updated `kernel/mstflint_kernel.spec` to include `s390x` in supported architectures.
- Updated `mstflint.spec.in` to add proper configure flags (`--host=s390x-linux-gnu`) when building on s390x.
- Ensured autotools outputs (`configure`, `Makefile.in`) are included in the source tarball for RPM builds.

**Testing performed:**
- Environment: IBM Z (s390x), RHEL 9.6.
<img width="1978" height="816" alt="image" src="https://github.com/user-attachments/assets/b81cdaff-88e3-4ddc-8697-88163babf4bc" />

- Ran `./autogen.sh` to generate autotools files and created a source tarball (`mstflint-4.34.0.tar.gz`).
- Installed required build dependencies (`expat-devel`, `xz-devel`, etc.).
- Built RPM with `rpmbuild -ba mstflint.spec`.
- Verified RPM creation under `~/rpmbuild/RPMS/s390x/`.
- Installed RPM with `yum localinstall` and confirmed:
  - `rpm -q mstflint` → `mstflint-4.34.0-1.s390x`
  - `which mstflint` → `/usr/bin/mstflint`
  - `mstflint --version` → `mstflint 4.34.0-1, Git SHA Hash: 0990c40b`
<img width="884" height="148" alt="image" src="https://github.com/user-attachments/assets/eb865c85-9c43-4926-80d5-28781fc1437a" />

<img width="3288" height="1296" alt="image" src="https://github.com/user-attachments/assets/7f155d64-9ddd-4035-9482-b1450a9dfee1" />

<img width="3440" height="1272" alt="image" src="https://github.com/user-attachments/assets/d7529146-6864-45b4-aeda-d57b1920b556" />

**Result:**
- RPM builds, installs, and runs correctly on s390x.
- Confirms feasibility of adding official s390x packaging support.
- Addresses the gap reported in the issue where no official RPMs exist for s390x.
