### PR TITLE
mlxlink | NVL6 | adding support for Mode B new speeds FECs

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -5956,6 +5956,17 @@ void MlxlinkCommander::checkPplmCap()
             throw MlxRegException("\nFEC speed %s is not valid%s", uiSpeed.c_str(), validSpeeds.c_str());
         }
     }
+
+    if (_isNvlinkModeB || _isNvlinkModeA)
+    {
+        string nvlinkSpeed = convertSpeedToNVLINK(toUpperCase(speedFec));
+        if (nvlinkSpeed.empty())
+        {
+            throw MlxRegException("\nFEC speed %s is not valid", uiSpeed.c_str());
+        }
+        speedFec = toLowerCase(nvlinkSpeed);
+    }
+
     // Validate the FEC for the speed
     if (speedFec == "10g" || speedFec == "40g")
     {

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -249,7 +249,9 @@ void MlxlinkMaps::initFecAndLoopbackMapping()
     _fecPerSpeed.push_back(make_pair("XDR_1X", ""));
     _fecPerSpeed.push_back(make_pair("XDR_2X", ""));
     _fecPerSpeed.push_back(make_pair("400G_2X_MODE_B", ""));
+    _fecPerSpeed.push_back(make_pair("378G_2X_MODE_B", ""));
     _fecPerSpeed.push_back(make_pair("360G_2X_MODE_B", ""));
+    _fecPerSpeed.push_back(make_pair("345G_2X_MODE_B", ""));
     _fecPerSpeed.push_back(make_pair("328G_2X_MODE_B", ""));
 
     _fecPerSpeed.push_back(make_pair("1600G_8X", ""));

--- a/mlxlink/modules/mlxlink_utils.cpp
+++ b/mlxlink/modules/mlxlink_utils.cpp
@@ -781,21 +781,13 @@ string convertSpeedToNVLINK(const string& speed)
     {
         return "400g_2x_mode_b";
     }
-    if (speed == "360G_2X_MODE_B")
+    if (speed == "360G_2X_MODE_B" || speed == "378G_2X_MODE_B")
     {
         return "360g_2x_mode_b";
     }
-    if (speed == "328G_2X_MODE_B")
+    if (speed == "328G_2X_MODE_B" || speed == "345G_2X_MODE_B")
     {
         return "328g_2x_mode_b";
-    }
-    if (speed == "378G_2X_MODE_B")
-    {
-        return "378g_2x_mode_b";
-    }
-    if (speed == "345G_2X_MODE_B")
-    {
-        return "345g_2x_mode_b";
     }
     if (speed == "NDR")
     {


### PR DESCRIPTION
Description:

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: