### PR TITLE
mstlink | Fix missing --primary/--secondary flags and Test Mode FSM S…

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -2550,6 +2550,30 @@ void MlxlinkCommander::setPrecoding()
     }
 }
 
+bool MlxlinkCommander::isTestModeFsmStateSupported()
+{
+    bool isTestModeFsmStateSupported = false;
+    u_int64_t fdCapMask = PCAM_TEST_MODE_FSM_STATE_CAP_MASK; // feature_cap_mask.Bit 120 (feature_cap_mask[0].bit 25)
+    sendPrmReg(ACCESS_REG_PCAM, GET);
+    // checking test_mode_fsm_state cap
+    // important note: by FW implmentation the feature_cap_mask is implemented reversed.
+    // meaning bit 120 in PRM will be in feature_cap_mask[(128-120)\32]
+    isTestModeFsmStateSupported = getFieldValue("feature_cap_mask[0]") & fdCapMask;
+
+    return isTestModeFsmStateSupported;
+}
+
+string MlxlinkCommander::getTestModeFsmStateStr()
+{
+    if (!isTestModeFsmStateSupported())
+    {
+        return NA_FIELD_VALUE;
+    }
+    sendPrmReg(ACCESS_REG_PDDR, GET, "page_select=%d", PDDR_OPERATIONAL_INFO_PAGE);
+    u_int32_t testModeFsmState = getFieldValue("test_mode_fsm_state");
+    return getStrByValue(testModeFsmState, _mlxlinkMaps->_testModeFsmState);
+}
+
 void MlxlinkCommander::showTestMode()
 {
     std::map<std::string, std::string> pprtMap = getPprt();
@@ -2570,6 +2594,7 @@ void MlxlinkCommander::showTestMode()
         setPrintVal(_testModeInfoCmd, "Nvlink Mode",
                     pprtMap["pprtLaneRate"] == _mlxlinkMaps->_prbsLaneRateList[PRBS_XDR] ? "A" : "B");
         setPrintVal(_testModeInfoCmd, "Primary/Secondary", getStrByValue(_priOrSec, _mlxlinkMaps->_priOrSec));
+        setPrintVal(_testModeInfoCmd, "Test Mode FSM State", getTestModeFsmStateStr());
     }
 
     cout << _testModeInfoCmd;
@@ -5152,7 +5177,7 @@ void MlxlinkCommander::handlePrbs()
                 MlxlinkRecord::printCmdLine("Configuring Port to Physical Test Mode", _jsonRoot);
                 resetPprtPptt(isNvl6);
                 sendPprtPptt(isNvl6);
-                sendPrbsPpaos(true, _userInput._prbsDcCoupledAllow);
+                sendPrbsPpaos(true, _userInput._prbsDcCoupledAllow, isNvl6);
             }
             else
             {

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -183,6 +183,10 @@
 #define PPTT_MODULATION_FLAG_SHORT ' '
 #define PRBS_LANES_FLAG "lanes"
 #define PRBS_LANES_FLAG_SHORT ' '
+#define PRBS_PRIMARY_FLAG "primary"
+#define PRBS_PRIMARY_FLAG_SHORT ' '
+#define PRBS_SECONDARY_FLAG "secondary"
+#define PRBS_SECONDARY_FLAG_SHORT ' '
 #define PRBS_INVERT_TX_POL_FLAG "invert_tx_polarity"
 #define PRBS_INVERT_TX_POL_FLAG_SHORT ' '
 #define PRBS_INVERT_RX_POL_FLAG "invert_rx_polarity"

--- a/mlxlink/modules/mlxlink_enums.h
+++ b/mlxlink/modules/mlxlink_enums.h
@@ -2216,6 +2216,19 @@ enum PRECODING_OPER_STATUS
     PRECODING_OPER_STATUS_DISABLED = 2
 };
 
+enum TEST_MODE_FSM_STATE
+{
+    TEST_MODE_FSM_DISABLE,                    // This state is shared by Mode A and Mode B links test mode FSM
+    TEST_MODE_FSM_OPEN_LANE,                  // Mode B links test mode FSM
+    TEST_MODE_FSM_IDLE,                       // Mode A and Mode B links test mode FSM
+    TEST_MODE_FSM_CLOSE_LANE,                 // Mode B links test mode FSM
+    TEST_MODE_FSM_RECEIVER_DETECT,            // Mode A links test mode FSM
+    TEST_MODE_FSM_IDLE_MODE_A,                // Mode A links test mode FSM
+    TEST_MODE_FSM_SIGNAL_DETECT,              // Mode A links test mode FSM
+    TEST_MODE_FSM_AUTO_FIX_REVERSAL_POLARITY, // Mode A links test mode FSM
+    TEST_MODE_FSM_TUNING                      // Mode A links test mode FSM
+};
+
 // Anonymous namespace to ensure the constants are only used in relevant scope
 namespace
 {

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -56,6 +56,16 @@ void MlxlinkMaps::initPortStateMapping()
     _priOrSec[MODE_B_PRI_OR_SEC_PRIMARY] = "Primary";
     _priOrSec[MODE_B_PRI_OR_SEC_SECONDARY] = "Secondary";
 
+    _testModeFsmState[TEST_MODE_FSM_DISABLE] = "Disabled";
+    _testModeFsmState[TEST_MODE_FSM_OPEN_LANE] = "Open lane";
+    _testModeFsmState[TEST_MODE_FSM_IDLE] = "Idle";
+    _testModeFsmState[TEST_MODE_FSM_CLOSE_LANE] = "Close lane";
+    _testModeFsmState[TEST_MODE_FSM_RECEIVER_DETECT] = "Receiver detect";
+    _testModeFsmState[TEST_MODE_FSM_IDLE_MODE_A] = "Idle mode A";
+    _testModeFsmState[TEST_MODE_FSM_SIGNAL_DETECT] = "Signal detect";
+    _testModeFsmState[TEST_MODE_FSM_AUTO_FIX_REVERSAL_POLARITY] = "Auto fix reversal polarity";
+    _testModeFsmState[TEST_MODE_FSM_TUNING] = "Tuning";
+
     _pmFsmState[PHY_MNGR_DISABLED] = "Disable";
     _pmFsmState[PHY_MNGR_OPEN_PORT] = "Port PLL Down";
     _pmFsmState[PHY_MNGR_POLLING] = "Polling";

--- a/mlxlink/modules/mlxlink_maps.h
+++ b/mlxlink/modules/mlxlink_maps.h
@@ -246,6 +246,7 @@ public:
 
     std::map<u_int32_t, std::string> _pmFsmState;
     std::map<u_int32_t, std::string> _priOrSec;
+    std::map<u_int32_t, std::string> _testModeFsmState;
     std::map<u_int32_t, std::string> _proFileFecInUse;
     std::map<u_int32_t, u_int32_t> _ETHSpeed2gRate;
     std::map<u_int32_t, u_int32_t> _IBSpeed2gRate;

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -344,6 +344,11 @@ void MlxlinkUi::printSynopsisCommands()
     MlxlinkRecord::printFlagLine(PRBS_DC_COUPLE_ALLOW_FLAG_SHORT, PRBS_DC_COUPLE_ALLOW_FLAG, "",
                                  "For DC coupled ports only: This flag must be set to enter test mode");
     printf(IDENT);
+    MlxlinkRecord::printFlagLine(PRBS_PRIMARY_FLAG_SHORT, PRBS_PRIMARY_FLAG, "", "Set the current device as primary");
+    printf(IDENT);
+    MlxlinkRecord::printFlagLine(PRBS_SECONDARY_FLAG_SHORT, PRBS_SECONDARY_FLAG, "",
+                                 "Set the current device as secondary");
+    printf(IDENT);
     MlxlinkRecord::printFlagLine(FORCE_TX_ALLOWED_FLAG_SHORT, FORCE_TX_ALLOWED_FLAG, "",
                                  "Force TX allowed for PRBS test mode");
     printf(IDENT);
@@ -729,7 +734,7 @@ void MlxlinkUi::validatePRBSParams()
 {
     bool prbsFlags = _userInput._sendPprt || _userInput._sendPptt || _userInput._pprtRate != "" ||
                      _userInput._pprtRate != "" || _userInput._prbsTxInv || _userInput._prbsRxInv ||
-                     _userInput._prbsDcCoupledAllow ||
+                     _userInput._prbsDcCoupledAllow || _userInput._primarySecondarySpecified ||
                      _userInput._prbsLanesToSet.size() > 0 || !_userInput._pprtModulation.empty() ||
                      !_userInput._ppttModulation.empty();
     if (isIn(SEND_PRBS, _sendRegFuncMap))
@@ -1307,6 +1312,8 @@ void MlxlinkUi::initCmdParser()
     AddOptions(PPRT_RATE_FLAG, PPRT_RATE_FLAG_SHORT, "PPRT_RATE", "PPRT Lane Rate");
     AddOptions(PPTT_RATE_FLAG, PPTT_RATE_FLAG_SHORT, "PPTT_RATE", "PPTT Lane Rate");
     AddOptions(PRBS_LANES_FLAG, PRBS_LANES_FLAG_SHORT, "lanes", "PRBS lanes to set");
+    AddOptions(PRBS_PRIMARY_FLAG, PRBS_PRIMARY_FLAG_SHORT, "", "Set the current device as primary");
+    AddOptions(PRBS_SECONDARY_FLAG, PRBS_SECONDARY_FLAG_SHORT, "", "Set the current device as secondary");
     AddOptions(PRBS_INVERT_TX_POL_FLAG, PRBS_INVERT_TX_POL_FLAG_SHORT, "", "PRBS TX polarity inversion");
     AddOptions(PRBS_INVERT_RX_POL_FLAG, PRBS_INVERT_RX_POL_FLAG_SHORT, "", "PRBS RX polarity inversion");
     AddOptions(PRBS_DC_COUPLE_ALLOW_FLAG, PRBS_DC_COUPLE_ALLOW_FLAG_SHORT, "", "Allow PRBS for DC coupled ports");
@@ -1914,6 +1921,18 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     {
         _userInput._sendPptt = true;
         _userInput._ppttMode = toUpperCase(value);
+        return PARSE_OK;
+    }
+    else if (name == PRBS_PRIMARY_FLAG)
+    {
+        _userInput._setPrimary = true;
+        _userInput._primarySecondarySpecified = true;
+        return PARSE_OK;
+    }
+    else if (name == PRBS_SECONDARY_FLAG)
+    {
+        _userInput._setPrimary = false;
+        _userInput._primarySecondarySpecified = true;
         return PARSE_OK;
     }
     else if (name == PPRT_MODULATION_FLAG)


### PR DESCRIPTION
…tate field

Fixed issue where --primary and --secondary flags were not recognized in mstlink, and added missing "Test Mode FSM State" field in Test Mode Info output.

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: Quantum3 (Rosalind)
Tested flows:
* mstlink -d 01:00.0 --test_mode EN --dc_cpl_allow -y --rx_rate 328G_2X_MODE_B --tx_rate 328G_2X_MODE_B --secondary

Known gaps (with RM ticket):
Issue: 4918223