### PR TITLE
[pldm] disable_custom_psid: add --minor_version, sync APSKU byte

### DIFF
--- a/mft_utils/mft_utils.cpp
+++ b/mft_utils/mft_utils.cpp
@@ -65,6 +65,8 @@ bool strToNum(const string& str, u_int32_t& num, int base)
 {
     char* endp;
     char* numStr = strcpy(new char[str.size() + 1], str.c_str());
+    // clear errno
+    errno = 0;
     num = strtoul(numStr, &endp, base);
     if (*endp)
     {

--- a/pldmgen/pldm.cpp
+++ b/pldmgen/pldm.cpp
@@ -13,6 +13,7 @@
  #include "pldm.h"
 
  #include <algorithm>
+ #include <cstdio>
  #include <fstream>
  
  #include <json/reader.h>
@@ -461,8 +462,52 @@
      }
  }
 
-void PLDM::DisableCustomPsid(const string& inputFile, const string& outputFile, const string& psid)
+// Write `count` bytes into the selected record's vendor-defined descriptor of `type` at `offset`,
+// then repack it into the buffer.
+static bool setVendorDescriptorBytes(PldmDevIdRecord* rec,
+                                     PldmRecordDescriptor::VendorDefinedType type,
+                                     size_t offset,
+                                     const u_int8_t* bytes,
+                                     size_t count,
+                                     PldmBuffer& buff)
 {
+    PldmRecordDescriptor* desc = rec->findVendorDefinedDescriptor(type);
+    if (desc == NULL)
+    {
+        return false;
+    }
+    u_int8_t* value = desc->getMutableValue();
+    if (value == NULL || desc->getValueLength() < offset + count)
+    {
+        return false;
+    }
+    for (size_t i = 0; i < count; i++)
+    {
+        value[offset + i] = bytes[i];
+    }
+    if (!desc->pack(buff))
+    {
+        throw PLDMException("Failed to pack modified descriptor back into buffer.");
+    }
+    return true;
+}
+
+void PLDM::DisableCustomPsid(const string& inputFile,
+                             const string& outputFile,
+                             const string& psid,
+                             const string& minorVersion)
+{
+    // Convert the validated minor value to a single byte; both the PSID (ASCII) and the
+    // APSKU (numeric) edits use this one byte.
+    u_int32_t minorNum = 0;
+    if (!mft_utils::strToNum(minorVersion, minorNum, 16) || minorNum > 0xFF)
+    {
+        throw PLDMException("Invalid minor version '%s'; expected a hex byte (00-FF).", minorVersion.c_str());
+    }
+    u_int8_t minorByte = (u_int8_t)minorNum;
+    char minorHex[3];
+    snprintf(minorHex, sizeof(minorHex), "%02X", minorByte);
+
     PldmBuffer buff;
     if (!buff.loadFile(inputFile))
     {
@@ -480,31 +525,27 @@ void PLDM::DisableCustomPsid(const string& inputFile, const string& outputFile, 
     {
         throw PLDMException("PSID '%s' not found in package.", psid.c_str());
     }
-    PldmRecordDescriptor* psidDesc = rec->findVendorDefinedDescriptor(PldmRecordDescriptor::VendorDefinedType::PSID);
-    if (psidDesc == NULL)
-    {
-        throw PLDMException("No PSID descriptor in selected device record.");
-    }
 
-    // Position of the "minor" digit within the PSID value buffer (from start of value).
+    // Set the PSID minor digits (uppercase ASCII hex of the chosen byte).
     // Per PSID-format spec from architecture: bytes [5] and [6] are the minor digits.
     const size_t PSID_MINOR_OFFSET = 5;
-
-    u_int16_t valueLen = psidDesc->getValueLength();
-    u_int8_t* value = psidDesc->getMutableValue();
-    if (value == NULL || valueLen == 0 || PSID_MINOR_OFFSET + 1 >= valueLen)
+    // Convert the minor version to two bytes (ASCII hex of the chosen byte)
+    u_int8_t psidMinor[2] = {(u_int8_t)minorHex[0], (u_int8_t)minorHex[1]};
+    if (!setVendorDescriptorBytes(rec, PldmRecordDescriptor::VendorDefinedType::PSID, PSID_MINOR_OFFSET, psidMinor, 2,
+                                  buff))
     {
-        throw PLDMException("PSID value too short (length=%u) for minor edit at offset %zu.", (unsigned)valueLen,
-                            PSID_MINOR_OFFSET);
+        throw PLDMException("No PSID descriptor in selected record, or PSID value too short for minor edit.");
     }
-    // Zero the two minor digits.
-    value[PSID_MINOR_OFFSET] = '0';
-    value[PSID_MINOR_OFFSET + 1] = '0';
 
-    if (!psidDesc->pack(buff))
+    // Keep the APSKU descriptor's minor byte consistent. APSKU is stored little-endian, so its
+    // most-significant byte (offset 3) tracks the PSID minor. An absent/short APSKU is skipped.
+    const size_t APSKU_MINOR_BYTE_OFFSET = 3;
+    if (!setVendorDescriptorBytes(rec, PldmRecordDescriptor::VendorDefinedType::APSKU, APSKU_MINOR_BYTE_OFFSET,
+                                  &minorByte, 1, buff))
     {
-        throw PLDMException("Failed to pack modified PSID descriptor back into buffer.");
+        printf("-I- APSKU descriptor absent or too short in selected record; APSKU byte not updated.\n");
     }
+
     if (!pkg.recomputeHeaderChecksum(buff))
     {
         throw PLDMException("Failed to recompute package header checksum.");

--- a/pldmgen/pldm.h
+++ b/pldmgen/pldm.h
@@ -39,7 +39,10 @@
                                                bool reuseComponents,
                                                const std::string& fname,
                                                bool keepDescriptorsOrder = false);
-     static void DisableCustomPsid(const std::string& inputFile, const std::string& outputFile, const std::string& psid);
+     static void DisableCustomPsid(const std::string& inputFile,
+                                  const std::string& outputFile,
+                                  const std::string& psid,
+                                  const std::string& minorVersion);
 
  
  private:

--- a/pldmgen/pldm_arg_parser.cpp
+++ b/pldmgen/pldm_arg_parser.cpp
@@ -128,6 +128,10 @@
      {
          _parsedParams->_psid = value;
      }
+     else if (name == "minor_version")
+     {
+         _parsedParams->_minorVersion = value;
+     }
      else if (name == "help" || name == "h")
      {
          printUsage();
@@ -165,10 +169,13 @@
      AddOptions("keep_descriptors_order", ' ', "", "Keep descriptors in the order from cookbook definition");
      AddOptions("kdo", ' ', "", "short for keep_descriptors_order");
      AddOptions("psid", ' ', "<psid>", "PSID of the FD to edit (required only when the package has multiple FDs)");
+     AddOptions("minor_version", ' ', "<XX>",
+                "Minor byte (2 hex digits, e.g. 1A or 0x1A) to set in the PSID and matching APSKU byte; default 00");
      AddOptionalSectionData("COMMANDS SUMMARY", "gen_empty_cookbook", "Generates an empty cookbook");
      AddOptionalSectionData("COMMANDS SUMMARY", "gen_pldm_package", "Generates a PLDM package");
-     AddOptionalSectionData("COMMANDS SUMMARY", "disable_custom_psid",
-                            "Zero the last 2 bytes (minor) of the PSID in an existing PLDM package");
+     AddOptionalSectionData(
+       "COMMANDS SUMMARY", "disable_custom_psid",
+       "Set the PSID minor digits and matching APSKU byte in an existing PLDM package (default 00)");
  }
  
  /************************************
@@ -187,7 +194,7 @@
  
     printf(IDENT "mstpldm_pkg_gen --input_file/-i <input cookbook> --output_file/-o <output_pldm> gen_pldm_package \n");
     printf(IDENT "mstpldm_pkg_gen --input_file/-i <input.fwpkg> --output_file/-o <output.fwpkg> "
-        "[--psid <CURRENT_PSID>] disable_custom_psid \n");
+        "[--psid <CURRENT_PSID>] [--minor_version <XX>] disable_custom_psid \n");
 
     printf("\n");
     printf("EXAMPLES\n");

--- a/pldmgen/pldm_params.cpp
+++ b/pldmgen/pldm_params.cpp
@@ -23,7 +23,8 @@
      _cookbookDefinition(""),
      _reuseComponents(false),
      _keepDescriptorsOrder(false),
-     _psid("")
+     _psid(""),
+     _minorVersion("00")
  {
  }
  
@@ -79,6 +80,11 @@
          {
              throw PLDMException(
                "Invalid arguments for disable_custom_psid. --cookbook_definition is not supported for disable_custom_psid.");
+         }
+         else if (!ValidSizeAndFormat(_minorVersion, 1))
+         {
+             throw PLDMException("Invalid --minor_version '%s'; expected a hex byte (e.g. 1A or 0x1A).",
+                                 _minorVersion.c_str());
          }
      }
  }

--- a/pldmgen/pldm_params.h
+++ b/pldmgen/pldm_params.h
@@ -36,7 +36,8 @@
      bool _reuseComponents;
      bool _keepDescriptorsOrder;
      string _psid;
-     
+     string _minorVersion;
+
      CmdLineParams();
      virtual ~CmdLineParams() = default;
      void validateInputParams();

--- a/pldmgen/pldmgen.cpp
+++ b/pldmgen/pldmgen.cpp
@@ -60,9 +60,9 @@
 
 void disableCustomPsid(std::unique_ptr<CmdLineParams>& params)
 {
-    PLDM::DisableCustomPsid(params->_input_file, params->_output_file, params->_psid);
-    printf("-I- Wrote %s with custom PSID disabled,PSID minor digits were set to the generic value.\n",
-            params->_output_file.c_str());
+    PLDM::DisableCustomPsid(params->_input_file, params->_output_file, params->_psid, params->_minorVersion);
+    printf("-I- Wrote %s: PSID minor digit (and APSKU byte if present) set to %s.\n", params->_output_file.c_str(),
+           params->_minorVersion.c_str());
 }
  
  int Main(int argc, char* argv[])


### PR DESCRIPTION
Description:
Add an optional --minor_version flag to the disable_custom_psid subcommand so the PSID minor digits can be set to a chosen hex byte (default 00 keeps the previous behavior), and patch the matching byte (offset 3) of the FD's APSKU descriptor so it stays consistent with the PSID minor. Only that one APSKU byte is changed and the descriptor is never regenerated; an absent or too-short APSKU is skipped with a note. The shared descriptor-edit logic is extracted into a helper.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: N/A
Tested flows: pldm_pkg_gen -i <input.fwpkg> -o <output.fwpkg> [--minor_version <XX>] disable_custom_psid

Known gaps (with RM ticket):

Issue: 5091937
Change-Id: Id342ce91dd0900c42c1d9d1b436ab6e9c645dd5b