### PR TITLE
Mlxlink | Bug fix for missing PRBS per-lane fields in test mode

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -258,6 +258,11 @@ void MlxlinkAmBerCollector::init()
             _isPortETH = (_protoActive == ETH) && (_pnat != PNAT_PCIE);
             _maxLanes = MAX_NETWORK_LANES;
 
+            resetLocalParser(ACCESS_REG_PPAOS);
+            updateField("local_port", _localPort);
+            sendRegister(ACCESS_REG_PPAOS, MACCESS_REG_METHOD_GET);
+            _inPRBSMode = getFieldValue("phy_test_mode_status") == 1;
+
             if (_protoActive == IB)
             {
                 updateModeAsActive();
@@ -266,7 +271,14 @@ void MlxlinkAmBerCollector::init()
                                                              _activeSpeed, true, _isModeAsActive);
                 if (_isNvlinkModeB || _isNvlinkModeA)
                 {
-                    _numOfLanes = linkSpeedActive.empty() ? 0 : checkNvl6ModeBSpeed(linkSpeedActive) ? 2 : 1;
+                    if (_inPRBSMode)
+                    {
+                        updateNumOfLanesForTestModeNVL6();
+                    }
+                    else
+                    {
+                        _numOfLanes = linkSpeedActive.empty() ? 0 : checkNvl6ModeBSpeed(linkSpeedActive) ? 2 : 1;
+                    }
                 }
                 else
                 {
@@ -3079,4 +3091,25 @@ void MlxlinkAmBerCollector::updateModeAsActive()
     updateField("proto_mask", protoMask);
     sendRegister(ACCESS_REG_PTYS, MACCESS_REG_METHOD_GET);
     _isModeAsActive = getFieldValue("xdr_2x_slow_active");
+}
+
+void MlxlinkAmBerCollector::updateNumOfLanesForTestModeNVL6()
+{
+    // In test mode, determine number of lanes from PRBS register
+    resetLocalParser(ACCESS_REG_PPRT);
+    updateField("local_port", _localPort);
+    updateField("e", PPRT_PPTT_ENABLE);
+    sendRegister(ACCESS_REG_PPRT, MACCESS_REG_METHOD_GET);
+    string laneRateStr = getStrByValue(getFieldValue("lane_rate_oper"), _mlxlinkMaps->_prbsLaneRateList);
+    if (_isNvlinkModeB || _isNvlinkModeA)
+    {
+        if (laneRateStr == _mlxlinkMaps->_prbsLaneRateList[PRBS_XDR])
+        {
+            _numOfLanes = 1; // XDR_1X mode has 1 lane (XDR_2X is currently not supported)
+        }
+        else
+        {
+            _numOfLanes = 2; // Mode B has 2 lanes, usually we should query PMLP to get the actual number of lanes
+        }
+    }
 }

--- a/mlxlink/modules/mlxlink_amBER_collector.h
+++ b/mlxlink/modules/mlxlink_amBER_collector.h
@@ -182,6 +182,7 @@ protected:
     virtual void getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params);
     virtual void getModuleLinkUpInfoPage(vector<AmberField>& fields);
     virtual void updateModeAsActive();
+    void updateNumOfLanesForTestModeNVL6();
 
     // Callers
 


### PR DESCRIPTION
Description:
Fixed issue where per-lane PRBS fields showed N/A values in amber_collect output when running on test mode. The root cause was that _numOfLanes was set to 0 in test mode, preventing the PRBS collection loop from running.

MSTFlint port needed: no

Tested OS: Linux

Tested devices: Quantum4 (Rosalind)

Tested flows:
• mlxlink -d <device> -p <port> --amber_collect /tmp/amber.csv (on test mode)

Known gaps (with RM ticket):

Issue: 4915731