### PR TITLE
Title : [mlxdpa] Add --remove_all_dpa_apps flag to create_dpa_app_rem…

### DIFF
--- a/mlxdpa/dpaAppRemoval.cpp
+++ b/mlxdpa/dpaAppRemoval.cpp
@@ -38,11 +38,11 @@
 #include <iostream>
 #include <cstring>
 
-DpaAppRemoveMetadata::DpaAppRemoveMetadata(u_int32_t dpaAppUUID[4], u_int32_t keypairUUID[4])
+DpaAppRemoveMetadata::DpaAppRemoveMetadata(u_int32_t dpaAppUUID[4], u_int32_t keypairUUID[4], bool removeAll) :
+    _removeAll(removeAll)
 {
     memcpy(_dpaAppUUID, dpaAppUUID, DPA_APP_UUID_SIZE);
     memcpy(_keypairUUID, keypairUUID, KEY_PAIR_UUID_SIZE);
-    _reserved = 0x0;
 }
 
 vector<u_int8_t> DpaAppRemoveMetadata::Serialize()
@@ -53,7 +53,7 @@ vector<u_int8_t> DpaAppRemoveMetadata::Serialize()
     memcpy(serializedData.data(), _dpaAppUUID, DPA_APP_UUID_SIZE);
     CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
     memcpy(serializedData.data() + DPA_APP_UUID_SIZE, _keypairUUID, KEY_PAIR_UUID_SIZE);
-    serializedData[DPA_APP_UUID_SIZE + KEY_PAIR_UUID_SIZE] = _reserved;
+    serializedData[REMOVE_ALL_OFFSET] |= (_removeAll ? 1 : 0);
 
     return serializedData;
 }
@@ -64,5 +64,5 @@ void DpaAppRemoveMetadata::Deserialize(vector<u_int8_t> buf)
     CPUTOn(_dpaAppUUID, sizeof(_dpaAppUUID) / 4);
     memcpy(_keypairUUID, buf.data() + DPA_APP_UUID_SIZE, KEY_PAIR_UUID_SIZE);
     CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
-    _reserved = buf[DPA_APP_UUID_SIZE + KEY_PAIR_UUID_SIZE];
+    _removeAll = buf[REMOVE_ALL_OFFSET] & 1;
 }

--- a/mlxdpa/dpaAppRemoval.h
+++ b/mlxdpa/dpaAppRemoval.h
@@ -49,22 +49,25 @@ using namespace std;
 class DpaAppRemoveMetadata
 {
 public:
-    DpaAppRemoveMetadata(u_int32_t dpaAppUUID[4], u_int32_t keypairUUID[4]);
+    DpaAppRemoveMetadata(u_int32_t dpaAppUUID[4], u_int32_t keypairUUID[4], bool removeAll = false);
     virtual ~DpaAppRemoveMetadata() {}
 
     vector<u_int8_t> Serialize();
     void Deserialize(vector<u_int8_t> buf);
     u_int16_t GetSize() { return METADATA_SIZE; };
     DpaAppStructHeader::StructType GetType() { return DpaAppStructHeader::StructType::DPA_APP_REMOVE_METADATA; };
+    bool IsRemoveAll() { return _removeAll != 0; }
     static const u_int32_t KEY_PAIR_UUID_SIZE = 16;
     static const u_int32_t DPA_APP_UUID_SIZE = 16;
-    static const u_int32_t RESERVED_SIZE = 4;
+    static const u_int32_t REMOVE_ALL_FLAG_SIZE = 1;
+    static const u_int32_t RESERVED_SIZE = 3;
+    static const u_int32_t REMOVE_ALL_OFFSET = KEY_PAIR_UUID_SIZE + DPA_APP_UUID_SIZE;
 
 private:
     const u_int16_t METADATA_SIZE = 0x24;
     u_int32_t _dpaAppUUID[4];
     u_int32_t _keypairUUID[4];
-    u_int32_t _reserved;
+    u_int8_t _removeAll;
 };
 
 class DpaAppRemoveSignature

--- a/mlxdpa/mlxdpa.cpp
+++ b/mlxdpa/mlxdpa.cpp
@@ -87,6 +87,7 @@
  const string MlxDpa::CERT_UUID_FLAG = "cert_uuid";
  const string MlxDpa::DPA_APP_UUID_FLAG = "dpa_app_uuid";
  const string MlxDpa::REMOVE_ALL_CERTS_FLAG = "remove_all_certs";
+ const string MlxDpa::REMOVE_ALL_DPA_APPS_FLAG = "remove_all_dpa_apps";
  const string MlxDpa::CERT_CONTAINER_FLAG = "cert_container";
  const string MlxDpa::DPA_APP_REMOVAL_CONTAINER_FLAG = "dpa_app_removal_container";
  const string MlxDpa::CERT_CONTAINER_TYPE_FLAG = "cert_container_type";
@@ -137,6 +138,7 @@
      _dpaAppUUID{0, 0, 0, 0},
      _removeAllCertsSpecified(false),
      _removeAllCerts(false),
+     _removeAllDpaApps(false),
      _certContainerPath(""),
      _dpaAppRemovalContainerPath(""),
      _certContainerType(CertContainerType::UnknownType),
@@ -183,6 +185,8 @@
      printFlagLine(DPA_APP_UUID_FLAG, ' ', "UUID", "Time base UUID generated right before signing");
      printFlagLine(REMOVE_ALL_CERTS_FLAG, ' ', "",
                    "Remove all CA Certificates, provide with the sign_cert_remove command");
+     printFlagLine(REMOVE_ALL_DPA_APPS_FLAG, ' ', "",
+                   "Remove all DPA apps from device, provide with the create_dpa_app_removal command");
      printFlagLine(DPA_APP_REMOVAL_CONTAINER_FLAG, ' ', "Path", "Path to a dpa app removal container to sign");
      printFlagLine(CERT_CONTAINER_FLAG, ' ', "Path", "Path to a certificate container to sign");
      printFlagLine(CERT_CONTAINER_TYPE_FLAG, ' ', "Add/Remove", "Type of certificate container to create");
@@ -265,6 +269,10 @@
        "mstdpa --dpa_app_uuid 7c0ab0fc-082e-11ee-bd9d-e43d1a1f06ae -o /tmp/dpa_app_removal_container.bin --life_cycle_priority OEM create_dpa_app_removal");
      printf(
        INDENT2 "%-52s: %s\n",
+       "Create remove all DPA apps container",
+       "mstdpa --remove_all_dpa_apps -o /tmp/dpa_app_removal_container.bin --life_cycle_priority OEM create_dpa_app_removal");
+     printf(
+       INDENT2 "%-52s: %s\n",
        "Sign Dpa app removal container",
        "mstdpa --dpa_app_removal_container /tmp/dpa_app_removal_container.bin --keypair_uuid 3c8f46b2-159f-11ee-9ac4-e43d1a1f06ae -p /tmp/p_key.pem"
        "-o /tmp/signed_dpa_app_removal_container.bin --life_cycle_priority OEM sign_dpa_app_removal");
@@ -290,6 +298,7 @@
      AddOptions(CERT_UUID_FLAG, ' ', "<uuid>", "RFC-4122 compliant time-based UUID.");
      AddOptions(DPA_APP_UUID_FLAG, ' ', "<uuid>", "RFC-4122 compliant time-based UUID.");
      AddOptions(REMOVE_ALL_CERTS_FLAG, ' ', "", "Remove all CA Certificates.");
+     AddOptions(REMOVE_ALL_DPA_APPS_FLAG, ' ', "", "Remove all DPA apps from device.");
      AddOptions(DPA_APP_REMOVAL_CONTAINER_FLAG, ' ', "<path>", "dpa app removal container to sign.");
      AddOptions(CERT_CONTAINER_FLAG, ' ', "<path>", "Certificate container to sign.");
      AddOptions(CERT_CONTAINER_TYPE_FLAG, ' ', "<Add/Remove>", "Type of certificate container to create.");
@@ -429,6 +438,11 @@
          {
              throw MlxDpaException("remove_all_certs can be provided only with containter type \"remove\".");
          }
+         return PARSE_OK;
+     }
+     else if (name == REMOVE_ALL_DPA_APPS_FLAG)
+     {
+         _removeAllDpaApps = true;
          return PARSE_OK;
      }
      else if (name == NO_COMPRESSION_FLAG)
@@ -594,9 +608,13 @@
          {
              throw MlxDpaException("Output file path must be specified to create dpa app removal container.");
          }
-         if (!_dpaAppUUIDSpecified)
+         if (_dpaAppUUIDSpecified && _removeAllDpaApps)
          {
-             throw MlxDpaException("dpa app uuid must be specified to create dpa app removal container.");
+             throw MlxDpaException("--dpa_app_uuid and --remove_all_dpa_apps are mutually exclusive.");
+         }
+         if (!_dpaAppUUIDSpecified && !_removeAllDpaApps)
+         {
+             throw MlxDpaException("dpa app uuid must be specified or --remove_all_dpa_apps flag must be set.");
          }
      }
      else if (_command == CreateDPACertContainer)
@@ -820,7 +838,7 @@ vector<CertContainerItem> MlxDpa::GetCertContainer(CertContainerType type)
  
      const string X = SINGLE_APP_DPA_FINGERPRINT;
  
-     DpaAppRemoveMetadata dpaAppRemovalMetadata(_dpaAppUUID, _keypairUUID);
+     DpaAppRemoveMetadata dpaAppRemovalMetadata(_dpaAppUUID, _keypairUUID, _removeAllDpaApps);
      vector<u_int8_t> serializedMetadata = dpaAppRemovalMetadata.Serialize();
      DpaAppStructHeader headerDpaAppRemovalMetadata(_priority, DpaAppStructHeader::StructType::DPA_APP_REMOVE_METADATA,
                                                     serializedMetadata.size());
@@ -870,7 +888,8 @@ void MlxDpa::CreateCertContainer()
  
      if (dpaRemoveContainer.size() < SINGLE_APP_DPA_FINGERPRINT.size() + DpaAppStructHeader::HEADER_SIZE_NO_AUTH +
                                        DpaAppRemoveMetadata::KEY_PAIR_UUID_SIZE +
-                                       DpaAppRemoveMetadata::DPA_APP_UUID_SIZE + DpaAppRemoveMetadata::RESERVED_SIZE)
+                                       DpaAppRemoveMetadata::DPA_APP_UUID_SIZE +
+                                       DpaAppRemoveMetadata::REMOVE_ALL_FLAG_SIZE + DpaAppRemoveMetadata::RESERVED_SIZE)
      {
          throw MlxDpaException("Invalid dpa app removal container.");
      }

--- a/mlxdpa/mlxdpa.h
+++ b/mlxdpa/mlxdpa.h
@@ -124,6 +124,7 @@
      static const string CERT_UUID_FLAG;
      static const string DPA_APP_UUID_FLAG;
      static const string REMOVE_ALL_CERTS_FLAG;
+     static const string REMOVE_ALL_DPA_APPS_FLAG;
      static const string CERT_CONTAINER_FLAG;
      static const string CERT_CONTAINER_TYPE_FLAG;
      static const string DPA_APP_REMOVAL_CONTAINER_FLAG;
@@ -166,6 +167,7 @@
      u_int32_t _dpaAppUUID[4];
      bool _removeAllCertsSpecified;
      bool _removeAllCerts;
+     bool _removeAllDpaApps;
      string _certContainerPath;
      string _dpaAppRemovalContainerPath;
      CertContainerType _certContainerType;


### PR DESCRIPTION
Description:
Add support for removing all DPA applications from a device in a single operation, without requiring a specific app UUID. This is needed for selective attested wipe during BF4 re-provisioning between customer tenants (OCI use case).

Changes:
- dpaAppRemoval.h/cpp: replace reserved u_int32_t field with u_int8_t _removeAll at offset 0x20 (bit 0), matching the CACertRemove pattern. Add REMOVE_ALL_FLAG_SIZE = 1 and RESERVED_SIZE = 3 constants. Add REMOVE_ALL_OFFSET = 32 constant. Update constructor, Serialize(), and Deserialize() accordingly.
- mlxdpa.h/cpp: add --remove_all_dpa_apps CLI flag. When set, remove_all bit is 1 and dpa_app_uuid defaults to {0,0,0,0}. --dpa_app_uuid and --remove_all_dpa_apps are mutually exclusive. Neither flag is an error.

Known gaps (with RM ticket): no

Issue: #4612705