### PR TITLE
Mlxlink |Add bonus loopback port support on Spectrum-4+ devices

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -91,6 +91,9 @@ void MlxlinkCommander::updatePortInfo()
     {
         checkValidFW();
     }
+
+    updateBonusPortStatus();
+
     if (!(_mf->tp == MST_PCICONF && (dm_is_gpu(static_cast<dm_dev_id_t>(_devID)))))
     {
         getProductTechnology();
@@ -115,6 +118,8 @@ void MlxlinkCommander::updatePortInfo()
         initValidDPNList();
     }
     updateDPNDomain();
+
+    checkBonusPortAllowedCommands();
 }
 
 void MlxlinkCommander::checkIBDeviceCompatibility()
@@ -226,6 +231,7 @@ MlxlinkCommander::MlxlinkCommander() : _userInput()
     _isSwControled = false;
     _isSwControledStandAlone = false;
     _pcieMgmtSupported = false;
+    _isBonusPort = false;
     _ignoreIbFECCheck = true;
     _isNVLINK = false;
     _isNvlinkModeA = false;
@@ -432,15 +438,13 @@ void MlxlinkCommander::checkValidFW()
     }
 }
 
-u_int32_t MlxlinkCommander::getTechnologyFromMGIR()
-{
-    sendPrmReg(ACCESS_REG_MGIR, REG_GET);
-
-    return getFieldValue("technology");
-}
-
 void MlxlinkCommander::getProductTechnology()
 {
+    if (isBonusPort())
+    {
+        return;
+    }
+
     // Use SLTP to get the product technology, for backward compatibility
     try
     {
@@ -704,6 +708,215 @@ void MlxlinkCommander::updateNvlinkModeBStatus()
         // _isNvlinkModeB = false;
         return;
     }
+}
+
+bool MlxlinkCommander::deviceSupportsBonusPort() const
+{
+    return _devID == DeviceSpectrum4 || _devID == DeviceSpectrum5 || _devID == DeviceSpectrum6;
+}
+
+bool MlxlinkCommander::probeLocalPortForBonusPort(u_int32_t localPort, u_int32_t& labelPort)
+{
+    try
+    {
+        sendPrmReg(ACCESS_REG_PMDR, REG_GET, "local_port=%d", localPort);
+        if (getFieldValue("status") != PMDR_STATUS_VALID)
+        {
+            return false;
+        }
+        labelPort = getFieldValue("label_port_query");
+        u_int32_t moduleNum = getFieldValue("module");
+        u_int32_t slotIndex = getFieldValue("slot_index");
+
+        sendPrmReg(ACCESS_REG_PMTM, REG_GET, "module=%d,slot_index=%d", moduleNum, slotIndex);
+        return getFieldValue("module_type") == PMTM_MODULE_TYPE_LOOPBACK;
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+
+void MlxlinkCommander::updateBonusPortStatus()
+{
+    _isBonusPort = false;
+    if (!deviceSupportsBonusPort() || _localPort == 0 || _userInput._pcie)
+    {
+        return;
+    }
+
+    u_int32_t labelPort = 0;
+    if (probeLocalPortForBonusPort(_localPort, labelPort))
+    {
+        _isBonusPort = true;
+    }
+}
+
+void MlxlinkCommander::setRequestedCommands(const std::vector<OPTION_TYPE>& requestedCommands)
+{
+    _requestedCommands = requestedCommands;
+}
+
+void MlxlinkCommander::checkBonusPortAllowedCommands()
+{
+    if (!isBonusPort())
+    {
+        return;
+    }
+
+    for (OPTION_TYPE opt : _requestedCommands)
+    {
+        if (!isIn(static_cast<u_int32_t>(opt), bonusPortAllowedCommands))
+        {
+            throw MlxRegException("Command is not supported on loopback port (bonus port, label port %d)",
+                                  _userInput._labelPort);
+        }
+    }
+
+    if (!_userInput._loopbackMode.empty() && _userInput._loopbackMode != LOOPBACK_LL_STR)
+    {
+        throw MlxRegException("Only %s loopback mode is supported on loopback port (bonus port, label port %d)",
+                              LOOPBACK_LL_STR, _userInput._labelPort);
+    }
+}
+
+bool MlxlinkCommander::isBonusPort() const
+{
+    return _isBonusPort;
+}
+
+void MlxlinkCommander::collectBonusPortTableFields(const PortGroup& portInfo, BonusPortTableFields& fields)
+{
+    _localPort = portInfo.localPort;
+
+    fields.labelPortStr = getLabelPortString(portInfo);
+
+    string plainState = getBonusPortSmpiPlainState(fields.logicalLinkUp);
+    string stateColor = MlxlinkRecord::state2Color(RESET);
+    if (fields.logicalLinkUp)
+    {
+        stateColor = MlxlinkRecord::state2Color(GREEN);
+    }
+    else if (plainState != NA_FIELD_VALUE)
+    {
+        stateColor = MlxlinkRecord::state2Color(RED);
+    }
+    string resetColor = MlxlinkRecord::state2Color(RESET);
+    fields.stateStr = stateColor + plainState + resetColor;
+    fields.plainStateLen = plainState.length();
+
+    fields.speedStr = getSpeedStrForTableView();
+    getPddrOperInfo();
+    fields.fecStr = _mlxlinkMaps->_fecModeActiveForTableDispaly[_fecActive];
+}
+
+void MlxlinkCommander::appendBonusPortToSmpiTable(const PortGroup& portInfo, vector<string>& tableData)
+{
+    BonusPortTableFields fields;
+    collectBonusPortTableFields(portInfo, fields);
+
+    u_int32_t pos = 0;
+    auto& hdr = _mlxlinkMaps->_multiPortInfoTableHeader;
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.labelPortStr, fields.labelPortStr.length());
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.stateStr, fields.plainStateLen);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.speedStr, fields.speedStr.length());
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.fecStr, fields.fecStr.length(), fields.logicalLinkUp);
+
+    const string cableInfoStr = "Loopback";
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, cableInfoStr, cableInfoStr.length(), true);
+
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, strlen(NA_FIELD_VALUE), fields.logicalLinkUp);
+
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+}
+
+void MlxlinkCommander::appendBonusPortToSmpmiTable(const PortGroup& portInfo, vector<string>& tableData)
+{
+    BonusPortTableFields fields;
+    collectBonusPortTableFields(portInfo, fields);
+
+    u_int32_t pos = 0;
+    auto& hdr = _mlxlinkMaps->_multiPortModuleInfoTableHeader;
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.labelPortStr, fields.labelPortStr.length());
+
+    // Cable S/N, P/N, and length are not applicable on bonus port.
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+
+    const string cableTypeStr = "Loopback";
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, cableTypeStr, cableTypeStr.length(), true);
+
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.stateStr, fields.plainStateLen);
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.speedStr, fields.speedStr.length());
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, fields.fecStr, fields.fecStr.length(), fields.logicalLinkUp);
+
+    // Net BER is not applicable on bonus port.
+    updateColumnWidthPopulateTable(hdr, pos++, tableData, NA_FIELD_VALUE, 0, false);
+}
+
+bool MlxlinkCommander::isBonusPortPplrLoopbackEnabled()
+{
+    try
+    {
+        sendPrmReg(ACCESS_REG_PPLR, REG_GET);
+        return (getFieldValue("lb_en") & LOOPBACK_MODE_LL) != 0;
+    }
+    catch (const std::exception&)
+    {
+        return false;
+    }
+}
+
+string MlxlinkCommander::getBonusPortSmpiPlainState(bool& logicalLinkUp)
+{
+    logicalLinkUp = false;
+    string stateStr = "DIS(L)";
+
+    try
+    {
+        sendPrmReg(ACCESS_REG_PAOS, REG_GET);
+        u_int32_t operStatus = getFieldValue("oper_status");
+
+        if (operStatus == PAOS_UP && isBonusPortPplrLoopbackEnabled())
+        {
+            logicalLinkUp = true;
+            stateStr = "ACT(L)";
+        }
+    }
+    catch (const std::exception&)
+    {
+        return NA_FIELD_VALUE;
+    }
+
+    return stateStr;
+}
+
+string MlxlinkCommander::getBonusPortOperationalState(bool& logicalLinkUp)
+{
+    logicalLinkUp = false;
+
+    try
+    {
+        sendPrmReg(ACCESS_REG_PAOS, REG_GET);
+        u_int32_t operStatus = getFieldValue("oper_status");
+
+        if (operStatus == PAOS_UP && isBonusPortPplrLoopbackEnabled())
+        {
+            logicalLinkUp = true;
+            return string(PM_STATE_ACTIVE) + " (Logical)";
+        }
+    }
+    catch (const std::exception&)
+    {
+        return NA_FIELD_VALUE;
+    }
+
+    return string(PM_STATE_DISABLE) + " (Logical)";
 }
 
 void MlxlinkCommander::findFirstValidPort()
@@ -1296,6 +1509,11 @@ void MlxlinkCommander::getCableParams()
 
 bool MlxlinkCommander::inPrbsTestMode()
 {
+    if (isBonusPort())
+    {
+        return false;
+    }
+
     try
     {
         bool res = checkPaosDown() && checkPpaosTestMode();
@@ -1426,6 +1644,18 @@ void MlxlinkCommander::handleAllNewSwitchesLocalPorts(std::vector<string> labelP
 
     for (u_int32_t localPort = 1; localPort <= maxLocalPort(); localPort++)
     {
+        if (deviceSupportsBonusPort() && !_userInput._pcie)
+        {
+            u_int32_t bonusLabelPort = 0;
+            if (probeLocalPortForBonusPort(localPort, bonusLabelPort))
+            {
+                PortGroup bonusPortGroup(localPort, bonusLabelPort, _userInput._setGroup, 0);
+                bonusPortGroup.isBonusPort = true;
+                _localPortsPerGroup.push_back(bonusPortGroup);
+                continue;
+            }
+        }
+
         try
         {
             sendPrmReg(ACCESS_REG_PLLP, REG_GET, "local_port=%d", localPort);
@@ -2351,15 +2581,75 @@ void MlxlinkCommander::runningVersion()
     string bkvVersion = getBKVVersion();
     setPrintTitle(_toolInfoCmd, "Tool Information", TOOL_INFORMAITON_INFO_LAST, !_prbsTestMode);
     setPrintVal(_toolInfoCmd, "Firmware Version", getFwVersion(), ANSI_COLOR_GREEN, true, !_prbsTestMode);
-    setPrintVal(_toolInfoCmd, "amBER Version", AMBER_VERSION, ANSI_COLOR_GREEN, _productTechnology >= PRODUCT_16NM, !_prbsTestMode);
+    setPrintVal(_toolInfoCmd, "amBER Version", AMBER_VERSION, ANSI_COLOR_GREEN,
+                isBonusPort() || _productTechnology >= PRODUCT_16NM, !_prbsTestMode);
     setPrintVal(_toolInfoCmd, "BKV Version", bkvVersion, ANSI_COLOR_GREEN, !bkvVersion.empty() && !_prbsTestMode);
     setPrintVal(_toolInfoCmd, PKG_NAME " Version", PKG_VER, ANSI_COLOR_GREEN, true, !_prbsTestMode);
+}
+
+void MlxlinkCommander::operatingInfoPageForBonusPort()
+{
+    try
+    {
+        getPddrOperInfo();
+        u_int32_t ethAnFsmState = getFieldValue("eth_an_fsm_state");
+
+        _protoActive = getFieldValue("proto_active");
+        getPtys();
+
+        bool logicalLinkUp = false;
+        string stateStr = getBonusPortOperationalState(logicalLinkUp);
+        string color = MlxlinkRecord::state2Color(RESET);
+        if (logicalLinkUp)
+        {
+            color = MlxlinkRecord::state2Color(GREEN);
+        }
+        else if (stateStr != NA_FIELD_VALUE)
+        {
+            color = MlxlinkRecord::state2Color(RED);
+        }
+
+        _linkUP = logicalLinkUp;
+        int loopbackMode = logicalLinkUp ? _loopbackMode : -1;
+
+        bool extended = _activeSpeedEx && _protoAdminEx;
+        _linkSpeed = extended ? _activeSpeedEx : _activeSpeed;
+        _speedStrG = activeSpeed2Str(_linkSpeed, extended, _isModeAsActive);
+
+        setPrintTitle(_operatingInfoCmd, "Operational Info", PDDR_OPERATIONAL_INFO_LAST, !_prbsTestMode);
+
+        setPrintVal(_operatingInfoCmd, "State", stateStr, color, true, !_prbsTestMode);
+        setPrintVal(_operatingInfoCmd, "Physical state", getStrByValue(ethAnFsmState, _mlxlinkMaps->_ethANFsmState),
+                    color, !_prbsTestMode);
+        setPrintVal(_operatingInfoCmd, "Speed", _speedStrG, color, !_prbsTestMode, _linkUP);
+        setPrintVal(_operatingInfoCmd, "Width", NA_FIELD_VALUE, MlxlinkRecord::state2Color(RESET), !_prbsTestMode,
+                    _linkUP);
+        setPrintVal(_operatingInfoCmd, "FEC", getStrByValue(_fecActive, _mlxlinkMaps->_fecModeActive),
+                    _mlxlinkMaps->_fecModeActive[_fecActive] == "" ? MlxlinkRecord::state2Color(0) : color,
+                    !_prbsTestMode, _linkUP);
+        setPrintVal(_operatingInfoCmd, "Loopback Mode", _mlxlinkMaps->_loopbackModeList[loopbackMode].second,
+                    getLoopbackColor(loopbackMode), true, !_prbsTestMode && loopbackMode != -1);
+        setPrintVal(_operatingInfoCmd, "Auto Negotiation", _mlxlinkMaps->_anDisableList[_anDisable] + _speedForce,
+                    getAnDisableColor(_anDisable), true, !_prbsTestMode);
+
+        getPrecodingStatus();
+    }
+    catch (const std::exception& exc)
+    {
+        throw MlxRegException(string(exc.what()));
+    }
 }
 
 void MlxlinkCommander::operatingInfoPage()
 {
     try
     {
+        if (isBonusPort())
+        {
+            operatingInfoPageForBonusPort();
+            return;
+        }
+
         getPddrOperInfo();
         int loopbackMode = (_phyMngrFsmState != PHY_MNGR_DISABLED) ? _loopbackMode : -1;
         u_int32_t ethAnFsmState = getFieldValue("eth_an_fsm_state");
@@ -2505,11 +2795,44 @@ bool MlxlinkCommander::isC2C()
     return isC2C;
 }
 
+void MlxlinkCommander::supportedInfoPageForBonusPort()
+{
+    try
+    {
+        u_int32_t speeds_mask = _protoAdminEx ? _protoAdminEx : _protoAdmin;
+        string supported_speeds = SupportedSpeeds2Str(_protoActive, speeds_mask, (bool)_protoAdminEx, _isModeAsActive);
+        string color = MlxlinkRecord::supported2Color(supported_speeds);
+        stringstream value;
+        value << "0x" << std::hex << setfill('0') << setw(8) << speeds_mask << " (" << supported_speeds << ")"
+              << setfill(' ');
+        string extStr = "";
+        if (_protoCapabilityEx && _protoActive == ETH)
+        {
+            extStr = " (Ext.)";
+        }
+        string title = string("Enabled Link Speed") + extStr;
+        setPrintVal(_supportedInfoCmd, title, value.str(), color, true, !_prbsTestMode, true);
+        title = string("Supported Cable Speed") + extStr;
+        setPrintVal(_supportedInfoCmd, title, "Loopback", ANSI_COLOR_RESET, true, !_prbsTestMode, true);
+    }
+    catch (const std::exception& exc)
+    {
+        throw MlxRegException(string(exc.what()));
+    }
+}
+
 void MlxlinkCommander::supportedInfoPage()
 {
     try
     {
         setPrintTitle(_supportedInfoCmd, HEADER_SUPPORTED_INFO, PDDR_SUPPORTED_INFO_LAST, !_prbsTestMode);
+
+        if (isBonusPort())
+        {
+            supportedInfoPageForBonusPort();
+            return;
+        }
+
         u_int32_t speeds_mask = _protoAdminEx ? _protoAdminEx : _protoAdmin;
         string supported_speeds =
           SupportedSpeeds2Str((_isNvlinkModeB || _isNvlinkModeA) ? (u_int32_t)NVLINK : _protoActive, speeds_mask,
@@ -4758,6 +5081,11 @@ string MlxlinkCommander::getLabelPortString(const PortGroup& portInfo)
         labelPortStr += "(FNM)";
     }
 
+    if (portInfo.isBonusPort)
+    {
+        labelPortStr += "(LOGIC)";
+    }
+
     return labelPortStr;
 }
 
@@ -4813,6 +5141,13 @@ void MlxlinkCommander::showMultiPortModuleInfo()
     // Process each port group
     for (const auto& portInfo : _localPortsPerGroup)
     {
+        if (portInfo.isBonusPort)
+        {
+            _isBonusPort = true;
+            appendBonusPortToSmpmiTable(portInfo, tableData);
+            continue;
+        }
+        _isBonusPort = false;
         u_int32_t posToUpdateWidthInVector = 0;
 
         // Get and update label port string
@@ -4936,6 +5271,13 @@ void MlxlinkCommander::showMultiPortInfo()
 
     for (const auto& portInfo : _localPortsPerGroup)
     {
+        if (portInfo.isBonusPort)
+        {
+            _isBonusPort = true;
+            appendBonusPortToSmpiTable(portInfo, tableData);
+            continue;
+        }
+        _isBonusPort = false;
         u_int32_t posToUpdateWidthInVector = 0;
         updatePortInfo(tableData, portInfo, posToUpdateWidthInVector);
     }
@@ -5221,6 +5563,14 @@ void MlxlinkCommander::clearCounters()
     try
     {
         MlxlinkRecord::printCmdLine("Clearing Counters", _jsonRoot);
+        if (isBonusPort())
+        {
+            for (auto grp : bonusPortCounterGroups)
+            {
+                sendPrmReg(ACCESS_REG_PPCNT, REG_SET, "clr=%d,grp=%d", 1, grp);
+            }
+            return;
+        }
         if (_mf->tp != MST_IB && _mf->tp != MST_NVML)
         {
             sendPrmReg(ACCESS_REG_PPCNT, REG_SET, "clr=%d,grp=%d", 1, PPCNT_ALL_GROUPS);
@@ -5493,6 +5843,7 @@ void MlxlinkCommander::sendPaos()
                 _userInput._secondSplitProvided = false;
                 handlePortStr(portStr);
                 labelToLocalPort();
+                updateBonusPortStatus();
                 validPorts.push_back(portStr);
             }
             catch (const std::exception& exc)
@@ -5526,6 +5877,7 @@ void MlxlinkCommander::sendPaos()
                 _userInput._secondSplitProvided = false;
                 handlePortStr(portStr);
                 labelToLocalPort();
+                updateBonusPortStatus();
                 _allPortsCurrentLabelStr = portStr;
                 sendPaosOnce();
             }
@@ -5560,6 +5912,7 @@ void MlxlinkCommander::sendPaos()
     for (const auto& portInfo : _localPortsPerGroup)
     {
         _localPort = portInfo.localPort;
+        _isBonusPort = portInfo.isBonusPort;
         _allPortsCurrentLabelStr = getLabelPortString(portInfo);
         try
         {
@@ -5614,6 +5967,17 @@ void MlxlinkCommander::sendPaosDown(bool toggleCommand)
 
 void MlxlinkCommander::sendPaosUP()
 {
+    if (isBonusPort() && !isBonusPortPplrLoopbackEnabled())
+    {
+        string suffix = _allPortsCurrentLabelStr.empty() ? "" : " - Port " + _allPortsCurrentLabelStr;
+        MlxlinkRecord::printCmdLine("Configuring Port State (Up)" + suffix, _jsonRoot);
+        string labelPortStr =
+          _allPortsCurrentLabelStr.empty() ? to_string(_userInput._labelPort) : _allPortsCurrentLabelStr;
+        _allUnhandledErrors += string("Port up (-a UP) on loopback port (bonus port, label port ") + labelPortStr +
+                               ") requires link-layer loopback (LL). Enable LL first with -l LL.\n";
+        return;
+    }
+
     string suffix = _allPortsCurrentLabelStr.empty() ? "" : " - Port " + _allPortsCurrentLabelStr;
     MlxlinkRecord::printCmdLine("Configuring Port State (Up)" + suffix, _jsonRoot);
     sendPaosCmd(PAOS_UP);
@@ -6231,7 +6595,7 @@ void MlxlinkCommander::sendPtys()
         }
         else
         {
-            if (_productTechnology >= PRODUCT_16NM)
+            if (isBonusPort() || _productTechnology >= PRODUCT_16NM)
             {
                 protoAdminField = "ext_eth_proto_admin";
             }
@@ -6259,12 +6623,14 @@ void MlxlinkCommander::sendPtys()
 
 u_int32_t MlxlinkCommander::ptysSpeedToMask(const string& speed)
 {
-    bool extended = _productTechnology >= PRODUCT_16NM;
+    bool extended = isBonusPort() || _productTechnology >= PRODUCT_16NM;
     u_int32_t speedMask = 0;
 
     if (!isBackplane())
     {
-        checkSupportedSpeed(speed, _protoCapability, extended);
+        // Bonus port has no cable; validate against device capability only.
+        u_int32_t cableCap = isBonusPort() ? _deviceCapability : _protoCapability;
+        checkSupportedSpeed(speed, cableCap, extended);
     }
 
     if (_isNvlinkModeB || _isNvlinkModeA)
@@ -6948,7 +7314,7 @@ void MlxlinkCommander::checkPplrCap()
             throw MlxRegException("\n%s Loopback configuration is not supported, supported Loopback configurations are [%s]", _userInput._loopbackMode.c_str(), supportedLoopbacks.c_str());
         }
     }
-    if (loopBackVal == LOOPBACK_MODE_REMOTE && _productTechnology < PRODUCT_7NM)
+    if (loopBackVal == LOOPBACK_MODE_REMOTE && !isBonusPort() && _productTechnology < PRODUCT_7NM)
     {
         string warMsg = "Remote loopback mode pre-request (all should be satisfied):\n";
         warMsg += "1. Remote loopback is supported only in force mode.\n";
@@ -6964,6 +7330,16 @@ void MlxlinkCommander::sendLoopback()
     if (_userInput._loopbackMode == LOOPBACK_TRAN_STR)
     {
         sendPmlr();
+        return;
+    }
+
+    if (isBonusPort() && !_userInput._loopbackMode.empty() &&
+        getLoopbackMode(_userInput._loopbackMode) == LOOPBACK_MODE_LL && isBonusPortPplrLoopbackEnabled())
+    {
+        MlxlinkRecord::printCmdLine("Configuring Port Loopback", _jsonRoot);
+        _allUnhandledErrors +=
+          string("Link-layer loopback (LL) is already enabled on loopback port (bonus port, label port ") +
+          to_string(_userInput._labelPort) + ").\n";
         return;
     }
 
@@ -7815,15 +8191,25 @@ std::string MlxlinkCommander::getSpeedStrForTableView()
     getPtys();
     if (_protoActive == ETH)
     {
-        _activeSpeed =
-          _productTechnology >= PRODUCT_16NM ? getFieldValue("ext_eth_proto_oper") : getFieldValue("eth_proto_oper");
+        _activeSpeed = (isBonusPort() || _productTechnology >= PRODUCT_16NM) ? getFieldValue("ext_eth_proto_oper") :
+                                                                               getFieldValue("eth_proto_oper");
     }
 
-    _linkUP = (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    if (!isBonusPort())
+    {
+        _linkUP = (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP);
+    }
     bool extended = _activeSpeedEx && _protoAdminEx;
     _linkSpeed = extended ? _activeSpeedEx : _activeSpeed;
     _isPam4Speed = isPAM4Speed(_protoActive == IB ? _activeSpeed : _activeSpeedEx, _protoActive, extended);
     _speedStrG = activeSpeed2Str(_linkSpeed, extended, _isModeAsActive);
+
+    if (isBonusPort())
+    {
+        // Bonus port: oper speed only (no PHY FSM linkup), no lane suffix.
+        return _linkSpeed ? _speedStrG : "";
+    }
+
     getActualNumOfLanes(_linkSpeed, extended);
     if (_phyMngrFsmState == PHY_MNGR_ACTIVE_LINKUP)
     {

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -493,7 +493,6 @@ public:
     void checkLocalPortDPNMapping(u_int32_t localPort);
     int getLocalPortFromMPIR(DPN& dpn);
     void checkValidFW();
-    u_int32_t getTechnologyFromMGIR();
     void getProductTechnology();
     bool checkPortStatus(u_int32_t localPort);
     void checkAllPortsStatus();
@@ -599,6 +598,20 @@ public:
     void updateSwControlStatus();
     void initSwControledModule();
     void updateNvlinkModeBStatus();
+    void updateBonusPortStatus();
+    bool isBonusPort() const;
+    bool deviceSupportsBonusPort() const;
+    void appendBonusPortToSmpiTable(const PortGroup& portInfo, vector<string>& tableData);
+    void appendBonusPortToSmpmiTable(const PortGroup& portInfo, vector<string>& tableData);
+    void collectBonusPortTableFields(const PortGroup& portInfo, BonusPortTableFields& fields);
+    bool isBonusPortPplrLoopbackEnabled();
+    string getBonusPortSmpiPlainState(bool& logicalLinkUp);
+    string getBonusPortOperationalState(bool& logicalLinkUp);
+    void operatingInfoPageForBonusPort();
+    void supportedInfoPageForBonusPort();
+    virtual void checkBonusPortAllowedCommands();
+    void setRequestedCommands(const std::vector<OPTION_TYPE>& requestedCommands);
+    bool probeLocalPortForBonusPort(u_int32_t localPort, u_int32_t& labelPort);
     u_int32_t getNumberOfPorts();
     bool checkDPNvSupport();
     bool checkPcieMgmtSupport();
@@ -843,6 +856,8 @@ public:
     bool _isSwControled;
     bool _isSwControledStandAlone;
     bool _pcieMgmtSupported;
+    bool _isBonusPort;
+    std::vector<OPTION_TYPE> _requestedCommands;
     bool _ignoreIbFECCheck;
     bool _isNVLINK;
     bool _isNvlinkModeA;

--- a/mlxlink/modules/mlxlink_enums.h
+++ b/mlxlink/modules/mlxlink_enums.h
@@ -488,7 +488,10 @@ struct DPN
         bdf = _bdf;
     }
 
-    bool operator==(DPN dpn) { return (dpn.depth == depth && dpn.pcieIndex == pcieIndex && dpn.node == node); }
+    bool operator==(const DPN& dpn) const
+    {
+        return (dpn.depth == depth && dpn.pcieIndex == pcieIndex && dpn.node == node);
+    }
 
     u_int32_t depth;
     u_int32_t pcieIndex;
@@ -2093,7 +2096,8 @@ enum PRODUCT_TECHNOLOGY
     PRODUCT_16NM = 3,
     PRODUCT_7NM = 4,
     PRODUCT_5NM = 5,
-    SERDES_GEN_8 = 6
+    SERDES_GEN_8 = 6,
+    PRODUCT_3NM = 7
 };
 
 enum STATUS_OPCODE
@@ -2590,6 +2594,10 @@ const char* const EXTERNAL_LOOPBACK = "External Local Loopback";
 const char* const LINK_LAYER_LOOPBACK = "Link Layer Local Loopback";
 const char* const NEAR_END_ANALOG_LOOPBACK = "Near End Analog Loopback";
 const char* const NEAR_END_DIGITAL_LOOPBACK = "Near End Digital Loopback";
+
+// Loopback bonus port register values
+const uint32_t PMTM_MODULE_TYPE_LOOPBACK = 0x15;
+const uint32_t PMDR_STATUS_VALID = 1;
 
 // Loopback mode mnemonic strings (used on the command line)
 const char* const LOOPBACK_NO_STR = "NO";

--- a/mlxlink/modules/mlxlink_maps.cpp
+++ b/mlxlink/modules/mlxlink_maps.cpp
@@ -34,6 +34,25 @@
 
 #include "mlxlink_maps.h"
 #include "mlxlink_fields.h"
+#include "mlxlink_commander.h"
+
+const std::vector<u_int32_t> bonusPortAllowedCommands = {SHOW_PDDR,
+                                                         SEND_PAOS,
+                                                         SEND_PTYS,
+                                                         HANDLE_LOOPBACK,
+                                                         SEND_CLEAR_COUNTERS,
+                                                         SHOW_MULTI_PORT_INFO,
+                                                         SHOW_MULTI_PORT_MODULE_INFO};
+
+const std::vector<u_int32_t> bonusPortCounterGroups = {PPCNT_IEEE_802_3_COUNTERS_GROUP,
+                                                       PPCNT_RFC_2863_GROUP,
+                                                       PPCNT_RFC_2819_GROUP,
+                                                       PPCNT_RFC_3635_GROUP,
+                                                       PPCNT_ETHERNET_EXTENDED_GROUP,
+                                                       PPCNT_DISC_COUNTERS_GROUP,
+                                                       PPCNT_PER_PRIORITY_COUNTERS_GROUP,
+                                                       PPCNT_PER_TRAFFIC_CLASS_COUNTERS_GROUP,
+                                                       PPCNT_PER_TRAFFIC_CLASS_CONGESTION_COUNTERS_GROUP};
 
 MlxlinkMaps* MlxlinkMaps::instance = NULL;
 

--- a/mlxlink/modules/mlxlink_maps.h
+++ b/mlxlink/modules/mlxlink_maps.h
@@ -42,6 +42,7 @@
 #include <fstream>
 #include <sstream>
 #include <iterator>
+#include <string>
 #include <vector>
 #include <mlxreg/mlxreg_lib/mlxreg_lib.h>
 #include <mlxreg/mlxreg_lib/mlxreg_parser.h>
@@ -60,6 +61,7 @@ struct PortGroup
         split = 0;
         secondSplit = 0;
         isFnm = false;
+        isBonusPort = false;
     }
     PortGroup(u_int32_t _localPort, u_int32_t _labelPort, u_int32_t _groupId, u_int32_t _split)
     {
@@ -69,6 +71,7 @@ struct PortGroup
         split = _split;
         secondSplit = 0;
         isFnm = false;
+        isBonusPort = false;
     }
     PortGroup(u_int32_t _localPort, u_int32_t _labelPort, u_int32_t _groupId, u_int32_t _split, u_int32_t _secondSplit)
     {
@@ -78,6 +81,7 @@ struct PortGroup
         split = _split;
         secondSplit = _secondSplit;
         isFnm = false;
+        isBonusPort = false;
     }
     PortGroup(u_int32_t _localPort,
               u_int32_t _labelPort,
@@ -92,6 +96,7 @@ struct PortGroup
         split = _split;
         secondSplit = _secondSplit;
         isFnm = _isFnm;
+        isBonusPort = false;
     }
     u_int32_t localPort;
     u_int32_t labelPort;
@@ -99,6 +104,7 @@ struct PortGroup
     u_int32_t split;
     u_int32_t secondSplit;
     bool isFnm;
+    bool isBonusPort;
 
     bool operator<(const PortGroup& b) const
     {
@@ -194,6 +200,19 @@ struct PRM_FIELD
     bool isSigned;
     u_int32_t validationMask;
 };
+
+struct BonusPortTableFields
+{
+    std::string labelPortStr;
+    std::string stateStr;
+    u_int32_t plainStateLen = 0;
+    std::string speedStr;
+    std::string fecStr;
+    bool logicalLinkUp = false;
+};
+
+extern const std::vector<u_int32_t> bonusPortAllowedCommands;
+extern const std::vector<u_int32_t> bonusPortCounterGroups;
 
 class MlxlinkMaps
 {

--- a/mlxlink/modules/mlxlink_ui.cpp
+++ b/mlxlink/modules/mlxlink_ui.cpp
@@ -75,6 +75,7 @@ void MlxlinkUi::initPortInfo()
 void MlxlinkUi::initMlxlinkCommander()
 {
     createMlxlinkCommander();
+    _mlxlinkCommander->setRequestedCommands(_sendRegFuncMap);
 
     initPortInfo();
 }

--- a/mlxlink/modules/mlxlink_utils.h
+++ b/mlxlink/modules/mlxlink_utils.h
@@ -61,7 +61,7 @@ std::string to_string(T toConvert)
 #endif
 
 template<typename T>
-bool isIn(const T& val, std::vector<T>& vect)
+bool isIn(const T& val, const std::vector<T>& vect)
 {
     auto it = find(vect.begin(), vect.end(), val);
     return (it != vect.end());


### PR DESCRIPTION
Description:
This change adds mlxlink support for the bonus (loopback) port on Spectrum-4 and newer switches, discovered via PMDR and PMTM when standard PLLP mapping is unavailable. Product technology is read from MGIR (mapped to SLTP encoding) for extended PTYS flows; show, speed config, PAOS, LL loopback, and multi-port tables use dedicated bonus-port logic (logical link state via PAOS and PPLR). Unsupported commands on the bonus port are rejected with a clear error.

MSTFlint port needed: yes
Tested OS: Linux
Tested devices: Spectrum-4
Tested flows:
	• mlxlink -d <device> -p <bonus_label_port>
	• mlxlink -d <device> -p <bonus_label_port> -s <speed>
	• mlxlink -d <device> -p <bonus_label_port> -a UP
	• mlxlink -d <device> -p <bonus_label_port> -a DN
	• mlxlink -d <device> -p <bonus_label_port> -l LL
	• mlxlink -d <device> --smpi
	• mlxlink -d <device> --smpmi
	• mlxlink -d <device> -p <bonus_label_port> -pc

Known gaps (with RM ticket):

Issue: 4971341