### PR TITLE
[build] Fix --enable-dpa and --disable-openssl build breaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser mlxfwops mlxconfig $(NVFWRESET_DIR) $(DPA) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} $(HCA_CAP_DIR) $(MSTFLINT_SDK_DIR) tracers resourcetools $(IBDUMP_DIR)
+SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser $(DPA) mlxfwops mlxconfig $(NVFWRESET_DIR) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump ${ADABE_TOOLS} tracers resourcetools $(IBDUMP_DIR)
 
 DIST_SUBDIRS = tracers
 

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -95,7 +95,6 @@ mstconfig_DEPENDENCIES = \
     $(top_builddir)/libmfa/libmfa.la \
     $(top_builddir)/ext_libs/minixz/libminixz.la \
     $(top_builddir)/mflash/libmflash.la \
-    $(top_builddir)/tools_crypto/libtools_crypto.a \
     $(top_builddir)/mft_utils/libmftutils.la \
     $(top_builddir)/cmdif/libcmdif.la \
     $(top_builddir)/reg_access/libreg_access.la \
@@ -128,6 +127,7 @@ endif
 
 if ENABLE_OPENSSL
 AM_CPPFLAGS += $(openssl_CFLAGS)
+mstconfig_DEPENDENCIES += $(top_builddir)/tools_crypto/libtools_crypto.a
 mstconfig_LDADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 libmlxcfg_la_LIBADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 else


### PR DESCRIPTION
Description:
- Makefile.am: move $(DPA) before mlxfwops in SUBDIRS; mlxfwops links mlxdpa/libmstdpa.a, which must be built first.
- mlxconfig/Makefile.am: move tools_crypto/libtools_crypto.a dependency into the ENABLE_OPENSSL block; it is only built when OpenSSL is enabled (regression from ba9b0e1).

MSTFlint port needed: yes
Tested OS: linux
Tested devices: n/a
Tested flows: make -j

Known gaps (with RM ticket):

Issue: None