### PR TITLE
Bug Fix mstvpd raw pipe parsing for check_raw_vpd

### DIFF
--- a/small_utils/vpd.c
+++ b/small_utils/vpd.c
@@ -311,10 +311,13 @@ int main(int argc, char** argv)
     }
     if (!strcmp("-", name))
     {
-        if (fread(d, VPD_MAX_SIZE, 1, stdin) != 1)
+        ssize_t nbytes = read(STDIN_FILENO, d, VPD_MAX_SIZE);
+
+        if (nbytes <= 0)
         {
             return 3;
         }
+        mvpd_len = (int)nbytes;
     }
     else
     {


### PR DESCRIPTION
Issue: SW #5055040

mstvpd -m <dev> | mstvpd - failed with RC=3 while direct query succeeded. Validated on apps-124-002 (aarch64): old RC=3, fixed RC=0 (PIPESTATUS=0 0).