### PR TITLE
Title: [mlxlink] Bug fix - Test mode info printed before multi port

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -2387,7 +2387,7 @@ void MlxlinkCommander::showPddr()
         supportedInfoPage();
         troubInfoPage();
         runningVersion();
-        if (_prbsTestMode && !_userInput._showMultiPortInfo)
+        if (_prbsTestMode && !_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
         {
             showTestMode();
         }
@@ -2481,9 +2481,9 @@ void MlxlinkCommander::getPrecodingStatus()
     {
         // in case PLTC is not supported, do nothing and continue
     }
-    setPrintVal(_operatingInfoCmd, "TX Precoding Status",
+    setPrintVal(_operatingInfoCmd, "Tx Precoding Status",
                 getStrByValue(txPrecodingOper, _mlxlinkMaps->_precodingOperStatus), txColor, !_prbsTestMode, _linkUP);
-    setPrintVal(_operatingInfoCmd, "RX Precoding Status",
+    setPrintVal(_operatingInfoCmd, "Rx Precoding Status",
                 getStrByValue(rxPrecodingOper, _mlxlinkMaps->_precodingOperStatus), rxColor, !_prbsTestMode, _linkUP);
 }
 


### PR DESCRIPTION
table for --smpci and --smpmi flags

Description:
When the first port was in PRBS test mode, running --smpmi or --smpci caused the test mode info block to be printed before the multi-port table.

MSTFlint port needed: Yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: #4962345