### PR TITLE
Backport fixes at mlxlink from master_devel:

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -262,6 +262,13 @@ void MlxlinkAmBerCollector::init()
             if (_protoActive == IB)
             {
                 updateModeAsActive();
+
+                // Restore PDDR parser after updateModeAsActive() changed it to PTYS.
+                resetLocalParser(ACCESS_REG_PDDR);
+                updateField("local_port", _localPort);
+                updateField("page_select", PDDR_OPERATIONAL_INFO_PAGE);
+                sendRegister(ACCESS_REG_PDDR, MACCESS_REG_METHOD_GET);
+                
                 _activeSpeed = _isPortNVLINK ? getFieldValue("link_nvlink_active") : getFieldValue("link_speed_active");
                 string linkSpeedActive = SupportedSpeeds2Str((_isNvlinkModeB || _isNvlinkModeA) ? NVLINK : IB,
                                                              _activeSpeed, true, _isModeAsActive);

--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -259,6 +259,11 @@ void MlxlinkAmBerCollector::init()
             _isPortETH = (_protoActive == ETH) && (_pnat != PNAT_PCIE);
             _maxLanes = MAX_NETWORK_LANES;
 
+            resetLocalParser(ACCESS_REG_PPAOS);
+            updateField("local_port", _localPort);
+            sendRegister(ACCESS_REG_PPAOS, MACCESS_REG_METHOD_GET);
+            _inPRBSMode = getFieldValue("phy_test_mode_status") == 1;
+
             if (_protoActive == IB)
             {
                 updateModeAsActive();
@@ -274,7 +279,14 @@ void MlxlinkAmBerCollector::init()
                                                              _activeSpeed, true, _isModeAsActive);
                 if (_isNvlinkModeB || _isNvlinkModeA)
                 {
-                    _numOfLanes = linkSpeedActive.empty() ? 0 : checkNvl6ModeBSpeed(linkSpeedActive) ? 2 : 1;
+                    if (_inPRBSMode)
+                    {
+                        updateNumOfLanesForTestModeNVL6();
+                    }
+                    else
+                    {
+                        _numOfLanes = linkSpeedActive.empty() ? 0 : checkNvl6ModeBSpeed(linkSpeedActive) ? 2 : 1;
+                    }
                 }
                 else
                 {
@@ -3413,4 +3425,25 @@ void MlxlinkAmBerCollector::handleSltrAbGroup(vector<AmberField>& fields, u_int3
 void MlxlinkAmBerCollector::handleSltrYGroup(vector<AmberField>& fields, u_int32_t lane)
 {
     handleSltrGroup(fields, lane, "y_group", {0, 1});
+}
+
+void MlxlinkAmBerCollector::updateNumOfLanesForTestModeNVL6()
+{
+    // In test mode, determine number of lanes from PRBS register
+    resetLocalParser(ACCESS_REG_PPRT);
+    updateField("local_port", _localPort);
+    updateField("e", PPRT_PPTT_ENABLE);
+    sendRegister(ACCESS_REG_PPRT, MACCESS_REG_METHOD_GET);
+    string laneRateStr = getStrByValue(getFieldValue("lane_rate_oper"), _mlxlinkMaps->_prbsLaneRateList);
+    if (_isNvlinkModeB || _isNvlinkModeA)
+    {
+        if (laneRateStr == _mlxlinkMaps->_prbsLaneRateList[PRBS_XDR])
+        {
+            _numOfLanes = 1; // XDR_1X mode has 1 lane (XDR_2X is currently not supported)
+        }
+        else
+        {
+            _numOfLanes = 2; // Mode B has 2 lanes, usually we should query PMLP to get the actual number of lanes
+        }
+    }
 }

--- a/mlxlink/modules/mlxlink_amBER_collector.h
+++ b/mlxlink/modules/mlxlink_amBER_collector.h
@@ -185,6 +185,7 @@ protected:
     virtual void getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params);
     virtual void getModuleLinkUpInfoPage(vector<AmberField>& fields);
     virtual void updateModeAsActive();
+    void updateNumOfLanesForTestModeNVL6();
 
     virtual void getSlsirGen8Fields(vector<AmberField>& fields);
     void getSltpGen8Fields(vector<AmberField>& fields);

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -6936,6 +6936,7 @@ void MlxlinkCommander::initAmBerCollector()
 void MlxlinkCommander::prepareJsonOut()
 {
     _operatingInfoCmd.toJsonFormat(_jsonRoot);
+    _portInfoCmd.toJsonFormat(_jsonRoot);
     _supportedInfoCmd.toJsonFormat(_jsonRoot);
     _troubInfoCmd.toJsonFormat(_jsonRoot);
     _toolInfoCmd.toJsonFormat(_jsonRoot);


### PR DESCRIPTION
Backport fixes from master_devel:

- Bug fix for amber_collect test mode and module information issues
- Bug fix for missing PRBS per-lane fields in test mode
- Bug fix for missing port info from JSON output