### PR TITLE
[msttokengenerator][auto_generate_tokens] is broken

### DIFF
--- a/mlxtokengenerator/mlxtkngenerator.cpp
+++ b/mlxtokengenerator/mlxtkngenerator.cpp
@@ -720,11 +720,16 @@ void MlxTknGenerator::AggregateTokensXML()
         throw MlxTknGeneratorException("Given tokens directory is empty.");
     }
 
-    token->LoadFromXMLFile(tokensXML.back());
+    vector<u_int8_t> binData = ReadFromFile(tokensXML.back());
+    string xmlContent(binData.begin(), binData.end());
+    token->LoadFromXMLFile(xmlContent);
     tokensXML.pop_back();
 
-    for (auto file : tokensXML) {
-        tokenForAggregation->LoadFromXMLFile(file);
+    for (auto file : tokensXML)
+    {
+        binData = ReadFromFile(file);
+        xmlContent = string(binData.begin(), binData.end());
+        tokenForAggregation->LoadFromXMLFile(xmlContent);
         token->Aggregate(*tokenForAggregation);
     }
 

--- a/mlxtokengenerator/mlxtoken.cpp
+++ b/mlxtokengenerator/mlxtoken.cpp
@@ -46,9 +46,8 @@ MlxToken::MlxToken(Device_Type deviceType, string aggregatableTLV, vector<string
 {
 }
 
-void MlxToken::LoadFromXMLFile(string filePath)
+void MlxToken::LoadFromXMLFile(string xmlContent)
 {
-    vector<u_int8_t> token = ReadFromFile(filePath);
     string dbName = "";
     GenericCommander commander(nullptr, dbName, _deviceType);
 
@@ -56,7 +55,7 @@ void MlxToken::LoadFromXMLFile(string filePath)
 
     try
     {
-        commander.XML2TLVConf(string(token.begin(), token.end()), _tlvs);
+        commander.XML2TLVConf(xmlContent, _tlvs);
         VerifyTokenStructure();
         VerifyTokenContent();
     }


### PR DESCRIPTION
Description: aligning token loading method to mft implementation

MSTFlint port needed: no
Tested OS: linux
Tested devices: cx8
Tested flows: msttokengenerator auto generate tokens

Known gaps (with RM ticket): N/A

Issue: 4993831