### PR TITLE
kernel/mst_main.c: Fix bug in mst_init() handling livefish devices

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -2335,8 +2335,8 @@ static int __init mst_init(void)
         if (!dev)
         {
             mst_err("failed to mst_device_create\n");
+            continue; /* PCICONF creation failed, no point creating a PCIMEM device */
         }
-        continue; /* PCICONF creation failed, no point creating a PCIMEM device */
 
         /*
          * for livefish devices we only allocate PCICONF


### PR DESCRIPTION
From code observation there seems to be a bug in mst_init() introduced during clang enforcement changes.