### PR TITLE
[mlxconfig] Fix build break introduced by ba9b0e1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser mlxconfig $(NVFWRESET_DIR) $(DPA) mlxfwops $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} tracers resourcetools $(IBDUMP_DIR)
+SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser mlxfwops mlxconfig $(NVFWRESET_DIR) $(DPA) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} tracers resourcetools $(IBDUMP_DIR)
 
 DIST_SUBDIRS = tracers
 

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -110,7 +110,7 @@ mstconfig_DEPENDENCIES = \
 
 mstconfig_LDADD = $(mstconfig_DEPENDENCIES) ${LDL}
 
-mstconfig_LDFLAGS = -static
+mstconfig_LDFLAGS = -static -Wl,--gc-sections
 
 if DISABLE_XML2
 AM_CXXFLAGS += -DDISABLE_XML2

--- a/mlxconfig/mlxcfg_ui.cpp
+++ b/mlxconfig/mlxcfg_ui.cpp
@@ -57,6 +57,7 @@
 #include "mft_utils/mft_utils.h"
 #include "common/tools_string.h"
 #include "mlxfwops/lib/fs_pldm.h"
+#include "pldm_utils/pldm_utils.h"
 
 using nbu::mft::common::string_format;
 
@@ -1585,9 +1586,24 @@ mlxCfgStatus MlxCfg::readBinFile(string fileName, vector<u_int32_t>& buff)
     return MLX_CFG_OK;
 }
 
+bool MlxCfg::isPldmFile(const string& path)
+{
+    std::ifstream ifs(path.c_str(), std::ios::in | std::ios::binary);
+    u_int8_t header[16] = {0};
+    if (ifs)
+        ifs.read(reinterpret_cast<char*>(header), sizeof(header));
+    for (const auto& entry : PACKAGE_HEADER_FORMAT_REVISION_MAP)
+    {
+        const std::vector<u_int8_t>& id = entry.second;
+        if (std::equal(id.begin(), id.end(), header))
+            return true;
+    }
+    return false;
+}
+
 mlxCfgStatus MlxCfg::readNVInputFile(vector<u_int32_t>& buff)
 {
-    if (FwOperations::IsPLDM(_mlxParams.NVInputFile))
+    if (isPldmFile(_mlxParams.NVInputFile))
     {
         if (FsPldmOperations::GetComponentData(
               _mlxParams.NVInputFile,

--- a/mlxconfig/mlxcfg_ui.h
+++ b/mlxconfig/mlxcfg_ui.h
@@ -245,6 +245,7 @@ private:
     mlxCfgStatus clrDevSem();
 
     mlxCfgStatus readBinFile(string fileName, vector<u_int32_t>& buff);
+    static bool isPldmFile(const string& path);
     mlxCfgStatus readNVInputFile(vector<u_int32_t>& buff);
     mlxCfgStatus readNVInputFile(string& content);
     mlxCfgStatus readNVInputFile(vector<string>& lines);

--- a/mlxfwops/lib/Makefile.am
+++ b/mlxfwops/lib/Makefile.am
@@ -101,9 +101,9 @@ libmlxfwops_a_SOURCES = \
     security_version_gw.h \
     signature_manager_factory.h \
     signature_manager.h \
+    components/fs_comps_factory.h \
     components/fs_cert_ops.cpp \
     components/fs_cert_ops.h \
-    components/fs_comps_factory.h \
     components/fs_comps_ops.cpp \
     components/fs_comps_ops.h \
     components/fs_synce_ops.cpp \


### PR DESCRIPTION
Description:
Replace FwOperations::IsPLDM() with a local 16-byte header check (isPldmFile) to avoid pulling fw_ops.o and its transitive DPA dependency into the mstconfig link. Add libmlxfwops.a with --gc-sections to prune the dead FsPldmOperations vtable chain, and move mlxfwops before mlxconfig in SUBDIRS to satisfy build order.

MSTFlint port needed:
Tested OS: Linux
Tested devices:
Tested flows: ./autogen.sh && ./configure [10 flag permutations] && make -j

Known gaps (with RM ticket):

Issue: 5103587