### PR TITLE
mstlink | Bug fixes for lane rate mapping, phy recovery type validati…

### DIFF
--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -542,7 +542,7 @@ void MlxlinkMaps::initPrbsMapping()
     _prbsLaneRateList[6] = "53.125G";
     _prbsLaneRateList[7] = "106.25G";
     _prbsLaneRateList[8] = "212.5G";
-    _prbsLaneRateList[9] = NA_FIELD_VALUE;
+    _prbsLaneRateList[9] = "180G";
     _prbsLaneRateList[10] = "1.25G";
     _prbsLaneRateList[11] = "3.125G";
     _prbsLaneRateList[12] = "12.89G";

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -777,7 +777,8 @@ void MlxlinkUi::validatePhyRecoveryParams()
                 throw MlxRegException("recovery_type flag should be provided for phy_recovery EN command");
             }
             else if (_userInput._phyRecoveryType != "host_serdes_feq" &&
-                     _userInput._phyRecoveryType != "host_logic_re_lock")
+                     _userInput._phyRecoveryType != "host_logic_re_lock" &&
+                     _userInput._phyRecoveryType != "phy_recovery_steps")
             {
                 throw MlxRegException("Invalid Recovery Type!");
             }
@@ -793,7 +794,8 @@ void MlxlinkUi::validatePhyRecoveryParams()
                 throw MlxRegException("recovery_type flag should be provided for PHY Recovery DS command");
             }
             else if (_userInput._phyRecoveryType != "host_serdes_feq" &&
-                     _userInput._phyRecoveryType != "host_logic_re_lock")
+                     _userInput._phyRecoveryType != "host_logic_re_lock" &&
+                     _userInput._phyRecoveryType != "phy_recovery_steps")
             {
                 throw MlxRegException("Invalid PHY Recovery Type!");
             }

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -1647,7 +1647,7 @@ bool isNRZSpeed(u_int32_t speed, u_int32_t protocol)
     return !isSpeed100GPerLane(speed, protocol) &&
            (isSpeed25GPerLane(speed, protocol) ||
             !(isSpeed50GPerLane(speed, protocol) || isSpeed100GPerLane(speed, protocol) ||
-              isSpeed200GPerLane(speed, protocol) || isSpeed25GPerLane(speed, protocol)));
+              isSpeed200GPerLane(speed, protocol) || isSpeed25GPerLane(speed, protocol) || (protocol == NVLINK)));
 }
 
 string linkWidthMaskToStr(u_int32_t width)


### PR DESCRIPTION
…on, and eye opening grades display

Fixed three bugs in mstlink:
1. Incorrect Lane Rate in Test Mode - Lane Rate 9 was mapped to NA_FIELD_VALUE instead of "180G"
2. --recovery_type phy_recovery_steps validation - Added missing validation for "phy_recovery_steps" recovery type
3. Incorrect Display of Upper/Mid/Lower Grades in EYE Opening Info - Added NVLINK protocol check to isNRZSpeed function

MSTFlint port needed: Yes
Tested OS: Linux
Tested devices: Quantum 4 (Rosalind)
Tested flows:
* mstlink -d <device> -p <port> --test_mode EN --rx_rate 360G_2X_MODE_B --tx_rate 360G_2X_MODE_B
* mstlink -d <device> -p <port> -phy_recovery DS --recovery_type phy_recovery_steps
* mstlink -d <device> -p <port> -e

Known gaps (with RM ticket):
Issue: 4924598
Issue: 4924639
Issue: 4924850