### PR TITLE
Mlxlink | VR bugfixes for amber test mode, link speeds, and precoding

### DIFF
--- a/mlxlink/modules/mlxlink_amBER_collector.cpp
+++ b/mlxlink/modules/mlxlink_amBER_collector.cpp
@@ -45,6 +45,7 @@ MlxlinkAmBerCollector::MlxlinkAmBerCollector(Json::Value& jsonRoot) : _jsonRoot(
     _numOfLanes = 0;
     _isNvlinkModeA = false;
     _isNvlinkModeB = false;
+    _isNvlinkTestModeBOper = false;
     _maxLanes = MAX_NETWORK_LANES;
     _csvFileName = "";
     _mstDevName = "";
@@ -2356,7 +2357,36 @@ string MlxlinkAmBerCollector::getPrbsModeCap(u_int32_t modeSelector, u_int32_t c
     return deleteLastChar(modeCapStr);
 }
 
-void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params)
+bool MlxlinkAmBerCollector::isTestModeNvlinkModeB()
+{
+    // Only check Mode B for NVLink ports (Mode A or Mode B)
+    if (!(_isNvlinkModeB || _isNvlinkModeA))
+    {
+        return false;
+    }
+
+    try
+    {
+        // Check if Mode B by reading lane_rate_oper from lane 0
+        resetLocalParser(ACCESS_REG_PPRT);
+        updateField("local_port", _localPort);
+        updateField("lane", 0);
+        updateField("pnat", _pnat);
+        sendRegister(ACCESS_REG_PPRT, MACCESS_REG_METHOD_GET);
+
+        string laneRateOperStr = getStrByValue(getFieldValue("lane_rate_oper"), _mlxlinkMaps->_prbsLaneRateList);
+        // XDR = Mode A, others = Mode B
+        return (laneRateOperStr != _mlxlinkMaps->_prbsLaneRateList[PRBS_XDR]);
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg,
+                                                vector<vector<string>>& params,
+                                                bool isNvlinkTestModeB)
 {
     string laneRateStr = "lane_rate_admin";
     if (prbsReg == ACCESS_REG_PPRT)
@@ -2370,6 +2400,10 @@ void MlxlinkAmBerCollector::getTestModePrpsInfo(const string& prbsReg, vector<ve
         updateField("local_port", _localPort);
         updateField("lane", lane);
         updateField("pnat", _pnat);
+        if (isNvlinkTestModeB)
+        {
+            updateField("mode_b_idx", (u_int32_t)PRBS_MODE_B_MODE_B);
+        }
         sendRegister(prbsReg, MACCESS_REG_METHOD_GET);
 
         if (prbsReg == ACCESS_REG_PPRT)
@@ -2400,8 +2434,13 @@ vector<AmberField> MlxlinkAmBerCollector::getTestModeInfo()
     {
         vector<vector<string>> pprtParams(PRBS_PARAMS_LAST, vector<string>(_maxLanes, ""));
         vector<vector<string>> ppttParams(PRBS_PARAMS_LAST, vector<string>(_maxLanes, ""));
-        getTestModePrpsInfo(ACCESS_REG_PPRT, pprtParams);
-        getTestModePrpsInfo(ACCESS_REG_PPTT, ppttParams);
+        _isNvlinkTestModeBOper = false;
+        if (_isNvlinkModeB || _isNvlinkModeA)
+        {
+            _isNvlinkTestModeBOper = isTestModeNvlinkModeB();
+        }
+        getTestModePrpsInfo(ACCESS_REG_PPRT, pprtParams, _isNvlinkTestModeBOper);
+        getTestModePrpsInfo(ACCESS_REG_PPTT, ppttParams, _isNvlinkTestModeBOper);
 
         fillParamsToFields("prbs_rx_tuning_status", pprtParams[PRBS_PARAMS_RX_TUNING_STATUS], fields);
         fillParamsToFields("prbs_rx_lock_status", pprtParams[PRBS_PARAMS_LOCK_STATUS], fields);

--- a/mlxlink/modules/mlxlink_amBER_collector.h
+++ b/mlxlink/modules/mlxlink_amBER_collector.h
@@ -105,6 +105,7 @@ public:
     bool _isModeAsActive;
     bool _isNvlinkModeA;
     bool _isNvlinkModeB;
+    bool _isNvlinkTestModeBOper;
     vector<PortGroup> _localPorts; // will be valid for switches
     bool _isHca;
     vector<AMBER_SHEET> _sheetsToDump;
@@ -179,7 +180,8 @@ protected:
 
     // Helper functions
     virtual string getBerAndErrorTitle(u_int32_t portType);
-    virtual void getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params);
+    bool isTestModeNvlinkModeB();
+    virtual void getTestModePrpsInfo(const string& prbsReg, vector<vector<string>>& params, bool isNvlinkTestModeB);
     virtual void getModuleLinkUpInfoPage(vector<AmberField>& fields);
     virtual void updateModeAsActive();
     void updateNumOfLanesForTestModeNVL6();

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -136,7 +136,7 @@ void MlxlinkMaps::initPortStateMapping()
     _anDisableList[AN_DISABLE_NORMAL] = "ON";
     _anDisableList[AN_DISABLE_FORCE] = "FORCE";
 
-    _precodingOperStatus[PRECODING_OPER_STATUS_AUTO] = "Auto";
+    _precodingOperStatus[PRECODING_OPER_STATUS_AUTO] = "unknown / no active link";
     _precodingOperStatus[PRECODING_OPER_STATUS_ENABLED] = "Enabled";
     _precodingOperStatus[PRECODING_OPER_STATUS_DISABLED] = "Disabled";
 

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -320,25 +320,21 @@ string EthSupportedSpeeds2Str(u_int32_t int_mask)
 string EthExtSupportedSpeeds2Str(u_int32_t int_mask)
 {
     string maskStr = "";
-    if (int_mask & ETH_LINK_SPEED_EXT_200GAUI_1)
+    if (int_mask & ETH_LINK_SPEED_EXT_1_6TAUI_8)
     {
-        maskStr += "200G_1X,";
-    }
-    if (int_mask & ETH_LINK_SPEED_EXT_400GAUI_2)
-    {
-        maskStr += "400G_2X,";
+        maskStr += "1600G_8X,";
     }
     if (int_mask & ETH_LINK_SPEED_EXT_800GAUI_4)
     {
         maskStr += "800G_4X,";
     }
-    if (int_mask & ETH_LINK_SPEED_EXT_1_6TAUI_8)
-    {
-        maskStr += "1600G_8X,";
-    }
     if (int_mask & ETH_LINK_SPEED_EXT_800GAUI_8)
     {
         maskStr += "800G_8X,";
+    }
+    if (int_mask & ETH_LINK_SPEED_EXT_400GAUI_2)
+    {
+        maskStr += "400G_2X,";
     }
     if (int_mask & ETH_LINK_SPEED_EXT_400GAUI_4)
     {
@@ -347,6 +343,10 @@ string EthExtSupportedSpeeds2Str(u_int32_t int_mask)
     if (int_mask & ETH_LINK_SPEED_EXT_400GAUI_8)
     {
         maskStr += "400G_8X,";
+    }
+    if (int_mask & ETH_LINK_SPEED_EXT_200GAUI_1)
+    {
+        maskStr += "200G_1X,";
     }
     if (int_mask & ETH_LINK_SPEED_EXT_200GAUI_2)
     {


### PR DESCRIPTION
Description:
Consolidates three separate fixes ported from MFT into a single change. 1) Amber / test mode (Issue 4798403)
   Lane0_prbs_rx_lane_rate_cap showed XDR simplex rates instead of bidirectional
   (Mode B) rates in the amber report in test mode. Detect Mode B via
   lane_rate_oper from PPRT and set mode_b_idx accordingly when reading
   lane_rate_cap.
2) Extended link speed ordering (Issue 4933163)
   Sort extended Ethernet link-speed strings in mlxlink Supported Info output.
3) Precoding status display (Issue 4923267)
   Corrected precoding status value 0 mapping from "auto" to "unknown" per PRM specification

MSTFlint port needed: no

Tested OS: Linux

Tested devices: Quantum 4 (Rosalind); ConnectX-9 (apps-128)

Tested flows:
• mlxlink -d <device> -p <port> --amber_collect /tmp/amber.csv (test mode, Mode A and Mode B) • mlxlink -d <device>
• mlxlink -d <device> -p <port>
• mlxlink -d <device> -p <port> --set_tx_precoding EN

Issue: 4798403
Issue: 4933163
Issue: 4923267