### PR TITLE
[configure] warn if --disable-static is passed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -608,6 +608,9 @@ AS_IF([test "x$enable_all_static" = "xyes"],
     ]
 )
 
+AS_IF([if test "x$enable_static" = "xno"],
+    [AC_MSG_ERROR([--disable-static is not supported for this project])])
+
 AC_SUBST(TOOLS_CRYPTO)
 AM_CONDITIONAL(ENABLE_OPENSSL, [test "x$enable_openssl" = "xyes"])
 AM_CONDITIONAL(ENABLE_CS, [test  "x$enable_cs" = "xyes" || test "x$enable_openssl" = "xyes"])


### PR DESCRIPTION
[Reopen of https://github.com/Mellanox/mstflint/pull/1701 as I cannot change target branch]

Build internally relies to generation of static libs and some distro's (e.g. yocto) pass --disable-static under the hood.

Rationale is - while working in incorporating code to bitbake recipe, following was occuring:

/usr/bin/ld: cannot find ../mtcr_ul/.libs/libmtcr_ul.a: No such file or directory

It would save me quite some time warning like the proposed one.