### PR TITLE
mlxfwreset | sync2 | cant execute mlxfwreset sync 2 on BF3 device on GB and Viking systems

### DIFF
--- a/small_utils/mlxfwresetlib/drivers_safety_check.py
+++ b/small_utils/mlxfwresetlib/drivers_safety_check.py
@@ -128,14 +128,19 @@ class DriversSafetyCheckManager:
 
         self._logger.debug('_set_hot_reset_flow: sdm = {0}, devices_sd length = {1}'.format(sdm, len(self._devices_sd)))
 
+        # check if the device is a hidden nic
+        aux_dbdf = self.get_hidden_aux_device()
+        if aux_dbdf:
+            return HotResetFlow.HIDDEN_SOCKET_DIRECT
+        
         if sdm == 1 and len(self._devices_sd) > 0:
             return HotResetFlow.SOCKET_DIRECT
-        elif sdm == 1 and len(self._devices_sd) == 0:
-            return HotResetFlow.HIDDEN_SOCKET_DIRECT
-        elif sdm == 0:
-            return HotResetFlow.SINGLE_DEVICE
-        else:
-            return None
+        
+        if sdm == 1 and len(self._devices_sd) == 0:
+            # ask the user if they want to continue this flow when we found one link for the SD device
+            print("-W- Provided device is a socket direct device but we found one link for the SD device.")
+
+        return HotResetFlow.SINGLE_DEVICE
 
     def prepare_hot_reset_targets(self):
         """
@@ -618,10 +623,7 @@ class DriversSafetyCheckManager:
                 self._logger.debug('V3 numbers are identical, found aux device, dbdf: {0}, v3 number: {1}'.format(aux_dbdf, v3_aux_str))
                 break
 
-        if not aux_dbdf:
-            raise RuntimeError("failed to find aux device both as hidden and as discovered")
-
-        self._logger.debug("aux_dbdf: {}".format(aux_dbdf))
+        self._logger.debug("aux_dbdf: {}".format(aux_dbdf))  # if device is not hidden nic then aux_dbdf will be None
         return aux_dbdf
 
     def check_binded_drivers(self):
@@ -651,6 +653,8 @@ class DriversSafetyCheckManager:
         if self._hot_reset_flow == HotResetFlow.HIDDEN_SOCKET_DIRECT:
             aux_pci_index = 1  # for hidden SD aux pci_index is always 1
             aux_dbdf = self.get_hidden_aux_device()
+            if not aux_dbdf:
+                raise RuntimeError("failed to find aux device both as hidden and as discovered")  # if we determined the device is hidden nic - we must locate its aux device
             self._logger.debug("DriversSafetyCheckManager: Auxiliary device DBDF: {}".format(aux_dbdf))
             forbidden_drivers += self.check_forbidden_drivers_on_hidden_device(aux_dbdf, aux_pci_index)
 


### PR DESCRIPTION
Description: MPIR.sdm may indicate Socket Direct (SD) even when only one link is active. In this case, the current Sync 2 flow fails when the second link is not found. Solution proposed by arch:
If MPIR.sdm = 1 and only one link is detected, issue a warning and allow the Sync 2 flow to continue using the single link.

So now we ask the user if he'd like to continue the hot reset flow with the one detected link. if yes then we'll treat the given device as single device even though it's reported as SD.

Warning: Since we cannot reliably determine whether the second link is truly disabled or simply not discovered, this behavior may allow the flow to continue in some unjustified cases and lead to bad flows.