### PR TITLE
Mlxlink | Bug fix for amber_collect test mode and module information …

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -261,6 +261,13 @@ void MlxlinkAmBerCollector::init()
             if (_protoActive == IB)
             {
                 updateModeAsActive();
+
+                // Restore PDDR parser after updateModeAsActive() changed it to PTYS.
+                resetLocalParser(ACCESS_REG_PDDR);
+                updateField("local_port", _localPort);
+                updateField("page_select", PDDR_OPERATIONAL_INFO_PAGE);
+                sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
+                
                 _activeSpeed = _isPortNVLINK ? getFieldValue("link_nvlink_active") : getFieldValue("link_speed_active");
                 string linkSpeedActive = SupportedSpeeds2Str((_isNvlinkModeB || _isNvlinkModeA) ? NVLINK : IB,
                                                              _activeSpeed, true, _isModeAsActive);


### PR DESCRIPTION
…issues

Description:
Fixed two bugs related to incorrect register context after updateXdrSlowActive() call:
1. amber_collect on test mode was missing PRBS fields in the output (fields were not appearing at all)
2. Module information shown in mlxlink output was not valid

The fix restores PDDR parser context after updateXdrSlowActive() changes it to PTYS, ensuring correct field values are read from PDDR registers.

MSTFlint port needed: yes

Tested OS: Linux

Tested devices: Quantum4 (Rosalind), Quantum3 (Croc)

Tested flows:
• mlxlink -d <device> -p <port> -m
• mlxlink -d <device> -p <port> --amber_collect /tmp/amber.csv (on test mode)

Known gaps (with RM ticket):

Issue: 4909591
Issue: 4904023