### PR TITLE
mstcable_discovery: fix double free on cable open failure

### DIFF
--- a/mst_utils/cable_discovery.cpp
+++ b/mst_utils/cable_discovery.cpp
@@ -123,11 +123,7 @@ int main(int argc, char* argv[])
             {
                 std::string cable_name = std::string(devs[i].dev_name) + "_" + CABLE_DEVICE_STR + std::to_string(num_ports);
                 mfile* cable_mf = mopen_adv(cable_name.c_str(), (MType)(MST_DEFAULT | MST_CABLE));
-                if (!cable_mf)
-                {
-                    mclose(mf);
-                }
-                else
+                if (cable_mf)
                 {
                     u_int32_t dev_type = 0;
                     mget_mdevs_type(cable_mf, &dev_type);
@@ -136,6 +132,7 @@ int main(int argc, char* argv[])
                         CreateCableDeviceFile(cable_name);
                         cable_count++;    
                     }
+                    mclose(cable_mf);
                 }
             }
         } 

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -4351,10 +4351,12 @@ int mclose_ul(mfile* mf)
                 close(ctx->res_fdlock);
             }
             free(ctx);
+            ctx = NULL;
         }
         if (mf->dev_name)
         {
             free(mf->dev_name);
+            mf->dev_name = NULL;   
         }
         if (mf->user_page_list.page_amount)
         {


### PR DESCRIPTION
Removed extra mclose(mf) when cable_mf fails to open, and added missing mclose(cable_mf) on success