### PR TITLE
[mstfwmanager] fix PLDM package parsing failure in loadPldmPkg

### DIFF
--- a/mlxfwupdate/image_access.cpp
+++ b/mlxfwupdate/image_access.cpp
@@ -574,7 +574,7 @@ clean_up:
 
 int ImageAccess::getFileSignature(const string& fname)
 {
-    static const int header_size = 16;
+    static const u_int32_t header_size = 16;
     FILE           * fin = NULL;
     char             tmpb[header_size];
     int              res = -2;
@@ -1174,7 +1174,7 @@ clean_up:
 bool ImageAccess::loadPldmPkg(const string& fname)
 {
     _pldm_buff.reset();
-    if (_pldm_buff.loadFile(fname))
+    if (!_pldm_buff.loadFile(fname))
     {
         return false;
     }


### PR DESCRIPTION
Description:
PldmBuffer::loadFile returns true on success, but the condition in loadPldmPkg was missing the negation — causing it to always return false for valid .fwpkg files, which resulted in "Error parsing file" for any PLDM firmware package passed to -l or -i.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: mstfwmanager -d 08:00.0  -i /mswg/projects/tool_vfn/bin_images_ca che/07_06_2026/ARGAMAN/PLDMS/mc_fw_MT_0000001590.fwpkg -u --force

Known gaps (with RM ticket):

Issue: 5075526