### PR TITLE
new efuse tool for SPC6

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldmlib cmdparser mlxconfig $(NVFWRESET_DIR) $(DPA) mlxfwops $(FW_MGR_TOOLS) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} tracers resourcetools
+SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldmlib cmdparser mlxconfig $(NVFWRESET_DIR) $(DPA) mlxfwops $(FW_MGR_TOOLS) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} tracers resourcetools efuse_tool
 
 DIST_SUBDIRS = tracers
 

--- a/configure.ac
+++ b/configure.ac
@@ -910,4 +910,5 @@ AC_OUTPUT( \
     mft_core/mft_core_utils/logger/Makefile \
     mft_core/mft_core_utils/operating_system_api/Makefile \
     mft_core/mft_core_utils/mft_exceptions/Makefile \
+    efuse_tool/Makefile \
  )

--- a/efuse_tool/efuse.cpp
+++ b/efuse_tool/efuse.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efuse.h"
+#include "efuse_config.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+#include <vector>
+
+#include "mtcr.h"
+#include "reg_access/reg_access.h"
+#include <tools_layouts/reg_access_hca_layouts.h>
+#include <tools_layouts/reg_access_switch_layouts.h>
+#include "dev_mgt/tools_dev_types.h"
+#include "mft_core/mft_core_utils/logger/Logger.h"
+#include "common/bit_slice.h"
+
+#define MQIS_INFO_TYPE_MODEL_NAME 0x1 // MODEL_NAME is part number
+
+static std::string instance_label(int inst)
+{
+    if (inst == 0)
+    {
+        return "main";
+    }
+    return "tile[" + std::to_string(inst - 1) + "]";
+}
+
+static int32_t sign_extend_6bit(uint8_t val)
+{
+    if (val & 0x20)
+    {
+        return static_cast<int32_t>(val | 0xFFFFFFC0);
+    }
+    return static_cast<int32_t>(val);
+}
+
+static int32_t sign_extend_26bit(uint32_t val)
+{
+    if (val & 0x02000000)
+    {
+        return static_cast<int32_t>(val | 0xFC000000);
+    }
+    return static_cast<int32_t>(val);
+}
+
+static bool read_device_part_number(mfile* mf, std::string& part_number)
+{
+    struct reg_access_hca_mqis_reg_ext mqis;
+    memset(&mqis, 0, sizeof(mqis));
+    mqis.info_type = MQIS_INFO_TYPE_MODEL_NAME;
+    mqis.read_length = sizeof(mqis.info_string);
+
+    reg_access_status_t rc = reg_access_mqis(mf, REG_ACCESS_METHOD_GET, &mqis);
+    if (rc != ME_OK)
+    {
+        LOG.Error("reg_access_mqis failed for part number, rc=" + std::to_string(rc));
+        return false;
+    }
+
+    int total_len = mqis.info_length;
+    if (total_len == 0)
+    {
+        return false;
+    }
+
+    std::vector<char> buf(total_len + 1, '\0');
+    int first_chunk = std::min(static_cast<int>(mqis.read_length), total_len);
+    memcpy(buf.data(), mqis.info_string, first_chunk);
+
+    int remaining = total_len - first_chunk;
+    while (remaining > 0)
+    {
+        mqis.read_offset = total_len - remaining;
+        mqis.read_length =
+          remaining > static_cast<int>(sizeof(mqis.info_string)) ? sizeof(mqis.info_string) : remaining;
+
+        rc = reg_access_mqis(mf, REG_ACCESS_METHOD_GET, &mqis);
+        if (rc != ME_OK || mqis.read_length == 0)
+        {
+            LOG.Error("reg_access_mqis failed for part number, rc=" + std::to_string(rc));
+            return false;
+        }
+        if (mqis.read_offset + mqis.read_length > total_len)
+        {
+            LOG.Error(
+              "mqis.read_offset + mqis.read_length > total_len, read_offset=" + std::to_string(mqis.read_offset) +
+              " read_length=" + std::to_string(mqis.read_length) + " total_len=" + std::to_string(total_len));
+            return false;
+        }
+        memcpy(buf.data() + mqis.read_offset, mqis.info_string, mqis.read_length);
+        remaining -= mqis.read_length;
+    }
+
+    part_number = buf.data();
+    LOG.Debug("part_number: " + part_number);
+    return true;
+}
+
+struct FuseReading
+{
+    std::string rail_name;
+    std::string die_label;
+    bool fuse_mismatch;
+    double voltage_mv;
+};
+
+static std::vector<FuseReading> read_fuse_values(mfile* mf, const DeviceConfig& config)
+{
+    std::vector<FuseReading> readings;
+
+    for (const auto& fuse : config.fuses)
+    {
+        for (int inst : fuse.instance_ids)
+        {
+            struct reg_access_switch_MRFV_ext mrfv;
+            memset(&mrfv, 0, sizeof(mrfv));
+            mrfv.fuse_id = static_cast<u_int8_t>(fuse.fuse_id);
+            mrfv.instance_id = static_cast<u_int8_t>(inst);
+
+            LOG.Debug("Querying fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst));
+
+            reg_access_status_t rc = reg_access_mrfv_switch(mf, REG_ACCESS_METHOD_GET, &mrfv);
+
+            if (rc != ME_OK)
+            {
+                LOG.Error("reg_access_mrfv_switch failed for fuse_id=" + std::to_string(fuse.fuse_id) +
+                          " instance_id=" + std::to_string(inst) + " error=" + std::to_string(rc));
+                continue;
+            }
+
+            if (mrfv.v != 1)
+            {
+                LOG.Debug("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) +
+                          " v=" + std::to_string(mrfv.v) + " (not valid). Skipping this fuse reading.");
+                continue;
+            }
+
+            std::string die_label = instance_label(inst);
+
+            if (mrfv.fm == 1)
+            {
+                readings.push_back({fuse.name, die_label, true, 0.0});
+                continue;
+            }
+            else if (mrfv.fm != 0)
+            {
+                LOG.Debug("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) +
+                          " unexpected fm=" + std::to_string(mrfv.fm));
+                continue;
+            }
+
+            uint8_t value_valid = mrfv.data.MRFV_RAW_AND_VALUE_ext.value_valid;
+            uint32_t value_base_raw = mrfv.data.MRFV_RAW_AND_VALUE_ext.value_base;
+            uint8_t value_exponent_raw = mrfv.data.MRFV_RAW_AND_VALUE_ext.value_exponent;
+            uint8_t raw_fuses_highest_bit = mrfv.data.MRFV_RAW_AND_VALUE_ext.raw_fuses_highest_bit;
+
+            if (raw_fuses_highest_bit > 31)
+            {
+                LOG.Error("raw_fuses_highest_bit=" + std::to_string(raw_fuses_highest_bit) +
+                          " out of range for fuse_id=" + std::to_string(fuse.fuse_id) +
+                          " instance_id=" + std::to_string(inst));
+                continue;
+            }
+
+            uint32_t raw_fuses = EXTRACT(mrfv.data.MRFV_RAW_AND_VALUE_ext.raw_fuses, 0, raw_fuses_highest_bit + 1);
+
+            LOG.Debug("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) +
+                      " value_valid=" + std::to_string(value_valid) + " value_base=" + std::to_string(value_base_raw) +
+                      " value_exponent=" + std::to_string(value_exponent_raw) + " raw_fuses=" +
+                      std::to_string(raw_fuses) + " raw_fuses_highest_bit=" + std::to_string(raw_fuses_highest_bit));
+
+            if (value_valid != 1)
+            {
+                continue;
+            }
+
+            int32_t base = sign_extend_26bit(value_base_raw);
+            int32_t exponent = sign_extend_6bit(value_exponent_raw);
+            double voltage_mv = base * pow(10.0, exponent) * 1000.0;
+            readings.push_back({fuse.name, die_label, false, voltage_mv});
+        }
+    }
+
+    return readings;
+}
+
+static void print_fuse_readings(dm_dev_id_t dev_type,
+                                u_int32_t hw_dev_id,
+                                u_int32_t hw_rev,
+                                const std::string& part_number,
+                                const std::vector<FuseReading>& readings)
+{
+    printf("Device:       %s\n", dm_dev_type2str(dev_type));
+    printf("HW ID:        %u (rev %u)\n", hw_dev_id, hw_rev);
+    if (!part_number.empty())
+    {
+        printf("Part number:  %s\n", part_number.c_str());
+    }
+
+    if (readings.empty())
+    {
+        printf("\nNo fuse voltage readings available.\n");
+        return;
+    }
+
+    printf("\nFuse Voltage Readings:\n");
+    printf("  %-16s%-16s%s\n", "RAIL", "DIE", "VOLTAGE");
+    for (const auto& r : readings)
+    {
+        if (r.fuse_mismatch)
+        {
+            printf("  %-16s%-16sFuse mismatch detected\n", r.rail_name.c_str(), r.die_label.c_str());
+        }
+        else
+        {
+            printf("  %-16s%-16s%.1f mV\n", r.rail_name.c_str(), r.die_label.c_str(), r.voltage_mv);
+        }
+    }
+}
+
+void EfuseTool::InitCmdParser()
+{
+    AddDescription("Print fuse voltage readings (from MRFV prm-register) using a JSON config.");
+    AddOptions(
+      "device", 'd', "<device>", "MST device path (required). Example: /dev/mst/mt53124_pciconf0", false, true);
+    AddOptions(
+      "config", 'c', "<json>", "Efuse JSON config (required). Example: /path/to/efuse_config.json", false, true);
+    AddOptions("help", 'h', "", "Show this help message and exit");
+    _cmdParser.AddRequester(this);
+}
+
+ParseStatus EfuseTool::HandleOption(std::string name, std::string value)
+{
+    if (name == "device")
+    {
+        _device = value;
+        return PARSE_OK;
+    }
+    else if (name == "config")
+    {
+        _configPath = value;
+        return PARSE_OK;
+    }
+    else if (name == "help")
+    {
+        printf("%s\n", _cmdParser.GetUsage().c_str());
+        return PARSE_OK_WITH_EXIT;
+    }
+    return PARSE_ERROR;
+}
+
+ParseStatus EfuseTool::ParseCmdLine(int argc, char* argv[])
+{
+    ParseStatus status = _cmdParser.ParseOptions(argc, argv, false);
+    if (status != PARSE_OK)
+    {
+        return status;
+    }
+    if (_device.empty())
+    {
+        fprintf(stderr, "-E- Missing device argument. Use -d <mst_device>.\n");
+        return PARSE_ERROR_SHOW_USAGE;
+    }
+    if (_configPath.empty())
+    {
+        fprintf(stderr, "-E- Missing config argument. Use -c <config.json>.\n");
+        return PARSE_ERROR_SHOW_USAGE;
+    }
+    return PARSE_OK;
+}
+
+int EfuseTool::Run()
+{
+    int ret = 1;
+
+    mfile* mf = mopen_adv(_device.c_str(), MST_DEFAULT);
+    if (!mf)
+    {
+        fprintf(stderr, "-E- Failed to open device %s\n", _device.c_str());
+        return 1;
+    }
+
+    if (dm_is_livefish_mode(mf))
+    {
+        fprintf(stderr, "-E- Device is in livefish mode. This tool requires running firmware.\n");
+        goto cleanup;
+    }
+
+    {
+        dm_dev_id_t dev_type = DeviceUnknown;
+        u_int32_t hw_dev_id = 0;
+        u_int32_t hw_rev = 0;
+        if (dm_get_device_id(mf, &dev_type, &hw_dev_id, &hw_rev))
+        {
+            fprintf(stderr, "-E- Failed to identify device.\n");
+            goto cleanup;
+        }
+        hw_rev = mf->rev_id;
+
+        std::string part_number;
+        if (!read_device_part_number(mf, part_number))
+        {
+            fprintf(stderr, "-E- Failed to read part number from device (MQIS register).\n");
+            goto cleanup;
+        }
+
+        DeviceConfig device_config;
+        int schema_version = 0;
+        std::string config_error;
+        if (!load_matching_device_config(
+              _configPath, hw_dev_id, static_cast<int>(hw_rev), part_number, device_config, schema_version, config_error))
+        {
+            fprintf(stderr, "-E- %s\n", config_error.c_str());
+            goto cleanup;
+        }
+
+        if (schema_version != 1)
+        {
+            fprintf(stderr, "-E- Unsupported schema_version %d. Only version 1 is supported.\n", schema_version);
+            goto cleanup;
+        }
+
+        std::vector<FuseReading> readings = read_fuse_values(mf, device_config);
+        print_fuse_readings(dev_type, hw_dev_id, hw_rev, part_number, readings);
+        ret = 0;
+    }
+
+cleanup:
+    mclose(mf);
+    return ret;
+}
+
+std::string EfuseTool::GetUsage()
+{
+    return _cmdParser.GetUsage();
+}
+
+int main(int argc, char* argv[])
+{
+    EfuseTool efuse;
+
+    ParseStatus status = efuse.ParseCmdLine(argc, argv);
+    if (status == PARSE_OK_WITH_EXIT)
+    {
+        return 0;
+    }
+    else if (status == PARSE_ERROR_SHOW_USAGE)
+    {
+        printf("%s\n", efuse.GetUsage().c_str());
+        return 1;
+    }
+    else if (status != PARSE_OK)
+    {
+        fprintf(stderr, "-E- Failed to parse arguments.\n");
+        printf("%s\n", efuse.GetUsage().c_str());
+        return 1;
+    }
+
+    return efuse.Run();
+}

--- a/efuse_tool/efuse.h
+++ b/efuse_tool/efuse.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) Jan 2013 Mellanox Technologies Ltd. All rights reserved.
- * Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,31 +30,25 @@
  * SOFTWARE.
  */
 
-#ifndef REG_IDS_H
-#define REG_IDS_H
+#pragma once
 
-#define REG_ID_MMHI 0x904A
-#define REG_ID_MGIR  0x9020
-#define REG_ID_MORD  0x9153
-#define REG_ID_MCAM  0x907f
-#define REG_ID_MPQD 0x9700
-#define REG_ID_PLIB  0x500a
-#define REG_ID_PMLP  0x5002
-#define REG_ID_PTYS  0x5004
-#define REG_ID_PAOS  0x5006
-#define REG_ID_PPCNT 0x5008
-#define REG_ID_PMAOS 0x5012
-#define REG_ID_SLTP  0x5027
-#define REG_ID_PDDR  0x5031
-#define REG_ID_PPHCR 0x503e
-#define REG_ID_PPAOS 0x5040
-#define REG_ID_PGUID 0x5066
-#define REG_ID_PPSLS 0x50e3
-#define REG_ID_MTCAP 0x9009
-#define REG_ID_MPEGC 0x9056
-#define REG_ID_MPIR 0x9059
-#define REG_ID_MROQ 0x902F
-#define REG_ID_MRFV 0x906d
+#include <string>
 
+#include "cmdparser/cmdparser.h"
 
-#endif
+class EfuseTool : public CommandLineRequester
+{
+public:
+    EfuseTool() : CommandLineRequester("efuse"), _cmdParser("efuse") { InitCmdParser(); }
+
+    void InitCmdParser();
+    ParseStatus HandleOption(std::string name, std::string value) override;
+    ParseStatus ParseCmdLine(int argc, char* argv[]);
+    int Run();
+    std::string GetUsage();
+
+private:
+    CommandLineParser _cmdParser;
+    std::string _device;
+    std::string _configPath;
+};

--- a/efuse_tool/efuse_config.cpp
+++ b/efuse_tool/efuse_config.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efuse_config.h"
+
+#include <climits>
+#include <fstream>
+
+#include <json/reader.h>
+#include <json/value.h>
+
+static bool parse_instance_ids(const Json::Value& instance_ids_node, std::vector<int>& instance_ids, std::string& error)
+{
+    if (!instance_ids_node.isArray() || instance_ids_node.empty())
+    {
+        error = "JSON config format error: instance_ids must be a non-empty array";
+        return false;
+    }
+
+    instance_ids.clear();
+    for (Json::ArrayIndex idx = 0; idx < instance_ids_node.size(); idx++)
+    {
+        const Json::Value& instance_value = instance_ids_node[idx];
+        if (!instance_value.isInt())
+        {
+            error =
+              "JSON config format error: instance_ids entry at index " + std::to_string(idx) + " must be an integer";
+            return false;
+        }
+        int val = instance_value.asInt();
+        if (val < 0 || val > UINT8_MAX)
+        {
+            error = "JSON config format error: instance_ids entry at index " + std::to_string(idx) + " value " +
+                    std::to_string(val) + " out of valid range [0..255]";
+            return false;
+        }
+        instance_ids.push_back(val);
+    }
+    return true;
+}
+
+static bool parse_fuse_entry(const Json::Value& fuse_node,
+                             const std::string& device_path,
+                             Json::ArrayIndex fuse_idx,
+                             FuseConfig& fuse,
+                             std::string& error)
+{
+    std::string path = device_path + ".fuses[" + std::to_string(fuse_idx) + "]";
+
+    if (!fuse_node.isObject())
+    {
+        error = "JSON config format error: " + device_path + ".fuses entry at index " + std::to_string(fuse_idx) +
+                " must be an object";
+        return false;
+    }
+
+    if (!fuse_node.isMember("fuse_id"))
+    {
+        error = "JSON config format error: " + path + " missing required field 'fuse_id'";
+        return false;
+    }
+    const Json::Value& fuse_id_node = fuse_node["fuse_id"];
+    if (!fuse_id_node.isInt())
+    {
+        error = "JSON config format error: " + path + ".fuse_id must be an integer";
+        return false;
+    }
+
+    if (!fuse_node.isMember("name"))
+    {
+        error = "JSON config format error: " + path + " missing required field 'name'";
+        return false;
+    }
+    const Json::Value& name_node = fuse_node["name"];
+    if (!name_node.isString())
+    {
+        error = "JSON config format error: " + path + ".name must be a string";
+        return false;
+    }
+
+    int fuse_id_val = fuse_id_node.asInt();
+    if (fuse_id_val < 0 || fuse_id_val > UINT8_MAX)
+    {
+        error = "JSON config format error: " + path + ".fuse_id value " + std::to_string(fuse_id_val) +
+                " out of valid range [0..255]";
+        return false;
+    }
+
+    fuse.fuse_id = fuse_id_val;
+    fuse.name = name_node.asString();
+
+    if (!fuse_node.isMember("instance_ids"))
+    {
+        error = "JSON config format error: " + path + " missing required field 'instance_ids'";
+        return false;
+    }
+    std::string instance_error;
+    if (!parse_instance_ids(fuse_node["instance_ids"], fuse.instance_ids, instance_error))
+    {
+        error = instance_error + " in " + path;
+        return false;
+    }
+
+    return true;
+}
+
+static bool parse_device_match(const Json::Value& device_node,
+                               const std::string& device_path,
+                               uint32_t& hw_dev_id,
+                               int& hw_rev_id,
+                               std::string& part_number,
+                               std::string& error)
+{
+    if (!device_node.isMember("match"))
+    {
+        error = "JSON config format error: " + device_path + " missing required field 'match'";
+        return false;
+    }
+    const Json::Value& match_node = device_node["match"];
+    if (!match_node.isObject())
+    {
+        error = "JSON config format error: " + device_path + ".match must be an object";
+        return false;
+    }
+
+    if (!match_node.isMember("hw_dev_id"))
+    {
+        error = "JSON config format error: " + device_path + ".match missing required field 'hw_dev_id'";
+        return false;
+    }
+    const Json::Value& hw_dev_id_node = match_node["hw_dev_id"];
+    if (!hw_dev_id_node.isUInt())
+    {
+        error = "JSON config format error: " + device_path + ".match.hw_dev_id must be a non-negative integer";
+        return false;
+    }
+    hw_dev_id = hw_dev_id_node.asUInt();
+
+    if (!match_node.isMember("hw_rev_id"))
+    {
+        error = "JSON config format error: " + device_path + ".match missing required field 'hw_rev_id'";
+        return false;
+    }
+    const Json::Value& hw_rev_id_node = match_node["hw_rev_id"];
+    if (!hw_rev_id_node.isInt())
+    {
+        error = "JSON config format error: " + device_path + ".match.hw_rev_id must be an integer";
+        return false;
+    }
+    hw_rev_id = hw_rev_id_node.asInt();
+
+    if (!match_node.isMember("part_number"))
+    {
+        error = "JSON config format error: " + device_path + ".match missing required field 'part_number'";
+        return false;
+    }
+    const Json::Value& part_number_node = match_node["part_number"];
+    if (!part_number_node.isString())
+    {
+        error = "JSON config format error: " + device_path + ".match.part_number must be a string";
+        return false;
+    }
+    part_number = part_number_node.asString();
+
+    return true;
+}
+
+static bool parse_device_fuses(const Json::Value& device_node,
+                               const std::string& device_path,
+                               DeviceConfig& device,
+                               std::string& error)
+{
+    if (!device_node.isMember("fuses"))
+    {
+        error = "JSON config format error: " + device_path + " missing required field 'fuses'";
+        return false;
+    }
+    const Json::Value& fuses_node = device_node["fuses"];
+    if (!fuses_node.isArray() || fuses_node.empty())
+    {
+        error = "JSON config format error: " + device_path + ".fuses must be a non-empty array";
+        return false;
+    }
+
+    for (Json::ArrayIndex fuse_idx = 0; fuse_idx < fuses_node.size(); fuse_idx++)
+    {
+        FuseConfig fuse;
+        if (!parse_fuse_entry(fuses_node[fuse_idx], device_path, fuse_idx, fuse, error))
+        {
+            return false;
+        }
+        device.fuses.push_back(fuse);
+    }
+
+    return true;
+}
+
+bool load_matching_device_config(const std::string& path,
+                                 uint32_t target_hw_dev_id,
+                                 int target_hw_rev_id,
+                                 const std::string& target_part_number,
+                                 DeviceConfig& device,
+                                 int& schema_version,
+                                 std::string& error)
+{
+    std::ifstream config_file(path);
+    if (!config_file.is_open())
+    {
+        error = "Failed to open config file: " + path;
+        return false;
+    }
+
+    Json::CharReaderBuilder builder;
+    builder["collectComments"] = false;
+    Json::Value root;
+    std::string parse_errors;
+    if (!Json::parseFromStream(builder, config_file, &root, &parse_errors))
+    {
+        error = "Failed to parse config file: " + parse_errors;
+        return false;
+    }
+
+    if (!root.isObject())
+    {
+        error = "JSON config format error: Config root must be a JSON object";
+        return false;
+    }
+
+    if (!root.isMember("schema_version"))
+    {
+        error = "JSON config format error: missing required field 'schema_version'";
+        return false;
+    }
+    const Json::Value& schema_node = root["schema_version"];
+    if (!schema_node.isInt())
+    {
+        error = "JSON config format error: schema_version must be an integer";
+        return false;
+    }
+    schema_version = schema_node.asInt();
+
+    if (!root.isMember("devices"))
+    {
+        error = "JSON config format error: missing required field 'devices'";
+        return false;
+    }
+    const Json::Value& devices_node = root["devices"];
+    if (!devices_node.isArray() || devices_node.empty())
+    {
+        error = "JSON config format error: 'devices' must be a non-empty array";
+        return false;
+    }
+
+    for (Json::ArrayIndex idx = 0; idx < devices_node.size(); idx++)
+    {
+        const Json::Value& device_node = devices_node[idx];
+        if (!device_node.isObject())
+        {
+            error = "JSON config format error: devices entry at index " + std::to_string(idx) + " must be an object";
+            return false;
+        }
+
+        std::string device_path = "devices[" + std::to_string(idx) + "]";
+
+        uint32_t hw_dev_id;
+        int hw_rev_id;
+        std::string part_number;
+        if (!parse_device_match(device_node, device_path, hw_dev_id, hw_rev_id, part_number, error))
+        {
+            return false;
+        }
+
+        if (hw_dev_id != target_hw_dev_id || hw_rev_id != target_hw_rev_id)
+        {
+            continue;
+        }
+        // Empty part_number in JSON matches any device part number
+        if (!part_number.empty() && part_number != target_part_number)
+        {
+            continue;
+        }
+
+        if (!parse_device_fuses(device_node, device_path, device, error))
+        {
+            return false;
+        }
+
+        device.hw_dev_id = hw_dev_id;
+        device.hw_rev_id = hw_rev_id;
+        device.part_number = part_number;
+
+        return true;
+    }
+
+    error = "No matching device config found for hw_dev_id=" + std::to_string(target_hw_dev_id) +
+            " hw_rev_id=" + std::to_string(target_hw_rev_id) + " part_number=" + target_part_number;
+    return false;
+}

--- a/efuse_tool/efuse_config.h
+++ b/efuse_tool/efuse_config.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) Jan 2013 Mellanox Technologies Ltd. All rights reserved.
- * Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,31 +30,31 @@
  * SOFTWARE.
  */
 
-#ifndef REG_IDS_H
-#define REG_IDS_H
+#pragma once
 
-#define REG_ID_MMHI 0x904A
-#define REG_ID_MGIR  0x9020
-#define REG_ID_MORD  0x9153
-#define REG_ID_MCAM  0x907f
-#define REG_ID_MPQD 0x9700
-#define REG_ID_PLIB  0x500a
-#define REG_ID_PMLP  0x5002
-#define REG_ID_PTYS  0x5004
-#define REG_ID_PAOS  0x5006
-#define REG_ID_PPCNT 0x5008
-#define REG_ID_PMAOS 0x5012
-#define REG_ID_SLTP  0x5027
-#define REG_ID_PDDR  0x5031
-#define REG_ID_PPHCR 0x503e
-#define REG_ID_PPAOS 0x5040
-#define REG_ID_PGUID 0x5066
-#define REG_ID_PPSLS 0x50e3
-#define REG_ID_MTCAP 0x9009
-#define REG_ID_MPEGC 0x9056
-#define REG_ID_MPIR 0x9059
-#define REG_ID_MROQ 0x902F
-#define REG_ID_MRFV 0x906d
+#include <cstdint>
+#include <string>
+#include <vector>
 
+struct FuseConfig
+{
+    int fuse_id;
+    std::string name;
+    std::vector<int> instance_ids;
+};
 
-#endif
+struct DeviceConfig
+{
+    uint32_t hw_dev_id;
+    int hw_rev_id;
+    std::string part_number;
+    std::vector<FuseConfig> fuses;
+};
+
+bool load_matching_device_config(const std::string& path,
+                                 uint32_t hw_dev_id,
+                                 int hw_rev_id,
+                                 const std::string& part_number,
+                                 DeviceConfig& device,
+                                 int& schema_version,
+                                 std::string& error);

--- a/reg_access/reg_access.c
+++ b/reg_access/reg_access.c
@@ -116,6 +116,7 @@
 #define REG_ID_MRSV  0x9164
 #define REG_ID_MISOC 0x9026
 #define REG_ID_MPEIN 0x9050
+#define REG_ID_MRFV  0x906d
 
 
 /* For mstdump oob feature: */
@@ -873,4 +874,10 @@ reg_access_status_t reg_access_misoc(mfile* mf, reg_access_method_t method, stru
 reg_access_status_t reg_access_mpein(mfile* mf, reg_access_method_t method, struct reg_access_hca_mpein_reg_ext* mpein)
 {
     REG_ACCCESS(mf, method, REG_ID_MPEIN, mpein, mpein_reg_ext, reg_access_hca);
+}
+
+reg_access_status_t
+reg_access_mrfv_switch(mfile* mf, reg_access_method_t method, struct reg_access_switch_MRFV_ext* mrfv)
+{
+    REG_ACCCESS(mf, method, REG_ID_MRFV, mrfv, MRFV_ext, reg_access_switch);
 }

--- a/reg_access/reg_access.h
+++ b/reg_access/reg_access.h
@@ -294,6 +294,10 @@ struct reg_access_hca_mpein_reg_ext;
 reg_access_status_t
 reg_access_mpein(mfile* mf, reg_access_method_t method, struct reg_access_hca_mpein_reg_ext* mpein);
 
+struct reg_access_switch_MRFV_ext;
+reg_access_status_t
+reg_access_mrfv_switch(mfile* mf, reg_access_method_t method, struct reg_access_switch_MRFV_ext* mrfv);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Description: adds a new 'efuse' tool (Linux OS only) intended for customers.
The tool uses a JSON config file and prints accordingly fuse values which are obtained from MRFV prm -register.
if the fuse's data is not valid, the tool will skip it and continue to the next fuse. in case of fuse-mismatch a message will be printed alongside the relevant fuse.

Tested OS: linux
Tested devices: SPC6
Tested flows:
efuse -d <> -c /swgwork/ssela/workspace/MFT/mft/user/efuse_tool/efuse_config.json

Known gaps (with RM ticket):n/a

Issue:4746957