### PR TITLE
mtcr_ul: complete mopen_ul_int cable handling on VR

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -3964,7 +3964,6 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
             {
                 goto open_failed;
             }
-            return mf;
             break;
 
         case MST_FWCTL_CONTROL_DRIVER:
@@ -3973,7 +3972,6 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
             {
                 goto open_failed;
             }
-            return mf;
             break;
 
         case MST_NVML:
@@ -3983,7 +3981,6 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
                 DBG_PRINTF("Failed to open GPU mst driver device");
                 goto open_failed;
             }
-            return mf;
             break;
 
 #ifdef ENABLE_VFIO
@@ -3993,7 +3990,6 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
             {
                 goto open_failed;
             }
-            return mf;
             break;
 #endif
 
@@ -4005,7 +4001,6 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
                 DBG_PRINTF("Failed to open I2C device: %s\n", name);
                 goto open_failed;
             }
-            return mf;
 #endif
 
         default:


### PR DESCRIPTION
Remove premature return mf after driver-backed opens (CR/CONF, fwctl, NVML, VFIO, I2C) so cable virtual device names reach the existing return_mf path and is_cable_device() when CABLES_SUPPORT is defined.

Matches the intent of upstream commit 42dc787; fixes a partial cherry-pick that added return_mf but left the early returns.