### PR TITLE
[3rd party][Molex] FW burning enters a loop

### DIFF
--- a/cable_access/cdb_cable_access.cpp
+++ b/cable_access/cdb_cable_access.cpp
@@ -58,6 +58,7 @@ const u_int16_t CmisCdbAccess::CDB_WRITABLE_BYTES_PER_PAGE = 0x0080;
 const u_int16_t CmisCdbAccess::CDB_PAGE_INDEX_IN_ADDRESS = 0x0100;
 const u_int16_t CmisCdbAccess::CDB_PASSWORD_ENTRY_AREA_ADDRESS = 0x7A;
 const u_int16_t CmisCdbAccess::CDB_IMPLEMENTED_BANKS_ADDRESS = 0x018E;
+const u_int16_t CmisCdbAccess::CDB_OUI_ADDRESS = 0x0091;
 
 void CmisCdbAccess::CreateStatusMap()
 {
@@ -83,6 +84,7 @@ void CmisCdbAccess::CreateStatusMap()
 CmisCdbAccess::CmisCdbAccess(string mstDevName, mfile* mf, bool clearCompletionFlag) :
     _cableAccess(mstDevName.c_str(), mf),
     _cmisVersion(CMIS_UNKNOWN),
+    _oui(),
     _isBackgroundCommand(true),
     _isInitDone(false),
     _statusWaitingTimeMilliSec(1000),
@@ -113,6 +115,22 @@ CmisCdbAccess::CMISVersion CmisCdbAccess::ToCMISVersion(u_int8_t cmisVersionByte
     return cmisVersion;
 }
 
+bool CmisCdbAccess::IsOuiRequiringActivationWA() const
+{
+    static const vector<OUI> ouisRequiringActivationWa = {
+      OUI(vector<u_int8_t>({0x00, 0x09, 0x3a})), // Molex
+    };
+
+    for (size_t i = 0; i < ouisRequiringActivationWa.size(); ++i)
+    {
+        if (_oui == ouisRequiringActivationWa[i])
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 void CmisCdbAccess::InnerInit()
 {
     if (!_isInitDone)
@@ -132,6 +150,11 @@ void CmisCdbAccess::InnerInit()
         }
         u_int8_t cmis = (u_int8_t)(ReadDWord(CDB_CMIS_REVISION_ADDRESS) & 0xff);
         _cmisVersion = ToCMISVersion(cmis);
+
+        vector<u_int8_t> ouiBytes = ReadData(CDB_OUI_ADDRESS, OUI::OUI_SIZE, OTHER);
+        _oui = OUI(ouiBytes);
+        CDB_ACCESS_DPRINTF(("OUI: %02X %02X %02X\n", ouiBytes[0], ouiBytes[1], ouiBytes[2]));
+
         _isInitDone = true;
     }
 }

--- a/cable_access/cdb_cable_access.h
+++ b/cable_access/cdb_cable_access.h
@@ -81,6 +81,21 @@ public:
     virtual ~UnknownStatusCdbAccessException() throw(){};
 };
 
+class OUI
+{
+public:
+    OUI() : _bytes() {}
+
+    explicit OUI(const vector<u_int8_t>& bytes) : _bytes(bytes) {}
+
+    bool operator==(const OUI& other) const { return _bytes == other._bytes; }
+
+    static const size_t OUI_SIZE = 3;
+
+private:
+    vector<u_int8_t> _bytes;
+};
+
 class CmisCdbAccess
 {
 public:
@@ -110,7 +125,7 @@ public:
     void SetBackgroundCommand() { _isBackgroundCommand = true; }
     void SetForegroundCommand() { _isBackgroundCommand = false; }
     virtual u_int32_t GetMaxPayloadSizeInBytes(PayloadMethod payloadMethod);
-    bool IsActivationWANeeded() { return _isIgnoreCompletionTimeOut; }
+    bool IsActivationWANeeded() { return _isIgnoreCompletionTimeOut || IsOuiRequiringActivationWA(); }
     void OverrideCommandCompletionWaitingTime(u_int32_t waitTime);
 
 protected:
@@ -144,12 +159,14 @@ protected:
     u_int8_t CalcChkCode(PayloadMethod payloadMethod, const std::vector<u_int8_t>& payload);
 
     CMISVersion ToCMISVersion(u_int8_t cmisVersionByte);
+    bool IsOuiRequiringActivationWA() const;
 
     static void CreateStatusMap();
 
     cableAccess _cableAccess;
     CdbCommandHeader _header;
     CMISVersion _cmisVersion;
+    OUI _oui;
     bool _isBackgroundCommand;
     bool _isInitDone;
     u_int32_t _statusWaitingTimeMilliSec;
@@ -172,6 +189,7 @@ protected:
     static const u_int16_t CDB_SUPPORT_ADVERTISEMENT_ADDRESS;
     static const u_int16_t CDB_PASSWORD_ENTRY_AREA_ADDRESS;
     static const u_int16_t CDB_IMPLEMENTED_BANKS_ADDRESS;
+    static const u_int16_t CDB_OUI_ADDRESS;
 };
 
 class FWManagementCdbAccess : public CmisCdbAccess

--- a/cable_access/cdb_cable_commander.cpp
+++ b/cable_access/cdb_cable_commander.cpp
@@ -372,7 +372,7 @@ void FwManagementCdbCommander::ActivateImage()
 
     if (_fwMngCableAccess.IsActivationWANeeded())
     {
-        msleep(5000); // WA for Hydra - CDB 0h stuck in 0x82
+        msleep(5000); // CDB 0h stuck in 0x82
     }
     if (_modulePasswordSet)
     {


### PR DESCRIPTION
Description: activate step was failing due to status CDB being ignored by the module. Added Molex modules to a list of OUIs that require a waiting time between run and commit commands.

MSTFlint port needed: yes
Tested OS: linux on arm64
Tested devices: Molex module
Tested flows: flint burn and activation in a single command

Known gaps (with RM ticket): N/A

Issue: 4985824