### PR TITLE
[mlxfwupdate] Fix PLDM file detection passing wrong buffer size

### DIFF
--- a/mlxfwupdate/image_access.cpp
+++ b/mlxfwupdate/image_access.cpp
@@ -440,7 +440,7 @@ clean_up:
 
 int ImageAccess::getFileSignature(const string& fname)
 {
-    static const int header_size = 16;
+    static const u_int32_t header_size = 16;
     FILE           * fin;
     char             tmpb[header_size];
     int              res = -2;
@@ -453,7 +453,7 @@ int ImageAccess::getFileSignature(const string& fname)
         if (1 > fread(tmpb, header_size, 1, fin)) {
             break;
         }
-        res = getBufferSignature((u_int8_t*)tmpb, 4);
+        res = getBufferSignature((u_int8_t*)tmpb, header_size);
     } while (0);
 
     if (fin) {
@@ -753,7 +753,7 @@ string ImageAccess::getLog()
 bool ImageAccess::loadPldmPkg(const string& fname)
 {
     _pldm_buff.reset();
-    if (_pldm_buff.loadFile(fname))
+    if (!_pldm_buff.loadFile(fname))
     {
         return false;
     }


### PR DESCRIPTION
Description:
getFileSignature() was passing hardcoded size 4 to getBufferSignature() while the buffer is 16 bytes. This caused PLDM packages to never be classified as IMG_SIG_TYPE_PLDM, breaking mlxfwmanager -i <fwpkg> -l.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: N/A
Tested flows: mlxfwmanager -i <fwpkg> -l

Known gaps (with RM ticket):

Issue: 5075526