### PR TITLE
[mcra] missing break statement in i2c case in mopen

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -4001,6 +4001,7 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
                 DBG_PRINTF("Failed to open I2C device: %s\n", name);
                 goto open_failed;
             }
+            break;
 #endif
 
         default:


### PR DESCRIPTION
Description: missing break statement cause an undefined behaviour adding break statement for i2c case

Tested OS: linux
Tested devices: i2c
Tested flows: mstmcra /dev/i2c-2 0xf0014

Known gaps (with RM ticket):

Issue: 5015508