### PR TITLE
I2C livefish: treat CX9 device id 0 as ConnectX9

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -542,6 +542,15 @@ static struct device_info g_devs_info[] = {{
                                              DM_GEARBOX         /* dev_type */
                                            },
                                            {
+                                             DeviceConnectX9, /* dm_id - CX9 in I2C livefish reports 0 at 0xf0014 */
+                                             0,                /* hw_dev_id */
+                                             -1,               /* hw_rev_id */
+                                             4133,             /* sw_dev_id */
+                                             "ConnectX9_Livefish", /* name */
+                                             4,                /* port_num */
+                                             DM_HCA            /* dev_type */
+                                           },
+                                           {
                                              DeviceUnknown,    /* dm_id */
                                              0,                /* hw_dev_id */
                                              0,                /* hw_rev_id */

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -2771,7 +2771,8 @@ u_int32_t supported_device_ids[] = {DeviceConnectX3_HwId,
                                     DeviceGR100_HwId,
                                     DeviceConnectX8_Pure_PCIe_Switch_HwId,
                                     DeviceConnectX9_HwId,
-                                    DeviceConnectX9_Pure_PCIe_Switch_HwId};
+                                    DeviceConnectX9_Pure_PCIe_Switch_HwId,
+                                    0}; /* 0 = CX9 in I2C livefish (0xf0014 returns 0) */
 #define SUPPORTED_DEVICE_ID_TABLE_SIZE (sizeof(supported_device_ids) / sizeof(u_int32_t))
 
 int is_supported_device_id(u_int16_t dev_id)

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -1162,6 +1162,7 @@ static int icmd_init_cr(mfile* mf)
             mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
             break;
 
+        case (0): /* CX9 in I2C livefish reports 0 at 0xf0014; use CX9 layout */
         case (CX8_HW_ID):
         case (CX9_HW_ID):
         case (CX8_PURE_PCIE_SWITCH_HW_ID):
@@ -1204,6 +1205,17 @@ static int icmd_init_cr(mfile* mf)
             return ME_ICMD_NOT_SUPPORTED;
     }
     mf->icmd.max_cmd_size = ICMD_MAX_CMD_SIZE;
+#ifdef ENABLE_MST_DEV_I2C
+    /* CX9 in I2C livefish: 0xf0014 returns 0; ICMD version read may fail - use fixed CX9 layout */
+    if ((hw_id & 0xffff) == 0 && mf->tp == MST_DEV_I2C)
+    {
+        mf->icmd.cmd_addr = CMD_PTR_ADDR_CX8;
+        mf->icmd.ctrl_addr = CMD_PTR_ADDR_CX8 + CTRL_OFFSET;
+        mf->icmd.syndrome_addr = CMD_PTR_ADDR_CX8 + SYNDROME_OFFSET;
+        mf->icmd.icmd_opened = 1;
+        return ME_OK;
+    }
+#endif
     icmd_ver = get_version(mf, hcr_address);
     /* get command and control addresses */
     switch (icmd_ver)


### PR DESCRIPTION
When the CX9 NIC is in I2C livefish (recovery) mode, register 0xf0014 returns 0 instead of 0x224. mstflint then fails with "Can't find device id" or "ICMD interface is not supported". Treat device id 0 over I2C as ConnectX9 and use the same init path so burn can proceed with --override_cache_replacement (direct flash access).

- tools_dev_types.c: add device table entry hw_dev_id 0 -> DeviceConnectX9
- mtcr_ul_com.c: add 0 to supported_device_ids[]
- mtcr_ul_icmd_cif.c: case 0 in hw_id switch (same as CX9); for I2C and hw_id 0 skip get_version() and set ICMD addrs to CX8/CX9 defaults

Tested: Lupine BMC, I2C bus 14, CX9 at 0x48; burn in livefish succeeds.