### PR TITLE
flint | QTM4 | extend WP support to 256 Sectors (16MB)

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -4444,6 +4444,12 @@ int is_WINBOND_60MB_bottom_protection_supported(uint8_t vendor, uint8_t type, ui
     return 0;
 }
 
+int is_256_sectors_number_supported(mflash* mfl)
+{
+    return is_macronix_mx25u51294g_mx25u51294gxdi08_wrapper(mfl) ||
+           is_WINBOND_60MB_bottom_protection_supported(mfl->attr.vendor, mfl->attr.type, mfl->attr.log2_bank_size);
+}
+
 int is_60MB_bottom_protection_params(write_protect_info_t* protect_info)
 {
     if ((protect_info->sectors_num != SECTOR_NUM_60MB_SPECIAL_CASE) || !protect_info->is_bottom || protect_info->is_subsector)
@@ -4523,11 +4529,10 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
     }
     if (protect_info->sectors_num > MAX_SECTORS_NUM)
     {
-        if (!is_60MB_bottom_protection_supported_wrapper(mfl))
-        {
-            return MFE_EXCEED_SECTORS_MAX_NUM;
-        }
-        if (!is_60MB_bottom_protection_params(protect_info))
+        bool is_256_exception = (protect_info->sectors_num == 256 && is_256_sectors_number_supported(mfl));
+        bool is_60mb_exception =
+          (is_60MB_bottom_protection_supported_wrapper(mfl) && is_60MB_bottom_protection_params(protect_info));
+        if (!is_256_exception && !is_60mb_exception)
         {
             return MFE_EXCEED_SECTORS_MAX_NUM;
         }
@@ -4569,7 +4574,8 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
         }
     }
 
-    for (log2_sect_num = 0; log2_sect_num < 8; log2_sect_num++)
+    const u_int32_t max_bp = 9;
+    for (log2_sect_num = 0; log2_sect_num <= max_bp; log2_sect_num++)
     {
         if (sectors_num == 0)
         {
@@ -4585,6 +4591,13 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
          ((mfl->attr.vendor == FV_WINBOND) && (mfl->attr.type == FMT_WINBOND_3V) && (mfl->attr.log2_bank_size == FD_128))))
     {
         log2_sect_num -= 2; /* spec alignment */
+    }
+
+    int bp_size = is_ISSI_is25wj032f(mfl) ? BP_SIZE : BP_SIZE + 1;
+    if (bp_size < 4 && log2_sect_num > 7) // not enough bits to set the BP value
+    {
+        DPRINTF(("BP Size (%d) is not enough to set the BP value (%d)\n", bp_size, log2_sect_num));
+        return MFE_NOT_SUPPORTED_OPERATION;
     }
 
     if ((mfl->attr.vendor == FV_ST) && (mfl->attr.type == FMT_N25QXXX))
@@ -4659,7 +4672,6 @@ int mf_set_write_protect_direct_access(mflash* mfl, u_int8_t bank_num, write_pro
             CHECK_RC(rc);
         }
 
-        int bp_size = is_ISSI_is25wj032f(mfl) ? BP_SIZE : BP_SIZE + 1;
         return mf_read_modify_status_winbond(mfl, bank_num, 1, log2_sect_num, BP_OFFSET, bp_size);
     }
     else

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -38,6 +38,7 @@
  */
 
 #include <errno.h>
+#include <stdint.h>
 #include <tools_dev_types.h>
 #include "flint_io.h"
 
@@ -1168,13 +1169,22 @@ bool Flash::check_and_set_sector_num_field(std::string& param_val_str,
     if (rc)
     {
         char* endp;
-        u_int8_t sector_num_as_int = strtoul(sector_num.c_str(), &endp, 0); // convert given sectors number to integer
-        if (*endp != '\0')
+        errno = 0;
+        unsigned long sector_num_as_ulong =
+          strtoul(sector_num.c_str(), &endp, 0); // convert given sectors number to integer
+
+        if (*endp != '\0' || sector_num.empty())
         {
             err_msg = "bad argument (" + sector_num + "), only integer value is allowed.\n";
             rc = false;
         }
-        else if (!sector_num_as_int)
+        else if (errno == ERANGE || sector_num_as_ulong > UINT16_MAX)
+        {
+            err_msg =
+              "bad argument (" + sector_num + "), value out of range (max " + std::to_string(UINT16_MAX) + ").\n";
+            rc = false;
+        }
+        else if (!sector_num_as_ulong)
         {
             err_msg = "Invalid sectors number, Use \"Disabled\" instead.\n";
             rc = false;


### PR DESCRIPTION
Description: For QTM4, the required WP configuration is bottom 16MB (not bottom 60MB).

In DFA flow, WP is disabled → burn → restored to its previous configuration. If the previous configuration is 16MB (top/bottom), restore will fail due to missing WP support, causing burn failure.

Added support for this configuration for needed flashes MX25U51294GXDI08 and W25Q512NWBIV_DTR

Bottom 16MB corresponds to: TBS=1, BP=0b1001.