### PR TITLE
Mlxlink | Bug fix for missing port info from JSON output

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -6936,6 +6936,7 @@ void MlxlinkCommander::initAmBerCollector()
 void MlxlinkCommander::prepareJsonOut()
 {
     _operatingInfoCmd.toJsonFormat(_jsonRoot);
+    _portInfoCmd.toJsonFormat(_jsonRoot);
     _supportedInfoCmd.toJsonFormat(_jsonRoot);
     _troubInfoCmd.toJsonFormat(_jsonRoot);
     _toolInfoCmd.toJsonFormat(_jsonRoot);


### PR DESCRIPTION
Description:
Fixed issue where port information was missing from JSON output.

MSTFlint port needed: no

Tested OS: Linux

Tested devices: Quantum3, Quantum4

Tested flows:
• mlxlink -d <device> -p <port> --json

Known gaps (with RM ticket):

Issue: 4894501