### PR TITLE
[pci_library] Fix memory leak in SetPCIDomain

### DIFF
--- a/pci_library/PCILibrary.cpp
+++ b/pci_library/PCILibrary.cpp
@@ -304,6 +304,6 @@ namespace Regex = mstflint::common::regex;
          }
          mclose(mf);
      }
-     free(pciDevices);
+     mdevices_info_destroy(pciDevices, numDevices);
  }
  #endif


### PR DESCRIPTION
Description:
Replace bare free(pciDevices) with mdevices_info_destroy() to properly free ib_devs, net_devs, and virtfn_arr sub-allocations within each dev_info entry returned by mdevices_info().

Tested OS: Linux
Tested devices: n/a
Tested flows: valgrind --leak-check=full -s mlxlink_ext -d /dev/mst/mt4123_pciconf1 --port_type PCIE --show_links

Known gaps (with RM ticket): n/a

Issue: 4845969