### PR TITLE
porting for AprGA

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -686,7 +686,7 @@ FlintStatus SubCommand::openIo()
         if (!((Flash*)_io)
                ->open(_flintParams.device.c_str(), _flintParams.clear_semaphore, false, _flintParams.banks,
                       _flintParams.flash_params_specified ? &_flintParams.flash_params : NULL,
-                      _flintParams.override_cache_replacement, true, _flintParams.use_fw))
+                      _flintParams.override_cache_replacement, true, _flintParams.use_fw, _flintParams.no_fw_ctrl))
         {
             // if we have Hw_Access command we dont fail straght away
             u_int8_t lockedCrSpace = ((Flash*)_io)->get_cr_space_locked();

--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -946,7 +946,7 @@ MfError gen_access_commands(mflash* mfl, flash_access_commands_t* access_command
 
 int is_srwd_supported_by_flash(u_int8_t vendor, u_int8_t type)
 {
-    return (vendor == FV_IS25LPXXX && type == FMT_IS25WPXXX);
+    return (vendor == FV_IS25LPXXX && (type == FMT_IS25WPXXX || type == FMT_IS25LPXXX));
 }
 
 int is_srp_supported_by_flash(uint8_t vendor, uint8_t type, u_int32_t log2_bank_size, MacronixSeriesCode series_code)

--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -1926,8 +1926,106 @@ int connectib_flash_lock(mflash* mfl, int lock_state)
 
 #define CACHE_REP_OFF_RAVEN 0xf0440
 #define CACHE_REP_CMD_RAVEN 0xf0448
-#define CACHE_REP_OFF_NEW_GW_ADDR 0xf0484
-#define CACHE_REP_CMD_NEW_GW_ADDR 0xf0488
+#define CACHE_REP_OFF_GEN_5_LEGACY 0xf0408
+#define CACHE_REP_CMD_GEN_5_LEGACY 0xf040c
+#define CACHE_REP_OFF_GEN_5 0xf0444
+#define CACHE_REP_CMD_GEN_5 0xf0448
+#define CACHE_REP_OFF_GEN_6 0xf0484
+#define CACHE_REP_CMD_GEN_6 0xf0488
+#define PAGER_OFF_GEN_7_HCA 0x8a1204
+#define PAGER_CMD_GEN_7_HCA 0x8a1208
+#define PAGER_OFF_GEN_7_SWITCH 0x101204
+#define PAGER_CMD_GEN_7_SWITCH 0x101208
+
+/*
+ * Read cache-replacement offset and cmd from cr space.
+ * off_len == 32 means use full 32-bit value; else off = EXTRACT(data, off_start, off_len).
+ * cmd = EXTRACT(data, cmd_start, cmd_len).
+ * Non-zero offset or cmd => running FW (use MFBA to avoid hang); both zero => no running FW (prefer DFA).
+ */
+static int read_cache_rep_regs(mflash* mfl,
+                               u_int32_t off_addr,
+                               u_int32_t cmd_addr,
+                               u_int32_t* off,
+                               u_int32_t* cmd,
+                               int off_start,
+                               int off_len,
+                               int cmd_start,
+                               int cmd_len)
+{
+    FLASH_ACCESS_DPRINTF(
+      ("read_cache_rep_regs(): off_addr=0x%08x, cmd_addr=0x%08x, off_start=%d, off_len=%d, cmd_start=%d, cmd_len=%d\n",
+       off_addr, cmd_addr, off_start, off_len, cmd_start, cmd_len));
+    u_int32_t data = 0;
+    MREAD4(off_addr, &data);
+    *off = (off_len == 32) ? data : EXTRACT(data, off_start, off_len);
+    MREAD4(cmd_addr, &data);
+    *cmd = EXTRACT(data, cmd_start, cmd_len);
+    return 0;
+}
+
+typedef enum
+{
+    CACHE_REP_GEN_5_LEGACY,
+    CACHE_REP_GEN_5,
+    CACHE_REP_GEN_6,
+    PAGER_GEN_7_HCA,
+    PAGER_GEN_7_SWITCH,
+    CACHE_REP_RAVEN,
+    CACHE_REP_DYNAMIC,
+} cache_rep_or_pager_reg_type_t;
+
+static cache_rep_or_pager_reg_type_t get_reg_type(dm_dev_id_t devid_t)
+{
+    cache_rep_or_pager_reg_type_t reg_type = CACHE_REP_RAVEN;
+    switch (devid_t)
+    {
+        case DeviceBlueField:
+        case DeviceConnectX4:
+        case DeviceConnectX4LX:
+        case DeviceConnectX5:
+        case DeviceSpectrum:
+        case DeviceConnectIB:
+            reg_type = CACHE_REP_GEN_5_LEGACY;
+            break;
+        case DeviceBlueField2:
+        case DeviceConnectX6:
+        case DeviceConnectX6DX:
+        case DeviceConnectX6LX:
+        case DeviceSpectrum2:
+        case DeviceSpectrum3:
+        case DeviceQuantum:
+            reg_type = CACHE_REP_GEN_5;
+            break;
+        case DeviceQuantum2:
+        case DeviceSpectrum4:
+        case DeviceSpectrum5:
+        case DeviceConnectX7:
+        case DeviceBlueField3:
+            reg_type = CACHE_REP_GEN_6;
+            break;
+        case DeviceBlueField4:
+        case DeviceConnectX8:
+        case DeviceConnectX8_Pure_PCIe_Switch:
+        case DeviceConnectX9:
+        case DeviceConnectX9_Pure_PCIe_Switch:
+            reg_type = PAGER_GEN_7_HCA;
+            break;
+        case DeviceSpectrum6:
+        case DeviceQuantum3:
+        case DeviceNVLink6_Switch:
+            reg_type = PAGER_GEN_7_SWITCH;
+            break;
+        default:
+            if (!dm_dev_is_raven_family_switch(devid_t))
+            {
+                reg_type = CACHE_REP_DYNAMIC;
+            }
+            break;
+    }
+    return reg_type;
+}
+
 int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement)
 {
     *needs_cache_replacement = 0;
@@ -1946,45 +2044,59 @@ int check_cache_replacement_guard(mflash* mfl, u_int8_t* needs_cache_replacement
 
     if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
     {
-        u_int32_t off = 0, cmd = 0, data = 0;
+        u_int32_t off = 0, cmd = 0;
         dm_dev_id_t devid_t = DeviceUnknown;
         u_int32_t devid = 0;
         u_int32_t revid = 0;
+
         int rc = dm_get_device_id(mfl->mf, &devid_t, &devid, &revid);
         if (rc)
         {
             return rc;
         }
 
-        /* TODO - fix for QTM3/CX8/ArcusE/BF4 */
-        /* Read the Cache replacement offset and cmd fields */
-        if ((devid_t == DeviceQuantum2) || (devid_t == DeviceQuantum3) || (devid_t == DeviceNVLink6_Switch) || (devid_t == DeviceSpectrum4) || (devid_t == DeviceSpectrum5) ||
-            (devid_t == DeviceSpectrum6) || (devid_t == DeviceConnectX7) || (devid_t == DeviceConnectX8) || (devid_t == DeviceConnectX8_Pure_PCIe_Switch) || (devid_t == DeviceConnectX9) ||
-            (devid_t == DeviceConnectX9_Pure_PCIe_Switch))
+        // Read the Cache replacement offset and cmd fields
+        cache_rep_or_pager_reg_type_t reg_type = get_reg_type(devid_t);
+        FLASH_ACCESS_DPRINTF(("check_cache_replacement_guard(): reg_type=%d\n", reg_type));
+
+        switch (reg_type)
         {
-            MREAD4(CACHE_REP_OFF_NEW_GW_ADDR, &data);
-            off = data;
-            MREAD4(CACHE_REP_CMD_NEW_GW_ADDR, &data);
-            cmd = EXTRACT(data, 24, 8);
+            case CACHE_REP_GEN_5_LEGACY:
+                rc = read_cache_rep_regs(mfl, CACHE_REP_OFF_GEN_5_LEGACY, CACHE_REP_CMD_GEN_5_LEGACY, &off, &cmd, 0, 26,
+                                         16, 8);
+                break;
+            case CACHE_REP_GEN_5:
+                rc = read_cache_rep_regs(mfl, CACHE_REP_OFF_GEN_5, CACHE_REP_CMD_GEN_5, &off, &cmd, 0, 32, 16, 8);
+                break;
+            case CACHE_REP_GEN_6:
+                rc = read_cache_rep_regs(mfl, CACHE_REP_OFF_GEN_6, CACHE_REP_CMD_GEN_6, &off, &cmd, 0, 32, 24, 8);
+                break;
+            case PAGER_GEN_7_HCA:
+                rc = read_cache_rep_regs(mfl, PAGER_OFF_GEN_7_HCA, PAGER_CMD_GEN_7_HCA, &off, &cmd, 0, 32, 24, 8);
+                break;
+            case PAGER_GEN_7_SWITCH:
+                rc = read_cache_rep_regs(mfl, PAGER_OFF_GEN_7_SWITCH, PAGER_CMD_GEN_7_SWITCH, &off, &cmd, 0, 32, 24, 8);
+                break;
+            case CACHE_REP_RAVEN:
+                rc = read_cache_rep_regs(mfl, CACHE_REP_OFF_RAVEN, CACHE_REP_CMD_RAVEN, &off, &cmd, 0, 26, 16, 8);
+                break;
+            case CACHE_REP_DYNAMIC:
+                rc = read_cache_rep_regs(mfl, mfl->cache_rep_offset_field_addr, mfl->cache_rep_cmd_field_addr, &off,
+                                         &cmd, 0, 26, 16, 8);
+                break;
+
+            default:
+                /* Defensive: get_cache_rep_reg_type() always returns one of the enum values above, so we should never
+                 * reach here.*/
+                rc = MFE_BAD_PARAMS;
+                break;
         }
-        else if (!dm_dev_is_raven_family_switch(devid_t))
-        {
-            MREAD4(mfl->cache_rep_offset_field_addr, &data);
-            off = EXTRACT(data, 0, 26);
-            MREAD4(mfl->cache_rep_cmd_field_addr, &data);
-            cmd = EXTRACT(data, 16, 8);
-        }
-        else
-        { /* switches */
-            MREAD4(CACHE_REP_OFF_RAVEN, &data);
-            off = EXTRACT(data, 0, 26);
-            MREAD4(CACHE_REP_CMD_RAVEN, &data);
-            cmd = EXTRACT(data, 16, 8);
-        }
+        CHECK_RC(rc);
+
         FLASH_ACCESS_DPRINTF(("check_cache_replacement_guard(): off=%d, cmd=%d\n", off, cmd));
 
-        /* Check if the offset and cmd are zero in order to continue burning. */
-        if ((cmd != 0) || (off != 0))
+        // Check if the offset and cmd are zero in order to continue burning.
+        if (cmd != 0 || off != 0)
         {
             *needs_cache_replacement = 1;
         }
@@ -2453,6 +2565,36 @@ static int update_max_write_size(mflash* mfl)
     return ME_OK;
 }
 
+typedef int (*flash_direct_init_fn)(mflash* mfl, flash_params_t* flash_params);
+static int flash_init_with_cache_guard(mflash* mfl,
+                                       flash_params_t* flash_params,
+                                       flash_direct_init_fn direct_init,
+                                       u_int8_t check_icmd_before_fw_access)
+{
+    int rc;
+    u_int8_t needs_cache_replacement = 0;
+
+    rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
+    CHECK_RC(rc);
+
+    if (needs_cache_replacement)
+    {
+        if (check_icmd_before_fw_access && mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
+        {
+            rc = icmd_init(mfl);
+            CHECK_RC(rc);
+        }
+        rc = flash_init_fw_access(mfl, flash_params);
+        CHECK_RC(rc);
+    }
+    else
+    {
+        rc = direct_init(mfl, flash_params);
+        CHECK_RC(rc);
+    }
+    return MFE_OK;
+}
+
 /* access flash via FW using Flash Access Registers (either by INBAND/ICMD/TOOLS_HCR) */
 int flash_init_inband_access(mflash* mfl, flash_params_t* flash_params)
 {
@@ -2571,22 +2713,9 @@ int flash_init_fw_access(mflash* mfl, flash_params_t* flash_params)
 
 int sx_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
-    u_int8_t needs_cache_replacement = 0;
-
-    rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
+    int rc = flash_init_with_cache_guard(mfl, flash_params, sx_flash_init_direct_access, 0);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
-        rc = flash_init_fw_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
-    else
-    {
-        rc = sx_flash_init_direct_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
     return MFE_OK;
 }
 
@@ -2616,89 +2745,64 @@ int tools_cmdif_init(mflash* mfl)
     return MFE_OK;
 }
 
+// we reach here due to one of the following cases:
+// 1. mcc failure -> choose DFA
+// 2. ocr flag is set -> choose DFA
+// 3. no_fw_ctrl flag is set -> if in LF, choose DFA. Otherwise, use legacy decision mechanism for choosing DFA vs MFBA
 int seven_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
     int rc = MFE_OK;
-
-    if (mfl->opts[MFO_IGNORE_CASHE_REP_GUARD] == 0)
+    if (mfl->opts[MFO_NO_FW_CTRL] == 0)
     {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
-            rc = icmd_init(mfl);
-            CHECK_RC(rc);
-        }
-        rc = flash_init_fw_access(mfl, flash_params);
+        FLASH_ACCESS_DPRINTF(("seven_gen_flash_init(): --no_fw_ctrl flag is not set\n")); // reached here due to mcc
+                                                                                          // failure or ocr flag
+        rc = seventh_gen_init_direct_access(mfl, flash_params);
+        CHECK_RC(rc);
     }
     else
     {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_MLNXOS_CMDIF)
+        FLASH_ACCESS_DPRINTF(("seven_gen_flash_init(): no_fw_ctrl flag is set\n"));
+        if (dm_is_livefish_mode(mfl->mf))
         {
-            /* dont allow overidding cache replacement in mellanox OS env */
-            return MFE_OCR_NOT_SUPPORTED;
+            FLASH_ACCESS_DPRINTF(("seven_gen_flash_init(): device is in LF\n"));
+            rc = seventh_gen_init_direct_access(mfl, flash_params);
+            CHECK_RC(rc);
         }
-        rc = seventh_gen_init_direct_access(mfl, flash_params);
+        else
+        {
+            FLASH_ACCESS_DPRINTF(
+              ("seven_gen_flash_init(): no_fw_ctrl used + device is not in LF\n")); // use legacy decision mechanism for
+                                                                                    // choosing DFA vs MFBA
+            rc = flash_init_with_cache_guard(mfl, flash_params, seventh_gen_init_direct_access, 1);
+            CHECK_RC(rc);
+        }
     }
+
     return rc;
 }
 
 int six_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
-    u_int8_t needs_cache_replacement = 0;
-
-    rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
+    int rc = flash_init_with_cache_guard(mfl, flash_params, sixth_gen_init_direct_access, 1);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
-            rc = icmd_init(mfl);
-            CHECK_RC(rc);
-        }
-        rc = flash_init_fw_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
-    else
-    {
-        rc = sixth_gen_init_direct_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
     return MFE_OK;
 }
 
 int fifth_gen_flash_init(mflash* mfl, flash_params_t* flash_params)
 {
-    int rc = 0;
-    u_int8_t needs_cache_replacement = 0;
-
     if (mfl->mf->gb_info.is_gb_mngr)
     {
-        /* need to update GW offsets before calling to the check_cache_replacement_guard */
+        // need to update GW offsets before calling to the check_cache_replacement_guard
         flash_update_amos_gearbox_gw(mfl);
     }
     else if (mfl->mf->gb_info.is_gearbox)
     {
-        return MFE_OCR_NOT_SUPPORTED; /* Accessing flash GW of GB that's not manager is not possible */
+        return MFE_OCR_NOT_SUPPORTED; // Accessing flash GW of GB that's not manager is not possible
     }
-    rc = check_cache_replacement_guard(mfl, &needs_cache_replacement);
+    int rc = flash_init_with_cache_guard(mfl, flash_params, fifth_gen_init_direct_access, 1);
     CHECK_RC(rc);
 
-    if (needs_cache_replacement)
-    {
-        if (mfl->opts[MFO_FW_ACCESS_TYPE_BY_MFILE] == ATBM_ICMD)
-        {
-            rc = icmd_init(mfl);
-            CHECK_RC(rc);
-        }
-        rc = flash_init_fw_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
-    else
-    {
-        rc = fifth_gen_init_direct_access(mfl, flash_params);
-        CHECK_RC(rc);
-    }
     return MFE_OK;
 }
 
@@ -3322,7 +3426,7 @@ int mf_open_fw(mflash* mfl, flash_params_t* flash_params, int num_of_banks)
     return MFE_OK;
 }
 
-int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, u_int8_t access_type, void* dev_extra, int cx3_fw_access)
+int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, u_int8_t access_type, void* dev_extra, int cx3_fw_access, int no_fw_ctrl)
 {
     int rc = 0;
 
@@ -3335,6 +3439,7 @@ int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params
     memset(*pmfl, 0, sizeof(mflash));
 
     (*pmfl)->opts[MFO_IGNORE_CASHE_REP_GUARD] = ignore_cache_rep_guard;
+    (*pmfl)->opts[MFO_NO_FW_CTRL] = no_fw_ctrl;
     (*pmfl)->opts[MFO_CX3_FW_ACCESS_EN] = cx3_fw_access;
     (*pmfl)->access_type = access_type;
     if (access_type == MFAT_MFILE)
@@ -3362,12 +3467,12 @@ int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params
     return rc;
 }
 
-int mf_open_uefi(mflash** pmfl, uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_dev_extra)
+int mf_open_uefi(mflash** pmfl, uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_dev_extra, int no_fw_ctrl)
 {
-    return mf_opend_int(pmfl, (void*)uefi_dev, 4, (flash_params_t*)NULL, 0, MFAT_UEFI, (void*)uefi_dev_extra, 0);
+    return mf_opend_int(pmfl, (void*)uefi_dev, 4, (flash_params_t*)NULL, 0, MFAT_UEFI, (void*)uefi_dev_extra, 0, no_fw_ctrl);
 }
 
-int mf_open_int(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int cx3_fw_access)
+int mf_open_int(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int cx3_fw_access, int no_fw_ctrl)
 {
     mfile* mf;
     int rc = MFE_OK;
@@ -3396,7 +3501,7 @@ int mf_open_int(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t
             }
         }
     }
-    rc = mf_opend_int(pmfl, (struct mfile_t*)mf, num_of_banks, flash_params, ignore_cache_rep_guard, MFAT_MFILE, NULL, cx3_fw_access);
+    rc = mf_opend_int(pmfl, (struct mfile_t*)mf, num_of_banks, flash_params, ignore_cache_rep_guard, MFAT_MFILE, NULL, cx3_fw_access, no_fw_ctrl);
     if ((*pmfl))
     {
         (*pmfl)->opts[MFO_CLOSE_MF_ON_EXIT] = 1;
@@ -3408,14 +3513,14 @@ int mf_open_int(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t
     return rc;
 }
 
-int mf_open_adv(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int cx3_fw_access)
+int mf_open_adv(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int cx3_fw_access, int no_fw_ctrl)
 {
-    return mf_open_int(pmfl, dev, num_of_banks, flash_params, ignore_cache_rep_guard, cx3_fw_access);
+    return mf_open_int(pmfl, dev, num_of_banks, flash_params, ignore_cache_rep_guard, cx3_fw_access, no_fw_ctrl);
 }
 
-int mf_open(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard)
+int mf_open(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int no_fw_ctrl)
 {
-    return mf_open_int(pmfl, dev, num_of_banks, flash_params, ignore_cache_rep_guard, 0);
+    return mf_open_int(pmfl, dev, num_of_banks, flash_params, ignore_cache_rep_guard, 0, no_fw_ctrl);
 }
 
 void mf_close(mflash* mfl)

--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -4340,6 +4340,11 @@ int mf_set_quad_en_direct_access(mflash* mfl, u_int8_t quad_en)
 
     if (!(mfl->attr.quad_en_support && mfl->supp_sr_mod))
     {
+        if (is_macronix_mx25u51294g_mx25u51294gxdi08_wrapper(mfl) && quad_en == 1)
+        {
+            DPRINTF(("QE is constant 1, skipping\n"));
+            return MFE_OK;
+        }
         return MFE_NOT_SUPPORTED_OPERATION;
     }
     for (bank = 0; bank < mfl->attr.banks_num; bank++)

--- a/mflash/mflash.h
+++ b/mflash/mflash.h
@@ -187,7 +187,7 @@ struct mfile_t;
 // mf_close() : Deallocates mflash resources.
 //   Note: User should call mf_close() even if mf_open failed (and the returning mfl is not NULL)
 //
-int mf_open(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard);
+int mf_open(mflash** pmfl, const char* dev, int num_of_banks, flash_params_t* flash_params, int ignore_cache_rep_guard, int no_fw_ctrl);
 // int     mf_opend(mflash **pmfl, struct mfile_t *mf, int num_of_banks,  flash_params_t *flash_params,
 //               int ignore_cache_rep_guard);
 int mf_open_adv(mflash** pmfl,
@@ -195,9 +195,10 @@ int mf_open_adv(mflash** pmfl,
                 int num_of_banks,
                 flash_params_t* flash_params,
                 int ignore_cache_rep_guard,
-                int cx3_fw_access);
+                int cx3_fw_access,
+                int no_fw_ctrl);
 
-int mf_open_uefi(mflash** pmfl, uefi_Dev_t* uefi_dev, uefi_dev_extra_t* dev_extra);
+int mf_open_uefi(mflash** pmfl, uefi_Dev_t* uefi_dev, uefi_dev_extra_t* dev_extra, int no_fw_ctrl);
 
 int mf_open_ignore_lock(mflash* mfl);
 void mf_close(mflash* mfl);

--- a/mflash/mflash_common_structs.h
+++ b/mflash/mflash_common_structs.h
@@ -53,6 +53,7 @@ typedef enum MfOpt
     MFO_SX_TYPE,
     MFO_NEW_CACHE_REPLACEMENT_EN,
     MFO_CX3_FW_ACCESS_EN,
+    MFO_NO_FW_CTRL,
     MFO_LAST
 } MfOpt;
 

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -497,14 +497,15 @@ bool Flash::open(const char* device,
                  flash_params_t* flash_params,
                  int ignore_cashe_replacement,
                  bool advErr,
-                 int cx3_fw_access)
+                 int cx3_fw_access,
+                 int no_fw_ctrl)
 {
     // Open device
     int rc;
     _advErrors = advErr;
     _ignore_cache_replacement = ignore_cashe_replacement ? true : false;
     (void)read_only; // not used , avoid compiler warnings TODO: remove this var from function def
-    rc = mf_open_adv(&_mfl, device, num_of_banks, flash_params, ignore_cashe_replacement, cx3_fw_access);
+    rc = mf_open_adv(&_mfl, device, num_of_banks, flash_params, ignore_cashe_replacement, cx3_fw_access, no_fw_ctrl);
     // printf("device: %s , forceLock: %s , read only: %s, num of banks: %d, flash params is null: %s, ocr: %d, rc:
     // %d\n", 		device, force_lock? "true":"false", read_only?"true":"false", num_of_banks, flash_params?
     // "no":"yes",
@@ -513,11 +514,11 @@ bool Flash::open(const char* device,
 }
 
 ////////////////////////////////////////////////////////////////////////
-bool Flash::open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock, bool advErr)
+bool Flash::open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock, bool advErr, int no_fw_ctrl)
 {
     int rc;
     _advErrors = advErr;
-    rc = mf_open_uefi(&_mfl, uefi_dev, uefi_extra);
+    rc = mf_open_uefi(&_mfl, uefi_dev, uefi_extra, no_fw_ctrl);
     return open_com_checks("uefi", rc, force_lock);
 }
 

--- a/mlxfwops/lib/flint_io.h
+++ b/mlxfwops/lib/flint_io.h
@@ -129,11 +129,11 @@ public:
     virtual ~FBase() {}
 
     virtual bool
-      open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock = false, bool advErr = true) = 0;
+      open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock = false, bool advErr = true, int no_fw_ctrl = 0) = 0;
 
     virtual bool open(const char*, bool, bool) = 0;
 
-    virtual bool open(const char* device, bool, bool, int, flash_params_t*, int, bool, int) = 0;
+    virtual bool open(const char* device, bool, bool, int, flash_params_t*, int, bool, int, int = 0) = 0;
 
     virtual bool is_fifth_gen() = 0;
     virtual void close() = 0;
@@ -300,12 +300,12 @@ public:
         check_uefi_build();
         return false;
     }
-    virtual bool open(uefi_Dev_t*, uefi_dev_extra_t*, bool, bool)
+    virtual bool open(uefi_Dev_t*, uefi_dev_extra_t*, bool, bool, int = 0)
     {
         check_uefi_build();
         return false;
     }
-    virtual bool open(const char*, bool, bool, int, flash_params_t*, int, bool, int)
+    virtual bool open(const char*, bool, bool, int, flash_params_t*, int, bool, int, int = 0)
     {
         check_uefi_build();
         return false;
@@ -416,10 +416,11 @@ public:
                       flash_params_t* flash_params = (flash_params_t*)NULL,
                       int ignoe_cache_replacement = 0,
                       bool advErr = true,
-                      int cx3_fw_access = 0);
+                      int cx3_fw_access = 0,
+                      int no_fw_ctrl = 0);
     using FBase::open;
 
-    virtual bool open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock = false, bool advErr = true);
+    virtual bool open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_lock = false, bool advErr = true, int no_fw_ctrl = 0);
 
     virtual bool open(const char*, bool, bool)
     {

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -574,7 +574,7 @@ bool FwOperations::FwAccessCreate(fw_ops_params_t& fwParams, FBase** ioAccessP, 
     else if (fwParams.hndlType == FHT_UEFI_DEV)
     {
         *ioAccessP = new Flash;
-        if (!(*ioAccessP)->open(fwParams.uefiHndl, &fwParams.uefiExtra, false, !fwParams.shortErrors))
+        if (!(*ioAccessP)->open(fwParams.uefiHndl, &fwParams.uefiExtra, false, !fwParams.shortErrors, fwParams.noFwCtrl))
         {
             WriteToErrBuff(fwParams.errBuff, (char*)(*ioAccessP)->err(), fwParams.errBuffSize);
             delete *ioAccessP;
@@ -584,7 +584,7 @@ bool FwOperations::FwAccessCreate(fw_ops_params_t& fwParams, FBase** ioAccessP, 
     else if (fwParams.hndlType == FHT_MST_DEV)
     {
         *ioAccessP = new Flash;
-        if (!(*ioAccessP)->open(fwParams.mstHndl, fwParams.forceLock, fwParams.readOnly, fwParams.numOfBanks, fwParams.flashParams, fwParams.ignoreCacheRep, !fwParams.shortErrors, fwParams.cx3FwAccess))
+        if (!(*ioAccessP)->open(fwParams.mstHndl, fwParams.forceLock, fwParams.readOnly, fwParams.numOfBanks, fwParams.flashParams, fwParams.ignoreCacheRep, !fwParams.shortErrors, fwParams.cx3FwAccess, fwParams.noFwCtrl))
         {
             // TODO: release memory here ?
             WriteToErrBuff(fwParams.errBuff, (char*)(*ioAccessP)->err(), fwParams.errBuffSize);


### PR DESCRIPTION
* flint | remove block of setting QE to 1 in case of mx25u51294gxdi08 flash
*  flint | IS25LP512MG JEDEC_ID Missing support for SRWD
*  flint | Gen7 flashes | MCC fallback incorrectly forces MFBA instead of DFA when MFBA is unsupported