### PR TITLE
Porting several commits from MFT into mstflint

### DIFF
--- a/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
+++ b/small_utils/mlxfwresetlib/cmd_reg_mfrl.py
@@ -328,10 +328,10 @@ class CmdRegMfrl():
         else:
             raise CmdNotSupported('Failed to send MFRL! reset-level {0} is not supported!'.format(reset_level))
 
-        # If the reset level it is WARM_REBOOT, we need to set the PCI toggle bit because some servers may not perform PERST during the power cycle.
+        # If the reset level it is WARM_REBOOT, we need to set the PCI toggle bit (if supported) because some servers may not perform PERST during the power cycle.
         if reset_level == CmdRegMfrl.WARM_REBOOT:
             for reset_level_ii in self._reset_levels:
-                if reset_level_ii['level'] == CmdRegMfrl.PCI_RESET:
+                if reset_level_ii['level'] == CmdRegMfrl.PCI_RESET and self.is_reset_level_supported(CmdRegMfrl.PCI_RESET):
                     reset_level_2_send = reset_level_2_send | reset_level_ii['mask']
 
         # Reset-type to send

--- a/small_utils/mstfwreset.py
+++ b/small_utils/mstfwreset.py
@@ -2684,6 +2684,9 @@ def main():
     args.ignore_list = list(set(args.ignore_list + args.ignore_file))
     logger.debug("Ignore drivers: {0}".format(args.ignore_list))
 
+    if "fwctl" in device:
+        raise RuntimeError("mlxfwreset is not supported for fwctl devices")
+
     # Insert Flow here
     if isSwitchDevice(device):
         return reset_flow_switch(device, args, command)


### PR DESCRIPTION
mlxfwreset | block mlxfwreset execution when the device is fwctl