### PR TITLE
Mlxlink | Bug fixes for help output, PLR inputs, and empty BKV values

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -7141,13 +7141,13 @@ void MlxlinkCommander::setPlr()
                 }
                 catch (...)
                 {
-                    throw MlxRegException("Invalid plr_reject_mode value. Valid values are 0-2 or Margin/CRC_CS/CS");
+                    throw MlxRegException("Invalid plr_reject_mode value. Valid values are 0/MARGIN, 1/CRC_CS, 2/CS");
                 }
             }
 
             if (rejectMode > 2)
             {
-                throw MlxRegException("Invalid plr_reject_mode value. Valid values are 0-2 or Margin/CRC_CS/CS");
+                throw MlxRegException("Invalid plr_reject_mode value. Valid values are 0/MARGIN, 1/CRC_CS, 2/CS");
             }
 
             u_int32_t rejectModeSupport = getFieldValue("plr_reject_mode_support");
@@ -7182,11 +7182,30 @@ void MlxlinkCommander::setPlr()
 
         if (_userInput._plrTxCrcProvided)
         {
-            u_int32_t txCrc = _userInput._plrTxCrc;
+            u_int32_t txCrc = (u_int32_t)-1;
+            if (_userInput._plrTxCrc == "DS")
+            {
+                txCrc = 0;
+            }
+            else if (_userInput._plrTxCrc == "EN")
+            {
+                txCrc = 1;
+            }
+            else
+            {
+                try
+                {
+                    RegAccessParser::strToUint32((char*)_userInput._plrTxCrc.c_str(), txCrc);
+                }
+                catch (...)
+                {
+                    throw MlxRegException("Invalid plr_tx_crc value. Valid values are 0/DS(disable), 1/EN(enable)");
+                }
+            }
 
             if (txCrc > 1)
             {
-                throw MlxRegException("Invalid plr_tx_crc value. Valid values are 0 or 1");
+                throw MlxRegException("Invalid plr_tx_crc value. Valid values are 0/DS(disable), 1/EN(enable)");
             }
 
             if (txCrc == 1)

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -1765,7 +1765,7 @@ void MlxlinkMaps::initPlrRejectModeMapping()
     _plrRejectModeToStr[PLR_REJECT_MODE_CRC_AND_CS] = "rejection based on CRC and CS";
     _plrRejectModeToStr[PLR_REJECT_MODE_CS] = "rejection based on CS";
 
-    _plrRejectModeStrToValue["Margin"] = PLR_REJECT_MODE_PLR_MARGIN;
+    _plrRejectModeStrToValue["MARGIN"] = PLR_REJECT_MODE_PLR_MARGIN;
     _plrRejectModeStrToValue["CRC_CS"] = PLR_REJECT_MODE_CRC_AND_CS;
     _plrRejectModeStrToValue["CS"] = PLR_REJECT_MODE_CS;
 

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -302,14 +302,19 @@ void MlxlinkUi::printSynopsisCommands()
         "Keep primary/secondary role constant [EN(enable)/DS(disable)] (Optional, use with --set_primary or --set_secondary)");
     MlxlinkRecord::printFlagLine(SET_PLR_FLAG_SHORT, SET_PLR_FLAG, "", "Set PLR Configuration");
     printf(IDENT);
-    MlxlinkRecord::printFlagLine(PLR_REJECT_MODE_FLAG_SHORT, PLR_REJECT_MODE_FLAG, "reject_mode",
-                                 "PLR Reject Mode: 0(PLR margin)/1(CRC and CS)/2(CS) or Margin/CRC_CS/CS (Optional)");
+    MlxlinkRecord::printFlagLine(
+      PLR_REJECT_MODE_FLAG_SHORT, PLR_REJECT_MODE_FLAG, "reject_mode",
+      "PLR Reject Mode: 0/MARGIN (PLR margin), 1/CRC_CS (CRC and CS), 2/CS (CS only) (Optional)");
     printf(IDENT);
     MlxlinkRecord::printFlagLine(PLR_MARGIN_THRESHOLD_FLAG_SHORT, PLR_MARGIN_THRESHOLD_FLAG, "margin_th",
                                  "PLR Margin Threshold [0-7] (Optional)");
     printf(IDENT);
     MlxlinkRecord::printFlagLine(PLR_TX_CRC_FLAG_SHORT, PLR_TX_CRC_FLAG, "tx_crc",
-                                 "TX CRC over PLR: 0(disable)/1(enable) (Optional)");
+                                 "TX CRC over PLR: 0/DS(disable), 1/EN(enable) (Optional)");
+    MlxlinkRecord::printFlagLine(SET_TX_PRECODING_FLAG_SHORT, SET_TX_PRECODING_FLAG, "tx_precoding",
+                                 "Set TX Precoding [EN(enable)/DS(disable)]");
+    MlxlinkRecord::printFlagLine(SET_RX_PRECODING_FLAG_SHORT, SET_RX_PRECODING_FLAG, "rx_precoding",
+                                 "Set RX Precoding [EN(enable)/DS(disable)]");
     MlxlinkRecord::printFlagLine(PRBS_MODE_FLAG_SHORT, PRBS_MODE_FLAG, "prbs_mode",
                                  "Physical Test Mode Configuration [EN(enable)/DS(disable)/TU(perform tuning)]");
     printf(IDENT);
@@ -1243,6 +1248,14 @@ void MlxlinkUi::checkStrLength(const string& str)
     }
 }
 
+void MlxlinkUi::validateNonEmptyValue(const string& value, const string& flagName)
+{
+    if (value.empty())
+    {
+        throw MlxRegException("The %s flag requires a non-empty argument.", flagName.c_str());
+    }
+}
+
 void MlxlinkUi::paramValidate()
 {
     validateMandatoryParams();
@@ -1291,10 +1304,11 @@ void MlxlinkUi::initCmdParser()
     AddOptions(PLR_INFO_FLAG, PLR_INFO_FLAG_SHORT, "", "Show PLR Info");
     AddOptions(SET_PLR_FLAG, SET_PLR_FLAG_SHORT, "", "Set PLR configuration");
     AddOptions(PLR_REJECT_MODE_FLAG, PLR_REJECT_MODE_FLAG_SHORT, "PLR_REJECT_MODE",
-               "PLR reject mode (0-2 or Margin/CRC_CS/CS)");
+               "PLR Reject Mode: 0/MARGIN (PLR margin), 1/CRC_CS (CRC and CS), 2/CS (CS only) (Optional)");
     AddOptions(PLR_MARGIN_THRESHOLD_FLAG, PLR_MARGIN_THRESHOLD_FLAG_SHORT, "PLR_MARGIN_TH",
                "PLR margin threshold (0-7)");
-    AddOptions(PLR_TX_CRC_FLAG, PLR_TX_CRC_FLAG_SHORT, "PLR_TX_CRC", "TX CRC over PLR (0/1)");
+    AddOptions(PLR_TX_CRC_FLAG, PLR_TX_CRC_FLAG_SHORT, "PLR_TX_CRC",
+               "TX CRC over PLR: 0/DS(disable), 1/EN(enable) (Optional)");
     AddOptions(KR_INFO_FLAG, KR_INFO_FLAG_SHORT, "", "Show KR Info");
     AddOptions(PERIODIC_EQ_FLAG, PERIODIC_EQ_FLAG_SHORT, "", "Show Link PEQ (Periodic Equalization) Info");
     AddOptions(RX_RECOVERY_COUNTERS_FLAG, RX_RECOVERY_COUNTERS_FLAG_SHORT, "", "Show Rx Recovery Counters");
@@ -1688,7 +1702,8 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == PLR_REJECT_MODE_FLAG)
     {
-        _userInput._plrRejectMode = value;
+        validateNonEmptyValue(value, "--" PLR_REJECT_MODE_FLAG);
+        _userInput._plrRejectMode = toUpperCase(value);
         _userInput._plrRejectModeProvided = true;
         return PARSE_OK;
     }
@@ -1700,7 +1715,8 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == PLR_TX_CRC_FLAG)
     {
-        RegAccessParser::strToUint32((char*)value.c_str(), _userInput._plrTxCrc);
+        validateNonEmptyValue(value, "--" PLR_TX_CRC_FLAG);
+        _userInput._plrTxCrc = toUpperCase(value);
         _userInput._plrTxCrcProvided = true;
         return PARSE_OK;
     }
@@ -1759,6 +1775,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_GROUP_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_GROUP_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvGroupId);
         addCmd(SHOW_BKV_GROUP);
@@ -1766,6 +1783,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == SET_BKV_GROUP_FLAG)
     {
+        validateNonEmptyValue(value, "--" SET_BKV_GROUP_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvGroupId);
         addCmd(SET_BKV_GROUP);
@@ -1773,21 +1791,25 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_RATES_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_RATES_FLAG);
         _userInput._bkvRates = parseParamsFromLine(toUpperCase(value));
         return PARSE_OK;
     }
     else if (name == BKV_ROLES_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_ROLES_FLAG);
         _userInput._bkvRoles = parseParamsFromLine(toUpperCase(value));
         return PARSE_OK;
     }
     else if (name == BKV_MODE_B_ROLES_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_MODE_B_ROLES_FLAG);
         _userInput._bkvModeBRoles = parseParamsFromLine(toUpperCase(value));
         return PARSE_OK;
     }
     else if (name == SET_BKV_ENTRY_FLAG)
     {
+        validateNonEmptyValue(value, "--" SET_BKV_ENTRY_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvGroupId);
         addCmd(SET_BKV_ENTRY);
@@ -1795,6 +1817,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_ENTRY_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_ENTRY_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvEntry);
         _userInput._bkvEntrySpecified = true;
@@ -1802,6 +1825,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_ADDRESS_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_ADDRESS_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvAddress);
         _userInput._bkvAddressSpecified = true;
@@ -1809,6 +1833,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_WDATA_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_WDATA_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvWdata);
         _userInput._bkvWdataSpecified = true;
@@ -1816,6 +1841,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == BKV_WMASK_FLAG)
     {
+        validateNonEmptyValue(value, "--" BKV_WMASK_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._bkvWmask);
         _userInput._bkvWmaskSpecified = true;
@@ -2191,6 +2217,7 @@ ParseStatus MlxlinkUi::HandleOption(string name, string value)
     }
     else if (name == LANE_INDEX_FLAG)
     {
+        validateNonEmptyValue(value, "--" LANE_INDEX_FLAG);
         checkStrLength(value);
         RegAccessParser::strToUint32((char*)value.c_str(), (u_int32_t&)_userInput._lane);
         _userInput.gradeScanPerLane = true;

--- a/mlxlink/modules/mlxlink_ui.h
+++ b/mlxlink/modules/mlxlink_ui.h
@@ -87,6 +87,7 @@ protected:
     std::map<u_int32_t, u_int32_t> getSltpParamsFromVector(const string& paramsLine);
     std::map<u_int32_t, bool> getprbsLanesFromParams(const string& paramsLine);
     void checkStrLength(const string& str);
+    void validateNonEmptyValue(const string& value, const string& flagName);
 
     CommandLineParser _cmdParser;
     std::vector<OPTION_TYPE> _sendRegFuncMap;

--- a/mlxlink/modules/mlxlink_user_input.cpp
+++ b/mlxlink/modules/mlxlink_user_input.cpp
@@ -143,7 +143,7 @@ UserInput::UserInput()
     _phyRecoveryType = "";
     _plrRejectMode = "";
     _plrMarginThreshold = 0;
-    _plrTxCrc = 0;
+    _plrTxCrc = "";
     _plrRejectModeProvided = false;
     _plrMarginThresholdProvided = false;
     _plrTxCrcProvided = false;

--- a/mlxlink/modules/mlxlink_user_input.h
+++ b/mlxlink/modules/mlxlink_user_input.h
@@ -132,7 +132,7 @@ public:
     string _phyRecoveryType;
     string _plrRejectMode;
     u_int32_t _plrMarginThreshold;
-    u_int32_t _plrTxCrc;
+    string _plrTxCrc;
     bool _plrRejectModeProvided;
     bool _plrMarginThresholdProvided;
     bool _plrTxCrcProvided;


### PR DESCRIPTION
Description:

Port to MSTFlint as one commit, combining two separate upstream MFT mlxlink commits.

(1) Clarified PLR help and parsing; --plr_reject_mode now accepts number or
    uppercase name, and --plr_tx_crc accepts 0/1 or DS/EN.

(2) Rejected empty-string inputs for BKV flags with clear errors.

(3) Document --set_tx_precoding and --set_rx_precoding in the COMMANDS section
    printed by mstlink -h.

MSTFlint port needed: yes

Tested OS: Linux

Tested devices: Quantum4 (Rosalind)

Tested flows:
- mstlink --help | grep -A3 -E 'plr_reject_mode|plr_tx_crc'
- mstlink -d <device> -p <port> --set_plr --plr_reject_mode <arg> (valid / invalid)
- mstlink -d <device> -p <port> --set_plr --plr_tx_crc <arg> (valid / invalid)
- mstlink -d <device> -p <port> <bkv_flag> "" (invalid) Flags covered: --show_bkv_group, --set_bkv_group, --set_bkv_entry, --bkv_entry, --bkv_address, --wdata, --wmask, --lane, --bkv_rates, --bkv_roles, --bkv_mode_b_roles
- mstlink -h

Known gaps (with RM ticket):

Issue: 4877380
Issue: 4843002
Issue: 4842785
Issue: 4925074