### PR TITLE
[MLXCONFIG] Setting With --with_default Incorrectly Rests Parameters …

### DIFF
--- a/mlxconfig/mlxcfg_commander.h
+++ b/mlxconfig/mlxcfg_commander.h
@@ -42,6 +42,7 @@
 
 #include <map>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 #include "tools_dev_types.h"
 #include "mlxcfg_configuration.h"
@@ -81,6 +82,9 @@ public:
     virtual void dumpRawCfg(std::vector<u_int32_t> rawTlvVec, std::string& tlvDump) = 0;
     virtual void backupCfgs(vector<BackupView>& views) = 0;
     virtual void updateParamViewValue(ParamView&, std::string val, QueryType qt) = 0;
+    /* TLV instance keys for this mlxconfig token (matches invalidateCfg grouping).*/
+    virtual void addTlvInstanceKeysForParam(const std::string& mlxconfigName,
+                                            std::unordered_set<std::string>& keysOut) = 0;
     virtual std::shared_ptr<SystemConfiguration>
       getSystemConfiguration(const std::string& name, int32_t asicNumber, const std::string& deviceName) = 0;
     virtual std::vector<std::shared_ptr<SystemConfiguration>>

--- a/mlxconfig/mlxcfg_generic_commander.cpp
+++ b/mlxconfig/mlxcfg_generic_commander.cpp
@@ -1264,6 +1264,40 @@ void GenericCommander::updateParamViewValue(ParamView& p, string v, QueryType qt
     }
 }
 
+void GenericCommander::addTlvInstanceKeysForParam(const string& mlxconfigName, unordered_set<string>& keysOut)
+{
+    if (isIndexedMlxconfigName(mlxconfigName))
+    {
+        size_t p = mlxconfigName.find('[');
+        string base = mlxconfigName.substr(0, p);
+        if (!isContinuanceArray(base))
+        {
+            // Ordinary indexed array: one backing TLV for the whole parameter.
+            shared_ptr<TLVConf> tlv = _dbManager->getTLVByParamMlxconfigNameAndIndex(base, 0, _mf);
+            keysOut.insert(tlv->_name + "_P" + to_string(tlv->_port) + "_M" + to_string(tlv->_module));
+            return;
+        }
+        // Continuance array (e.g. SPLIT_PORT): each index can map to a different NV TLV (32_1, 64_33, ...).
+        string indexStr = parseIndexStr(mlxconfigName);
+        vector<u_int32_t> indexes;
+        extractIndexes(indexStr, indexes);
+        for (u_int32_t idx : indexes)
+        {
+            shared_ptr<TLVConf> tlv = _dbManager->getTLVByParamMlxconfigNameAndIndex(base, idx, _mf);
+            keysOut.insert(tlv->_name + "_P" + to_string(tlv->_port) + "_M" + to_string(tlv->_module));
+        }
+        return;
+    }
+    if (isContinuanceArray(mlxconfigName))
+    {
+        shared_ptr<TLVConf> tlv = _dbManager->getTLVByParamMlxconfigNameAndIndex(mlxconfigName, 1, _mf);
+        keysOut.insert(tlv->_name + "_P" + to_string(tlv->_port) + "_M" + to_string(tlv->_module));
+        return;
+    }
+    shared_ptr<TLVConf> tlv = _dbManager->getTLVByParamMlxconfigName(mlxconfigName, _mf);
+    keysOut.insert(tlv->_name + "_P" + to_string(tlv->_port) + "_M" + to_string(tlv->_module));
+}
+
 std::shared_ptr<SystemConfiguration>
   GenericCommander::getSystemConfiguration(const std::string& name, int32_t asicNumber, const std::string& deviceName)
 {

--- a/mlxconfig/mlxcfg_generic_commander.h
+++ b/mlxconfig/mlxcfg_generic_commander.h
@@ -99,6 +99,8 @@ public:
     void dumpRawCfg(std::vector<u_int32_t> rawTlvVec, std::string& tlvDump) override;
     void backupCfgs(vector<BackupView>& view) override;
     void updateParamViewValue(ParamView& p, std::string v, QueryType qt) override;
+    void addTlvInstanceKeysForParam(const std::string& mlxconfigName,
+                                    std::unordered_set<std::string>& keysOut) override;
     std::shared_ptr<SystemConfiguration>
       getSystemConfiguration(const std::string& name, int32_t asicNumber, const std::string& deviceName) override;
     std::vector<std::shared_ptr<SystemConfiguration>>

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -1002,6 +1002,12 @@ void MlxCfg::setDevCfgWithDefault(Commander* commander, std::vector<ParamView>& 
     compareNextParamsVectors(paramsNext, paramsDefault, alignNextToDefault);
     // alignNextToDefault now contain the parameters that needs to be invalidated or set.
 
+    std::unordered_set<std::string> invalidatedTlvKeys;
+    for (const ParamView& alignParam : alignNextToDefault)
+    {
+        commander->addTlvInstanceKeysForParam(alignParam.mlxconfigName, invalidatedTlvKeys);
+    }
+
     // 4 compare what user asked for (userParams) with next value, skip params that already have the same value
     std::vector<ParamView> filteredSetParams = {};
     for (const ParamView& userParam : userParams)
@@ -1030,6 +1036,20 @@ void MlxCfg::setDevCfgWithDefault(Commander* commander, std::vector<ParamView>& 
                     shouldSkip = (userParam.val == nextParam.val);
                 }
                 break;
+            }
+        }
+        // Invalidate resets a whole TLV; we cant skip parameters on a TLV we invalidate.
+        if (shouldSkip && !invalidatedTlvKeys.empty())
+        {
+            std::unordered_set<std::string> userTlvKeys;
+            commander->addTlvInstanceKeysForParam(userParam.mlxconfigName, userTlvKeys);
+            for (const std::string& k : userTlvKeys)
+            {
+                if (invalidatedTlvKeys.count(k))
+                {
+                    shouldSkip = false;
+                    break;
+                }
             }
         }
         if (!shouldSkip)


### PR DESCRIPTION
…Under Certain Condition

Description:
we should not filter out matching parameters on TLV that is going to be invalidated due to other parameter on the same TLV.

Issue: 4983323
Change-Id: If95a404c3a70dfac676d2c1700b3e0b4c92c1ea8