### PR TITLE
[flint][pldm_pkg_gen] add fwpkg package_info query and disable_custom…

### DIFF
--- a/flint/cmd_line_parser.cpp
+++ b/flint/cmd_line_parser.cpp
@@ -252,6 +252,7 @@ FlagMetaData::FlagMetaData()
     _flags.push_back(new Flag("", "component_type", 1));
     _flags.push_back(new Flag("", "pending", 0));
     _flags.push_back(new Flag("", "skip_if_same", 0));
+    _flags.push_back(new Flag("", "package_info", 0));
 }
 
 FlagMetaData::~FlagMetaData()
@@ -769,6 +770,12 @@ void Flint::initCmdParser()
                "Make the burn process burn two images on flash (previously default algorithm). Current default"
                " failsafe burn process burns a single image (in alternating locations).\n"
                "Commands affected: burn");
+    
+    AddOptions("package_info",
+               ' ',
+               "",
+               "Show full PLDM fwpkg package information.\n"
+               "Commands affected: query");
 
     AddOptions("striped_image",
                ' ',
@@ -1487,6 +1494,10 @@ ParseStatus Flint::HandleOption(string name, string value)
     else if (name == "pending")
     {
         _flintParams.pending = true;
+    }
+    else if (name == "package_info")
+    {
+        _flintParams.package_info = true;
     }
     else
     {

--- a/flint/flint_params.cpp
+++ b/flint/flint_params.cpp
@@ -124,6 +124,7 @@ FlintParams::FlintParams()
     cert_uuid = "";
     skip_if_same = false;
     pending = false;
+    package_info = false;
 }
 
 FlintParams::~FlintParams() {}

--- a/flint/flint_params.h
+++ b/flint/flint_params.h
@@ -208,6 +208,7 @@ public:
     string cert_uuid;
     bool skip_if_same;
     bool pending;
+    bool package_info;
 };
 
 #endif

--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1654,7 +1654,7 @@ const char* SubCommand::fwImgTypeToStr(u_int8_t fwImgType)
             return "COMPS";
             break;
         
-        case FIT_PLDM_1_0:
+        case FIT_PLDM:
             return "PLDM_1_0";
             break;
 
@@ -2907,120 +2907,6 @@ FlintStatus BurnSubCommand::burnFs3()
     return FLINT_SUCCESS;
 }
 
-FlintStatus BurnSubCommand::burnPldmComp(FsPldmOperations* pldmOps, string& componentType)
-{
-    u_int8_t* buff;
-    u_int32_t buffSize = 0;
-    if (!pldmOps->GetPldmComponentData(componentType, _devInfo.fw_info.psid, &buff, buffSize))
-    {
-        reportErr(true, "Failed to get PLDM component data.\n");
-        return FLINT_FAILED;
-    }
-
-    // TODO: Update the component support check to be in the fwctrl burn function
-    FwComponent::comps_ids_t compId = pldmOps->ToCompId(_flintParams.component_type);
-    if (compId == FwComponent::COMPID_UNKNOWN || !_fwOps->IsComponentSupported(compId))
-    {
-        reportErr(true, "Component type %s is not supported by the device.\n", _flintParams.component_type.c_str());
-        delete[] buff;
-        UnlockDevice(_fwOps);
-        return FLINT_FAILED;
-    }
-    vector<u_int8_t> compData(*buff, *buff + buffSize);
-    if (!_fwOps->FwBurnAdvanced(compData, _burnParams, compId))
-    {
-        reportErr(true, FLINT_FSPLDM_BURN_ERROR, _flintParams.component_type.c_str(), _fwOps->err());
-        delete[] buff;
-        UnlockDevice(_fwOps);
-        return FLINT_FAILED;
-    }
-
-    UnlockDevice(_fwOps);
-    return FLINT_SUCCESS;
-}
-
-FlintStatus BurnSubCommand::PldmToFwOps(FsPldmOperations* pldmOps)
-{
-    std::string psid(_devInfo.fw_info.psid);
-    u_int8_t* buff;
-    u_int32_t buffSize = 0;
-    // if psid empty in fwpkg the first component will be extracted
-    if (!pldmOps->GetPldmComponentData("FW", psid, &buff, buffSize))
-    {
-        if (pldmOps->err())
-        {
-            reportErr(true, "%s\n", pldmOps->err());
-            return FLINT_FAILED;
-        }
-        else
-        {
-            psid = "";
-            if (!pldmOps->GetPldmComponentData("FW", psid, &buff, buffSize))
-            {
-                reportErr(true, "The component was not found in the PLDM fwpkg.\n");
-                return FLINT_FAILED;
-            }
-        }
-    }
-
-    // extract devid from device
-    mfile* mf = _fwOps->getMfileObj();
-    dm_dev_id_t devid_t = DeviceUnknown;
-    u_int32_t devid = 0, revid = 0;
-    int rc = dm_get_device_id(mf, &devid_t, &devid, &revid);
-    if (rc != 0)
-    {
-        reportErr(true, "Can not detect the device type.\n");
-        return FLINT_FAILED;
-    }
-
-    // extract devid from fwpkg
-    u_int16_t swDevId = 0;
-    if (!psid.empty())
-    {
-        if (!pldmOps->GetPldmDescriptor(psid, DEV_ID_TYPE, swDevId))
-        {
-            reportErr(true, "DEVICE ID descriptor is not found in the PLDM fwpkg for PSID: %s.\n", psid.c_str());
-            delete[] buff;
-            return FLINT_FAILED;
-        }
-    }
-    else
-    {
-        swDevId = dm_dev_type2sw_id(devid_t);
-    }
-
-    // create new image ops
-    FwOperations* newImageOps = NULL;
-    if (!pldmOps->CreateFwOpsImage((u_int32_t*)buff, buffSize, &newImageOps, swDevId, true))
-    {
-        reportErr(true, "Failed to use image from PLDM fwpkg. %s\n", pldmOps->err());
-        return FLINT_FAILED;
-    }
-    delete _imgOps;
-    _imgOps = newImageOps;
-    delete[] buff;
-
-    // query the image to get the device id and check if it is compatible with the device
-    if (!_imgOps->FwQuery(&_imgInfo))
-    {
-        reportErr(true, "Failed to query the PLDM fwpkg image.\n");
-        return FLINT_FAILED;
-    }
-
-    // Check if device HW ID matches any of the image's supported HW IDs
-    u_int32_t* supportedHwId = nullptr;
-    u_int32_t supportedHwIdNum = 0;
-    _imgOps->getSupporteHwId(&supportedHwId, supportedHwIdNum);
-    if (!_imgOps->CheckMatchingHwDevId(devid, revid, supportedHwId, supportedHwIdNum))
-    {
-        reportErr(true, "%s\n", _imgOps->err());
-        return FLINT_FAILED;
-    }
-
-    return FLINT_SUCCESS;
-}
-
 FlintStatus BurnSubCommand::burnFs2()
 {
     _shouldSkip = false;
@@ -3589,6 +3475,54 @@ FlintStatus BurnSubCommand::PerformBurn(std::vector<u_int8_t>& fwImage, std::vec
 #endif
 }
 
+FlintStatus BurnSubCommand::PldmOpsToFwOps(const string& component_type, FsPldmOperations* pldmOps)
+{
+    if (_imgOps->FwType() != FIT_PLDM)
+    {
+        reportErr(true, "Image is not a PLDM fwpkg, cannot convert to fwops.\n");
+        return FLINT_FAILED;
+    }
+
+    FwOperations* newImageOps = nullptr;
+    if (!pldmOps->FwOperationsCreate(_devInfo.fw_info.psid, component_type, &newImageOps, _fwOps->getMfileObj()))
+    {
+        reportErr(true, "Failed to convert PLDM fwpkg to fwops.\n");
+        return FLINT_FAILED;
+    }
+
+    delete _imgOps;
+    _imgOps = newImageOps;
+
+    if (!_imgOps->FwQuery(&_imgInfo))
+    {
+        reportErr(true, "Failed to query the PLDM fwpkg image.\n");
+        return FLINT_FAILED;
+    }
+
+    if (_flintParams.device_specified && _fwOps->getMfileObj() != nullptr)
+    {
+        dm_dev_id_t devid_t = DeviceUnknown;
+        u_int32_t devid = 0, revid = 0;
+        int rc = dm_get_device_id(_fwOps->getMfileObj(), &devid_t, &devid, &revid);
+        if (rc != 0)
+        {
+            reportErr(true, "Can not detect the device type.\n");
+            return FLINT_FAILED;
+        }
+
+        // Check if device HW ID matches any of the image's supported HW IDs
+        u_int32_t* supportedHwId = nullptr;
+        u_int32_t supportedHwIdNum = 0;
+        _imgOps->getSupportedHwId(&supportedHwId, supportedHwIdNum);
+        if (!_imgOps->CheckMatchingHwDevId(devid, revid, supportedHwId, supportedHwIdNum))
+        {
+            reportErr(true, "%s\n", _imgOps->err());
+            return FLINT_FAILED;
+        }
+    }
+    return FLINT_SUCCESS;
+}
+
 FlintStatus BurnSubCommand::executeCommand()
 {
     if (_flintParams.linkx_control == true || _flintParams.linkx_els_control == true)
@@ -3734,9 +3668,8 @@ FlintStatus BurnSubCommand::executeCommand()
     // query both image and device (deviceQuery can fail but we save rc)
     _devQueryRes = _fwOps->FwQuery(&_devInfo, true, false, true, false, (_flintParams.silent == false));
     
-    if (_imgOps->FwType() == FIT_PLDM_1_0)
+    if (_imgOps->FwType() == FIT_PLDM)
     {
-        string component_type = _flintParams.component_type.empty() ? "FW" : _flintParams.component_type;
         FsPldmOperations* pldmOps = dynamic_cast<FsPldmOperations*>(_imgOps);
         if (pldmOps == nullptr)
         {
@@ -3755,17 +3688,26 @@ FlintStatus BurnSubCommand::executeCommand()
             return FLINT_FAILED;
         }
 
-        if (component_type == "FW")
+        if (_flintParams.component_type.empty())
         {
-            if (PldmToFwOps(pldmOps) == FLINT_FAILED)
+            string firstSupportedComponent = pldmOps->GetFirstSupportedComponent(_devInfo.fw_info.psid);
+            if (firstSupportedComponent.empty())
             {
-                reportErr(true, "%s", pldmOps->err());
+                reportErr(true, "No supported components found in PLDM package.");
                 return FLINT_FAILED;
             }
+            _flintParams.component_type = firstSupportedComponent;
         }
-        else
+        else if (!pldmOps->IsComponentInPackage(_devInfo.fw_info.psid, _flintParams.component_type))
         {
-            return burnPldmComp(pldmOps, component_type);
+            reportErr(true, "Component %s is not supported.\n", _flintParams.component_type.c_str());
+            return FLINT_FAILED;
+        }
+
+        if (PldmOpsToFwOps(_flintParams.component_type, pldmOps) == FLINT_FAILED)
+        {
+            reportErr(true, "%s", pldmOps->err());
+            return FLINT_FAILED;
         }
     }
 
@@ -5310,10 +5252,8 @@ FlintStatus QuerySubCommand::executeCommand()
         return FLINT_FAILED;
     }
 
-    if (_flintParams.image_specified && _imgOps->FwType() == FIT_PLDM_1_0)
+    if (_flintParams.image_specified && _imgOps->FwType() == FIT_PLDM)
     {
-        u_int8_t* buff;
-        u_int32_t buffSize = 0;
         FsPldmOperations* pldmOps = dynamic_cast<FsPldmOperations*>(_imgOps);
 
         if (!pldmOps->LoadPldmPackage())
@@ -5322,43 +5262,45 @@ FlintStatus QuerySubCommand::executeCommand()
             return FLINT_FAILED;
         }
 
-        std::string componentType("FW");
-        if (!pldmOps->GetPldmComponentData(componentType, _flintParams.psid, &buff, buffSize))
+        if (_imgOps->FwType() != FIT_PLDM)
         {
-            if (pldmOps->err())
-            {
-                reportErr(true, "%s\n", pldmOps->err());
-            }
-            else
-            {
-                reportErr(true, "The component was not found in the PLDM.\n");
-            }
+            reportErr(true, "Image is not a PLDM fwpkg, cannot convert to fwops.\n");
             return FLINT_FAILED;
         }
 
-        std::string recovery =
-          pldmOps->GetPldmVendorDefinedDescriptor(_flintParams.psid, PldmRecordDescriptor::VendorDefinedType::RECOVERY);
-        u_int16_t swDevId = 0;
-        if (recovery.empty())
+        if (_flintParams.package_info)
         {
-            if (!pldmOps->GetPldmDescriptor(_flintParams.psid, DEV_ID_TYPE, swDevId))
+            // // Query PLDM package
+            pldmOps->PrintInfo();
+            return FLINT_SUCCESS;
+        }
+
+        if (_flintParams.component_type.empty())
+        {
+            string firstSupportedComponent = pldmOps->GetFirstSupportedComponent(_flintParams.psid);
+            if (firstSupportedComponent.empty())
             {
-                reportErr(true, "DEVICE ID descriptor is not found in the PLDM.\n");
-                delete[] buff;
+                reportErr(true, "No supported components found in PLDM package.");
                 return FLINT_FAILED;
             }
+            _flintParams.component_type = firstSupportedComponent;
         }
-        FwOperations* newImageOps = NULL;
-        if (!pldmOps->CreateFwOpsImage((u_int32_t*)buff, buffSize, &newImageOps, swDevId, true))
+        else if (!pldmOps->IsComponentInPackage(_flintParams.psid, _flintParams.component_type))
         {
-            reportErr(true, " Failed to create new image ops. %s\n", pldmOps->err());
-            delete[] buff;
+            reportErr(true, "Component %s is not supported.", _flintParams.component_type.c_str());
             return FLINT_FAILED;
         }
+
+        // Query specific component in PLDM
+        FwOperations* newImageOps = nullptr;
+        if (!pldmOps->FwOperationsCreate(_flintParams.psid.c_str(), _flintParams.component_type, &newImageOps))
+        {
+            reportErr(true, "%s", pldmOps->err());
+            return FLINT_FAILED;
+        }
+
         delete _imgOps;
         _imgOps = newImageOps;
-        delete[] buff;
-
         _flintParams.striped_image = true;
     }
 

--- a/flint/subcommands.h
+++ b/flint/subcommands.h
@@ -240,7 +240,6 @@ private:
     bool _shouldSkip;
     int _unknownProgress; // used to trace the progress of unknown progress.
     FwCompsMgr* fwCompsAccess;
-    FlintStatus burnPldmComp(FsPldmOperations* pldmOps, string& componentType);
     FlintStatus burnFs3();
     FlintStatus burnFs2();
     bool checkFwVersion(bool CreateFromImgInfo = true,
@@ -271,7 +270,7 @@ private:
     FlintStatus ResetModule(string device);
     FlintStatus WaitForModuleInit(string device);
     FlintStatus PerformBurn(std::vector<u_int8_t>& fwImage, std::vector<u_int8_t>& vendorData);
-    FlintStatus PldmToFwOps(FsPldmOperations* pldmOps);
+    FlintStatus PldmOpsToFwOps(const string& componentType, FsPldmOperations* pldmOps);
 
 public:
     BurnSubCommand();

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -1277,34 +1277,38 @@ void FwCompsMgr::GenerateHandle()
     }
 }
 
-const char* CompNames[] = {"NO_COMPONENT 1",
-                           "COMPID_BOOT_IMG",
-                           "COMPID_RUNTIME_IMG",
-                           "COMPID_USER_NVCONFIG",
-                           "COMPID_OEM_NVCONFIG",
-                           "COMPID_MLNX_NVCONFIG",
-                           "COMPID_CS_TOKEN",
-                           "COMPID_DBG_TOKEN",
-                           "COMPID_DEV_INFO",
-                           "NO_COMPONENT 2",
-                           "COMPID_GEARBOX",
-                           "COMPID_CONGESTION_CONTROL",
-                           "COMPID_LINKX_PROPERTIES",
-                           "COMPID_CRYPTO_TO_COMMISSIONING",
-                           "COMPID_RMCS_TOKEN",
-                           "COMPID_RMDT_TOKEN",
-                           "COMPID_CRCS_TOKEN",
-                           "COMPID_CRDT_TOKEN",
-                           "COMPID_CLOCK_SYNC_EEPROM",
-                           "NO_COMPONENT 3",
-                           "NO_COMPONENT 4",
-                           "COMPID_DIGITAL_CACERT_CHAIN",
-                           "COMPID_DIGITAL_CACERT_REMOVAL",
-                           "COMPID_DIGITAL_CACERT_CHAIN_REMOVAL",
-                           "NO_COMPONENT 4",
-                           "COMPID_LINKX_ELS",
-                           "COMPID_DPA_COMPONENT",
-                           "COMPID_DPA_COMPONENT_REMOVAL"};
+const char* CompNames[] = {"NO_COMPONENT 1",                      // 0x0
+                           "COMPID_BOOT_IMG",                     // 0x1
+                           "COMPID_RUNTIME_IMG",                  // 0x2
+                           "COMPID_USER_NVCONFIG",                // 0x3
+                           "COMPID_OEM_NVCONFIG",                 // 0x4
+                           "COMPID_MLNX_NVCONFIG",                // 0x5
+                           "COMPID_CS_TOKEN",                     // 0x6
+                           "COMPID_DBG_TOKEN",                    // 0x7
+                           "COMPID_DEV_INFO",                     // 0x8
+                           "NO_COMPONENT 2",                      // 0x9
+                           "COMPID_GEARBOX",                      // 0xA
+                           "COMPID_CONGESTION_CONTROL",           // 0xB
+                           "COMPID_LINKX_PROPERTIES",             // 0xC
+                           "COMPID_CRYPTO_TO_COMMISSIONING",      // 0xD
+                           "COMPID_RMCS_TOKEN",                   // 0xE
+                           "COMPID_RMDT_TOKEN",                   // 0xF
+                           "COMPID_CRCS_TOKEN",                   // 0x10
+                           "COMPID_CRDT_TOKEN",                   // 0x11
+                           "COMPID_CLOCK_SYNC_EEPROM",            // 0x12
+                           "NO_COMPONENT 3",                      // 0x13
+                           "NO_COMPONENT 4",                      // 0x14
+                           "COMPID_DIGITAL_CACERT",               // 0x15
+                           "COMPID_DIGITAL_CACERT_CHAIN",         // 0x16
+                           "COMPID_DIGITAL_CACERT_REMOVAL",       // 0x17
+                           "COMPID_DIGITAL_CACERT_CHAIN_REMOVAL", // 0x18
+                           "NO_COMPONENT 5",                      // 0x19
+                           "COMPID_LINKX_ELS",                    // 0x1A
+                           "COMPID_BFB",                          // 0x1B
+                           "COMPID_DPA_COMPONENT",                // 0x1C
+                           "COMPID_DPA_COMPONENT_REMOVAL",        // 0x1D
+                           "COMPID_MTDT_TOKEN",                   // 0x1E
+                           "COMPID_CPO_VMOD_FW"};                 // 0x1F
 
 bool FwCompsMgr::RefreshComponentsStatus(comp_status_st* ComponentStatus)
 {
@@ -1753,6 +1757,12 @@ const char* FwComponent::getCompIdStr(comps_ids_t compId)
  
          case DPA_COMPONENT_REMOVAL:
              return "DPA_COMPONENT_REMOVAL";
+
+         case COMPID_MTDT_TOKEN:
+             return "COMPID_MTDT_TOKEN";
+
+         case COMPID_CPO_VMOD_FW:
+             return "COMPID_CPO_VMOD_FW";
  
     default:
         return "UNKNOWN_COMPONENT";

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -208,7 +208,9 @@ public:
         COMPID_BFB = 0x1B,
         DPA_COMPONENT = 0x1C,
         DPA_COMPONENT_REMOVAL = 0x1D,
-        COMPID_LAST_IDX = 0x1E,
+        COMPID_MTDT_TOKEN = 0x1E,
+        COMPID_CPO_VMOD_FW = 0x1F,
+        COMPID_LAST_IDX    = 0x20,
         COMPID_UNKNOWN = 0xFFFF,
     } comps_ids_t;
 
@@ -612,6 +614,7 @@ public:
     bool runMISOC(reg_access_hca_misoc_reg_ext* bfb_component, u_int32_t type, u_int32_t query_pending);
     bool AddElsPortOffset(int& elsOffsetIndex);
     bool IsCRDTDebugSessionActive();
+    bool IsVmodSupported() { return _compsQueryMap[FwComponent::COMPID_CPO_VMOD_FW].valid; }
 
 private:
     typedef enum

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -175,7 +175,7 @@ void FImage::close()
 } // FImage::close
 
 /////////////////////////////////////////////////////////////////////////
-u_int32_t* FImage::getBuf()
+u_int32_t* FImage::getBuf(bool keepFileAccess)
 {
     if (_isFile)
     {
@@ -204,7 +204,10 @@ u_int32_t* FImage::getBuf()
                 goto cleanup;
             }
         }
-        _isFile = false;
+        if (!keepFileAccess)
+        {
+            _isFile = false;
+        }
         retBuf = (u_int32_t*)_buf.data();
     cleanup:
         fclose(fh);

--- a/mlxfwops/lib/flint_io.h
+++ b/mlxfwops/lib/flint_io.h
@@ -275,8 +275,7 @@ class MLXFWOP_API FImage : public FBase
 public:
     FImage() : FBase(false), _fname(0), _isFile(false), _len(0), _buf() {}
     virtual ~FImage() { close(); }
-
-    u_int32_t* getBuf();
+    u_int32_t* getBuf(bool keepFileAccess = false);
     u_int32_t getBufLength() { return _len; }
     virtual bool open(const char* fname, bool read_only = false, bool advErr = true);
     using FBase::open;
@@ -361,6 +360,8 @@ public:
         return (mflash*)NULL;
     }
     virtual bool is_fifth_gen() { return false; }
+    virtual const char* get_fname() { return _fname; }
+    virtual bool is_file() { return _isFile; }
 
 protected:
     const char* _fname;
@@ -379,9 +380,8 @@ public:
     FPldm() : FImage() {}
     virtual ~FPldm() { close(); }
     virtual bool open(const char* fname, bool read_only, bool advErr);
-    virtual const char* get_fname() { return _fname; }
+    using FImage::open;
 };
-
 //
 // Flash access (R/W)
 //

--- a/mlxfwops/lib/fs_pldm.cpp
+++ b/mlxfwops/lib/fs_pldm.cpp
@@ -34,6 +34,8 @@
  */
 
 #include "fs_pldm.h"
+#include "pldmlib/pldm_dev_id_record.h"
+#include "pldmlib/pldm_component_image.h"
 #ifdef MFT_LEGACY_BUILD
 #include <mft_utils.h>
 #else
@@ -58,28 +60,39 @@
 //     return true;
 // }
 
+// component are ordered by priority
+const vector<string> FsPldmOperations::SupportedComponents = {"FW", "NIC_FW", "FW_SPC6", "VMOD"};
+
 bool FsPldmOperations::FwInit()
 {
     FwInitCom();
     // memset(&_fs2ImgInfo, 0, sizeof(_fs2ImgInfo)); init is done as part of the struct constructor
-    _fwImgInfo.fwType = FIT_PLDM_1_0;
+    _fwImgInfo.fwType = FIT_PLDM;
     return true;
 }
 
 bool FsPldmOperations::LoadPldmPackage()
 {
-    FPldm* pldmAccess = dynamic_cast<FPldm*>(_ioAccess);
+    FPldm* pldmAccess = static_cast<FPldm*>(_ioAccess);
     if (!pldmAccess)
     {
         return errmsg("File is not a valid PLDM package");
     }
-    _pldmFile = std::string(pldmAccess->get_fname());
 
     PldmBuffer buff;
-    if (buff.loadFile(_pldmFile))
+    if (!pldmAccess->is_file())
     {
-        return false;
+        buff.loadBuffer((u_int8_t*)(pldmAccess->getBuf()), pldmAccess->getBufLength());
     }
+    else
+    {
+        _pldmFile = std::string(pldmAccess->get_fname());
+        if (!buff.loadFile(_pldmFile))
+        {
+            return false;
+        }
+    }
+
     if (!_pkg.unpack(buff))
     {
         return false;
@@ -107,8 +120,9 @@ bool FsPldmOperations::FwReadData(void* image, u_int32_t*, bool)
     return true;
 }
 
-bool FsPldmOperations::GetPldmComponentData(string component, string psid, u_int8_t** buff, u_int32_t& buffSize)
+bool FsPldmOperations::GetPldmComponentDataByPsid(string component, string psid, u_int8_t** buff, u_int32_t& buffSize)
 {
+    DPRINTF(("FsPldmOperations::GetPldmComponentDataByPsid\n"));
     std::string strPsid(psid);
     ComponentIdentifier compIdentifier;
     try
@@ -128,8 +142,45 @@ bool FsPldmOperations::GetPldmDescriptor(string psid, u_int16_t type, u_int16_t&
     return _pkg.getPldmDescriptorByPsid(psid, type, descriptor);
 }
 
+// return the first component data found in the PLDM package
+bool FsPldmOperations::GetComponentData(const string& pldmFile,
+                                        const vector<ComponentIdentifier>& components,
+                                        vector<u_int32_t>& buff)
+{
+    PldmBuffer pldmBuffer;
+    if (!pldmBuffer.loadFile(pldmFile))
+    {
+        return false;
+    }
+
+    PldmPkg pldmPkg;
+    if (!pldmPkg.unpack(pldmBuffer))
+    {
+        return false;
+    }
+    for (auto component : components)
+    {
+        u_int8_t* data = nullptr;
+        u_int32_t dataSize = 0;
+        if (pldmPkg.getComponentDataByPsid(component, "", &data, dataSize))
+        {
+            if (dataSize % 4 != 0)
+            {
+                delete[] data;
+                return false;
+            }
+            buff.resize(dataSize / 4);
+            memcpy(buff.data(), data, dataSize);
+            delete[] data;
+            return true;
+        }
+    }
+    return false;
+}
+
 string FsPldmOperations::GetPldmVendorDefinedDescriptor(string psid, PldmRecordDescriptor::VendorDefinedType type)
 {
+    DPRINTF(("FsPldmOperations::GetPldmVendorDefinedDescriptor\n"));
     return _pkg.getPldmVendorDefinedDescriptorByPsid(psid, type);
 }
 
@@ -139,6 +190,7 @@ bool FsPldmOperations::CreateFwOpsImage(u_int32_t* buff,
                                         u_int16_t swDevId,
                                         bool isStripedImage)
 {
+    DPRINTF(("FsPldmOperations::CreateFwOpsImage\n"));
     if (!CreateBasicImageFromData(buff, buffSize, newImageOps, swDevId, isStripedImage))
     {
         return false;
@@ -155,68 +207,222 @@ FwComponent::comps_ids_t FsPldmOperations::ToCompId(string componentName)
     return FwComponent::comps_ids_t::COMPID_UNKNOWN;
 }
 
-bool FsPldmOperations::FwQuery(fw_info_t*, bool, bool, bool, bool, bool)
+bool FsPldmOperations::FwOperationsCreate(const char* requestedPsid,
+                                        const string& componentType,
+                                        FwOperations** newImageOps,
+                                        mfile* deviceMfile)
+{
+    DPRINTF(("FsPldmOperations::FwOperationsCreate\n"));
+    u_int8_t* buff;
+    u_int32_t buffSize = 0;
+    // TODO:: look for the image with relvant psid , if not found try to extract full image and query it.
+    std::string recovery = GetPldmVendorDefinedDescriptor("", PldmRecordDescriptor::VendorDefinedType::RECOVERY);
+    // if recovery set there is no PSID descriptor - use the first image in PLDM fwpkg
+    std::string psid = requestedPsid == nullptr || !recovery.empty() ? "" : requestedPsid;
+
+    if (!GetPldmComponentDataByPsid(componentType, psid, &buff, buffSize))
+    {
+        return errmsg("Failed to get PLDM component data: %s\n", err());
+    }
+
+    u_int16_t swDevId = 0;
+    // recovery is special case, the magic-pattern present in the image and the DEVICE ID not needed
+    // VMOD is a special case, part of image and the DEVICE ID is not needed
+    if (recovery.empty() && componentType != "VMOD")
+    {
+        // use PSID or if empty take the first image in PLDM fwpkg
+        if (!psid.empty() || deviceMfile == nullptr)
+        {
+            DPRINTF(("FsPldmOperations::FwOperationsCreate: use psid to get swDevId\n"));
+            if (!GetPldmDescriptor(psid, DEV_ID_TYPE, swDevId))
+            {
+                delete[] buff;
+                return errmsg("DEVICE ID descriptor is not found in the PLDM fwpkg for PSID: %s.\n", psid.c_str());
+            }
+        }
+        // use device mfile to detect SW DEVICE ID
+        else
+        {
+            DPRINTF(("FsPldmOperations::FwOperationsCreate: use device mfile to get swDevId\n"));
+            dm_dev_id_t devid_t = DeviceUnknown;
+            u_int32_t devid = 0, revid = 0;
+            int rc = dm_get_device_id(deviceMfile, &devid_t, &devid, &revid);
+            if (rc != 0)
+            {
+                delete[] buff;
+                return errmsg("Can not detect the device type from device.\n");
+            }
+
+            swDevId = dm_dev_type2sw_id(devid_t);
+        }
+    }
+
+    if (!CreateFwOpsImage((u_int32_t*)buff, buffSize, newImageOps, swDevId, true))
+    {
+        delete[] buff;
+        return errmsg("Failed to use image from PLDM fwpkg. %s\n", err());
+    }
+
+    delete[] buff;
+    return true;
+}
+
+void FsPldmOperations::PrintInfo()
+{
+    printf("%-26s%s\n", "Image type:", "PLDM");
+
+    u_int8_t deviceRecordCount = _pkg.getDeviceIDRecordCount();
+    for (u_int8_t devIdx = 0; devIdx < deviceRecordCount; devIdx++)
+    {
+        PldmDevIdRecord* devIdRec = _pkg.getDeviceIDRecord(devIdx);
+        PrintDeviceRecord(devIdRec, devIdx);
+    }
+}
+
+void FsPldmOperations::PrintDeviceRecord(PldmDevIdRecord* devIdRec, int index)
+{
+    printf("\n");
+    char deviceRecordLabel[32];
+    sprintf(deviceRecordLabel, "Device Record[%d]:", index);
+    printf("%-26s%s\n", deviceRecordLabel, devIdRec->getComponentImageSetVersionString().c_str());
+
+    for (auto recordDescriptor : devIdRec->getRecordDescriptors())
+    {
+        recordDescriptor->printFormatted();
+    }
+
+    PrintComponents(devIdRec);
+}
+
+void FsPldmOperations::PrintComponents(PldmDevIdRecord* devIdRec)
+{
+    std::vector<PldmComponenetImage*> applicableComponents;
+    u_int16_t comps_count = _pkg.getComponentImageCount();
+    std::vector<u_int8_t> appliedComponents = devIdRec->getComponentsIndexes();
+
+    // filter related component to the corresponding device record (0 - not related)
+    for (u_int16_t i = 0; i < comps_count; i++)
+    {
+        if (appliedComponents[i] != 0)
+        {
+            applicableComponents.push_back(_pkg.getComponentByIndex(i));
+        }
+    }
+
+    std::string componentNames;
+    for (auto comp : applicableComponents)
+    {
+        ComponentIdentifier identifier = static_cast<ComponentIdentifier>(comp->getComponentIdentifier());
+        std::string componentName;
+        ComponentIdentifierToStringValue(identifier, ComponentField::Name, componentName);
+        if (!componentNames.empty())
+        {
+            componentNames += ", ";
+        }
+        componentNames += componentName;
+    }
+    printf("%-26s%s\n", "Components:", componentNames.c_str());
+
+    // Print versions
+    for (auto comp : applicableComponents)
+    {
+        comp->printFormatted();
+    }
+}
+
+bool FsPldmOperations::IsComponentInPackage(const string& psid, const string& componentName)
+{
+    if (componentName.empty())
+    {
+        return errmsg("Component name is empty");
+    }
+
+    if (std::find(SupportedComponents.begin(), SupportedComponents.end(), componentName) == SupportedComponents.end())
+    {
+        return errmsg("Component %s is not supported.", componentName.c_str());
+    }
+
+    if (!_pkg.isComponentInPackage(psid, componentName))
+    {
+        return errmsg("Component %s is not found in the PLDM package.", componentName.c_str());
+    }
+    return true;
+}
+
+string FsPldmOperations::GetFirstSupportedComponent(const string& psid)
+{
+    for (const string& component : SupportedComponents)
+    {
+        if (_pkg.isComponentInPackage(psid, component))
+        {
+            return component;
+        }
+    }
+    return "";
+}
+
+bool FsPldmOperations::FwQuery(fw_info_t* fwInfo, bool, bool, bool, bool, bool)
 {
     return true;
 }
 
-bool FsPldmOperations::FwVerify(VerifyCallBack, bool, bool, bool)
+bool FsPldmOperations::FwVerify(VerifyCallBack verifyCallBackFunc, bool isStripedImage, bool showItoc, bool ignoreDToc)
 {
     return Unsupported(__FUNCTION__);
 }
 
-bool FsPldmOperations::FwReadRom(std::vector<u_int8_t>&)
+bool FsPldmOperations::FwReadRom(std::vector<u_int8_t>& romSect)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwBurnRom(FImage*,
-                                 bool,
-                                 bool,
-                                 ProgressCallBack)
+bool FsPldmOperations::FwBurnRom(FImage* romImg,
+                                bool ignoreProdIdCheck,
+                                bool ignoreDevidCheck,
+                                ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwDeleteRom(bool, ProgressCallBack)
+bool FsPldmOperations::FwDeleteRom(bool ignoreProdIdCheck, ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwBurn(FwOperations*, u_int8_t, ProgressCallBack)
+bool FsPldmOperations::FwBurn(FwOperations* imageOps, u_int8_t forceVersion, ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwBurnAdvanced(FwOperations*, ExtBurnParams&)
+bool FsPldmOperations::FwBurnAdvanced(FwOperations* imageOps, ExtBurnParams& burnParams)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwBurnBlock(FwOperations*, ProgressCallBack)
+bool FsPldmOperations::FwBurnBlock(FwOperations* imageOps, ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetGuids(sg_params_t&, PrintCallBack, ProgressCallBack)
+bool FsPldmOperations::FwSetGuids(sg_params_t& sgParam, PrintCallBack callBackFunc, ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetMFG(fs3_uid_t, PrintCallBack)
+bool FsPldmOperations::FwSetMFG(fs3_uid_t baseGuid, PrintCallBack callBackFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetMFG(guid_t, PrintCallBack)
+bool FsPldmOperations::FwSetMFG(guid_t baseGuid, PrintCallBack callBackFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetVSD(char*, ProgressCallBack, PrintCallBack)
+bool FsPldmOperations::FwSetVSD(char* vsdStr, ProgressCallBack progressFunc, PrintCallBack printFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetVPD(char*, PrintCallBack)
+bool FsPldmOperations::FwSetVPD(char* vpdFileStr, PrintCallBack callBackFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwSetAccessKey(hw_key_t, ProgressCallBack)
+bool FsPldmOperations::FwSetAccessKey(hw_key_t userKey, ProgressCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwGetSection(u_int32_t, std::vector<u_int8_t>&, bool)
+bool FsPldmOperations::FwGetSection(u_int32_t sectType, std::vector<u_int8_t>& sectInfo, bool stripedImage)
 {
     return Unsupported(__FUNCTION__);
 }
@@ -224,7 +430,7 @@ bool FsPldmOperations::FwResetNvData()
 {
     return Unsupported(__FUNCTION__);
 }
-bool FsPldmOperations::FwShiftDevData(PrintCallBack)
+bool FsPldmOperations::FwShiftDevData(PrintCallBack progressFunc)
 {
     return Unsupported(__FUNCTION__);
 }
@@ -233,7 +439,7 @@ const char* FsPldmOperations::FwGetResetRecommandationStr()
     Unsupported(__FUNCTION__);
     return "";
 }
-bool FsPldmOperations::FwCalcMD5(u_int8_t[16])
+bool FsPldmOperations::FwCalcMD5(u_int8_t md5sum[16])
 {
     return Unsupported(__FUNCTION__);
 }

--- a/mlxfwops/lib/fs_pldm.h
+++ b/mlxfwops/lib/fs_pldm.h
@@ -60,12 +60,20 @@ class MLXFWOP_API FsPldmOperations : public FwOperations
 public:
     FsPldmOperations(FBase* ioAccess) : FwOperations(ioAccess) {}
     virtual ~FsPldmOperations() {}
-    u_int8_t FwType() override { return FIT_PLDM_1_0; }
+    u_int8_t FwType() override { return FIT_PLDM; }
     bool FwInit() override;
     bool LoadPldmPackage();
     bool GetImageSize(u_int32_t* image_size) override;
     bool FwReadData(void* image, u_int32_t* image_size, bool verbose = false) override;
     FwComponent::comps_ids_t ToCompId(string componentName);
+    bool FwOperationsCreate(const char* requestedPsid,
+                            const string& componentType,
+                            FwOperations** newImageOps,
+                            mfile* deviceMfile = NULL);
+    bool IsComponentInPackage(const string& psid, const string& componentName);
+    string GetFirstSupportedComponent(const string& psid);
+
+    void PrintInfo();
     // Unsupported functionality
     bool FwQuery(fw_info_t* fwInfo, bool, bool, bool, bool, bool) override;
     bool FwVerify(VerifyCallBack verifyCallBackFunc,
@@ -98,7 +106,7 @@ public:
     bool FwShiftDevData(PrintCallBack progressFunc = (PrintCallBack)NULL) override;
     const char* FwGetResetRecommandationStr() override;
     bool FwCalcMD5(u_int8_t md5sum[16]) override;
-    bool GetPldmComponentData(string component, string psid, u_int8_t** buff, u_int32_t& buffSize);
+    bool GetPldmComponentDataByPsid(string component, string psid, u_int8_t** buff, u_int32_t& buffSize);
     bool GetPldmDescriptor(string psid, u_int16_t type, u_int16_t& descriptor);
     string GetPldmVendorDefinedDescriptor(string psid, PldmRecordDescriptor::VendorDefinedType type);
     bool CreateFwOpsImage(u_int32_t* buff,
@@ -107,7 +115,13 @@ public:
                           u_int16_t swDevId,
                           bool isStripedImage);
 
+    static const vector<string> SupportedComponents;
+    static bool
+      GetComponentData(const string& pldmFile, const vector<ComponentIdentifier>& components, vector<u_int32_t>& buff);
+
 private:
+    void PrintDeviceRecord(PldmDevIdRecord* devIdRec, int index);
+    void PrintComponents(PldmDevIdRecord* devIdRec);
     string _pldmFile;
     PldmPkg _pkg;
     bool Unsupported(const string& msg)

--- a/mlxfwops/lib/fsctrl_ops.h
+++ b/mlxfwops/lib/fsctrl_ops.h
@@ -135,6 +135,7 @@ public:
     virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
     virtual bool IsComponentSupported(FwComponent::comps_ids_t component);
     bool getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending);
+    virtual bool IsVmodSupported() { return _fwCompsAccess->IsVmodSupported(); }
 
 
 private:

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <errno.h>
 #include <algorithm>
+#include <fstream>
 
 #include "flint_base.h"
 #include "flint_io.h"
@@ -91,7 +92,7 @@ int FwOperations::getFileSignature(const char* fname)
         // abit ugly , need to establish a correct ret val
         return IMG_SIG_OPEN_FILE_FAILED;
     }
-    if (!fgets((char*)tmpb, sizeof(tmpb), fin))
+    if (fread(tmpb, 1, sizeof(tmpb) - 1, fin) == 0)
     {
         fclose(fin);
         return IMG_SIG_OPEN_FILE_FAILED;
@@ -266,12 +267,6 @@ void FwOperations::FwInitCom()
 void FwOperations::GetFwParams(fw_ops_params_t& fwParams)
 {
     fwParams = _fwParams;
-}
-
-void FwOperations::getSupporteHwId(u_int32_t** supportedHwId, u_int32_t& supportedHwIdNum)
-{
-    *supportedHwId = _fwImgInfo.supportedHwId;
-    supportedHwIdNum = _fwImgInfo.supportedHwIdNum;
 }
 
 bool FwOperations::CheckBoot2(u_int32_t beg, u_int32_t offs, u_int32_t& next, bool fullRead, const char* pref, VerifyCallBack verifyCallBackFunc)
@@ -710,14 +705,24 @@ u_int8_t FwOperations::IsPLDM(FBase& f)
     return FS_UNKNOWN_IMG;
 }
 
+bool FwOperations::IsPLDM(const string& pldmFile)
+{
+    std::ifstream ifs(pldmFile.c_str(), std::ios::in | std::ios::binary);
+    if (ifs.fail())
+    {
+        return false;
+    }
+    u_int8_t header[16] = {0};
+    ifs.read(reinterpret_cast<char*>(header), sizeof(header));
+    return IsPLDMHeader(header);
+}
+
 bool FwOperations::IsPLDMHeader(const u_int8_t* data)
 {
-    static const size_t PLDM_HEADER_IDENTIFIER_LENGTH = 16;
     for (const auto& entry : PACKAGE_HEADER_FORMAT_REVISION_MAP)
     {
         const std::vector<u_int8_t>& identifier = entry.second;
-        if (identifier.size() == PLDM_HEADER_IDENTIFIER_LENGTH &&
-            std::equal(identifier.begin(), identifier.end(), data))
+        if (std::equal(identifier.begin(), identifier.end(), data))
         {
             return true;
         }
@@ -862,7 +867,7 @@ bool FwOperations::imageDevOperationsCreate(fw_ops_params_t& devParams, fw_ops_p
         *imgFwOps = NULL;
         return false;
     }
-    if (imgQuery.fs3_info.security_mode == SM_NONE && ignoreSecurityAttributes == false && (*imgFwOps)->FwType() != FIT_COMPS && (*imgFwOps)->FwType() != FIT_PLDM_1_0)
+    if (imgQuery.fs3_info.security_mode == SM_NONE && ignoreSecurityAttributes == false && (*imgFwOps)->FwType() != FIT_COMPS && (*imgFwOps)->FwType() != FIT_PLDM)
     {
         devParams.noFwCtrl = true;
     }
@@ -2852,6 +2857,12 @@ bool FwOperations::VerifyBranchFormat(const char* vsdString)
     return false;
 }
 
+void FwOperations::getSupportedHwId(u_int32_t** supportedHwId, u_int32_t& supportedHwIdNum)
+{
+    *supportedHwId = _fwImgInfo.supportedHwId;
+    supportedHwIdNum = _fwImgInfo.supportedHwIdNum;
+}
+
 bool FwOperations::GetDtocAddress(u_int32_t&)
 {
     return errmsg("GetDtocAddress not supported.");
@@ -2865,6 +2876,11 @@ bool FwOperations::PrintQuery()
 bool FwOperations::IsLifeCycleAccessible(chip_type_t)
 {
     return errmsg("IsLifeCycleAccessible not supported.");
+}
+
+bool FwOperations::IsVmodSupported()
+{
+    return errmsg("IsVmodSupported is not supported");
 }
 
 bool FwOperations::IsSecurityVersionViolated(u_int32_t)

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -295,7 +295,6 @@ public:
     bool restoreWriteProtectInfo();
     
     void GetFwParams(fw_ops_params_t&);
-    void getSupporteHwId(u_int32_t** supportedHwId, u_int32_t& supportedHwIdNum);
 
     static FwVersion createFwVersion(const fw_info_com_t*);
     static FwVersion createFwVersion(u_int16_t fw_ver0, u_int16_t fw_ver1, u_int16_t fw_ver2);
@@ -318,6 +317,7 @@ public:
     virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
     virtual bool IsComponentSupported(FwComponent::comps_ids_t component);
     virtual bool getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending);
+    void getSupportedHwId(u_int32_t** supportedHwId, u_int32_t& supportedHwIdNum);
     
 #ifndef UEFI_BUILD
     static bool CheckPemKeySize(const string privPemFileStr, u_int32_t& keySize);
@@ -709,6 +709,8 @@ protected:
     bool TestAndSetTimeStamp(FwOperations* imageOps);
     virtual bool VerifyBranchFormat(const char* vsdString);
     virtual bool GetDtocAddress(u_int32_t& dTocAddress);
+    virtual bool IsVmodSupported();
+    static bool IsPLDM(const string& pldmFile);
 
     // Protected Members
     FBase* _ioAccess;

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -655,7 +655,7 @@ typedef enum fw_img_type
     FIT_FSCTRL = 4,
     FIT_FS5 = 5,
     FIT_COMPS = 6,
-    FIT_PLDM_1_0 = 7
+    FIT_PLDM = 7
 } fw_img_type_t;
 
 enum ExpRomProto

--- a/mlxfwupdate/image_access.cpp
+++ b/mlxfwupdate/image_access.cpp
@@ -325,7 +325,7 @@ int ImageAccess::queryPsid(const string&  fname,
         (signature == IMG_SIG_TYPE_BIN && psid_utils::areMajorCompatible(psid.c_str(), img_query.fw_info.psid))) {
         u_int32_t* supporteHwId;
         u_int32_t  supporteHwIdNum;
-        _imgFwOps->getSupporteHwId(&supporteHwId, supporteHwIdNum);
+        _imgFwOps->getSupportedHwId(&supporteHwId, supporteHwIdNum);
         ri.found = 1;
         ri.url = fname;
         ri.pns = "";
@@ -606,8 +606,10 @@ int ImageAccess::getBufferSignature(u_int8_t* buf, u_int32_t size)
         res = IMG_SIG_TYPE_MFA;
     } else if (size >= strlen(MFA2_FINGER_PRINT) && 0 == memcmp(buf, MFA2_FINGER_PRINT, strlen(MFA2_FINGER_PRINT))) {
         res = IMG_SIG_TYPE_MFA2;
-    } else if (size >= 16 && 0 == memcmp(buf, PldmPkg::UUID, 16)) {
-        res = IMG_SIG_TYPE_PLDM;
+    } else if ((size >= headerFormatRevision1.size() && 0 == memcmp(buf, headerFormatRevision1.data(), headerFormatRevision1.size())) ||
+    (size >= headerFormatRevision3.size() && 0 == memcmp(buf, headerFormatRevision3.data(), headerFormatRevision3.size())))
+    {
+    res = IMG_SIG_TYPE_PLDM;
     }
 
     return res;
@@ -970,7 +972,7 @@ int ImageAccess::fillQueryItemFromBuffer(const string& fname,
         goto clean_up;
     }
 
-    _imgFwOps->getSupporteHwId(&supporteHwId, supporteHwIdNum);
+    _imgFwOps->getSupportedHwId(&supporteHwId, supporteHwIdNum);
     ri.found = 1;
     ri.pns = strlen(img_query.fs3_info.name) ? img_query.fs3_info.name : "";
     ri.description = strlen(img_query.fs3_info.description) ? img_query.fs3_info.description : "";

--- a/pldm_utils/pldm_utils.cpp
+++ b/pldm_utils/pldm_utils.cpp
@@ -350,3 +350,18 @@ std::string ToLower(const std::string& str)
     std::transform(lowerStr.begin(), lowerStr.end(), lowerStr.begin(), ::tolower);
     return lowerStr;
 }
+
+u_int32_t pldm_crc32(const u_int8_t* data, size_t len)
+{
+    u_int32_t crc = 0xFFFFFFFF;
+    for (size_t i = 0; i < len; i++)
+    {
+        crc ^= data[i];
+        for (int j = 0; j < 8; j++)
+        {
+            u_int32_t mask = -(crc & 1);
+            crc = (crc >> 1) ^ (0xEDB88320 & mask);
+        }
+    }
+    return ~crc;
+}

--- a/pldm_utils/pldm_utils.h
+++ b/pldm_utils/pldm_utils.h
@@ -94,6 +94,7 @@ bool ValidSizeAndFormat(const std::string& number, const u_int8_t size);
 bool readFromFile(const std::string& fname, std::string& content);
 bool WriteToFile(const std::string& fname, const std::string& content);
 bool WriteToFile(const std::string& fname, const std::vector<u_int8_t>& buff);
+u_int32_t pldm_crc32(const u_int8_t* data, size_t len);
 
 void dumpUInt8(std::vector<u_int8_t>& buff, u_int8_t val);
 void dumpUInt16(std::vector<u_int8_t>& buff, u_int16_t val);

--- a/pldmgen/pldm.cpp
+++ b/pldmgen/pldm.cpp
@@ -22,6 +22,10 @@
  #include "pldm_utils/pldm_utils.h"
  #include "pldm_time.h"
  #include "pldm_descriptor.h"
+ #include "pldmlib/pldm_buff.h"
+ #include "pldmlib/pldm_pkg.h"
+ #include "pldmlib/pldm_dev_id_record.h"
+ #include "pldmlib/pldm_record_descriptor.h"
  
  #define PACKAGE_VERSION_STR "Package Version"
  #define PACKAGE_HEADER_FORMAT_REVISION_STR "Package Header Format Revision"
@@ -456,3 +460,57 @@
          throw PLDMException("Cannot write to file %s", fname.c_str());
      }
  }
+
+void PLDM::DisableCustomPsid(const string& inputFile, const string& outputFile, const string& psid)
+{
+    PldmBuffer buff;
+    if (!buff.loadFile(inputFile))
+    {
+        throw PLDMException("Failed to load input file: %s", inputFile.c_str());
+    }
+    PldmPkg pkg;
+    if (!pkg.unpack(buff))
+    {
+        throw PLDMException("Failed to parse PLDM package from: %s", inputFile.c_str());
+    }
+
+    // if psid emty the first FD will be taken
+    PldmDevIdRecord* rec = pkg.findRecordByPsid(psid);
+    if (rec == NULL)
+    {
+        throw PLDMException("PSID '%s' not found in package.", psid.c_str());
+    }
+    PldmRecordDescriptor* psidDesc = rec->findVendorDefinedDescriptor(PldmRecordDescriptor::VendorDefinedType::PSID);
+    if (psidDesc == NULL)
+    {
+        throw PLDMException("No PSID descriptor in selected device record.");
+    }
+
+    // Position of the "minor" digit within the PSID value buffer (from start of value).
+    // Per PSID-format spec from architecture: bytes [5] and [6] are the minor digits.
+    const size_t PSID_MINOR_OFFSET = 5;
+
+    u_int16_t valueLen = psidDesc->getValueLength();
+    u_int8_t* value = psidDesc->getMutableValue();
+    if (value == NULL || valueLen == 0 || PSID_MINOR_OFFSET + 1 >= valueLen)
+    {
+        throw PLDMException("PSID value too short (length=%u) for minor edit at offset %zu.", (unsigned)valueLen,
+                            PSID_MINOR_OFFSET);
+    }
+    // Zero the two minor digits.
+    value[PSID_MINOR_OFFSET] = '0';
+    value[PSID_MINOR_OFFSET + 1] = '0';
+
+    if (!psidDesc->pack(buff))
+    {
+        throw PLDMException("Failed to pack modified PSID descriptor back into buffer.");
+    }
+    if (!pkg.recomputeHeaderChecksum(buff))
+    {
+        throw PLDMException("Failed to recompute package header checksum.");
+    }
+    if (!buff.saveFile(outputFile))
+    {
+        throw PLDMException("Failed to write output file: %s", outputFile.c_str());
+    }
+}

--- a/pldmgen/pldm.h
+++ b/pldmgen/pldm.h
@@ -39,6 +39,8 @@
                                                bool reuseComponents,
                                                const std::string& fname,
                                                bool keepDescriptorsOrder = false);
+     static void DisableCustomPsid(const std::string& inputFile, const std::string& outputFile, const std::string& psid);
+
  
  private:
      static std::string FindComponentNameByIdentifier(const std::string& identifier, const Json::Value& components);

--- a/pldmgen/pldm_arg_parser.cpp
+++ b/pldmgen/pldm_arg_parser.cpp
@@ -87,6 +87,10 @@
      {
          _parsedParams->_cmd = GEN_PLDM_PACKAGE;
      }
+     else if (command == "disable_custom_psid")
+     {
+         _parsedParams->_cmd = DISABLE_CUSTOM_PSID;
+     }
      else
      {
          cout << "Unknown command: " << command << endl;
@@ -119,6 +123,10 @@
      else if (name == "keep_descriptors_order" || name == "kdo")
      {
          _parsedParams->_keepDescriptorsOrder = true;
+     }
+     else if (name == "psid")
+     {
+         _parsedParams->_psid = value;
      }
      else if (name == "help" || name == "h")
      {
@@ -156,8 +164,11 @@
      AddOptions("rc", ' ', "", "short for reuse_components");
      AddOptions("keep_descriptors_order", ' ', "", "Keep descriptors in the order from cookbook definition");
      AddOptions("kdo", ' ', "", "short for keep_descriptors_order");
+     AddOptions("psid", ' ', "<psid>", "PSID of the FD to edit (required only when the package has multiple FDs)");
      AddOptionalSectionData("COMMANDS SUMMARY", "gen_empty_cookbook", "Generates an empty cookbook");
      AddOptionalSectionData("COMMANDS SUMMARY", "gen_pldm_package", "Generates a PLDM package");
+     AddOptionalSectionData("COMMANDS SUMMARY", "disable_custom_psid",
+                            "Zero the last 2 bytes (minor) of the PSID in an existing PLDM package");
  }
  
  /************************************
@@ -165,20 +176,22 @@
   ************************************/
  void PldmgenCmdLineParser::printUsage()
  {
-     printf("%s", _cmdParser.GetUsage().c_str());
+    printf("%s", _cmdParser.GetUsage().c_str());
  
-     printf("TEMPLATES\n");
+    printf("TEMPLATES\n");
     printf(IDENT
            "mstpldm_pkg_gen --output_file/-o <output> --components/-c 2 --device_records/-d 4 gen_empty_cookbook \n");
-     printf(
+    printf(
        IDENT
        "mstpldm_pkg_gen --cookbook_definition/-cd <cookbook_def.json> --output_file/-o <output> gen_empty_cookbook \n");
  
     printf(IDENT "mstpldm_pkg_gen --input_file/-i <input cookbook> --output_file/-o <output_pldm> gen_pldm_package \n");
- 
-     printf("\n");
-     printf("EXAMPLES\n");
+    printf(IDENT "mstpldm_pkg_gen --input_file/-i <input.fwpkg> --output_file/-o <output.fwpkg> "
+        "[--psid <CURRENT_PSID>] disable_custom_psid \n");
+
+    printf("\n");
+    printf("EXAMPLES\n");
     printf(IDENT "mstpldm_pkg_gen --cd cookbook_def.json -o cookbook.json gen_empty_cookbook\n");
     printf(IDENT "mstpldm_pkg_gen -i cookbook.json -o pldm.fwpkg gen_pldm_package\n");
+    printf(IDENT "mstpldm_pkg_gen -i in.fwpkg -o out.fwpkg disable_custom_psid\n");
  }
- 

--- a/pldmgen/pldm_params.cpp
+++ b/pldmgen/pldm_params.cpp
@@ -22,7 +22,8 @@
      _deviceRecordCount(0),
      _cookbookDefinition(""),
      _reuseComponents(false),
-     _keepDescriptorsOrder(false)
+     _keepDescriptorsOrder(false),
+     _psid("")
  {
  }
  
@@ -64,4 +65,21 @@
              throw PLDMException("Invalid arguments for gen_pldm_package. --output_file must be specified.");
          }
      }
+     else if (_cmd == DISABLE_CUSTOM_PSID)
+     {
+         if (_input_file.empty())
+         {
+             throw PLDMException("Invalid arguments for disable_custom_psid. --input_file must be specified.");
+         }
+         else if (_output_file.empty())
+         {
+             throw PLDMException("Invalid arguments for disable_custom_psid. --output_file must be specified.");
+         }
+         else if (!_cookbookDefinition.empty())
+         {
+             throw PLDMException(
+               "Invalid arguments for disable_custom_psid. --cookbook_definition is not supported for disable_custom_psid.");
+         }
+     }
  }
+ 

--- a/pldmgen/pldm_params.h
+++ b/pldmgen/pldm_params.h
@@ -21,6 +21,7 @@
      MISSING_RUN_MODE,
      GEN_EMPTY_COOKBOOK,
      GEN_PLDM_PACKAGE,
+     DISABLE_CUSTOM_PSID,
  };
  
  class CmdLineParams
@@ -34,7 +35,8 @@
      string _cookbookDefinition;
      bool _reuseComponents;
      bool _keepDescriptorsOrder;
- 
+     string _psid;
+     
      CmdLineParams();
      virtual ~CmdLineParams() = default;
      void validateInputParams();

--- a/pldmgen/pldmgen.cpp
+++ b/pldmgen/pldmgen.cpp
@@ -57,6 +57,13 @@
      }
      printf("-I- PLDM fwpkg File %s generated successfully.\n", params->_output_file.c_str());
  }
+
+void disableCustomPsid(std::unique_ptr<CmdLineParams>& params)
+{
+    PLDM::DisableCustomPsid(params->_input_file, params->_output_file, params->_psid);
+    printf("-I- Wrote %s with custom PSID disabled,PSID minor digits were set to the generic value.\n",
+            params->_output_file.c_str());
+}
  
  int Main(int argc, char* argv[])
  {
@@ -80,6 +87,10 @@
          else if (pldmgenCmdParser._parsedParams->_cmd == GEN_PLDM_PACKAGE)
          {
              genPldmPackage(pldmgenCmdParser._parsedParams);
+         }
+         else if (pldmgenCmdParser._parsedParams->_cmd == DISABLE_CUSTOM_PSID)
+         {
+             disableCustomPsid(pldmgenCmdParser._parsedParams);
          }
          else
          {

--- a/pldmlib/pldm_buff.cpp
+++ b/pldmlib/pldm_buff.cpp
@@ -1,50 +1,51 @@
 /*
- * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_buff.cpp
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
+* Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* OpenIB.org BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* pldm_buff.cpp
+*
+*  Created on: Feb 27, 2019
+*      Author: Samer Deeb
+*/
+
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <string>
 
-#include <compatibility.h>
+#include "common/compatibility.h"
 
 #include "pldm_buff.h"
 
-PldmBuffer::PldmBuffer() : m_buff(NULL), m_pos(0), m_size(0) {}
+PldmBuffer::PldmBuffer() : m_fname(""), m_buff(NULL), m_pos(0), m_size(0) {}
 
 PldmBuffer::~PldmBuffer()
 {
@@ -53,13 +54,26 @@ PldmBuffer::~PldmBuffer()
 
 void PldmBuffer::reset()
 {
-    if (m_buff)
+    if (m_buff != NULL)
     {
         delete[] m_buff;
-        m_buff = NULL;
     }
+    m_fname = "";
+    m_buff = NULL;
     m_pos = 0;
     m_size = 0;
+}
+
+void PldmBuffer::loadBuffer(u_int8_t* data, size_t size)
+{
+    // Clean up existing buffer if it exists
+    reset();
+
+    // Allocate new memory
+    m_buff = new u_int8_t[size];
+    memcpy(m_buff, data, size);
+    m_size = static_cast<long>(size);
+    m_pos = 0;
 }
 
 bool PldmBuffer::loadFile(const std::string& fname)
@@ -91,11 +105,16 @@ bool PldmBuffer::loadFile(const std::string& fname)
         return false;
     }
 
-    // Read file contents into buffer
-    size_t read_size = fread(m_buff, m_size, 1, fp);
-    fclose(fp);
+    m_fname = fname;
 
-    return (read_size == (size_t)m_size);
+    // Read file contents into buffer
+    size_t read_size = fread(m_buff, 1, m_size, fp);
+    fclose(fp);
+    if (read_size == (size_t)m_size)
+    {
+        return true;
+    }
+    return false;
 }
 
 void PldmBuffer::read(u_int8_t& val)
@@ -132,6 +151,11 @@ void PldmBuffer::read(u_int8_t* arr, size_t arr_size)
     m_pos += arr_size;
 }
 
+std::string PldmBuffer::getFname() const
+{
+    return m_fname;
+}
+
 int PldmBuffer::seek(long offset, int whence)
 {
     long new_pos = -1;
@@ -160,4 +184,39 @@ int PldmBuffer::seek(long offset, int whence)
 long PldmBuffer::tell()
 {
     return m_pos;
+}
+
+bool PldmBuffer::writeAt(size_t offset, const u_int8_t* data, size_t len)
+{
+    if (m_buff == NULL || data == NULL)
+    {
+        return false;
+    }
+    size_t size = (m_size < 0) ? 0 : (size_t)m_size;
+    if (offset > size)
+    {
+        return false;
+    }
+    if (len > size - offset)
+    {
+        return false;
+    }
+    memcpy(m_buff + offset, data, len);
+    return true;
+}
+
+bool PldmBuffer::saveFile(const std::string& fname) const
+{
+    if (m_buff == NULL || m_size <= 0)
+    {
+        return false;
+    }
+    FILE* fp = fopen(fname.c_str(), "wb");
+    if (!fp)
+    {
+        return false;
+    }
+    size_t written = fwrite(m_buff, 1, m_size, fp);
+    fclose(fp);
+    return written == (size_t)m_size;
 }

--- a/pldmlib/pldm_buff.h
+++ b/pldmlib/pldm_buff.h
@@ -1,53 +1,53 @@
 /*
- * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_utils.h
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
+* Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* OpenIB.org BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* pldm_utils.h
+*
+*  Created on: Feb 27, 2019
+*      Author: Samer Deeb
+*/
 
 #ifndef _PLDM_BUFF_H_
 #define _PLDM_BUFF_H_
 #include <string>
-#include <compatibility.h>
+#include "common/compatibility.h"
 
 class PldmBuffer
 {
 public:
     PldmBuffer();
     virtual ~PldmBuffer();
-    void reset();
-
+    void loadBuffer(u_int8_t* data, size_t size);
     bool loadFile(const std::string& fname);
+    void reset();
 
     void read(u_int8_t& val);
     void read(u_int16_t& val);
@@ -57,8 +57,15 @@ public:
 
     int seek(long offset, int whence);
     long tell();
+    std::string getFname() const;
+
+    bool writeAt(size_t offset, const u_int8_t* data, size_t len);
+    bool saveFile(const std::string& fname) const;
+    const u_int8_t* data() const { return m_buff; }
+    size_t size() const { return (size_t)m_size; }
 
 private:
+    std::string m_fname;
     u_int8_t* m_buff;
     long m_pos;
     long m_size;

--- a/pldmlib/pldm_component_image.cpp
+++ b/pldmlib/pldm_component_image.cpp
@@ -1,47 +1,46 @@
 /*
- * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_buff.cpp
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
+* Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* OpenIB.org BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* pldm_buff.cpp
+*
+*  Created on: Feb 27, 2019
+*      Author: Samer Deeb
+*/
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <errno.h>
 #include <string>
 
 #include "pldm_buff.h"
 #include "pldm_component_image.h"
+#include "pldm_utils/pldm_utils.h"
 
 PldmComponenetImage::PldmComponenetImage() :
     componentClassification(0),
@@ -93,16 +92,11 @@ bool PldmComponenetImage::readComponentData(PldmBuffer& buff)
     return true;
 }
 
-void PldmComponenetImage::print(FILE* fp)
+void PldmComponenetImage::printFormatted() const
 {
-    fprintf(fp, "componentClassification: 0x%X\n", componentClassification);
-    fprintf(fp, "componentIdentifier: 0x%X\n", componentIdentifier);
-    fprintf(fp, "componentComparisonStamp: 0x%X\n", componentComparisonStamp);
-    fprintf(fp, "componentOptions: 0x%X\n", componentOptions);
-    fprintf(fp, "requestedComponentActivationMethod: 0x%X\n", requestedComponentActivationMethod);
-    fprintf(fp, "componentLocationOffset: 0x%X\n", componentLocationOffset);
-    fprintf(fp, "componentSize: 0x%X\n", componentSize);
-    fprintf(fp, "componentVersionStringType: 0x%X\n", componentVersionStringType);
-    fprintf(fp, "componentVersionStringLength: 0x%X\n", componentVersionStringLength);
-    fprintf(fp, "componentVersionString: %s\n", componentVersionString.c_str());
+    ComponentIdentifier identifier = static_cast<ComponentIdentifier>(componentIdentifier);
+    std::string componentName;
+    ComponentIdentifierToStringValue(identifier, ComponentField::Name, componentName);
+    std::string label = componentName + " Version:";
+    printf("  %-24s%s\n", label.c_str(), componentVersionString.c_str());
 }

--- a/pldmlib/pldm_component_image.h
+++ b/pldmlib/pldm_component_image.h
@@ -1,39 +1,39 @@
 /*
- * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_utils.h
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
+* Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* OpenIB.org BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* pldm_utils.h
+*
+*  Created on: Feb 27, 2019
+*      Author: Samer Deeb
+*/
 
 #ifndef _PLDM_COMPONENET_IMAGE_
 #define _PLDM_COMPONENET_IMAGE_
@@ -44,12 +44,11 @@ public:
     PldmComponenetImage();
     virtual ~PldmComponenetImage();
     bool unpack(PldmBuffer& buff);
-    void print(FILE* fp);
+    void printFormatted() const;
     u_int32_t getComponentSize() const { return componentSize; }
     const u_int8_t* getComponentData() const { return componentData; }
     u_int16_t getComponentIdentifier() const { return componentIdentifier; }
     std::string getcomponentVersionString() const { return componentVersionString; }
-
 
 private:
     bool readComponentData(PldmBuffer& buff);

--- a/pldmlib/pldm_dev_id_record.cpp
+++ b/pldmlib/pldm_dev_id_record.cpp
@@ -35,7 +35,6 @@
  *      Author: Samer Deeb
  */
 
-#include <stdlib.h>
 #include <stdio.h>
 #include <string>
 #include <vector>
@@ -104,30 +103,6 @@ bool PldmDevIdRecord::unpack(PldmBuffer& buff)
     return true;
 }
 
-void PldmDevIdRecord::print(FILE* fp)
-{
-    fprintf(fp, "recordLength: 0x%X\n", recordLength);
-    fprintf(fp, "descriptorCount: 0x%X\n", descriptorCount);
-    fprintf(fp, "deviceUpdateOptionFlags: 0x%X\n", deviceUpdateOptionFlags);
-    fprintf(fp, "componentImageSetVersionStringType: 0x%X\n", componentImageSetVersionStringType);
-    fprintf(fp, "componentImageSetVersionStringLength: 0x%X\n", componentImageSetVersionStringLength);
-    fprintf(fp, "firmwareDevicePackageDataLength: 0x%X\n", firmwareDevicePackageDataLength);
-    if (componentBitmapBitLength)
-    {
-        u_int8_t applicableComponentsLen = componentBitmapBitLength / 8;
-        for (u_int8_t i = 0; i < applicableComponentsLen; i++)
-        {
-            fprintf(fp, "applicableComponents[%d]: 0x%X\n", i, applicableComponents[i]);
-        }
-    }
-    fprintf(fp, "componentImageSetVersionString: %s\n", componentImageSetVersionString.c_str());
-    for (u_int8_t i = 0; i < descriptorCount; i++)
-    {
-        fprintf(fp, "recordDescriptors[%d]:\n", i);
-        recordDescriptors[i]->print(fp);
-    }
-}
-
 // return the first component in devRecord - using only for pldmlib_test.
 int PldmDevIdRecord::getComponentImageIndex() const
 {
@@ -172,29 +147,20 @@ std::vector<u_int8_t> PldmDevIdRecord::getComponentsIndexes() const
 
 std::string PldmDevIdRecord::GetVendorDefinedValue(PldmRecordDescriptor::VendorDefinedType type) const
 {
-    std::string vendorDefinedValue = "";
-    auto it =
-      std::find_if(recordDescriptors.begin(), recordDescriptors.end(),
-                   [&](PldmRecordDescriptor* descriptor) { return descriptor->GetVendorDefinedType() == type; });
-    if (it != recordDescriptors.end())
-    {
-        vendorDefinedValue = (*it)->GetVendorDefinedValue();
-    }
-    return vendorDefinedValue;
+    PldmRecordDescriptor* desc = findVendorDefinedDescriptor(type);
+    return desc ? desc->GetVendorDefinedValue(type) : std::string();
 }
 
-std::string PldmDevIdRecord::getDescription() const
+PldmRecordDescriptor* PldmDevIdRecord::findVendorDefinedDescriptor(PldmRecordDescriptor::VendorDefinedType type) const
 {
-    std::string description;
-    for (u_int8_t i = 0; i < descriptorCount - 1; i++)
+    for (PldmRecordDescriptor* desc : recordDescriptors)
     {
-        description += (recordDescriptors[i]->getDescription() + ", ");
+        if (desc->GetVendorDefinedType() == type)
+        {
+            return desc;
+        }
     }
-    if (descriptorCount > 0)
-    {
-        description += recordDescriptors[descriptorCount - 1]->getDescription();
-    }
-    return description;
+    return NULL;
 }
 
 bool PldmDevIdRecord::getDescriptor(u_int16_t type, u_int16_t& descriptor) const
@@ -205,7 +171,7 @@ bool PldmDevIdRecord::getDescriptor(u_int16_t type, u_int16_t& descriptor) const
         if (type == recordDescriptors[i]->getDescriptorType())
         {
             descriptor =
-              (recordDescriptors[i]->getDescriptorData()[1] << 8) | recordDescriptors[i]->getDescriptorData()[0];
+            (recordDescriptors[i]->getDescriptorData()[1] << 8) | recordDescriptors[i]->getDescriptorData()[0];
             found = true;
         }
     }

--- a/pldmlib/pldm_dev_id_record.h
+++ b/pldmlib/pldm_dev_id_record.h
@@ -40,8 +40,6 @@
 #include <vector>
 #include "pldm_record_descriptor.h"
 
-class PldmRecordDescriptor;
-
 class PldmDevIdRecord
 {
 public:
@@ -50,10 +48,12 @@ public:
     bool unpack(PldmBuffer& buff);
     int getComponentImageIndex() const;
     std::vector<u_int8_t> getComponentsIndexes() const;
+    std::vector<PldmRecordDescriptor*> getRecordDescriptors() const { return recordDescriptors; };
     std::string GetVendorDefinedValue(PldmRecordDescriptor::VendorDefinedType type) const;
-    std::string getDescription() const;
+    PldmRecordDescriptor* findVendorDefinedDescriptor(PldmRecordDescriptor::VendorDefinedType type) const;
+    std::string getComponentImageSetVersionString() const { return componentImageSetVersionString; };
     bool getDescriptor(u_int16_t type, u_int16_t& descriptor) const;
-    void print(FILE* fp);
+
     void reset();
 
 private:

--- a/pldmlib/pldm_pkg.cpp
+++ b/pldmlib/pldm_pkg.cpp
@@ -34,8 +34,7 @@
  *  Created on: Feb 27, 2019
  *      Author: Samer Deeb
  */
-
-#include <stdlib.h>
+ 
 #include <stdio.h>
 #include <string>
 #include <vector>
@@ -43,15 +42,12 @@
 #include <cstring>
 
 #include "pldm_buff.h"
-#include "pldm_pkg_hdr.h"
 #include "pldm_dev_id_record.h"
 #include "pldm_component_image.h"
 #include "pldm_pkg.h"
+#include "pldm_utils/pldm_utils.h"
 
-const u_int8_t PldmPkg::UUID[] = {0xF0, 0x18, 0x87, 0x8C, 0xCB, 0x7D, 0x49, 0x43,
-                                  0x98, 0x00, 0xA0, 0x2F, 0x05, 0x9A, 0xCA, 0x02};
-
-PldmPkg::PldmPkg() : deviceIDRecordCount(0), componentImageCount(0) {}
+PldmPkg::PldmPkg() : deviceIDRecordCount(0), componentImageCount(0), packageHeaderChecksum(0) {}
 
 PldmPkg::~PldmPkg()
 {
@@ -70,6 +66,7 @@ void PldmPkg::reset()
         delete componentImages.back();
         componentImages.pop_back();
     }
+    psidRecordMap.clear();
     deviceIDRecordCount = 0;
     componentImageCount = 0;
     packageHeader.reset();
@@ -77,6 +74,7 @@ void PldmPkg::reset()
 
 bool PldmPkg::unpack(PldmBuffer& buff)
 {
+    reset();
     if (!packageHeader.unpack(buff))
     {
         return false;
@@ -93,10 +91,13 @@ bool PldmPkg::unpack(PldmBuffer& buff)
             return false;
         }
         deviceIDRecords.push_back(deviceIDRecord);
-        psidImageMap[deviceIDRecord->GetVendorDefinedValue(PldmRecordDescriptor::VendorDefinedType::PSID)] =
-          deviceIDRecord->getComponentImageIndex();
-        psidComponentsMap[deviceIDRecord->GetVendorDefinedValue(PldmRecordDescriptor::VendorDefinedType::PSID)] =
-          deviceIDRecord->getComponentsIndexes();
+        std::string psid = deviceIDRecord->GetVendorDefinedValue(PldmRecordDescriptor::VendorDefinedType::PSID);
+        psidRecordMap[psid] = deviceIDRecord;
+    }
+    // downstream device record support is added in revision 3 and above
+    if (packageHeader.getPackageHeaderFormatRevision() >= FIRST_REVISION_SUPPORTED_DOWNSTREAM_DEVICES)
+    {
+        buff.read(downstreamDeviceRecordCount);
     }
     buff.read(componentImageCount);
     for (u_int8_t i = 0; i < componentImageCount; i++)
@@ -109,34 +110,51 @@ bool PldmPkg::unpack(PldmBuffer& buff)
     return true;
 }
 
-void PldmPkg::print(FILE* fp)
+bool PldmPkg::isComponentInPackage(const std::string& psid, const std::string& componentName) const
 {
-    fprintf(fp, "packageHeader:\n");
-    packageHeader.print(fp);
-    fprintf(fp, "deviceIDRecordCount: 0x%X\n", deviceIDRecordCount);
-    u_int8_t i;
-    for (i = 0; i < deviceIDRecordCount; i++)
+    PldmDevIdRecord* rec = findRecordByPsid(psid);
+    if (rec == NULL)
     {
-        fprintf(fp, "deviceIDRecords[%d]:\n", i);
-        deviceIDRecords[i]->print(fp);
+        return false;
     }
-    fprintf(fp, "componentImageCount: 0x%X\n", componentImageCount);
-    for (i = 0; i < componentImageCount; i++)
+    std::vector<u_int8_t> componentsIndexes = rec->getComponentsIndexes();
+
+    ComponentIdentifier componentIdentifier;
+    StringToComponentIdentifier(componentName, componentIdentifier);
+
+    for (u_int8_t i = 0; i < componentsIndexes.size(); i++)
     {
-        fprintf(fp, "componentImages[%d]:\n", i);
-        componentImages[i]->print(fp);
+        if (componentsIndexes[i] == 0)
+        {
+            continue;
+        }
+        PldmComponenetImage* ComponentImage = getComponentByIndex(i);
+        ComponentIdentifier currentComponentIdentifier =
+        static_cast<ComponentIdentifier>(ComponentImage->getComponentIdentifier());
+        std::string currentComponentName;
+        ComponentIdentifierToStringValue(currentComponentIdentifier, ComponentField::Name, currentComponentName);
+        if (currentComponentName == componentName ||
+            (isNicFwComponent(currentComponentIdentifier) &&
+            isNicFwComponent(componentIdentifier))) // 2 components for nic image FW, NIC_FW
+        {
+            return true;
+        }
     }
-    fprintf(fp, "packageHeaderChecksum: 0x%X\n", packageHeaderChecksum);
+    return false;
 }
 
 const PldmComponenetImage* PldmPkg::getImageByPsid(const std::string& psid) const
 {
-    PsidImageMap::const_iterator it = psidImageMap.find(psid);
-    if (it == psidImageMap.end())
+    PldmDevIdRecord* rec = findRecordByPsid(psid);
+    if (rec == NULL)
+    {
         return NULL;
-    int location = it->second;
+    }
+    int location = rec->getComponentImageIndex();
     if (location == -1 || location >= componentImageCount)
+    {
         return NULL;
+    }
     return componentImages[location];
 }
 
@@ -157,7 +175,7 @@ bool PldmPkg::getPldmDescriptorByPsid(std::string psid, u_int16_t type, u_int16_
 }
 
 std::string PldmPkg::getPldmVendorDefinedDescriptorByPsid(std::string psid,
-    PldmRecordDescriptor::VendorDefinedType type) const
+                                                        PldmRecordDescriptor::VendorDefinedType type) const
 {
     std::string descriptor = "";
     for (auto devIdRec : deviceIDRecords)
@@ -171,9 +189,12 @@ std::string PldmPkg::getPldmVendorDefinedDescriptorByPsid(std::string psid,
     }
     return descriptor;
 }
-
 bool PldmPkg::isPsidInPldm(std::string psid) const
 {
+    if (psid.empty())
+    {
+        return true;
+    }
     bool found = false;
     for (auto devIdRec : deviceIDRecords)
     {
@@ -186,9 +207,9 @@ bool PldmPkg::isPsidInPldm(std::string psid) const
 }
 
 bool PldmPkg::getComponentDataByPsid(ComponentIdentifier compIdentifier,
-                                     std::string psid,
-                                     u_int8_t** buff,
-                                     u_int32_t& buffSize)
+                                    std::string psid,
+                                    u_int8_t** buff,
+                                    u_int32_t& buffSize)
 {
     bool found = false;
     for (auto devIdRec : deviceIDRecords)
@@ -208,7 +229,7 @@ bool PldmPkg::getComponentDataByPsid(ComponentIdentifier compIdentifier,
 
                 PldmComponenetImage* ComponentImage = getComponentByIndex(i);
                 ComponentIdentifier identifier =
-                  static_cast<ComponentIdentifier>(ComponentImage->getComponentIdentifier());
+                static_cast<ComponentIdentifier>(ComponentImage->getComponentIdentifier());
                 if (identifier == compIdentifier ||
                     (isNicFwComponent(compIdentifier) && isNicFwComponent(identifier))) // 2 components for nic image
                                                                                         // FW, NIC_FW
@@ -231,4 +252,41 @@ bool PldmPkg::getComponentDataByPsid(ComponentIdentifier compIdentifier,
         }
     }
     return found;
+}
+
+PldmDevIdRecord* PldmPkg::findRecordByPsid(const std::string& psid) const
+{
+    if (deviceIDRecords.empty())
+    {
+        return NULL;
+    }
+    if (psid.empty())
+    {
+        return deviceIDRecords[0];
+    }
+    PsidRecordMap::const_iterator it = psidRecordMap.find(psid);
+    return (it == psidRecordMap.end()) ? NULL : it->second;
+}
+
+bool PldmPkg::recomputeHeaderChecksum(PldmBuffer& buff) const
+{
+    u_int16_t headerSize = packageHeader.getPackageHeaderSize();
+    if (headerSize < sizeof(u_int32_t))
+    {
+        return false;
+    }
+    size_t bufSize = buff.size();
+    if ((size_t)headerSize > bufSize)
+    {
+        return false;
+    }
+    // CRC is the last dword of the header; packageHeaderSize includes it.
+    size_t checksumOffset = (size_t)headerSize - sizeof(u_int32_t);
+    if (checksumOffset > bufSize)
+    {
+        return false;
+    }
+    u_int32_t newCrc = pldm_crc32(buff.data(), checksumOffset);
+    u_int32_t le = __cpu_to_le32(newCrc);
+    return buff.writeAt(checksumOffset, (const u_int8_t*)&le, sizeof(le));
 }

--- a/pldmlib/pldm_pkg.h
+++ b/pldmlib/pldm_pkg.h
@@ -1,39 +1,39 @@
 /*
- * Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_utils.h
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
+* Copyright (c) 2020-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+*
+* This software is available to you under a choice of one of two
+* licenses.  You may choose to be licensed under the terms of the GNU
+* General Public License (GPL) Version 2, available from the file
+* COPYING in the main directory of this source tree, or the
+* OpenIB.org BSD license below:
+*
+*     Redistribution and use in source and binary forms, with or
+*     without modification, are permitted provided that the following
+*     conditions are met:
+*
+*      - Redistributions of source code must retain the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer.
+*
+*      - Redistributions in binary form must reproduce the above
+*        copyright notice, this list of conditions and the following
+*        disclaimer in the documentation and/or other materials
+*        provided with the distribution.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* pldm_utils.h
+*
+*  Created on: Feb 27, 2019
+*      Author: Samer Deeb
+*/
 
 #ifndef _PLDM_PKG_H_
 #define _PLDM_PKG_H_
@@ -58,11 +58,8 @@ public:
     void reset();
 
     bool unpack(PldmBuffer& buff);
-    void print(FILE* fp);
 
     const PldmComponenetImage* getImageByPsid(const std::string& psid) const;
-
-    static const u_int8_t UUID[];
 
     u_int8_t getDeviceIDRecordCount() const { return deviceIDRecordCount; }
     u_int16_t getComponentImageCount() const { return componentImageCount; }
@@ -75,21 +72,22 @@ public:
                                 u_int32_t& buffSize);
     bool getPldmDescriptorByPsid(std::string psid, u_int16_t type, u_int16_t& descriptor) const;
     std::string getPldmVendorDefinedDescriptorByPsid(std::string psid,
-        PldmRecordDescriptor::VendorDefinedType type) const;
+                                                    PldmRecordDescriptor::VendorDefinedType type) const;
     bool isPsidInPldm(std::string psid) const;
+    bool isComponentInPackage(const std::string& psid, const std::string& componentName) const;
 
+    PldmDevIdRecord* findRecordByPsid(const std::string& psid) const;
+    bool recomputeHeaderChecksum(PldmBuffer& buff) const;
 
 private:
-    typedef std::map<std::string, int> PsidImageMap;
-    PsidImageMap psidImageMap;
-
-    typedef std::map<std::string, std::vector<u_int8_t>> PsidComponentsMap;
-    PsidComponentsMap psidComponentsMap;
+    typedef std::map<std::string, PldmDevIdRecord*> PsidRecordMap;
+    PsidRecordMap psidRecordMap;
 
     PldmPkgHdr packageHeader;
     u_int8_t deviceIDRecordCount;
     std::vector<PldmDevIdRecord*> deviceIDRecords;
     u_int16_t componentImageCount;
+    u_int8_t downstreamDeviceRecordCount;
     std::vector<PldmComponenetImage*> componentImages;
     u_int32_t packageHeaderChecksum;
 };

--- a/pldmlib/pldm_record_descriptor.cpp
+++ b/pldmlib/pldm_record_descriptor.cpp
@@ -1,54 +1,19 @@
-/*
- * Copyright (c) 2020-2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
- *
- * This software is available to you under a choice of one of two
- * licenses.  You may choose to be licensed under the terms of the GNU
- * General Public License (GPL) Version 2, available from the file
- * COPYING in the main directory of this source tree, or the
- * OpenIB.org BSD license below:
- *
- *     Redistribution and use in source and binary forms, with or
- *     without modification, are permitted provided that the following
- *     conditions are met:
- *
- *      - Redistributions of source code must retain the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer.
- *
- *      - Redistributions in binary form must reproduce the above
- *        copyright notice, this list of conditions and the following
- *        disclaimer in the documentation and/or other materials
- *        provided with the distribution.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
- * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
- * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
- * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
- * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- * SOFTWARE.
- *
- * pldm_buff.cpp
- *
- *  Created on: Feb 27, 2019
- *      Author: Samer Deeb
- */
-
-#include <stdlib.h>
 #include <stdio.h>
 #include <string>
+#include <algorithm>
+#include <vector>
 
 #include "pldm_buff.h"
 #include "pldm_record_descriptor.h"
 
 PldmRecordDescriptor::PldmRecordDescriptor() :
+    bufferOffset(0),
     descriptorType(0),
     descriptorLength(0),
     descriptorData(NULL),
     vendorDefinedType(VendorDefinedType::NOT_VENDOR_DEFINED),
-    vendorDefinedValue(""),
-    apsku(0)
+    vendorDefinedStringValue(""),
+    vendorDefinedNumericValue(0)
 {
 }
 
@@ -62,6 +27,7 @@ PldmRecordDescriptor::~PldmRecordDescriptor()
 
 bool PldmRecordDescriptor::unpack(PldmBuffer& buff)
 {
+    bufferOffset = buff.tell();
     buff.read(descriptorType);
     buff.read(descriptorLength);
     if (descriptorLength)
@@ -91,18 +57,23 @@ bool PldmRecordDescriptor::extractVendorDefined()
         vendoreDefinedPtr += prefixlen;
         if (descriptorName == "PSID")
         {
-            vendorDefinedValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
+            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
             vendorDefinedType = VendorDefinedType::PSID;
         }
         else if (descriptorName == "recovery")
         {
-            vendorDefinedValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
+            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
             vendorDefinedType = VendorDefinedType::RECOVERY;
         }
         else if (descriptorName == "APSKU")
         {
-            apsku = __cpu_to_le32(*reinterpret_cast<u_int32_t*>(vendoreDefinedPtr));
+            vendorDefinedNumericValue = __cpu_to_le32(*reinterpret_cast<u_int32_t*>(vendoreDefinedPtr));
             vendorDefinedType = VendorDefinedType::APSKU;
+        }
+        else if (descriptorName == "GLACIERDSD")
+        {
+            vendorDefinedNumericValue = __cpu_to_le32(*reinterpret_cast<u_int32_t*>(vendoreDefinedPtr));
+            vendorDefinedType = VendorDefinedType::GLACIERDSD;
         }
         else
         {
@@ -112,44 +83,170 @@ bool PldmRecordDescriptor::extractVendorDefined()
     return true;
 }
 
-void PldmRecordDescriptor::print(FILE* fp)
+bool PldmRecordDescriptor::IsStringVendorDefinedType(const PldmRecordDescriptor::VendorDefinedType type) const
 {
-    fprintf(fp, "descriptorType: 0x%X ", descriptorType);
-    fprintf(fp, "descriptorLength: 0x%X ", descriptorLength);
-    fprintf(fp, "data: %s\n", getDescription().c_str());
+    static const std::vector<VendorDefinedType> stringTypes = {
+      VendorDefinedType::PSID,
+      VendorDefinedType::RECOVERY,
+    };
+    return std::find(stringTypes.begin(), stringTypes.end(), type) != stringTypes.end();
 }
 
-std::string PldmRecordDescriptor::getDescription() const
+bool PldmRecordDescriptor::IsNumericVendorDefinedType(const PldmRecordDescriptor::VendorDefinedType type) const
 {
-    char description[256] = {'\0'};
+    static const std::vector<VendorDefinedType> numericTypes = {
+      VendorDefinedType::APSKU,
+      VendorDefinedType::GLACIERDSD,
+    };
+    return std::find(numericTypes.begin(), numericTypes.end(), type) != numericTypes.end();
+}
+
+std::string PldmRecordDescriptor::GetVendorDefinedValue(const VendorDefinedType type) const
+{
+    if (IsStringVendorDefinedType(type))
+    {
+        return vendorDefinedStringValue;
+    }
+    else if (IsNumericVendorDefinedType(type))
+    {
+        return std::to_string(vendorDefinedNumericValue);
+    }
+    return "";
+}
+
+u_int16_t PldmRecordDescriptor::getValueOffset() const
+{
+    // Vendor-defined descriptors carry an inline metadata prefix before the value:
+    //   descriptorData[0]      : title-string-type (1 byte, e.g. 0x01 = ASCII)
+    //   descriptorData[1]      : title-string-len  (1 byte, length of the title that follows)
+    //   descriptorData[2..2+N-1]: title-string     (N bytes, e.g. "PSID")
+    //   descriptorData[2+N..]  : the actual value bytes
+    // Non-vendor-defined descriptors have no prefix; the value is the whole descriptorData.
+    if (descriptorData == NULL || descriptorType != Vendor_Defined || descriptorLength < 2)
+    {
+        return 0;
+    }
+    // +2 accounts for the two fixed header bytes (title-string-type + title-string-len);
+    // descriptorData[1] holds the title-string length, so the total prefix to skip is 2 + that.
+    size_t valueOffset = (size_t)2 + descriptorData[1];
+    if (valueOffset > descriptorLength)
+    {
+        return 0;
+    }
+    return (u_int16_t)valueOffset;
+}
+
+u_int8_t* PldmRecordDescriptor::getMutableValue()
+{
+    if (descriptorData == NULL)
+    {
+        return NULL;
+    }
+    u_int16_t valueOffset = getValueOffset();
+    if (valueOffset == 0)
+    {
+        return NULL;
+    }
+    return descriptorData + valueOffset;
+}
+
+u_int16_t PldmRecordDescriptor::getValueLength() const
+{
+    u_int16_t offset = getValueOffset();
+    if (offset == 0 || offset > descriptorLength)
+    {
+        return 0;
+    }
+    return (u_int16_t)(descriptorLength - offset);
+}
+
+bool PldmRecordDescriptor::pack(PldmBuffer& buff) const
+{
+    if (descriptorData == NULL || bufferOffset < 0)
+    {
+        return false;
+    }
+    size_t off = (size_t)bufferOffset;
+
+    u_int16_t typeLE = __cpu_to_le16(descriptorType);
+    if (!buff.writeAt(off, (const u_int8_t*)&typeLE, sizeof(typeLE)))
+    {
+        return false;
+    }
+    off += sizeof(typeLE);
+
+    u_int16_t lenLE = __cpu_to_le16(descriptorLength);
+    if (!buff.writeAt(off, (const u_int8_t*)&lenLE, sizeof(lenLE)))
+    {
+        return false;
+    }
+    off += sizeof(lenLE);
+
+    if (descriptorLength == 0)
+    {
+        return true;
+    }
+    return buff.writeAt(off, descriptorData, descriptorLength);
+}
+
+void PldmRecordDescriptor::printFormatted() const
+{
+    const int LABEL_WIDTH = 26;
     switch (descriptorType)
     {
         case PCI_Vendor_ID:
-            sprintf(description, "PCI Vendor ID: 0x%02x%02x", descriptorData[1], descriptorData[0]);
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PCI Vendor ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case IANA_Enterprise_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "IANA Enterprise ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case FD_UUID:
+            printf("%-*s%s\n", LABEL_WIDTH, "FD UUID:", descriptorData);
+            break;
+        case PnP_Vendor_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PnP Vendor ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case ACPI_Vendor_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "ACPI Vendor ID:", descriptorData[1], descriptorData[0]);
             break;
         case PCI_Device_ID:
-            sprintf(description, "PCI Device ID: 0x%02x%02x", descriptorData[1], descriptorData[0]);
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PCI Device ID:", descriptorData[1], descriptorData[0]);
             break;
         case PCI_Subsystem_Vendor_ID:
-            sprintf(description, "PCI Subsystem Vendor ID: 0x%02x%02x", descriptorData[1], descriptorData[0]);
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PCI Subsystem Vendor ID:", descriptorData[1], descriptorData[0]);
             break;
         case PCI_Subsystem_ID:
-            sprintf(description, "PCI Subsystem ID: 0x%02x%02x", descriptorData[1], descriptorData[0]);
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PCI Subsystem ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case PCI_Revision_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PCI Revision ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case PnP_Product_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PnP Product ID:", descriptorData[1], descriptorData[0]);
+            break;
+        case ACPI_Product_ID:
+            printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "ACPI Product ID:", descriptorData[1], descriptorData[0]);
             break;
         case Vendor_Defined:
             if (vendorDefinedType == VendorDefinedType::PSID)
             {
-                sprintf(description, "PSID: %s", vendorDefinedValue.c_str());
+                printf("%-*s%s\n", LABEL_WIDTH, "PSID:", vendorDefinedStringValue.c_str());
             }
             else if (vendorDefinedType == VendorDefinedType::RECOVERY)
             {
-                sprintf(description, "RECOVERY: %s", vendorDefinedValue.c_str());
+                printf("%-*s%s\n", LABEL_WIDTH, "RECOVERY:", vendorDefinedStringValue.c_str());
             }
             else if (vendorDefinedType == VendorDefinedType::APSKU)
             {
-                sprintf(description, "APSKU: 0x%08X", apsku);
+                printf("%-*s0x%08X\n", LABEL_WIDTH, "APSKU:", vendorDefinedNumericValue);
+            }
+            else if (vendorDefinedType == VendorDefinedType::GLACIERDSD)
+            {
+                printf("%-*s0x%08X\n", LABEL_WIDTH, "GLACIERDSD:", vendorDefinedNumericValue);
             }
             break;
+        default:
+            printf("%-*s0x%04X\n", LABEL_WIDTH, "Unknown:", descriptorType);
+            break;
     }
-    return description;
 }

--- a/pldmlib/pldm_record_descriptor.h
+++ b/pldmlib/pldm_record_descriptor.h
@@ -38,8 +38,8 @@
 #ifndef _PLDM_RECORD_DESCRIPTOR_HDR_
 #define _PLDM_RECORD_DESCRIPTOR_HDR_
 
-
-
+#include <vector>
+#include <algorithm>
 
 class PldmRecordDescriptor
 {
@@ -50,30 +50,41 @@ public:
         PSID = 0x0001,
         APSKU = 0x0002,
         RECOVERY = 0x0003,
+        GLACIERDSD = 0x0004,
     };
-    
+
     PldmRecordDescriptor();
     virtual ~PldmRecordDescriptor();
 
     bool unpack(PldmBuffer& buff);
-    void print(FILE* fp);
+    void printFormatted() const;
 
-    const std::string& GetVendorDefinedValue() const { return vendorDefinedValue; }
     VendorDefinedType GetVendorDefinedType() const { return vendorDefinedType; }
+    std::string GetVendorDefinedValue(const VendorDefinedType type) const;
     u_int16_t getDescriptorLength() const { return descriptorLength; }
     const u_int8_t* getDescriptorData() const { return descriptorData; }
-    std::string getDescription() const;
     u_int16_t getDescriptorType() const { return descriptorType; }
 
+    u_int8_t* getMutableValue();
+    u_int16_t getValueLength() const;
+    bool pack(PldmBuffer& buff) const;
+
 private:
+    long bufferOffset;
     u_int16_t descriptorType;
     u_int16_t descriptorLength;
     u_int8_t* descriptorData;
 
-    VendorDefinedType vendorDefinedType;
-    std::string vendorDefinedValue;
-    u_int32_t apsku;
+    u_int16_t getValueOffset() const;
 
+    VendorDefinedType vendorDefinedType;
+    std::string vendorDefinedStringValue;
+    u_int32_t vendorDefinedNumericValue;
+
+    const std::string& GetVendorDefinedStringValue() const { return vendorDefinedStringValue; }
+    u_int32_t GetVendorDefinedNumericValue() const { return vendorDefinedNumericValue; }
+    bool IsStringVendorDefinedType(const PldmRecordDescriptor::VendorDefinedType type) const;
+    bool IsNumericVendorDefinedType(const PldmRecordDescriptor::VendorDefinedType type) const;
     bool extractVendorDefined();
     enum
     {


### PR DESCRIPTION
[flint][pldm_pkg_gen] add fwpkg package_info query and disable_custom_psid

Description:
  - flint: add `--package_info q` for fwpkg images so users can inspect PLDM packages (device records, components, version) without burning. Wires getFileSignature → FPldm path and adds FsPldmOperations::PrintInfo / PrintDeviceRecord / PrintComponents.

  - pldmgen: add `disable_custom_psid` subcommand to mstpldm_pkg_gen. Loads a fwpkg, looks up the device record by PSID (empty PSID = first record), patches the PSID minor digits in-place via the new PldmRecordDescriptor mutators, recomputes the package header CRC32, and writes the result back.

Tested OS: linux
Tested devices: n/a
Tested flows: pldm_pkg_gen -i <input.fwpkg> -o <output.fwpkg> disable_custom_psid mstflint -i cx7.fwpkg --package_info q

Known gaps (with RM ticket): None

Issue: 5024384