### PR TITLE
Fix mstflint-sdk deb/rpm package builds and align their flows

### DIFF
--- a/build_sdk.sh
+++ b/build_sdk.sh
@@ -128,8 +128,10 @@ build_deb() {
         --exclude=.git --exclude='*.o' --exclude='*.lo' --exclude='*.la' \
         --exclude='*.a' --exclude=.libs --exclude=.deps \
         --exclude=./debian --exclude='*.tar.gz' --exclude=./configure~ \
+        --exclude=config.status --exclude=config.log --exclude=autom4te.cache \
         -C "$SCRIPT_DIR" . | tar -x -C "$src"
     cp -r "$SCRIPT_DIR/debian-sdk" "$src/debian"
+    cp "$SCRIPT_DIR/debian/mstflint.install.in" "$src/debian/"
 
     echo ">> dpkg-buildpackage -b -uc -us"
     ( cd "$src" && dpkg-buildpackage -b -uc -us )

--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,7 @@ if test "x$enable_mstflint_sdk" = "xyes"; then
     # no libmtcr_ul.so runtime dependency. Held as a substituted variable so
     # automake does not reject the -Wl tokens in the SDK's _LIBADD.
     MTCR_SDK_WHOLE_ARCHIVE="-Wl,--whole-archive \$(top_builddir)/$MTCR_CONF_DIR/.libs/libmtcr_ul.a -Wl,--no-whole-archive"
+    MSTREG_SDK_WHOLE_ARCHIVE="-Wl,--whole-archive \$(top_builddir)/mlxreg/mlxreg_lib/.libs/libmstreg_lib.a -Wl,--no-whole-archive"
     AC_CONFIG_FILES(mft_sdk/Makefile)
     AC_CONFIG_FILES(mft_sdk/mstflint_sdk.pc)
     AC_CONFIG_FILES(hca_capabilities/Makefile)
@@ -616,6 +617,7 @@ if test "x$enable_mstflint_sdk" = "xyes"; then
 fi
 AC_SUBST(MSTFLINT_SDK_DIR)
 AC_SUBST(MTCR_SDK_WHOLE_ARCHIVE)
+AC_SUBST(MSTREG_SDK_WHOLE_ARCHIVE)
 AC_SUBST(HCA_CAP_DIR)
 AC_SUBST(MLXREG_SDK_DIR)
 AC_SUBST(DEVICE_DIR)

--- a/debian-sdk/rules
+++ b/debian-sdk/rules
@@ -7,14 +7,14 @@
 export DH_OPTIONS
 
 %:
-	dh $@
+	dh $@ --parallel
 
 override_dh_auto_configure:
 	./autogen.sh
 	dh_auto_configure -- --enable-adb-generic-tools --enable-mstflint-sdk
 
 override_dh_auto_build:
-	$(MAKE) sdk
+	dh_auto_build -- sdk
 
 override_dh_auto_install:
 	$(MAKE) install-sdk DESTDIR=$(CURDIR)/debian/mstflint-sdk

--- a/mft_sdk/Makefile.am
+++ b/mft_sdk/Makefile.am
@@ -90,7 +90,7 @@ libmstflint_sdk_la_LIBADD = \
     $(top_builddir)/hca_capabilities/libhca_capabilities.la \
     $(top_builddir)/mlxreg/mlxreg_sdk/libmlxreg_sdk.la \
     $(top_builddir)/mlxlink/modules/libmodules_lib.la \
-    $(top_builddir)/mlxreg/mlxreg_lib/libmstreg_lib.la \
+    $(MSTREG_SDK_WHOLE_ARCHIVE) \
     $(top_builddir)/mft_utils/libmftutils.la \
     $(MTCR_SDK_WHOLE_ARCHIVE) \
     $(top_builddir)/adb_parser/libadb_parser.la \

--- a/mstflint-sdk.spec.in
+++ b/mstflint-sdk.spec.in
@@ -12,8 +12,10 @@
 
 %if 0%{?suse_version}
 %define expat_devel_lib libexpat-devel
+%define openssl_devel_lib libopenssl-devel
 %else
 %define expat_devel_lib expat-devel
+%define openssl_devel_lib openssl-devel
 %endif
 
 Summary: mstflint SDK - standalone shared library and headers
@@ -32,7 +34,9 @@ BuildRequires: pkgconfig
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: libtool
+BuildRequires: gcc-c++
 BuildRequires: %{expat_devel_lib}
+BuildRequires: %{openssl_devel_lib}
 BuildRequires: xz-devel
 BuildRequires: zlib-devel
 


### PR DESCRIPTION
## Problem

`./build_sdk.sh --deb` failed at configure with:
```
config.status: error: cannot find input file: `mft_sdk/Makefile.in'
```

The deb staging replaces `debian/` with `debian-sdk/`, but configure.ac unconditionally declares `AC_CONFIG_FILES(debian/mstflint.install)`, so automake requires the `debian/mstflint.install.in` template. With it missing, automake failed (`required file 'debian/mstflint.install.in' not found`) and generated **no** Makefile.in files; `autogen.sh` does not stop on that error, so the failure only surfaced later in configure.

Fixing that exposed a second bug in **both** deb and rpm flows — `make install-sdk` failed with:
```
/usr/bin/ld: cannot find -lmtcr_ul
```
`libmstreg_lib.la` records `libmtcr_ul.la` in its `dependency_libs`, so libtool linked `libmstflint_sdk.so` against the *uninstalled shared* `libmtcr_ul.so` and scheduled an install-time relink with `-lmtcr_ul`. `install-sdk` does not install libmtcr_ul (the SDK embeds mtcr_ul statically via `--whole-archive`), so the relink only succeeded on machines that already had mstflint's `libmtcr_ul.so` installed system-wide.

## Fixes

- `build_sdk.sh`: stage `debian/mstflint.install.in` into the isolated deb tree. The generated `debian/mstflint.install` is inert — it belongs to the `mstflint` package, which `debian-sdk/control` does not declare.
- `mft_sdk/Makefile.am` + `configure.ac`: link `libmstreg_lib` into the SDK as a whole-archive static archive (same pattern as mtcr_ul, via a configure-substituted `MSTREG_SDK_WHOLE_ARCHIVE` variable, since automake rejects raw `-Wl` tokens in `_LIBADD`). This removes the libtool dependency edge to `libmtcr_ul.la` and with it the install-time relink.

## deb/rpm flow alignment

- deb staging now excludes `config.status`/`config.log`/`autom4te.cache`, as the rpm source tarball already does
- deb builds in parallel (`dh --parallel` + `dh_auto_build`), mirroring the spec's `make %{?_smp_mflags} sdk`
- the SDK spec now declares `gcc-c++` and `openssl-devel` BuildRequires, matching `debian-sdk/control` (`g++`, `libssl-dev`); configure defaults `--enable-openssl` to yes and errors without openssl headers

## Validation

- `./build_sdk.sh --deb` on Ubuntu 24.04
- `./build_sdk.sh --rpm` on RHEL 10, on a clean machine **without** mstflint installed (previously failed there at `%install`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)