### PR TITLE
[mlxconfig][pldm] Support reading NV config from PLDM package

### DIFF
--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -44,6 +44,7 @@ AM_CPPFLAGS = \
     -I$(top_srcdir)/dev_mgt \
     -I$(top_srcdir)/cmdif \
     -I$(top_srcdir)/tools_res_mgmt \
+    -I$(top_srcdir)/mflash \
     $(libxml2_CFLAGS) \
     $(openssl_CFLAGS)
 
@@ -89,6 +90,12 @@ libmlxcfg_la_LIBADD = $(libmlxcfg_la_DEPENDENCIES) ${LDL}
 
 mstconfig_DEPENDENCIES = \
     libmlxcfg.la \
+    $(top_builddir)/mlxfwops/lib/libmlxfwops.a \
+    $(top_builddir)/pldmlib/libpldm.la \
+    $(top_builddir)/libmfa/libmfa.la \
+    $(top_builddir)/ext_libs/minixz/libminixz.la \
+    $(top_builddir)/mflash/libmflash.la \
+    $(top_builddir)/tools_crypto/libtools_crypto.a \
     $(top_builddir)/mft_utils/libmftutils.la \
     $(top_builddir)/cmdif/libcmdif.la \
     $(top_builddir)/reg_access/libreg_access.la \
@@ -125,6 +132,10 @@ mstconfig_LDADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 libmlxcfg_la_LIBADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 else
 AM_CXXFLAGS += -DNO_OPEN_SSL
+endif
+
+if ENABLE_DPA
+mstconfig_DEPENDENCIES += $(top_builddir)/mlxdpa/libmstdpa.a
 endif
 
 mstconfig_SOURCES =  mlxcfg_ui.h mlxcfg_parser.cpp mlxcfg_ui.cpp

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -56,6 +56,7 @@
 #include "mlxcfg_utils.h"
 #include "mft_utils/mft_utils.h"
 #include "common/tools_string.h"
+#include "mlxfwops/lib/fs_pldm.h"
 
 using nbu::mft::common::string_format;
 
@@ -1586,6 +1587,17 @@ mlxCfgStatus MlxCfg::readBinFile(string fileName, vector<u_int32_t>& buff)
 
 mlxCfgStatus MlxCfg::readNVInputFile(vector<u_int32_t>& buff)
 {
+    if (FwOperations::IsPLDM(_mlxParams.NVInputFile))
+    {
+        if (FsPldmOperations::GetComponentData(
+              _mlxParams.NVInputFile,
+              {ComponentIdentifier::Identifier_OEM_NVCONFIG_Comp, ComponentIdentifier::Identifier_MLNX_NVCONFIG_Comp},
+              buff))
+        {
+            return MLX_CFG_OK;
+        }
+        return err(true, "Failed to read PLDM file: %s", _mlxParams.NVInputFile.c_str());
+    }
     return readBinFile(_mlxParams.NVInputFile, buff);
 }
 

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -316,6 +316,7 @@ public:
     virtual bool GetSecureHostState(u_int8_t& state);
     virtual bool ChangeSecureHostState(bool disable, u_int64_t key);
     virtual bool IsComponentSupported(FwComponent::comps_ids_t component);
+    static bool IsPLDM(const string& pldmFile);
     virtual bool getBFBComponentsVersions(std::map<std::string, std::string>& name_to_version, bool pending);
     void getSupportedHwId(u_int32_t** supportedHwId, u_int32_t& supportedHwIdNum);
     
@@ -710,7 +711,6 @@ protected:
     virtual bool VerifyBranchFormat(const char* vsdString);
     virtual bool GetDtocAddress(u_int32_t& dTocAddress);
     virtual bool IsVmodSupported();
-    static bool IsPLDM(const string& pldmFile);
 
     // Protected Members
     FBase* _ioAccess;


### PR DESCRIPTION
Description:
mlxconfig apply now accepts a PLDM firmware package as input in addition to a raw binary NV config file — the tool transparently detects the format and extracts the NVCONFIG component when a PLDM package is provided.

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: /dev/mst/mt4131_pciconf0
Tested flows: mlxconfig -d /dev/mst/mt4131_pciconf0 -t HCA apply <pldm_file>

Known gaps (with RM ticket):

Issue: 5024310
Change-Id: I1e2314204a434f4e2090b7b5e485c638f314b531