### PR TITLE
fwctrl | Set RPC scope based on access method to fix tool access in kernel lockdown

### DIFF
--- a/include/mtcr_ul/fwctrl_ioctl.h
+++ b/include/mtcr_ul/fwctrl_ioctl.h
@@ -115,6 +115,47 @@ struct fwctl_info {
 #define FWCTL_INFO _IO(FWCTL_TYPE, FWCTL_CMD_INFO)
 
 /**
+ * enum fwctl_rpc_scope - Scope of access for the RPC
+ *
+ * Refer to fwctl.rst for a more detailed discussion of these scopes.
+ */
+enum fwctl_rpc_scope {
+	/**
+	 * @FWCTL_RPC_CONFIGURATION: Device configuration access scope
+	 *
+	 * Read/write access to device configuration. When configuration
+	 * is written to the device it remains in a fully supported state.
+	 */
+	FWCTL_RPC_CONFIGURATION = 0,
+	/**
+	 * @FWCTL_RPC_DEBUG_READ_ONLY: Read only access to debug information
+	 *
+	 * Readable debug information. Debug information is compatible with
+	 * kernel lockdown, and does not disclose any sensitive information. For
+	 * instance exposing any encryption secrets from this information is
+	 * forbidden.
+	 */
+	FWCTL_RPC_DEBUG_READ_ONLY = 1,
+	/**
+	 * @FWCTL_RPC_DEBUG_WRITE: Writable access to lockdown compatible debug information
+	 *
+	 * Allows write access to data in the device which may leave a fully
+	 * supported state. This is intended to permit intensive and possibly
+	 * invasive debugging. This scope will taint the kernel.
+	 */
+	FWCTL_RPC_DEBUG_WRITE = 2,
+	/**
+	 * @FWCTL_RPC_DEBUG_WRITE_FULL: Write access to all debug information
+	 *
+	 * Allows read/write access to everything. Requires CAP_SYS_RAW_IO, so
+	 * it is not required to follow lockdown principals. If in doubt
+	 * debugging should be placed in this scope. This scope will taint the
+	 * kernel.
+	 */
+	FWCTL_RPC_DEBUG_WRITE_FULL = 3,
+};
+
+/**
  * struct fwctl_rpc - ioctl(FWCTL_RPC)
  * @size: sizeof(struct fwctl_rpc)
  * @flags: Must be 0

--- a/mtcr_ul/fwctrl.c
+++ b/mtcr_ul/fwctrl.c
@@ -160,7 +160,8 @@ int fwctl_control_access_register(int    fd,
 
     rpc = (struct fwctl_rpc) {
         .size = sizeof(rpc),
-        .scope = 3,
+        .scope = (method == FWCTL_METHOD_READ) ? FWCTL_RPC_DEBUG_READ_ONLY
+                                               : FWCTL_RPC_DEBUG_WRITE_FULL,
         .in = (uintptr_t)in,
         .in_len = inlen,
         .out = (uintptr_t)out,


### PR DESCRIPTION
Read-only register accesses via fwctl were failing on systems with kernel lockdown enabled because fwctl_control_access_register() hardcoded .scope = 3 (FWCTL_RPC_DEBUG_WRITE_FULL) for all operations. The kernel fwctl driver caps the maximum permitted scope under lockdown, rejecting even read-only RPCs that request write-level privileges. Set scope to FWCTL_RPC_DEBUG_READ_ONLY for read operations and FWCTL_RPC_DEBUG_WRITE_FULL for writes, using the existing fwctl_rpc_scope enum from fwctrl_ioctl.h.