### PR TITLE
mstflint | freeBSD | compilation error

### DIFF
--- a/common/compatibility.h
+++ b/common/compatibility.h
@@ -156,6 +156,13 @@
 #include <unistd.h>
 #include <sys/types.h>
 
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#endif
+
 #undef __be64_to_cpu
 #undef __be32_to_cpu
 #undef __be16_to_cpu

--- a/mtcr_freebsd/mtcr_ul_com_stub.c
+++ b/mtcr_freebsd/mtcr_ul_com_stub.c
@@ -1,0 +1,13 @@
+#include "../include/mtcr_ul/mtcr.h"
+
+int hot_reset(mfile* mf,
+    int in_parallel,
+    int domain_1, int bus_1, int device_1, int function_1,
+    int domain_2, int bus_2, int device_2, int function_2)
+{
+    (void)mf;
+    (void)in_parallel;
+    (void)domain_1; (void)bus_1; (void)device_1; (void)function_1;
+    (void)domain_2; (void)bus_2; (void)device_2; (void)function_2;
+    return -1;
+}


### PR DESCRIPTION
- Add __BYTE_ORDER, __BIG_ENDIAN, __LITTLE_ENDIAN defines for FreeBSD in compatibility.h (FreeBSD uses BYTE_ORDER without leading underscores)
- Add missing mtcr_ul_com.c file so FreeBSD build isn't missing hot_reset symbol