### PR TITLE
fwctrl: replace __uint32_t with __u32

### DIFF
--- a/include/mtcr_ul/fwctrl_ioctl.h
+++ b/include/mtcr_ul/fwctrl_ioctl.h
@@ -153,9 +153,9 @@ struct fwctl_rpc {
 struct mlx5_umem_buff {
 	void *buff;
 	size_t size;
-	__uint32_t umem_id;
-	__uint32_t umem_mkey;
-	__uint32_t rsc_id;
+	__u32 umem_id;
+	__u32 umem_mkey;
+	__u32 rsc_id;
 };
 
 struct fwctl_rsc_umem_reg {


### PR DESCRIPTION
The musl toolchain doesn't provide `__uint32_t`, so compilation fails when building with musl.
This header already uses Linux UAPI types, so use `__u32` here too.