### PR TITLE
port MFT 4.37.0 [adb_parser][hca_capabilities][mlxlink][mlxreg][mstdump][common]

### DIFF
--- a/adb_parser/adb_exceptionHolder.cpp
+++ b/adb_parser/adb_exceptionHolder.cpp
@@ -35,6 +35,9 @@
 
 #include "adb_exceptionHolder.h"
 
+#include <iostream>
+#include <utility>
+
 ExceptionsMap ExceptionHolder::adbExceptionMap;
 const string ExceptionHolder::FATAL_EXCEPTION = "FATAL";
 const string ExceptionHolder::ERROR_EXCEPTION = "ERROR";
@@ -106,6 +109,43 @@ void ExceptionHolder::insertNewException(const string exceptionType, string exce
 {
     ExceptionHolder::adbExceptionMap[exceptionType].push_back(exceptionTxt);
     ExceptionHolder::exceptionCounter += 1;
+}
+
+void ExceptionHolder::appendLocationSuffix(string& exceptionTxt, const string& fileName, int lineNumber)
+{
+    if (lineNumber < 0)
+    {
+        return;
+    }
+    if (fileName.empty())
+    {
+        exceptionTxt += ", line: " + std::to_string(lineNumber);
+    }
+    else
+    {
+        exceptionTxt += ", in file: \"" + fileName + "\" line: " + std::to_string(lineNumber);
+    }
+}
+
+bool ExceptionHolder::handle_exception(bool allowMultipleExceptions,
+                                       string exceptionTxt,
+                                       const string& expType,
+                                       const string& fileName,
+                                       int lineNumber,
+                                       bool raise_warnings)
+{
+    appendLocationSuffix(exceptionTxt, fileName, lineNumber);
+    if (allowMultipleExceptions)
+    {
+        insertNewException(expType, exceptionTxt);
+        return false;
+    }
+    if (!raise_warnings && expType == WARN_EXCEPTION)
+    {
+        cerr << "-WARNING-: " << exceptionTxt << endl;
+        return false;
+    }
+    throw AdbException(exceptionTxt);
 }
 
 /**

--- a/adb_parser/adb_exceptionHolder.h
+++ b/adb_parser/adb_exceptionHolder.h
@@ -52,6 +52,16 @@ class ExceptionHolder
 public:
     // METHODS
     static void insertNewException(const string exceptionType, string exceptionTxt);
+    // Appends the shared adb_parser location suffix (", in file: \"<file>\" line: <N>", or
+    // ", line: <N>" when the file name is empty). No-op when lineNumber < 0. This is THE
+    // single convention for annotating a-me errors/warnings with their source location.
+    static void appendLocationSuffix(string& exceptionTxt, const string& fileName = string(), int lineNumber = -1);
+    static bool handle_exception(bool allowMultipleExceptions,
+                                 string exceptionTxt,
+                                 const string& expType,
+                                 const string& fileName = string(),
+                                 int lineNumber = -1,
+                                 bool raise_warnings = true);
     static ExceptionsMap getAdbExceptionsMap();
     static int getNumberOfExceptions();
     static string printAdbExceptionMap();
@@ -85,6 +95,7 @@ private:
 class AdbStopException : public std::exception
 {
 };
+
 /**
  * Function: ExceptionHolder::getNumberOfExceptions
  * This function return the number of exceptions found

--- a/adb_parser/adb_instance.cpp
+++ b/adb_parser/adb_instance.cpp
@@ -116,7 +116,7 @@ _AdbInstance_impl<e, T_OFFSET>::_AdbInstance_impl(AdbField* i_fieldDesc,
 //     auto found = getInstanceAttr("condition", value);
 //     if (found && parent->getInstanceAttr("is_conditional") == "1")
 //     {
-//         inst_ops_props.condition.setCondition(value);
+//         inst_ops_props.condition.init(value);
 //     }
 
 //     found = getInstanceAttr("size_condition", value);
@@ -127,7 +127,7 @@ _AdbInstance_impl<e, T_OFFSET>::_AdbInstance_impl(AdbField* i_fieldDesc,
 //         {
 //             cond_size.erase(0, 10);
 //         }
-//         inst_ops_props.conditionalSize.setCondition(cond_size);
+//         inst_ops_props.conditionalSize.init(cond_size);
 //     }
 // }
 
@@ -539,7 +539,7 @@ string _AdbInstance_impl<e, O>::fullName(size_t skipLevel)
 
 template<bool e, typename O>
 void _AdbInstance_impl<e, O>::init_props(unsigned char adabe_version) // logic of this function is copied from devmon
-                                                                      // and it's bugous
+// and it's bugous
 {
     if (!fieldDesc)
     {
@@ -1244,6 +1244,9 @@ map<string, uint64_t> _AdbInstance_impl<e, O>::getEnumMap()
     vector<string> enumValues;
     Algorithm::split(enumValues, enums, Algorithm::is_any_of(","));
 
+    // This function is permissive to errors in the format of specific enum pairs, to return even partial enum if
+    // possible.
+    // TODO: add to AdbParse level warning for all those cases in addition to continuing (1)
     for (size_t i = 0; i < enumValues.size(); i++)
     {
         vector<string> pair;
@@ -1587,12 +1590,312 @@ _AdbInstance_impl<e, O>::LayoutPartitionProps::LayoutPartitionProps(PartitionTre
 {
 }
 
+namespace
+{
+template<bool eval_expr, typename T_OFFSET>
+uint64_t trvrs_calc_cond_num_elements(_AdbInstance_impl<eval_expr, T_OFFSET>* instance,
+                                      T_OFFSET offset_shift,
+                                      const uint8_t* buffer,
+                                      uint32_t buffer_size,
+                                      bool evaluate_conditions,
+                                      bool allow_multiple_exceptions)
+{
+    uint64_t num_elements = 1;
+    auto* array_size_condition = instance->getArraySizeCondition();
+    if (array_size_condition)
+    {
+        if (evaluate_conditions)
+        {
+            try
+            {
+                num_elements = array_size_condition->evaluate(const_cast<uint8_t*>(buffer), offset_shift);
+            }
+            catch (const AdbException& e)
+            {
+                num_elements = 1;
+                string message = "Field " + instance->get_field_name() +
+                                 " with array size condition, evaluation failed, treating as regular node and "
+                                 "processing all children\n" +
+                                 e.what();
+                ExceptionHolder::handle_exception(allow_multiple_exceptions, message, ExceptionHolder::WARN_EXCEPTION,
+                                                  "", -1, false);
+            }
+        }
+        else if (buffer_size > 0)
+        {
+            T_OFFSET current_bit_offset = instance->offset + offset_shift;
+            T_OFFSET current_byte_offset = current_bit_offset / 8;
+            T_OFFSET remaining_bytes = (buffer_size > current_byte_offset) ? (buffer_size - current_byte_offset) : 0;
+            T_OFFSET remaining_bits = remaining_bytes * 8;
+            T_OFFSET element_size_bits = instance->get_size();
+
+            if (element_size_bits > 0 && remaining_bits >= element_size_bits)
+            {
+                num_elements = remaining_bits / element_size_bits;
+            }
+            else
+            {
+                num_elements = 0;
+            }
+        }
+    }
+    return num_elements;
+}
+
+template<bool eval_expr, typename T_OFFSET>
+string trvrs_get_element_array_suffix(uint64_t i, _AdbInstance_impl<eval_expr, T_OFFSET>* instance, bool full_path)
+{
+    string array_index = "";
+    string array_suffix = "";
+    uint32_t low_bound = instance->fieldDesc ? instance->fieldDesc->lowBound : 0;
+
+    if (instance->fieldDesc && instance->fieldDesc->array_type == AdbField_impl<T_OFFSET>::ArrayType::dynamic)
+    {
+        array_index = to_string(i + low_bound);
+    }
+    else if (instance->fieldDesc && instance->fieldDesc->array_type >= AdbField_impl<T_OFFSET>::ArrayType::definite &&
+             instance->fieldDesc->array_type < AdbField_impl<T_OFFSET>::ArrayType::dynamic)
+    {
+        array_index = to_string(instance->arrIdx + low_bound);
+    }
+    if (!array_index.empty())
+    {
+        array_suffix =
+          full_path || !instance->isNode() || (instance->fieldDesc && instance->fieldDesc->subNode == "uint64") ?
+            "[" + array_index + "]" :
+            "_" + array_index;
+    }
+    return array_suffix;
+}
+
+template<bool eval_expr, typename T_OFFSET>
+void trvrs_handle_enums(_AdbInstance_impl<eval_expr, T_OFFSET>* instance,
+                        const string& element_path,
+                        T_OFFSET element_offset_shift,
+                        const uint8_t* buffer,
+                        bool (*func)(const string&, uint64_t, uint64_t, _AdbInstance_impl<eval_expr, T_OFFSET>*, void*),
+                        void* context)
+{
+    T_OFFSET field_offset = instance->offset + element_offset_shift;
+    uint64_t enum_value =
+      pop_from_buf(buffer, static_cast<uint32_t>(field_offset), static_cast<uint32_t>(instance->get_size()));
+
+    string enum_string;
+    if (instance->intToEnum(enum_value, enum_string))
+    {
+        func(element_path, field_offset, enum_value, instance, context);
+    }
+    else
+    {
+        func(element_path, field_offset, enum_value, instance, context);
+    }
+}
+
+template<bool eval_expr, typename T_OFFSET>
+_AdbInstance_impl<eval_expr, T_OFFSET>* trvrs_get_selected_node(_AdbInstance_impl<eval_expr, T_OFFSET>* instance,
+                                                                T_OFFSET element_offset_shift,
+                                                                const uint8_t* buffer)
+{
+    u_int32_t selectorValue =
+      pop_from_buf(buffer, static_cast<uint32_t>(instance->unionSelector->offset + element_offset_shift),
+                   static_cast<uint32_t>(instance->unionSelector->get_size()));
+
+    return instance->getUnionSelectedNodeName(selectorValue);
+}
+} // namespace
+
+/**
+ * Function: _AdbInstance_impl::traverse_layout
+ **/
+template<bool eval_expr, typename T_OFFSET>
+void _AdbInstance_impl<eval_expr, T_OFFSET>::traverse_layout(
+  const string& path,
+  T_OFFSET offset_shift,
+  const uint8_t* buffer,
+  uint32_t buffer_size,
+  bool (*func)(const string&, uint64_t, uint64_t, _AdbInstance_impl<eval_expr, T_OFFSET>*, void*),
+  void* context,
+  bool evaluate_conditions,
+  bool handle_enums,
+  bool full_path,
+  bool allow_multiple_exceptions)
+{
+    string suffix = "";
+    bool stop = false;
+    traverse_layout(path, offset_shift, buffer, buffer_size, func, context, suffix, stop, evaluate_conditions,
+                    handle_enums, full_path, allow_multiple_exceptions);
+}
+
+template<bool eval_expr, typename T_OFFSET>
+void _AdbInstance_impl<eval_expr, T_OFFSET>::traverse_layout(
+  const string& path,
+  T_OFFSET offset_shift,
+  const uint8_t* buffer,
+  uint32_t buffer_size,
+  bool (*func)(const string&, uint64_t, uint64_t, _AdbInstance_impl<eval_expr, T_OFFSET>*, void*),
+  void* context,
+  string suffix,
+  bool& stop,
+  bool evaluate_conditions,
+  bool handle_enums,
+  bool full_path,
+  bool allow_multiple_exceptions)
+{
+    string error_message;
+
+    if (stop || !func)
+    {
+        return;
+    }
+
+    evaluate_conditions = evaluate_conditions && buffer && buffer_size > 0;
+    handle_enums = handle_enums && buffer && buffer_size > 0;
+
+    auto* condition = this->getCondition();
+    if (evaluate_conditions && condition && !condition->get_condition().empty())
+    {
+        try
+        {
+            uint64_t condition_result = condition->evaluate(const_cast<uint8_t*>(buffer), offset_shift);
+            if (condition_result == 0)
+            {
+                return;
+            }
+        }
+        catch (const AdbException& e)
+        {
+            error_message = "Field " + this->get_field_name() +
+                            " with condition, evaluation failed, treating as regular node and processing all "
+                            "children\n" +
+                            e.what();
+            ExceptionHolder::handle_exception(allow_multiple_exceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                              "", -1, false);
+        }
+    }
+
+    uint64_t num_elements = trvrs_calc_cond_num_elements(this, offset_shift, buffer, buffer_size, evaluate_conditions,
+                                                         allow_multiple_exceptions);
+
+    string previous_suffix = suffix;
+    for (uint64_t i = 0; i < num_elements; i++)
+    {
+        if (stop)
+        {
+            return;
+        }
+
+        string path_suffix = trvrs_get_element_array_suffix(i, this, full_path);
+        string element_path = full_path ? path + path_suffix : path;
+        if (!full_path && !path_suffix.empty())
+        {
+            suffix = this->isNode() ? previous_suffix + path_suffix : path_suffix;
+        }
+
+        string sep = element_path.empty() ? "" : ".";
+        T_OFFSET element_offset_shift = offset_shift + (this->get_size() * i);
+
+        if (handle_enums && this->isEnumExists())
+        {
+            trvrs_handle_enums(this, element_path, element_offset_shift, buffer, func, context);
+        }
+        else if (this->isNode() && !this->subItems.empty())
+        {
+            if (evaluate_conditions && this->isUnion() && this->unionSelector)
+            {
+                _AdbInstance_impl<eval_expr, T_OFFSET>* selectedNode = nullptr;
+                try
+                {
+                    selectedNode = trvrs_get_selected_node(this, element_offset_shift, buffer);
+                }
+                catch (const AdbException& e)
+                {
+                    error_message = "Field " + this->get_field_name() +
+                                    " with union selector failed treating as regular node and processing all "
+                                    "children\n" +
+                                    e.what();
+                    ExceptionHolder::handle_exception(allow_multiple_exceptions, error_message,
+                                                      ExceptionHolder::WARN_EXCEPTION, "", -1, false);
+                    for (auto sub_item : this->subItems)
+                    {
+                        if (stop)
+                        {
+                            return;
+                        }
+                        string sub_item_path =
+                          full_path ? element_path + sep + sub_item->fieldDesc->name : sub_item->fieldDesc->name;
+                        sub_item->traverse_layout(sub_item_path, element_offset_shift, buffer, buffer_size, func,
+                                                  context, suffix, stop, evaluate_conditions, handle_enums, full_path,
+                                                  allow_multiple_exceptions);
+                    }
+                    return;
+                }
+                string selected_node_path =
+                  full_path ? element_path + sep + selectedNode->fieldDesc->name : selectedNode->fieldDesc->name;
+                selectedNode->traverse_layout(selected_node_path, element_offset_shift, buffer, buffer_size, func,
+                                              context, suffix, stop, evaluate_conditions, handle_enums, full_path,
+                                              allow_multiple_exceptions);
+            }
+            else
+            {
+                for (auto sub_item : this->subItems)
+                {
+                    if (stop)
+                    {
+                        return;
+                    }
+                    string sub_item_path =
+                      full_path ? element_path + sep + sub_item->fieldDesc->name : sub_item->fieldDesc->name;
+                    sub_item->traverse_layout(sub_item_path, element_offset_shift, buffer, buffer_size, func, context,
+                                              suffix, stop, evaluate_conditions, handle_enums, full_path,
+                                              allow_multiple_exceptions);
+                }
+            }
+        }
+        else
+        {
+            T_OFFSET field_offset = this->offset + element_offset_shift;
+            uint64_t value = 0;
+            if (buffer)
+            {
+                if (buffer_size >= (field_offset + this->get_size()) / 8)
+                {
+                    value = pop_from_buf(buffer, static_cast<uint32_t>(field_offset),
+                                         static_cast<uint32_t>(this->get_size()));
+                }
+                else
+                {
+                    error_message = "On layout traversal, trying to evaluate field, " + this->get_field_name() +
+                                    ", with offset, " + to_string(field_offset) + ",overflowing the buffer size, " +
+                                    to_string(buffer_size) + "\n";
+                    ExceptionHolder::handle_exception(allow_multiple_exceptions, error_message,
+                                                      ExceptionHolder::ERROR_EXCEPTION);
+                }
+            }
+            if (!full_path)
+            {
+                bool is_uint64 =
+                  this->parent && this->parent->fieldDesc && this->parent->fieldDesc->subNode == "uint64";
+                if (is_uint64)
+                {
+                    element_path = this->parent->fieldDesc->name + suffix + "_" + element_path;
+                }
+                else if (!suffix.empty())
+                {
+                    element_path += suffix;
+                }
+            }
+            stop = func(element_path, field_offset, value, this, context);
+        }
+    }
+}
+
 template class _AdbInstance_impl<false, uint32_t>;
 template class _AdbInstance_impl<true, uint32_t>;
 
 template class _AdbInstance_impl<false, uint64_t>;
 template class _AdbInstance_impl<true, uint64_t>;
 
+// Explicit instantiations for member template methods - only for valid enable_if combinations
 template typename enable_if<true, _AdbCondition_impl<uint32_t>*>::type
   _AdbInstance_impl<true, uint32_t>::getCondition<true>();
 template typename enable_if<true, _AdbCondition_impl<uint64_t>*>::type

--- a/adb_parser/adb_instance.h
+++ b/adb_parser/adb_instance.h
@@ -137,23 +137,24 @@ class _AdbInstance_impl
 {
     using AdbNode = AdbNode_impl<T_OFFSET>;
     using AdbField = AdbField_impl<T_OFFSET>;
+
     using AdbNodeLarge = AdbNodeLarge_impl<T_OFFSET>;
     using AdbFieldLarge = AdbFieldLarge_impl<T_OFFSET>;
+
     using AdbCondition = _AdbCondition_impl<T_OFFSET>;
-struct InstOpsPropertiesBasic
-{
-    LayoutItemAttrsMap* instAttrsMap{nullptr}; // Attributes after evaluations and array expanding
-};
 
-struct InstOpsPropertiesExtended
-{
+    struct InstOpsPropertiesBasic
+    {
         LayoutItemAttrsMap* instAttrsMap{nullptr}; // Attributes after evaluations and array expanding
-    AttrsMap varsMap{};               // all variables relevant to this item after evaluation
-    AdbCondition condition{};
-    AdbCondition conditionalSize{}; // for dynamic arrays
-};
+    };
 
-
+    struct InstOpsPropertiesExtended
+    {
+        LayoutItemAttrsMap* instAttrsMap{nullptr}; // Attributes after evaluations and array expanding
+        AttrsMap varsMap{};                        // all variables relevant to this item after evaluation
+        AdbCondition condition{};
+        AdbCondition conditionalSize{}; // for dynamic arrays
+    };
 
     using InstOpsProperties = typename conditional<eval_expr, InstOpsPropertiesExtended, InstOpsPropertiesBasic>::type;
 
@@ -271,8 +272,10 @@ public:
 
     template<bool U = eval_expr>
     typename enable_if<!U, AttrsMap>::type getVarsMap();
+
     template<bool U = eval_expr>
     typename enable_if<U, AdbCondition*>::type getCondition();
+
     template<bool U = eval_expr>
     typename enable_if<!U, AdbCondition*>::type getCondition();
 
@@ -287,6 +290,17 @@ public:
     void pushBufLE(uint8_t* buf, uint64_t value);
     uint64_t popBuf(uint8_t* buf);
     uint64_t popBufLE(uint8_t* buf);
+
+    void traverse_layout(const string& path,
+                         T_OFFSET offset_shift,
+                         const uint8_t* buffer,
+                         uint32_t buffer_size,
+                         bool (*func)(const string&, uint64_t, uint64_t, _AdbInstance_impl<eval_expr, T_OFFSET>*, void*),
+                         void* context,
+                         bool evaluate_conditions = true,
+                         bool handle_enums = false,
+                         bool full_path = true,
+                         bool allow_multiple_exceptions = false);
 
     template<bool U = eval_expr>
     typename enable_if<U>::type initInstOps();
@@ -316,8 +330,22 @@ public:
     AdbField* _max_leaf{nullptr}; // for DS alignment check
     InstancePropertiesMask inst_props{};
     LayoutPartitionProps* partition_props{nullptr};
+
 private:
     _AdbInstance_impl<eval_expr, T_OFFSET>* find_layout_item_dfs(const std::string& path);
+
+    void traverse_layout(const string& path,
+                         T_OFFSET offset_shift,
+                         const uint8_t* buffer,
+                         uint32_t buffer_size,
+                         bool (*func)(const string&, uint64_t, uint64_t, _AdbInstance_impl<eval_expr, T_OFFSET>*, void*),
+                         void* context,
+                         string suffix,
+                         bool& stop,
+                         bool evaluate_conditions = true,
+                         bool handle_enums = false,
+                         bool full_path = true,
+                         bool allow_multiple_exceptions = false);
 };
 
 // TODO: try to move the function definition below to the cpp file, currently fails linkage
@@ -331,7 +359,7 @@ typename enable_if<U>::type _AdbInstance_impl<eval_expr, O>::initInstOps()
     {
         auto is_conditional = parent->nodeDesc->attrs.find("is_conditional");
         if (is_conditional != parent->nodeDesc->attrs.end() && is_conditional->second == "1")
-    {
+        {
             inst_ops_props.condition.init(value);
         }
     }

--- a/adb_parser/adb_parser.cpp
+++ b/adb_parser/adb_parser.cpp
@@ -43,12 +43,12 @@
 #include "adb_instance.h"
 #include "adb_condition.h"
 #include "adb_condVar.h"
-#include "buf_ops.h"
 #include <iostream>
 #include <sstream>
 #include <algorithm>
 #include "common/tools_algorithm.h"
 #include "common/tools_regex.h"
+#include "common/tools_utils.h"
 
 namespace Algorithm = mstflint::common::algorithm;
 namespace Regex = mstflint::common::regex;
@@ -124,32 +124,6 @@ _Adb_impl<e, O>::~_Adb_impl()
         delete iter->second;
 
     delete _logFile;
-}
-
-/**
- * Function: _Adb_impl::raiseException
- **/
-template<bool e, typename O>
-void _Adb_impl<e, O>::raiseException(bool allowMultipleExceptions,
-                                     string exceptionTxt,
-                                     const string expType,
-                                     bool raise_warnings)
-{
-    if (allowMultipleExceptions)
-    {
-        ExceptionHolder::insertNewException(expType, exceptionTxt);
-    }
-    else
-    {
-        if (!raise_warnings && expType == ExceptionHolder::WARN_EXCEPTION)
-        {
-            cerr << "-WARNING-: " << exceptionTxt << endl;
-    	}
-    	else
-    	{
-            throw AdbException(exceptionTxt);
-    	}
-    }
 }
 
 /**
@@ -455,6 +429,7 @@ typename _Adb_impl<e, O>::PathPart
 {
     PathPart result;
     result.first = part;
+    string error_message;
 
     if (!ranges_str.empty())
     {
@@ -464,12 +439,13 @@ typename _Adb_impl<e, O>::PathPart
         {
             Algorithm::trim(range);
 
+            // Validate that range is not empty after trimming (throw if field[,2] or field[1,,3])
             if (range.empty())
             {
-                raiseException(
-                  allowMultipleExceptions,
-                  "Failed to parse missing_sons attribute: empty range in '" + part + "[" + ranges_str + "]'",
-                  ExceptionHolder::WARN_EXCEPTION);
+                error_message =
+                  "Failed to parse missing_sons attribute: empty range in '" + part + "[" + ranges_str + "]'";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::WARN_EXCEPTION);
                 break;
             }
 
@@ -478,29 +454,35 @@ typename _Adb_impl<e, O>::PathPart
             {
                 if (colon_pos != string::npos)
                 {
+                    // Parse range format: start:end
                     string start_str = range.substr(0, colon_pos);
                     string end_str = range.substr(colon_pos + 1);
 
+                    // Validate that both start and end parts are not empty
+                    // Example: field[:5] or field[3:] or field[:]
                     if (start_str.empty() || end_str.empty())
                     {
-                        raiseException(
-                          allowMultipleExceptions,
-                          "Failed to parse missing_sons attribute: invalid range '" + part + "[" + range + "]'",
-                          ExceptionHolder::WARN_EXCEPTION);
+                        error_message =
+                          "Failed to parse missing_sons attribute: invalid range '" + part + "[" + range + "]'";
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                          ExceptionHolder::WARN_EXCEPTION);
                         break;
                     }
 
+                    // Parse and validate that entire strings are consumed
                     size_t start_idx = 0;
                     size_t end_idx = 0;
                     uint32_t start = stoul(start_str, &start_idx);
                     uint32_t end = stoul(end_str, &end_idx);
 
+                    // Validate that the entire string was parsed and start <= end
+                    // Examples: field[1a:5] or field[1:5b] or field[3:2] or field[1-5]
                     if (start_idx != start_str.length() || end_idx != end_str.length() || start > end)
                     {
-                        raiseException(
-                          allowMultipleExceptions,
-                          "Failed to parse missing_sons attribute: invalid range '" + part + "[" + range + "]'",
-                          ExceptionHolder::WARN_EXCEPTION);
+                        error_message =
+                          "Failed to parse missing_sons attribute: invalid range '" + part + "[" + range + "]'";
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                          ExceptionHolder::WARN_EXCEPTION);
                         break;
                     }
 
@@ -511,15 +493,18 @@ typename _Adb_impl<e, O>::PathPart
                 }
                 else
                 {
+                    // Parse single index
                     size_t idx = 0;
                     uint32_t value = stoul(range, &idx);
 
+                    // Validate that the entire string was parsed (no trailing invalid characters)
+                    // Examples: field[1.] or field[5abc] or field[2-3]
                     if (idx != range.length())
                     {
-                        raiseException(
-                          allowMultipleExceptions,
-                          "Failed to parse missing_sons attribute: invalid index '" + part + "[" + range + "]'",
-                          ExceptionHolder::WARN_EXCEPTION);
+                        error_message =
+                          "Failed to parse missing_sons attribute: invalid index '" + part + "[" + range + "]'";
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                          ExceptionHolder::WARN_EXCEPTION);
                         break;
                     }
 
@@ -528,18 +513,18 @@ typename _Adb_impl<e, O>::PathPart
             }
             catch (const std::runtime_error&)
             {
-                raiseException(
-                  allowMultipleExceptions,
-                  "Failed to parse missing_sons attribute: invalid number in '" + part + "[" + range + "]'",
-                  ExceptionHolder::WARN_EXCEPTION);
+                error_message =
+                  "Failed to parse missing_sons attribute: invalid number in '" + part + "[" + range + "]'";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::WARN_EXCEPTION);
                 break;
             }
             catch (const std::logic_error&)
             {
-                raiseException(
-                  allowMultipleExceptions,
-                  "Failed to parse missing_sons attribute: invalid number in '" + part + "[" + range + "]'",
-                  ExceptionHolder::WARN_EXCEPTION);
+                error_message =
+                  "Failed to parse missing_sons attribute: invalid number in '" + part + "[" + range + "]'";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::WARN_EXCEPTION);
                 break;
             }
         }
@@ -570,9 +555,9 @@ vector<typename _Adb_impl<e, O>::SplittedPath> _Adb_impl<e, O>::parse_missing_so
                     auto& match = *it;
                     if (match.position() != prev_end)
                     {
-                        raiseException(allowMultipleExceptions,
-                                       "Failed to parse missing_sons: invalid format '" + path + "'",
-                                       ExceptionHolder::WARN_EXCEPTION);
+                        string message = "Failed to parse missing_sons: invalid format '" + path + "'";
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, message,
+                                                          ExceptionHolder::WARN_EXCEPTION);
                         return missing_sons;
                     }
                     prev_end = match.position() + match.length();
@@ -655,6 +640,7 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
 {
     try
     {
+        string error_message;
         // find root in nodes map
         typename NodesMap::iterator it;
         it = nodesMap.find(rootNodeName);
@@ -715,11 +701,13 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
             string path_prefix = string();
             if (!ancestor_path.empty())
             {
+                // Remove first element if it exists
                 size_t first_dot = ancestor_path.find('.');
                 if (first_dot != string::npos)
                 {
                     path_prefix = ancestor_path.substr(first_dot + 1);
                 }
+                // Add rootItem's field name
                 path_prefix =
                   path_prefix.empty() ? rootItem->get_field_name() : path_prefix + "." + rootItem->get_field_name();
             }
@@ -731,9 +719,12 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                 {
                     path = path.substr(idx + 1);
                 }
+
+                // If ancestor_th is provided, check if path starts with it and remove it
                 if (!path_prefix.empty() && path.compare(0, path_prefix.length(), path_prefix) == 0)
                 {
                     path = path.substr(path_prefix.length());
+                    // Remove leading dot if present
                     if (!path.empty() && path[0] == '.')
                     {
                         path = path.substr(1);
@@ -745,9 +736,10 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                 {
                     if (strict_instance_ops)
                     {
-                        raiseException(allowMultipleExceptions,
-                                       "Can't find instance path (" + it->first + ") defined in <instance_ops> section",
-                                       ExceptionHolder::ERROR_EXCEPTION);
+                        error_message =
+                          "Can't find instance path (" + it->first + ") defined in <instance_ops> section";
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                          ExceptionHolder::ERROR_EXCEPTION);
                     }
                     else
                     {
@@ -790,10 +782,10 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                         { // give this warning only if this root instantiation
                             if (allowMultipleExceptions)
                                 cout << "allow multiple";
-                            raiseException(allowMultipleExceptions,
-                                           "Invalid union selector (" + inst->fullName() +
-                                             "), must be a leaf field, cannot be a parent of root",
-                                           ExceptionHolder::ERROR_EXCEPTION);
+                            error_message = "Invalid union selector (" + inst->fullName() +
+                                            "), must be a leaf field, cannot be a parent of root";
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION);
                         }
                         break;
                     }
@@ -817,10 +809,10 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                         foundSelector = false;
                         if (rootNodeName == rootNode)
                         { // give this warning only if this root instantiation
-                            raiseException(allowMultipleExceptions,
-                                           "Failed to find union selector for union (" + inst->fullName() +
-                                             ") Can't find field (" + path[i] + ") under (" + curInst->fullName() + ")",
-                                           ExceptionHolder::ERROR_EXCEPTION);
+                            error_message = "Failed to find union selector for union (" + inst->fullName() +
+                                            ") Can't find field (" + path[i] + ") under (" + curInst->fullName() + ")";
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION);
                         }
                         break;
                     }
@@ -832,28 +824,35 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                 string selector_val;
                 inst->unionSelector = curInst;
 
+                // Validate the union selector: must be an enum, must have unique
+                // values (otherwise selection is ambiguous), and every subitem's
+                // "selected_by" value must exist in the enum.
                 if (!inst->unionSelector->isEnumExists())
                 {
-                    string exceptionTxt = "In union (" + inst->fullName() + ") the union selector (" +
-                                          inst->unionSelector->fullName() + ") is not an enum";
-                    raiseException(allowMultipleExceptions, exceptionTxt, ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "In union (" + inst->fullName() + ") the union selector (" +
+                                    inst->unionSelector->fullName() + ") is not an enum";
+                    ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                      ExceptionHolder::ERROR_EXCEPTION);
                 }
                 else
                 {
+                    // Build the enum map once (name -> value) for all subitem checks below.
                     map<string, uint64_t> selectorValMap = inst->unionSelector->getEnumMap();
 
+                    // // Detect duplicate enum values — e.g. "OPT_A=0, OPT_B=0" makes the
+                    // // selector ambiguous because the runtime value 0 could match either subnode.
                     // map<uint64_t, string> valueToName;
                     // for (auto it = selectorValMap.begin(); it != selectorValMap.end(); ++it)
                     // {
                     //     auto result = valueToName.insert({it->second, it->first});
                     //     if (!result.second)
                     //     {
-                    //         raiseException(allowMultipleExceptions,
-                    //                        "In union (" + inst->fullName() + ") the union selector (" +
-                    //                          inst->unionSelector->fullName() + ") has duplicate enum value: '" +
-                    //                          it->first + "' and '" + result.first->second + "' both map to " +
-                    //                          to_string(it->second),
-                    //                        ExceptionHolder::WARN_EXCEPTION, false);
+                    //         error_message = "In union (" + inst->fullName() + ") the union selector (" +
+                    //                         inst->unionSelector->fullName() + ") has duplicate enum value: '" +
+                    //                         it->first + "' and '" + result.first->second + "' both map to " +
+                    //                         to_string(it->second);
+                    //         ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                    //                                           ExceptionHolder::WARN_EXCEPTION, "", -1, false);
                     //     }
                     // }
 
@@ -868,10 +867,10 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                         bool found = inst->subItems[i]->getInstanceAttr("selected_by", selector_val);
                         if (!found)
                         {
-                            raiseException(allowMultipleExceptions,
-                                           "In union (" + inst->fullName() + ") the union subnode (" +
-                                             inst->subItems[i]->get_field_name() + ") doesn't define selection value",
-                                           ExceptionHolder::ERROR_EXCEPTION);
+                            error_message = "In union (" + inst->fullName() + ") the union subnode (" +
+                                            inst->subItems[i]->get_field_name() + ") doesn't define selection value";
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION);
                         }
 
                         if (selector_val == "")
@@ -879,13 +878,15 @@ typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
                             continue;
                         }
 
+                        // Verify the subitem's selected_by value exists in the selector enum
                         if (selectorValMap.find(selector_val) == selectorValMap.end())
                         {
-                            string exceptionTxt = "In union (" + inst->fullName() + ") the union subnode (" +
-                                                  inst->subItems[i]->get_field_name() + ") uses a selector value (" +
-                                                  selector_val + ") which isn't defined in the selector field (" +
-                                                  inst->unionSelector->fullName() + ")";
-                            raiseException(allowMultipleExceptions, exceptionTxt, ExceptionHolder::ERROR_EXCEPTION);
+                            error_message = "In union (" + inst->fullName() + ") the union subnode (" +
+                                            inst->subItems[i]->get_field_name() + ") uses a selector value (" +
+                                            selector_val + ") which isn't defined in the selector field (" +
+                                            inst->unionSelector->fullName() + ")";
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION);
                         }
                     }
                 }
@@ -957,6 +958,7 @@ typename enable_if<U>::type _Adb_impl<eval_expr, O>::updateLayoutConditions(bool
                 if (reffered_layout_item)
                 {
                     currentVar->set_instance(reffered_layout_item);
+
                     if (reffered_layout_item->isEnumExists())
                     {
                         conditionObj.update_enum(currentName);
@@ -1047,6 +1049,7 @@ bool _Adb_impl<eval_expr, O>::createInstance(AdbField* field,
                                              PartitionTree* partition_tree,
                                              bool array_path_wildcards)
 {
+    string error_message;
     // Stop on exclude tree leaf
     auto stop_on_partition_tree = partition_tree && partition_tree->stop;
 
@@ -1061,9 +1064,8 @@ bool _Adb_impl<eval_expr, O>::createInstance(AdbField* field,
         auto nodes_it = nodesMap.find(field->subNode);
         if (nodes_it == nodesMap.end())
         {
-            raiseException(allowMultipleExceptions,
-                           "Can't find the definition for subnode: " + field->subNode + " of field: " + field->name,
-                           ExceptionHolder::ERROR_EXCEPTION);
+            error_message = "Can't find the definition for subnode: " + field->subNode + " of field: " + field->name;
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::ERROR_EXCEPTION);
         }
         else
         {
@@ -1125,10 +1127,9 @@ bool _Adb_impl<eval_expr, O>::createInstance(AdbField* field,
                 {
                     delete inst;
                     inst = nullptr; // Set inst to nullptr to avoid dangling pointer
-                    raiseException(
-                      false,
-                      "Cyclic definition of nodes, node: " + field->name + " was already added to the layout",
-                      ExceptionHolder::ERROR_EXCEPTION);
+                    error_message =
+                      "Cyclic definition of nodes, node: " + field->name + " was already added to the layout";
+                    ExceptionHolder::handle_exception(false, error_message, ExceptionHolder::ERROR_EXCEPTION);
                 }
                 else
                 {
@@ -1165,10 +1166,10 @@ bool _Adb_impl<eval_expr, O>::createInstance(AdbField* field,
 
                 if (_checkDsAlign && inst->get_max_leaf_size() != 0 && inst->get_size() % inst->get_max_leaf_size() != 0)
                 {
-                    raiseException(allowMultipleExceptions,
-                                   "Node: " + inst->nodeDesc->name + " size(" + to_string(inst->get_size()) +
-                                     ") is not aligned with largest leaf(" + to_string(inst->get_max_leaf_size()) + ")",
-                                   ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "Node: " + inst->nodeDesc->name + " size(" + to_string(inst->get_size()) +
+                                    ") is not aligned with largest leaf(" + to_string(inst->get_max_leaf_size()) + ")";
+                    ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                      ExceptionHolder::ERROR_EXCEPTION);
                 }
 
                 if (!inst->isUnion() && inst->subItems.size() > 0)
@@ -1180,12 +1181,13 @@ bool _Adb_impl<eval_expr, O>::createInstance(AdbField* field,
                     {
                         if (inst->subItems[j + 1]->offset < inst->subItems[j]->offset + inst->subItems[j]->get_size())
                         {
-                            string exceptionTxt =
+                            error_message =
                               "Field (" + inst->subItems[j + 1]->get_field_name() + ") (" +
                               formatAddr(inst->subItems[j + 1]->offset, inst->subItems[j + 1]->get_size()).c_str() +
                               ") overlaps with (" + inst->subItems[j]->get_field_name() + ") (" +
                               formatAddr(inst->subItems[j]->offset, inst->subItems[j]->get_size()).c_str() + ")";
-                            raiseException(allowMultipleExceptions, exceptionTxt, ExceptionHolder::ERROR_EXCEPTION);
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION);
                         }
                     }
                 }
@@ -1211,17 +1213,10 @@ void _Adb_impl<e, O>::checkInstanceOffsetValidity(AdbInstance* inst,
 {
     if (inst->offset + inst->get_size() > parent->offset + parent->get_size())
     {
-        string exceptionTxt = "Field (" + inst->get_field_name() + ") " + formatAddr(inst->offset, inst->get_size()) +
-                              " crosses its parent node (" + parent->get_field_name() + ") " +
-                              formatAddr(parent->offset, parent->get_size()) + " boundaries";
-        if (allowMultipleExceptions)
-        {
-            ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-        }
-        else
-        {
-            throw AdbException(exceptionTxt);
-        }
+        string error_message = "Field (" + inst->get_field_name() + ") " + formatAddr(inst->offset, inst->get_size()) +
+                               " crosses its parent node (" + parent->get_field_name() + ") " +
+                               formatAddr(parent->offset, parent->get_size()) + " boundaries";
+        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::ERROR_EXCEPTION);
     }
 }
 
@@ -1338,312 +1333,6 @@ PartitionTree* _Adb_impl<e, O>::prune_up(PartitionTree* partition_tree)
         } while (parent_tree && current_tree && current_tree->sub_items.size() == 0);
     }
     return partition_tree;
-}
-
-template<bool eval_expr, typename T_OFFSET>
-uint64_t _Adb_impl<eval_expr, T_OFFSET>::_trvrs_calc_cond_num_elements(AdbInstance* instance,
-                                                                       T_OFFSET offset_shift,
-                                                                       const uint8_t* buffer,
-                                                                       uint32_t buffer_size,
-                                                                       bool evaluate_conditions,
-                                                                       bool allow_multiple_exceptions)
-{
-    uint64_t num_elements = 1;
-    auto* array_size_condition = instance->getArraySizeCondition();
-    if (array_size_condition)
-    {
-        if (evaluate_conditions)
-        {
-            try
-            {
-                // Evaluate the conditional size to get the number of elements
-                num_elements = array_size_condition->evaluate(const_cast<uint8_t*>(buffer), offset_shift);
-            }
-            catch (const AdbException& e)
-            {
-                // If conditional size evaluation fails, default to 1 element
-                num_elements = 1;
-                raiseException(
-                  allow_multiple_exceptions,
-                  "Field " + instance->get_field_name() +
-                    " with array size condition, evaluation failed, treating as regular node and processing all children\n" +
-                    e.what(),
-                  ExceptionHolder::WARN_EXCEPTION, false);
-            }
-        }
-        else if (buffer_size > 0)
-        {
-            // Calculate maximum number of elements that fit in the remaining buffer
-            T_OFFSET current_bit_offset = instance->offset + offset_shift;
-            T_OFFSET current_byte_offset = current_bit_offset / 8;
-            T_OFFSET remaining_bytes = (buffer_size > current_byte_offset) ? (buffer_size - current_byte_offset) : 0;
-            T_OFFSET remaining_bits = remaining_bytes * 8;
-            T_OFFSET element_size_bits = instance->get_size();
-
-            if (element_size_bits > 0 && remaining_bits >= element_size_bits)
-            {
-                num_elements = remaining_bits / element_size_bits;
-            }
-            else
-            {
-                num_elements = 0; // No space for even one element
-            }
-        }
-    }
-    return num_elements;
-}
-
-template<bool eval_expr, typename T_OFFSET>
-string _Adb_impl<eval_expr, T_OFFSET>::_trvrs_get_element_array_suffix(uint64_t i, AdbInstance* instance, bool full_path)
-{
-    string array_index = "";
-    string array_suffix = "";
-    uint32_t low_bound = instance->fieldDesc ? instance->fieldDesc->lowBound : 0;
-
-    if (instance->fieldDesc && instance->fieldDesc->array_type == AdbField::ArrayType::dynamic)
-    {
-        array_index = to_string(i + low_bound);
-    }
-    else if (instance->fieldDesc && instance->fieldDesc->array_type >= AdbField::ArrayType::definite &&
-             instance->fieldDesc->array_type < AdbField::ArrayType::dynamic)
-    {
-        array_index = to_string(instance->arrIdx + low_bound);
-    }
-    if (!array_index.empty())
-    {
-        array_suffix =
-          full_path || !instance->isNode() || (instance->fieldDesc && instance->fieldDesc->subNode == "uint64") ?
-            "[" + array_index + "]" :
-            "_" + array_index;
-    }
-    return array_suffix;
-}
-
-template<bool eval_expr, typename T_OFFSET>
-void _Adb_impl<eval_expr, T_OFFSET>::_trvrs_handle_enums(
-  AdbInstance* instance,
-  const string& element_path,
-  T_OFFSET element_offset_shift,
-  const uint8_t* buffer,
-  bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-  void* context)
-{
-    T_OFFSET field_offset = instance->offset + element_offset_shift;
-    uint64_t enum_value =
-      pop_from_buf(buffer, static_cast<uint32_t>(field_offset), static_cast<uint32_t>(instance->get_size()));
-
-    string enum_string;
-    if (instance->intToEnum(enum_value, enum_string))
-    {
-        // For enums, we could call func with enum string info, but for simplicity use numeric value
-        func(element_path, field_offset, enum_value, instance, context);
-    }
-    else
-    {
-        func(element_path, field_offset, enum_value, instance, context);
-    }
-}
-
-template<bool eval_expr, typename T_OFFSET>
-typename _Adb_impl<eval_expr, T_OFFSET>::AdbInstance*
-  _Adb_impl<eval_expr, T_OFFSET>::_trvrs_get_selected_node(AdbInstance* instance,
-                                                           T_OFFSET element_offset_shift,
-                                                           const uint8_t* buffer)
-{
-    u_int32_t selectorValue =
-      pop_from_buf(buffer, static_cast<uint32_t>(instance->unionSelector->offset + element_offset_shift),
-                   static_cast<uint32_t>(instance->unionSelector->get_size()));
-
-    return instance->getUnionSelectedNodeName(selectorValue);
-}
-
-template<bool eval_expr, typename T_OFFSET>
-void _Adb_impl<eval_expr, T_OFFSET>::traverse_layout(
-  AdbInstance* instance,
-  const string& path,
-  T_OFFSET offset_shift,
-  const uint8_t* buffer,
-  uint32_t buffer_size, // TODO: validate correct type size
-  bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-  void* context,
-  bool evaluate_conditions,
-  bool handle_enums,
-  bool full_path,
-  bool allow_multiple_exceptions)
-{
-    string suffix = "";
-    bool stop = false;
-    traverse_layout(instance, path, offset_shift, buffer, buffer_size, func, context, suffix, stop, evaluate_conditions,
-                    handle_enums, full_path, allow_multiple_exceptions);
-}
-
-template<bool eval_expr, typename T_OFFSET>
-void _Adb_impl<eval_expr, T_OFFSET>::traverse_layout(
-  AdbInstance* instance,
-  const string& path,
-  T_OFFSET offset_shift,
-  const uint8_t* buffer,
-  uint32_t buffer_size, // TODO: validate correct type size
-  bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-  void* context,
-  string suffix,
-  bool& stop,
-  bool evaluate_conditions,
-  bool handle_enums,
-  bool full_path,
-  bool allow_multiple_exceptions)
-{
-    if (stop || !instance || !func)
-    {
-        return;
-    }
-
-    evaluate_conditions = evaluate_conditions && buffer && buffer_size > 0;
-    handle_enums = handle_enums && buffer && buffer_size > 0;
-
-    auto* condition = instance->getCondition();
-    if (evaluate_conditions && condition && !condition->get_condition().empty())
-    {
-        try
-        {
-            // Use the condition's evaluate method with the buffer
-            uint64_t condition_result = condition->evaluate(const_cast<uint8_t*>(buffer), offset_shift);
-            if (condition_result == 0)
-            {
-                return; // Skip this field if condition evaluates to false
-            }
-        }
-        catch (const AdbException& e)
-        {
-            // failed to evaluate condition, continue with the layout traversal
-            raiseException(
-              allow_multiple_exceptions,
-              "Field " + instance->get_field_name() +
-                " with condition, evaluation failed, treating as regular node and processing all children\n" + e.what(),
-              ExceptionHolder::WARN_EXCEPTION, false);
-        }
-    }
-
-    // Handle conditional arrays - evaluate conditional size to get num_elements
-    uint64_t num_elements = _trvrs_calc_cond_num_elements(instance, offset_shift, buffer, buffer_size,
-                                                          evaluate_conditions, allow_multiple_exceptions);
-
-    string previous_suffix = suffix;
-    for (uint64_t i = 0; i < num_elements; i++)
-    {
-        if (stop)
-        {
-            return;
-        }
-
-        string path_suffix = _trvrs_get_element_array_suffix(i, instance, full_path);
-        string element_path = full_path ? path + path_suffix : path;
-        if (!full_path && !path_suffix.empty())
-        {
-            suffix = instance->isNode() ? previous_suffix + path_suffix : path_suffix;
-        }
-
-        string sep = element_path.empty() ? "" : ".";
-        T_OFFSET element_offset_shift = offset_shift + (instance->get_size() * i);
-
-        // Handle enum fields - similar to _parse_enum_field, but only if handle_enums is true
-        if (handle_enums && instance->isEnumExists())
-        {
-            _trvrs_handle_enums(instance, element_path, element_offset_shift, buffer, func, context);
-        }
-        // Handle nodes with sub-items (structs/unions) - similar to field.subItems handling
-        else if (instance->isNode() && !instance->subItems.empty())
-        {
-            // For unions, handle selected items (simplified version of _get_union_selected_items)
-            if (evaluate_conditions && instance->isUnion() && instance->unionSelector)
-            {
-                AdbInstance* selectedNode = nullptr;
-                try
-                {
-                    selectedNode = _trvrs_get_selected_node(instance, element_offset_shift, buffer);
-                }
-                catch (const AdbException& e)
-                {
-                    // If getUnionSelectedNodeName throws an exception, treat as a regular non-union node
-                    // and process all children
-                    raiseException(
-                      allow_multiple_exceptions,
-                      "Field " + instance->get_field_name() +
-                        " with union selector failed treating as regular node and processing all children\n" + e.what(),
-                      ExceptionHolder::WARN_EXCEPTION, false);
-                    for (auto sub_item : instance->subItems)
-                    {
-                        if (stop)
-                        {
-                            return;
-                        }
-                        string sub_item_path =
-                          full_path ? element_path + sep + sub_item->fieldDesc->name : sub_item->fieldDesc->name;
-                        traverse_layout(sub_item, sub_item_path, element_offset_shift, buffer, buffer_size, func,
-                                        context, suffix, stop, evaluate_conditions, handle_enums, full_path,
-                                        allow_multiple_exceptions);
-                    }
-                    return;
-                }
-                string selected_node_path =
-                  full_path ? element_path + sep + selectedNode->fieldDesc->name : selectedNode->fieldDesc->name;
-                traverse_layout(selectedNode, selected_node_path, element_offset_shift, buffer, buffer_size, func,
-                                context, suffix, stop, evaluate_conditions, handle_enums, full_path,
-                                allow_multiple_exceptions);
-            }
-            else
-            {
-                for (auto sub_item : instance->subItems)
-                {
-                    if (stop)
-                    {
-                        return;
-                    }
-                    string sub_item_path =
-                      full_path ? element_path + sep + sub_item->fieldDesc->name : sub_item->fieldDesc->name;
-                    traverse_layout(sub_item, sub_item_path, element_offset_shift, buffer, buffer_size, func, context,
-                                    suffix, stop, evaluate_conditions, handle_enums, full_path,
-                                    allow_multiple_exceptions);
-                }
-            }
-        }
-        // Handle leaf fields - similar to the final else clause in _parse_seg_field
-        else
-        {
-            T_OFFSET field_offset = instance->offset + element_offset_shift;
-            uint64_t value = 0;
-            if (buffer)
-            {
-                if (buffer_size >= (field_offset + instance->get_size()) / 8)
-                {
-                    value = pop_from_buf(buffer, static_cast<uint32_t>(field_offset),
-                                         static_cast<uint32_t>(instance->get_size()));
-                }
-                else
-                {
-                    raiseException(allow_multiple_exceptions,
-                                   "On layout traversal, trying to evaluate field, " + instance->get_field_name() +
-                                     ", with offset, " + to_string(field_offset) + ",overflowing the buffer size, " +
-                                     to_string(buffer_size) + "\n",
-                                   ExceptionHolder::ERROR_EXCEPTION);
-                }
-            }
-            if (!full_path)
-            {
-                bool is_uint64 =
-                  instance->parent && instance->parent->fieldDesc && instance->parent->fieldDesc->subNode == "uint64";
-                if (is_uint64)
-                {
-                    element_path = instance->parent->fieldDesc->name + suffix + "_" + element_path;
-                }
-                else if (!suffix.empty())
-                {
-                    element_path += suffix;
-                }
-            }
-            stop = func(element_path, field_offset, value, instance, context);
-        }
-    }
 }
 
 template class _Adb_impl<false, uint32_t>;

--- a/adb_parser/adb_parser.h
+++ b/adb_parser/adb_parser.h
@@ -121,6 +121,7 @@ public:
 
     using AdbCondition = _AdbCondition_impl<T_OFFSET>;
     using AdbCondVar = _AdbCondVar_impl<T_OFFSET>;
+
     using NodesMap = map<string, AdbNode*>;
     using PathPart = pair<string, vector<uint32_t>>;
     using SplittedPath = vector<PathPart>;
@@ -128,10 +129,6 @@ public:
     // Methods
     _Adb_impl();
     ~_Adb_impl();
-    void raiseException(bool allowMultipleExceptions,
-                        string exceptionTxt,
-                        const string expType,
-                        bool raise_warnings = true);
     // strict union means:
     //   1- dwrod aligned unions
     //   2- contains nodes only
@@ -178,20 +175,6 @@ public:
     vector<string> getNodeDeps(string nodeName);
     void add_include(string fileName, string filePath, string included_from, int lineNumber);
     string getLastError();
-
-    // Layout traversal function
-    void traverse_layout(AdbInstance* instance,
-                         const string& path,
-                         T_OFFSET offset_shift,
-                         const uint8_t* buffer,
-                         uint32_t buffer_size,
-                         bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-                         void* context,
-                         bool evaluate_conditions = true,
-                         bool handle_enums = false,
-                         bool full_path = true,
-                         bool allow_multiple_exceptions = false); // internal argument passed inside recursion, by
-                                                                  // return value of "func"
 
     string printAdbExceptionMap();
     void clearAdbExceptionMap();
@@ -264,36 +247,6 @@ private:
     list<AdbInstance*> _conditionalArrays;
     void checkInstanceOffsetValidity(AdbInstance* inst, AdbInstance* parent, bool allowMultipleExceptions);
     void throwExeption(bool allowMultipleExceptions, string exceptionTxt, string addedMsgMultiExp);
-
-    void traverse_layout(AdbInstance* instance,
-                         const string& path,
-                         T_OFFSET offset_shift,
-                         const uint8_t* buffer,
-                         uint32_t buffer_size,
-                         bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-                         void* context,
-                         string suffix, // internal argument for legacy array support
-                         bool& stop,    // internal argument passed inside recursion, by return value of "func"
-                         bool evaluate_conditions = true,
-                         bool handle_enums = false,
-                         bool full_path = true,
-                         bool allow_multiple_exceptions = false);
-
-    // Helper functions for traverse_layout
-    uint64_t _trvrs_calc_cond_num_elements(AdbInstance* instance,
-                                           T_OFFSET offset_shift,
-                                           const uint8_t* buffer,
-                                           uint32_t buffer_size,
-                                           bool evaluate_conditions,
-                                           bool allow_multiple_exceptions);
-    string _trvrs_get_element_array_suffix(uint64_t i, AdbInstance* instance, bool full_path);
-    void _trvrs_handle_enums(AdbInstance* instance,
-                             const string& element_path,
-                             T_OFFSET element_offset_shift,
-                             const uint8_t* buffer,
-                             bool (*func)(const string&, uint64_t, uint64_t, AdbInstance*, void*),
-                             void* context);
-    AdbInstance* _trvrs_get_selected_node(AdbInstance* instance, T_OFFSET element_offset_shift, const uint8_t* buffer);
 };
 
 using AdbLegacy = _Adb_impl<false, uint32_t>;

--- a/adb_parser/adb_xml_parser.cpp
+++ b/adb_parser/adb_xml_parser.cpp
@@ -284,16 +284,11 @@ bool AdbParser<e, O>::load(bool is_main)
     }
     catch (AdbException& exp)
     {
+        _lastError = exp.what_s();
         if (exp.what_s().find("in file:") == string::npos)
         {
             int line = XML_GetCurrentLineNumber(_xmlParser);
-            int column = XML_GetCurrentColumnNumber(_xmlParser);
-            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + to_string(line) +
-                         " column: " + to_string(column);
-        }
-        else
-        {
-            _lastError = exp.what_s();
+            ExceptionHolder::appendLocationSuffix(_lastError, _fileName, line);
         }
         if (allowMultipleExceptions)
         {
@@ -328,9 +323,8 @@ bool AdbParser<e, O>::load(bool is_main)
     catch (...)
     {
         int line = XML_GetCurrentLineNumber(_xmlParser);
-        int column = XML_GetCurrentColumnNumber(_xmlParser);
-        _lastError = string("An exception raised during the loading of the file: ") + _fileName +
-                     " at line: " + to_string(line) + " column: " + to_string(column);
+        _lastError = "An exception raised during the loading of the file";
+        ExceptionHolder::appendLocationSuffix(_lastError, _fileName, line);
         if (allowMultipleExceptions)
         {
             xmlStatus = false;
@@ -364,16 +358,11 @@ bool AdbParser<e, O>::loadFromString(const char* adbString)
     }
     catch (AdbException& exp)
     {
+        _lastError = exp.what_s();
         if (exp.what_s().find("in file:") == string::npos)
         {
             int line = XML_GetCurrentLineNumber(_xmlParser);
-            int column = XML_GetCurrentColumnNumber(_xmlParser);
-            _lastError = exp.what_s() + " in file: " + _fileName + " at line: " + to_string(line) +
-                         " column: " + to_string(column);
-        }
-        else
-        {
-            _lastError = exp.what_s();
+            ExceptionHolder::appendLocationSuffix(_lastError, _fileName, line);
         }
 
         _lastError += string("\nNOTE: this project is configured to work with: \"") +
@@ -388,9 +377,8 @@ bool AdbParser<e, O>::loadFromString(const char* adbString)
     catch (...)
     {
         int line = XML_GetCurrentLineNumber(_xmlParser);
-        int column = XML_GetCurrentColumnNumber(_xmlParser);
-        _lastError = string("An exception raised during the loading of the file: ") + _fileName +
-                     " at line: " + to_string(line) + " column: " + to_string(column);
+        _lastError = "An exception raised during the loading of the file";
+        ExceptionHolder::appendLocationSuffix(_lastError, _fileName, line);
         return false;
     }
 
@@ -538,34 +526,40 @@ bool AdbParser<e, T_OFFSET>::parse_size(const string& s,
     int lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
 
     bool exception_raised = false;
+    string error_message;
 
     Regex::smatch match;
+    // Matches "[0x]H[.D]" — hex bytes (group 1) with optional dot + decimal bits (group 4).
+    // Permissive on purpose; edge cases (.D, 0x.D, H.) are caught below.
     static Regex::regex correctHEXExpr("^\\s*((0[xX])?[0-9A-Fa-f]*)(\\.([0-9]*))?\\s*$");
     if (!regex_match(s, match, correctHEXExpr))
     {
-        exception_raised = raiseException(allowMultipleExceptions,
-                                          "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " +
-                                            "invalid format, valid formats are: \"0xH.D\", \"D.D\", \"0xH\", \".D\".",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " +
+                        "invalid format, valid formats are: \"0xH.D\", \"D.D\", \"0xH\", \".D\".";
+        exception_raised = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         res = static_cast<T_OFFSET>(-1);
         return false;
     }
 
     auto num_bytes_str = match[1].str();
     Algorithm::to_lower(num_bytes_str);
+
     auto num_bits_str = match[4].str();
+
     unsigned long long num_bytes = 0;
     unsigned long long num_bits = 0;
+
+    // Catch "0x.5" — bare 0x prefix with no hex digits
     if (num_bytes_str == "0x")
     {
         if (adbParser->_enforceExtraChecks)
         {
-            exception_raised = raiseException(
-              allowMultipleExceptions,
-              "Invalid format of " + tag_name + "'s " + attribute_name + ", \"" + s + "\". 0x.D is an invalid format",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-              ExceptionHolder::WARN_EXCEPTION);
+            error_message =
+              "Invalid format of " + tag_name + "'s " + attribute_name + ", \"" + s + "\". 0x.D is an invalid format";
+            exception_raised =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                                adbParser->_fileName, lineNumber);
         }
         num_bytes_str = "0";
     }
@@ -585,6 +579,7 @@ bool AdbParser<e, T_OFFSET>::parse_size(const string& s,
         {
             num_bytes = 0;
         }
+
         if (!num_bits_str.empty())
         {
             num_bits = stoull(num_bits_str, &end, 10);
@@ -600,21 +595,18 @@ bool AdbParser<e, T_OFFSET>::parse_size(const string& s,
     }
     catch (std::invalid_argument&)
     {
-        exception_raised = raiseException(allowMultipleExceptions,
-                                          "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " +
-                                            "invalid format, valid formats are: \"0xH.D\", \"D.D\", \"0xH\", \".D\".",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " +
+                        "invalid format, valid formats are: \"0xH.D\", \"D.D\", \"0xH\", \".D\".";
+        exception_raised = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         res = static_cast<T_OFFSET>(-1);
         return false;
     }
     catch (std::out_of_range&)
     {
-        exception_raised =
-          raiseException(allowMultipleExceptions,
-                         "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " + "out of range.",
-                         ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                         ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "Failed parsing " + tag_name + " " + attribute_name + ", " + s + "\", " + "out of range.";
+        exception_raised = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         res = static_cast<T_OFFSET>(-1);
         return false;
     }
@@ -623,23 +615,23 @@ bool AdbParser<e, T_OFFSET>::parse_size(const string& s,
     {
         if (num_bytes % 4 != 0)
         {
+            error_message = "Failed parsing " + tag_name + " " + attribute_name + ", " + s + ", " +
+                            "invalid format, address part must be dword aligned, while given, " + num_bytes_str;
             exception_raised =
-              raiseException(allowMultipleExceptions,
-                             "Failed parsing " + tag_name + " " + attribute_name + ", " + s + ", " +
-                               "invalid format, address part must be dword aligned, while given, " + num_bytes_str,
-                             ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                             ExceptionHolder::WARN_EXCEPTION);
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                                adbParser->_fileName, lineNumber);
         }
+
         if (num_bits > 31)
         {
+            error_message = "Failed parsing " + tag_name + " " + attribute_name + ", " + s + ", " +
+                            "invalid format, offset part must in range [0,31], while given, " + num_bits_str;
             exception_raised =
-              raiseException(allowMultipleExceptions,
-                             "Failed parsing " + tag_name + " " + attribute_name + ", " + s + ", " +
-                               "invalid format, offset part must in range [0,31], while given, " + num_bits_str,
-                             ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                             ExceptionHolder::WARN_EXCEPTION);
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                                adbParser->_fileName, lineNumber);
         }
     }
+
     res = num_bytes * 8 + num_bits;
     return !exception_raised;
 }
@@ -793,10 +785,15 @@ void AdbParser<e, O>::includeAllFilesInDir(AdbParser* adbParser, string dirPath,
 
 /**
  *  Function AdbParser::checkSpecialChars
+ *
+ *  Validates that a node/field/enum name is a valid C identifier, optionally
+ *  followed by an array subscript (e.g. "my_field[3]").
+ *  Allowed pattern: [_A-Za-z][_A-Za-z0-9]*  with optional  [<digits>]  suffix.
  */
 template<bool e, typename O>
 bool AdbParser<e, O>::checkSpecialChars(string tagName)
 {
+    // Uses explicit character classes instead of \w / \d for POSIX ERE compatibility (USE_STDLIB_REGEX).
     static Regex::regex validNameExpr("[_A-Za-z][_A-Za-z0-9]*(\\[[0-9]+\\])?$");
     Regex::smatch match;
     return !tagName.empty() && Regex::regex_match(tagName, match, validNameExpr);
@@ -839,13 +836,13 @@ template<bool e, typename O>
 void AdbParser<e, O>::startEnumElement(const XML_Char** atts, AdbParser<e, O>* adbParser, const int lineNumber)
 {
     bool expFound = false;
+    string error_message;
     if (!adbParser->_currentConfig || !adbParser->_currentConfig->attrs.count("type") ||
         TAG_ATTR_ENUM.compare(adbParser->_currentConfig->attrs["type"]))
     {
-        expFound = raiseException(allowMultipleExceptions,
-                                  "\"enum\" tag must be inside relevant \"config\" tag",
-                                  ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                  ExceptionHolder::ERROR_EXCEPTION);
+        error_message = "\"enum\" tag must be inside relevant \"config\" tag";
+        expFound = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
     }
 
     string tagName = attrValue(atts, "name");
@@ -854,18 +851,17 @@ void AdbParser<e, O>::startEnumElement(const XML_Char** atts, AdbParser<e, O>* a
     {
         if (!AdbParser::checkSpecialChars(tagName))
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Invalid character in enum name, in enum: \"" + tagName + "\"",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::WARN_EXCEPTION);
+            error_message = "Invalid character in enum name, in enum: \"" + tagName + "\"";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                                adbParser->_fileName, lineNumber);
         }
     }
     if (tagName.empty() || value.empty())
     {
-        expFound = raiseException(allowMultipleExceptions,
-                                  "Both \"name\" and \"value\" attributes must be specified",
-                                  ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                  ExceptionHolder::ERROR_EXCEPTION);
+        error_message = "Both \"name\" and \"value\" attributes must be specified";
+        expFound = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
     }
     if (!expFound)
     {
@@ -879,12 +875,13 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
     bool expFound = false;
     bool is_field_attribute = false;
 
+    string error_message;
+
     if (adbParser->_currentConfig)
     {
-        expFound = raiseException(allowMultipleExceptions,
-                                  "config tag can't appear within other config",
-                                  ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                  ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "config tag can't appear within other config";
+        expFound = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
     }
 
     adbParser->_currentConfig = new AdbConfig;
@@ -913,11 +910,10 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 static Regex::regex pattern(TAG_ATTR_DEFINE_PATTERN);
                 if (!Regex::regex_match(aValue, result, pattern))
                 {
-                    expFound =
-                      raiseException(allowMultipleExceptions,
-                                     string("Bad define format: \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                                     ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                     ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "Bad define format: \"" + aName + "\" attribute value: \"" + aValue + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
                 else
                 {
@@ -926,12 +922,11 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
 
                     if (adbParser->_adbCtxt->defines_map.find(define_key) != adbParser->_adbCtxt->defines_map.end())
                     {
-                        expFound =
-                          raiseException(allowMultipleExceptions,
-                                         string("Multiple definition of preprocessor variable: \"") + define_key +
-                                           "\" attribute name: \"" + aName + "\"",
-                                         ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                        error_message = "Multiple definition of preprocessor variable: \"" + define_key +
+                                        "\" attribute name: \"" + aName + "\"";
+                        expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                     ExceptionHolder::ERROR_EXCEPTION,
+                                                                     adbParser->_fileName, lineNumber);
                     }
                     else
                     {
@@ -946,11 +941,10 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 // check that the field_attr is unique
                 if (adbParser->field_attr_names_set.find(aValue) != adbParser->field_attr_names_set.end())
                 {
-                    expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("Redefinition of field_attr: \"") + aName + "\" attribute name: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "Redefinition of field_attr: \"" + aName + "\" attribute name: \"" + aValue + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
                 else
                 {
@@ -963,34 +957,30 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 // check attr 'type' is configured only when attr 'field_attr' is configured as well
                 if (field_attr.empty())
                 {
-                    expFound =
-                      raiseException(allowMultipleExceptions,
-                                     "Attribute \"type\" is supported only for attributes definition \"config\" tag",
-                                     "line: " + to_string(lineNumber),
-                                     ExceptionHolder::WARN_EXCEPTION);
+                    error_message = "Attribute \"type\" is supported only for attributes definition \"config\" tag";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::WARN_EXCEPTION, "", lineNumber);
                 }
 
                 // check that attr 'type' was provided and not empty
                 if (attr_type.empty())
                 {
-                    expFound =
-                      raiseException(allowMultipleExceptions,
-                                     string("field_attr type must be specified (not empty): \"") + aName +
-                                       "\" attribute value: \"" + aValue + "\"",
-                                     ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                     ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "field_attr type must be specified (not empty): \"" + aName +
+                                    "\" attribute value: \"" + aValue + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
                 else
                 {
                     // check that type 'multival' has a 'fw_label' value
                     if (!attr_type.compare("multival") && aValue.compare("fw_label"))
                     {
-                        expFound =
-                          raiseException(allowMultipleExceptions,
-                                         string("Type \"multival\" is supported only for \"fw_label\" not for: \"") +
-                                           aName + "\" attribute value: \"" + aValue + "\"",
-                                         ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                        error_message = "Type \"multival\" is supported only for \"fw_label\" not for: \"" + aName +
+                                        "\" attribute value: \"" + aValue + "\"";
+                        expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                     ExceptionHolder::ERROR_EXCEPTION,
+                                                                     adbParser->_fileName, lineNumber);
                     }
                 }
 
@@ -999,11 +989,10 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 // check that attr 'used_for' was not provided empty
                 if (checkAttrExist(atts, "used_for") && attr_used_for.empty())
                 {
-                    expFound = raiseException(
-                      allowMultipleExceptions,
-                      string("used_for is invalid: \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "used_for is invalid: \"" + aName + "\" attribute value: \"" + aValue + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
 
                 // check if 'pattern' was provided
@@ -1018,12 +1007,11 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                     }
                     catch (...)
                     {
-                        expFound =
-                          raiseException(allowMultipleExceptions,
-                                         string("Bad attribute pattern: \"") + aValue + "\" name Pattern: \"" +
-                                           attrValue(atts, "pattern") + "\"",
-                                         ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                        error_message = "Bad attribute pattern: \"" + aValue + "\" name Pattern: \"" +
+                                        attrValue(atts, "pattern") + "\"";
+                        expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                     ExceptionHolder::ERROR_EXCEPTION,
+                                                                     adbParser->_fileName, lineNumber);
                     }
                 }
             }
@@ -1040,12 +1028,11 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 }
                 catch (...)
                 {
-                    expFound =
-                      raiseException(allowMultipleExceptions,
-                                     string("Bad node name pattern: \"") + aValue + "\" pattern: \"" +
-                                       attrValue(atts, "nname_pattern") + "\"",
-                                     ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                     ExceptionHolder::ERROR_EXCEPTION);
+                    error_message =
+                      "Bad node name pattern: \"" + aValue + "\" pattern: \"" + attrValue(atts, "nname_pattern") + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
             }
 
@@ -1061,23 +1048,22 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
                 }
                 catch (...)
                 {
-                    expFound =
-                      raiseException(allowMultipleExceptions,
-                                     string("Bad field name pattern: \"") + aValue + "\" pattern: \"" +
-                                       attrValue(atts, "fname_pattern") + "\"",
-                                     ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                     ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "Bad field name pattern: \"" + aValue + "\" pattern: \"" +
+                                    attrValue(atts, "fname_pattern") + "\"";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
             }
             else if (!aName.compare("type") or !aName.compare("used_for") or !aName.compare("pattern"))
             {
                 if (!is_field_attribute)
                 {
-                    raiseException(
-                      allowMultipleExceptions,
-                      "Attribute \"" + aName + "\" is supported only for field_attr definition in \"config\" tag",
-                      " line: " + to_string(lineNumber),
-                      ExceptionHolder::WARN_EXCEPTION);
+                    error_message =
+                      "Attribute \"" + aName + "\" is supported only for field_attr definition in \"config\" tag";
+                    ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                      ExceptionHolder::WARN_EXCEPTION, adbParser->_fileName,
+                                                      lineNumber);
                 }
             }
             else if (aName.compare("sw_export") and aName.compare("disable_exports"))
@@ -1096,11 +1082,10 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
             }
             catch (std::exception&)
             {
+                error_message = "Filed to parse the \"" + aName + "\" attribute value: \"" + aValue + "\"";
                 expFound =
-                  raiseException(allowMultipleExceptions,
-                                 string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                                 ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                 ExceptionHolder::ERROR_EXCEPTION);
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1113,11 +1098,10 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
             }
             catch (std::exception&)
             {
+                error_message = "Filed to parse the \"" + aName + "\" attribute value: \"" + aValue + "\"";
                 expFound =
-                  raiseException(allowMultipleExceptions,
-                                 string("Filed to parse the \"") + aName + "\" attribute value: \"" + aValue + "\"",
-                                 ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                 ExceptionHolder::ERROR_EXCEPTION);
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1146,10 +1130,9 @@ void AdbParser<e, O>::startConfigElement(const XML_Char** atts, AdbParser<e, O>*
         }
         else if (!is_valid_att)
         {
-            raiseException(allowMultipleExceptions,
-                           "Attribute \"" + aName + "\" for config tag is not supported.",
-                           " line: " + to_string(lineNumber),
-                           ExceptionHolder::WARN_EXCEPTION);
+            error_message = "Attribute \"" + aName + "\" for config tag is not supported.";
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                              adbParser->_fileName, lineNumber);
         }
     }
 }
@@ -1173,16 +1156,17 @@ void AdbParser<e, O>::startIncludeElement(const XML_Char** atts, AdbParser<e, O>
         Algorithm::trim(includeAttr);
 
         bool expFound = false;
+        string error_message;
         if (includeAttr == "file")
         {
             string fname = attrValue(atts, "file");
             Algorithm::trim(fname);
             if (fname.empty())
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          string() + "File attribute isn't given within " + TAG_INCLUDE + " tag",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::FATAL_EXCEPTION);
+                error_message = "File attribute isn't given within " + TAG_INCLUDE + " tag";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
             }
             if (!expFound)
                 includeFile(adbParser, fname, lineNumber);
@@ -1193,10 +1177,10 @@ void AdbParser<e, O>::startIncludeElement(const XML_Char** atts, AdbParser<e, O>
             Algorithm::trim(includeAllDirPath);
             if (includeAllDirPath.empty())
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          string() + "Directory to include isn't given within " + TAG_INCLUDE + " tag",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::FATAL_EXCEPTION);
+                error_message = "Directory to include isn't given within " + TAG_INCLUDE + " tag";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
             }
 
             if (!expFound)
@@ -1204,10 +1188,10 @@ void AdbParser<e, O>::startIncludeElement(const XML_Char** atts, AdbParser<e, O>
         }
         else
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      string() + "Include is called without file or dir attribute.",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::ERROR_EXCEPTION);
+            error_message = "Include is called without file or dir attribute.";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
         }
     }
 }
@@ -1221,10 +1205,9 @@ void AdbParser<e, O>::startAttrReplaceElement(const XML_Char** atts,
     string path = attrValue(atts, "path");
     if (path.empty())
     {
-        raiseException(allowMultipleExceptions,
-                       "path attribute is missing in attr_replace operation",
-                       ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                       ExceptionHolder::ERROR_EXCEPTION);
+        string message = "path attribute is missing in attr_replace operation";
+        ExceptionHolder::handle_exception(allowMultipleExceptions, message, ExceptionHolder::ERROR_EXCEPTION,
+                                          adbParser->_fileName, lineNumber);
         return;
     }
 
@@ -1248,12 +1231,12 @@ void AdbParser<e, T_OFFSET>::startNodeElement(const XML_Char** atts,
                                               AdbParser<e, T_OFFSET>* adbParser,
                                               const int lineNumber)
 {
+    string error_message;
     if (adbParser->_currentNode || adbParser->skipNode)
     {
-        raiseException(allowMultipleExceptions,
-                       "Nested nodes are not allowed",
-                       ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                       ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "Nested nodes are not allowed";
+        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                          adbParser->_fileName, lineNumber);
     }
     bool cond = is_inst_ifdef_exist_and_correct_project(atts, adbParser);
 
@@ -1276,11 +1259,10 @@ void AdbParser<e, T_OFFSET>::startNodeElement(const XML_Char** atts,
             // check the node name is compatible with the nname_pattern
             if (!Regex::regex_match(nodeName, Regex::regex(adbParser->_nname_pattern)))
             {
-                raiseException(allowMultipleExceptions,
-                               "Illegal node name: \"" + nodeName + "\" doesn't match the given node name pattern: \"",
-                               adbParser->_nname_pattern + "\", in file: \"" + adbParser->_fileName +
-                                 "\" line: " + to_string(lineNumber),
-                               ExceptionHolder::WARN_EXCEPTION);
+                error_message = "Illegal node name: \"" + nodeName +
+                                "\" doesn't match the given node name pattern: \"" + adbParser->_nname_pattern + "\"";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::WARN_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1289,19 +1271,18 @@ void AdbParser<e, T_OFFSET>::startNodeElement(const XML_Char** atts,
         parse_size(size, node_size, adbParser, true, true);
         if (node_size == 0)
         {
-            raiseException(allowMultipleExceptions,
-                           "Node size is not allowed to be 0, in Node: \"" + nodeName + "\"",
-                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                           ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Node size is not allowed to be 0, in Node: \"" + nodeName + "\"";
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                              adbParser->_fileName, lineNumber);
         }
+
         if (adbParser->_enforceExtraChecks)
         {
             if (!AdbParser::checkSpecialChars(nodeName))
             {
-                raiseException(allowMultipleExceptions,
-                               "Invalid character in node name, in Node: \"" + nodeName + "\"",
-                               ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                               ExceptionHolder::WARN_EXCEPTION);
+                error_message = "Invalid character in node name, in Node: \"" + nodeName + "\"";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::WARN_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
         string desc = descXmlToNative(attrValue(atts, "descr", override_attrs));
@@ -1309,20 +1290,18 @@ void AdbParser<e, T_OFFSET>::startNodeElement(const XML_Char** atts,
         // Check for mandatory attrs
         if (nodeName.empty())
         {
-            raiseException(allowMultipleExceptions,
-                           "Missing node name",
-                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                           ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Missing node name";
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                              adbParser->_fileName, lineNumber);
         }
         // Check for duplications
         if (adbParser->_adbCtxt->nodesMap.count(nodeName))
         {
-            raiseException(allowMultipleExceptions,
-                           "node \"" + nodeName + "\" is already defined in file: \"" +
-                             adbParser->_adbCtxt->nodesMap[nodeName]->fileName +
-                             "\" line: " + to_string(adbParser->_adbCtxt->nodesMap[nodeName]->lineNumber),
-                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                           ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "node \"" + nodeName + "\" is already defined";
+            ExceptionHolder::appendLocationSuffix(error_message, adbParser->_adbCtxt->nodesMap[nodeName]->fileName,
+                                                  adbParser->_adbCtxt->nodesMap[nodeName]->lineNumber);
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                              adbParser->_fileName, lineNumber);
         }
 
         string unionAttrVal = attrValue(atts, "attr_is_union", override_attrs);
@@ -1372,22 +1351,23 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
     bool invalid_offset = false;
     bool default_offset = false;
 
+    string error_message;
+
     if (!adbParser->_currentNode && !adbParser->skipNode)
     {
-        expFound = raiseException(allowMultipleExceptions,
-                                  "Field definition outside of node",
-                                  ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                  ExceptionHolder::FATAL_EXCEPTION);
+        error_message = "Field definition outside of node";
+        expFound = ExceptionHolder::handle_exception(
+          allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
     }
 
     if (!adbParser->skipNode)
     {
         if (adbParser->_currentField)
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Nested fields are not allowed",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Nested fields are not allowed";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         string fieldName = attrValue(atts, "name");
@@ -1407,14 +1387,16 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
         string size = attrValue(atts, "size", override_attrs);
 
         T_OFFSET field_size = 0;
+
         expFound = !parse_size(size, field_size, adbParser, true, false);
         invalid_size = field_size == static_cast<T_OFFSET>(-1);
+
         if (field_size == 0)
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Missing or zero field size, in field: \"" + fieldName + "\"",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Missing or zero field size, in field: \"" + fieldName + "\"";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
             invalid_size = true;
         }
 
@@ -1423,27 +1405,29 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
         {
             default_offset = true;
         }
+
         T_OFFSET field_offset = 0;
         if (!default_offset)
         {
             expFound = expFound || !parse_size(offset, field_offset, adbParser, false, false);
         }
         invalid_offset = field_offset == static_cast<T_OFFSET>(-1);
+
         if (adbParser->_enforceExtraChecks)
         {
             if (!AdbParser::checkSpecialChars(fieldName))
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Invalid character in field name, in Field: \"" + fieldName + "\"",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::WARN_EXCEPTION);
+                error_message = "Invalid character in field name, in Field: \"" + fieldName + "\"";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::WARN_EXCEPTION, adbParser->_fileName, lineNumber);
             }
             if (!expFound && adbParser->_currentNode->isUnion && !default_offset && field_offset != 0)
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Offset must be 0x0.0 in Union fields",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::ERROR_EXCEPTION);
+                error_message = "Offset must be 0x0.0 in Union fields";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1462,27 +1446,27 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
             T_OFFSET entrySize = field_size / (high - low + 1);
             if (entrySize % 8 != 0 && entrySize > 8)
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Invalid size of array entries",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::ERROR_EXCEPTION);
+                error_message = "Invalid size of array entries";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
             if (entrySize < 8 && entrySize != 4 && entrySize != 2 && entrySize != 1 &&
                 ((field_size > 32 && highBound != "VARIABLE") || highBound == "VARIABLE"))
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Array with entry size 3, 5, 6 or 7 bits and array size is larger than 32bit",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::ERROR_EXCEPTION);
+                error_message = "Array with entry size 3, 5, 6 or 7 bits and array size is larger than 32bit";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
         else if (adbParser->_enforceGuiChecks && (lowBound != "" || highBound != ""))
         {
-            expFound = raiseException(
-              allowMultipleExceptions,
-              "Field: \"" + adbParser->_currentField->name + "\": both low_bound or high_bound must be specified",
-              ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-              ExceptionHolder::WARN_EXCEPTION);
+            error_message =
+              "Field: \"" + adbParser->_currentField->name + "\": both low_bound or high_bound must be specified";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::WARN_EXCEPTION,
+                                                adbParser->_fileName, lineNumber);
         }
 
         string subNode = attrValue(atts, "subnode", override_attrs);
@@ -1490,10 +1474,10 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
         // Check for mandatory attrs
         if (fieldName.empty())
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Missing field name",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Missing field name";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         // Create new fields
@@ -1543,6 +1527,7 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
         {
             throw AdbStopException();
         }
+
         // Check array element size
         if (adbParser->_currentField->array_type >= AdbField::ArrayType::definite &&
             adbParser->_currentField->array_type < AdbField::ArrayType::unlimited &&
@@ -1550,10 +1535,12 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
         {
             std::stringstream ss;
             ss << "In field \"" << fieldName << "\" invalid array element size \""
-               << adbParser->_currentField->get_size() << "/" << adbParser->_currentField->arrayLen()
-               << "\" in file: \"" << adbParser->_fileName << "\" line: " << lineNumber;
+               << adbParser->_currentField->get_size() << "/" << adbParser->_currentField->arrayLen() << "\"";
 
-            expFound = raiseException(allowMultipleExceptions, ss.str(), "", ExceptionHolder::FATAL_EXCEPTION);
+            error_message = ss.str();
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
         if (default_offset)
         {
@@ -1597,12 +1584,12 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
             adbParser->_currentField->offset + adbParser->_currentField->get_size() >
               adbParser->_currentNode->get_size())
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Node: " + adbParser->_currentNode->name + " size(" +
-                                        to_string(adbParser->_currentNode->get_size()) + ") - field (" +
-                                        adbParser->_currentField->name + ") continue over the node's end",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::ERROR_EXCEPTION);
+            error_message = "Node: " + adbParser->_currentNode->name + " size(" +
+                            to_string(adbParser->_currentNode->get_size()) + ") - field (" +
+                            adbParser->_currentField->name + ") continue over the node's end";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         // For DS alignment check
@@ -1610,37 +1597,37 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
 
         if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion && adbParser->_currentField->isLeaf())
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Fields are not allowed in unions (only subnodes)",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Fields are not allowed in unions (only subnodes)";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         if (!expFound && adbParser->_strict && adbParser->_currentNode->isUnion &&
             adbParser->_currentField->get_size() % 32)
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Union is allowed to contains only dword aligned subnodes",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Union is allowed to contains only dword aligned subnodes";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         if (!expFound && adbParser->_currentNode->isUnion &&
             adbParser->_currentField->get_size() > adbParser->_currentNode->get_size())
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Field size is greater than the parent node size",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Field size is greater than the parent node size";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         if (!expFound && adbParser->_strict && !adbParser->_currentField->isArray() &&
             adbParser->_currentField->isLeaf() && adbParser->_currentField->get_size() > 32)
         {
-            expFound = raiseException(allowMultipleExceptions,
-                                      "Leaf fields can't be > 32 bits",
-                                      ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                      ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Leaf fields can't be > 32 bits";
+            expFound =
+              ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
         }
 
         if (!expFound && adbParser->_checkDsAlign)
@@ -1649,13 +1636,13 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
             if ((adbParser->_currentField->isLeaf() || adbParser->_currentField->subNode == "uint64") &&
                 (esize == 16 || esize == 32 || esize == 64) && adbParser->_currentField->offset % esize != 0)
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Field: " + adbParser->_currentField->name +
-                                            " in Node: " + adbParser->_currentNode->name + " offset(" +
-                                            to_string(adbParser->_currentField->offset) + ") is not aligned to size(" +
-                                            to_string(esize) + ")",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::ERROR_EXCEPTION);
+                error_message = "Field: " + adbParser->_currentField->name +
+                                " in Node: " + adbParser->_currentNode->name + " offset(" +
+                                to_string(adbParser->_currentField->offset) + ") is not aligned to size(" +
+                                to_string(esize) + ")";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1666,31 +1653,30 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
             {
                 if (!checkAttrExist(atts, adbParser->field_mand_attr[i].c_str()))
                 {
-                    expFound = raiseException(
-                      allowMultipleExceptions,
-                      "Atrribute: \"" + adbParser->field_mand_attr[i] + "\" for field must be specified.",
-                      " in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                      ExceptionHolder::ERROR_EXCEPTION);
+                    error_message = "Atrribute: \"" + adbParser->field_mand_attr[i] + "\" for field must be specified.";
+                    expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                 ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                                 lineNumber);
                 }
             }
 
             // check if the field name is compatible with the fname pattern
             if (!Regex::regex_match(adbParser->_currentField->name, Regex::regex(adbParser->_fname_pattern)))
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Illegal field name: \"" + adbParser->_currentField->name +
-                                            "\" doesn't match the given field name pattern",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::WARN_EXCEPTION);
+                error_message = "Illegal field name: \"" + adbParser->_currentField->name +
+                                "\" doesn't match the given field name pattern";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::WARN_EXCEPTION, adbParser->_fileName, lineNumber);
             }
 
             // check if the field inside a union is an array
             if (!expFound && adbParser->_currentNode->isUnion && adbParser->_currentField->isArray())
             {
-                expFound = raiseException(allowMultipleExceptions,
-                                          "Arrays are not allowed in unions (only subnodes)",
-                                          ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                          ExceptionHolder::FATAL_EXCEPTION);
+                error_message = "Arrays are not allowed in unions (only subnodes)";
+                expFound =
+                  ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                    ExceptionHolder::FATAL_EXCEPTION, adbParser->_fileName, lineNumber);
             }
         }
 
@@ -1708,11 +1694,10 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
                         adbParser->field_attr_names_set.find(aName) != adbParser->field_attr_names_set.end() &&
                         adbParser->field_spec_attr.find(aName) != adbParser->field_spec_attr.end())
                     {
-                        expFound =
-                          raiseException(allowMultipleExceptions,
-                                         "Unknown attribute: " + aName + " at field: " + adbParser->_currentField->name,
-                                         ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                         ExceptionHolder::ERROR_EXCEPTION);
+                        error_message = "Unknown attribute: " + aName + " at field: " + adbParser->_currentField->name;
+                        expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                     ExceptionHolder::ERROR_EXCEPTION,
+                                                                     adbParser->_fileName, lineNumber);
                     }
 
                     if (!aName.compare("enum"))
@@ -1728,12 +1713,11 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
                         {
                             if (!Regex::regex_match(entry, Regex::regex(adbParser->_enum_pattern)))
                             {
-                                expFound =
-                                  raiseException(allowMultipleExceptions,
-                                                 "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
-                                                 "doesn't match the given attribute pattern, in file: \"" +
-                                                   adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                                 ExceptionHolder::ERROR_EXCEPTION);
+                                error_message = "Illegal value: \"" + aValue + "\" for attribute: \"" + aName +
+                                                "\" doesn't match the given attribute pattern";
+                                expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                             ExceptionHolder::ERROR_EXCEPTION,
+                                                                             adbParser->_fileName, lineNumber);
                             }
                         }
                     }
@@ -1743,12 +1727,11 @@ void AdbParser<e, T_OFFSET>::startFieldElement(const XML_Char** atts,
                         if (adbParser->attr_pattern.find(aName) != adbParser->attr_pattern.end() &&
                             !Regex::regex_match(aValue, Regex::regex(adbParser->attr_pattern[aName])))
                         {
-                            expFound =
-                              raiseException(allowMultipleExceptions,
-                                             "Illegal value: \"" + aValue + "\" for attribute: \"" + aName + "\" ",
-                                             "doesn't match the given attribute pattern, in file: \"" +
-                                               adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                                             ExceptionHolder::WARN_EXCEPTION);
+                            error_message = "Illegal value: \"" + aValue + "\" for attribute: \"" + aName +
+                                            "\" doesn't match the given attribute pattern";
+                            expFound = ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                                         ExceptionHolder::WARN_EXCEPTION,
+                                                                         adbParser->_fileName, lineNumber);
                         }
                     }
                 }
@@ -1768,6 +1751,8 @@ void AdbParser<e, O>::startElement(void* _adbParser, const XML_Char* name, const
 
     int lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
     adbParser->_currentTagValue = "";
+
+    string error_message;
 
     if (TAG_NODES_DEFINITION == name)
     {
@@ -1809,10 +1794,9 @@ void AdbParser<e, O>::startElement(void* _adbParser, const XML_Char* name, const
         }
         else
         {
-            raiseException(allowMultipleExceptions,
-                           "Operation attr_replace must be defined within <instance_ops> element only.",
-                           ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                           ExceptionHolder::FATAL_EXCEPTION);
+            error_message = "Operation attr_replace must be defined within <instance_ops> element only.";
+            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                              adbParser->_fileName, lineNumber);
         }
     }
     else if (TAG_NODE == name)
@@ -1829,17 +1813,10 @@ void AdbParser<e, O>::startElement(void* _adbParser, const XML_Char* name, const
     }
     else
     {
-        string exceptionTxt = "Unsupported tag: " + string(name);
-        if (allowMultipleExceptions)
-        {
-            exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber);
-            ExceptionHolder::insertNewException(ExceptionHolder::FATAL_EXCEPTION, exceptionTxt);
-            return;
-        }
-        else
-        {
-            throw AdbException(exceptionTxt);
-        }
+        error_message = "Unsupported tag: " + string(name);
+        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message, ExceptionHolder::FATAL_EXCEPTION,
+                                          adbParser->_fileName, lineNumber);
+        return;
     }
 }
 
@@ -1957,6 +1934,7 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
 {
     AdbParser<e, T_OFFSET>* adbParser = static_cast<AdbParser<e, T_OFFSET>*>(_adbParser);
     int lineNumber = XML_GetCurrentLineNumber(adbParser->_xmlParser);
+    string error_message;
     /*
      * Config
      * ----
@@ -2064,20 +2042,12 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
                 {
                     if (prevField->offset + prevField->get_size() > field->offset)
                     { // Overlapping
-                        string exceptionTxt = "Field: " + field->name + " " +
-                                              formatAddr(field->offset, field->get_size()) +
-                                              " overlaps with Field: " + prevField->name + " " +
-                                              formatAddr(prevField->offset, prevField->get_size());
-                        if (allowMultipleExceptions)
-                        {
-                            exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                                           "\" line: " + to_string(lineNumber);
-                            ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                        }
-                        else
-                        {
-                            throw AdbException(exceptionTxt);
-                        }
+                        error_message = "Field: " + field->name + " " + formatAddr(field->offset, field->get_size()) +
+                                        " overlaps with Field: " + prevField->name + " " +
+                                        formatAddr(prevField->offset, prevField->get_size());
+                        ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                          ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                          lineNumber);
                     }
                     T_OFFSET delta = field->offset - (prevField->offset + prevField->get_size());
                     if (delta > 0 && adbParser->_addReserved)
@@ -2132,12 +2102,11 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
             if (adbParser->_checkDsAlign && max_leaf_size != 0 &&
                 adbParser->_currentNode->get_size() % max_leaf_size != 0)
             {
-                raiseException(allowMultipleExceptions,
-                               "Node: " + adbParser->_currentNode->name + " size(" +
-                                 to_string(adbParser->_currentNode->get_size()) +
-                                 ") is not aligned with largest leaf(" + to_string(max_leaf_size) + ")",
-                               ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber),
-                               ExceptionHolder::ERROR_EXCEPTION);
+                error_message = "Node: " + adbParser->_currentNode->name + " size(" +
+                                to_string(adbParser->_currentNode->get_size()) + ") is not aligned with largest leaf(" +
+                                to_string(max_leaf_size) + ")";
+                ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                  ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName, lineNumber);
             }
 
             // Re-fix fields offset
@@ -2249,18 +2218,11 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
 
                 if (status < 0)
                 {
-                    string exceptionTxt = string("Error evaluating expression \"") + it->second.c_str() +
-                                          "\" : " + AdbExpr::statusStr(status);
-                    if (allowMultipleExceptions)
-                    {
-                        exceptionTxt =
-                          exceptionTxt + ", in file: \"" + adbParser->_fileName + "\" line: " + to_string(lineNumber);
-                        ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                    }
-                    else
-                    {
-                        throw AdbException(exceptionTxt);
-                    }
+                    error_message =
+                      "Error evaluating expression \"" + it->second + "\" : " + AdbExpr::statusStr(status);
+                    ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                      ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                      lineNumber);
                 }
                 cond = !!res;
             }
@@ -2274,18 +2236,10 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
                     {
                         if (!adbParser->_currentNode->fields[i]->name.compare(adbParser->_currentField->name))
                         {
-                            string exceptionTxt =
-                              "The field \"" + adbParser->_currentField->name + "\" isn't unique in node";
-                            if (allowMultipleExceptions)
-                            {
-                                exceptionTxt = exceptionTxt + ", in file: \"" + adbParser->_fileName +
-                                               "\" line: " + to_string(lineNumber);
-                                ExceptionHolder::insertNewException(ExceptionHolder::ERROR_EXCEPTION, exceptionTxt);
-                            }
-                            else
-                            {
-                                throw AdbException(exceptionTxt);
-                            }
+                            error_message = "The field \"" + adbParser->_currentField->name + "\" isn't unique in node";
+                            ExceptionHolder::handle_exception(allowMultipleExceptions, error_message,
+                                                              ExceptionHolder::ERROR_EXCEPTION, adbParser->_fileName,
+                                                              lineNumber);
                         }
                     }
                 }
@@ -2303,26 +2257,6 @@ void AdbParser<e, T_OFFSET>::endElement(void* _adbParser, const XML_Char* name)
             }
             adbParser->_currentField = 0;
         }
-    }
-}
-
-/**
- * Function: AdbParser::raiseException
- **/
-template<bool e, typename O>
-bool AdbParser<e, O>::raiseException(bool allowMultipleExceptions,
-                                     string exceptionTxt,
-                                     string addedMsg,
-                                     const string expType)
-{
-    if (allowMultipleExceptions)
-    {
-        ExceptionHolder::insertNewException(expType, exceptionTxt + addedMsg);
-        return false;
-    }
-    else
-    {
-        throw AdbException(exceptionTxt);
     }
 }
 

--- a/adb_parser/adb_xml_parser.h
+++ b/adb_parser/adb_xml_parser.h
@@ -147,7 +147,6 @@ private:
       parse_size(const string& s, T_OFFSET& res, AdbParser* adbParser, bool size_or_offset, bool node_or_field);
     static T_OFFSET aligned_word(T_OFFSET offset, uint8_t alignment = 32);
     static uint32_t startBit(T_OFFSET offset, uint8_t alignment = 32);
-    static bool raiseException(bool allowMultipleExceptions, string exceptionTxt, string addedMsg, const string expType);
 
 private:
     // MEMBERS

--- a/common/tools_algorithm.h
+++ b/common/tools_algorithm.h
@@ -91,11 +91,16 @@ inline void replace_all(std::string &input, const std::string &search,
                         const std::string &format) {
   if (search.empty())
     return;
-  size_t pos = 0;
-  while (std::string::npos != (pos = input.find(search, pos))) {
-    input.replace(pos, search.length(), format);
-    pos += format.length();
+  std::string out;
+  out.reserve(input.length());
+  size_t prev = 0, pos;
+  while (std::string::npos != (pos = input.find(search, prev))) {
+    out.append(input, prev, pos - prev);
+    out.append(format);
+    prev = pos + search.length();
   }
+  out.append(input, prev, std::string::npos);
+  input.swap(out);
 }
 
 inline std::string replace_all_copy(const std::string &input,

--- a/hca_capabilities/hca_capabilities.cpp
+++ b/hca_capabilities/hca_capabilities.cpp
@@ -324,7 +324,7 @@ void HcaCapabilities::fwctlSetHcaCapability(uint8_t* capabilityBuffer,
 std::vector<AdbInstanceAdvLegacy*> HcaCapabilities::getCapabilityFields(AdbInstanceAdvLegacy* capabilityTypeLayout)
 {
     std::vector<AdbInstanceAdvLegacy*> capabilities;
-    _adb->traverse_layout(capabilityTypeLayout, "", 0, nullptr, 0, _getHcaCapFieldsCallback, &capabilities, false, false);
+    capabilityTypeLayout->traverse_layout("", 0, nullptr, 0, _getHcaCapFieldsCallback, &capabilities, false, false);
     return capabilities;
 }
 

--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -3334,6 +3334,32 @@ void MlxlinkCommander::prepare5nmEyeInfo(u_int32_t numOfLanesToUse)
     }
 }
 
+void MlxlinkCommander::prepareSpc6EyeInfo(u_int32_t numOfLanesToUse)
+{
+    std::vector<string> legand, fomPerLane;
+
+    sendPrmReg(ACCESS_REG_SLRG, REG_GET, "all_lanes=%u", 1);
+    u_int32_t status = getFieldValue("status");
+
+    for (u_int32_t lane = 0; lane < numOfLanesToUse; lane++)
+    {
+        string fomStr = status ? getFieldStr("fom_lane" + to_string(lane), (u_int32_t)16) : NA_FIELD_VALUE;
+        fomPerLane.push_back(MlxlinkRecord::addSpaceForSlrg(fomStr));
+        legand.push_back(MlxlinkRecord::addSpaceForSlrg(to_string(lane)));
+        _fomStr += fomStr + " ";
+    }
+
+    if (!_userInput._showMultiPortInfo && !_userInput._showMultiPortModuleInfo)
+    {
+        string fomMode = status ? _mlxlinkMaps->_slrgFomMode5nm[getFieldValue("fom_mode")] : NA_FIELD_VALUE;
+        setPrintVal(_eyeOpeningInfoCmd, "FOM Mode", fomMode, ANSI_COLOR_RESET, true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "Lane", status ? getStringFromVector(legand) : NA_FIELD_VALUE, ANSI_COLOR_RESET,
+                    true, true, true);
+        setPrintVal(_eyeOpeningInfoCmd, "FOM [per lane]", status ? getStringFromVector(fomPerLane) : NA_FIELD_VALUE,
+                    ANSI_COLOR_RESET, true, true, true);
+    }
+}
+
 void MlxlinkCommander::showEye()
 {
     if (_userInput._pcie)
@@ -3365,7 +3391,11 @@ void MlxlinkCommander::showEye()
             showEyeTitle += " (PCIe)";
         }
         setPrintTitle(_eyeOpeningInfoCmd, showEyeTitle, EYE_OPENING_INFO_LAST);
-        if (_productTechnology <= PRODUCT_16NM)
+        if (_devID == DeviceSpectrum6)
+        {
+            prepareSpc6EyeInfo(numOfLanesToUse);
+        }
+        else if (_productTechnology <= PRODUCT_16NM)
         {
             prepare40_28_16nmEyeInfo(numOfLanesToUse);
         }

--- a/mlxlink/modules/mlxlink_commander.h
+++ b/mlxlink/modules/mlxlink_commander.h
@@ -602,6 +602,7 @@ public:
     void prepare40_28_16nmEyeInfo(u_int32_t numOfLanesToUse);
     void prepare7nmEyeInfo(u_int32_t numOfLanesToUse);
     void prepare5nmEyeInfo(u_int32_t numOfLanesToUse);
+    void prepareSpc6EyeInfo(u_int32_t numOfLanesToUse);
     void getPddrOperInfo();
     void getPrecodingStatus();
     void setPrecoding();

--- a/mlxlink/modules/mlxlink_reg_parser.cpp
+++ b/mlxlink/modules/mlxlink_reg_parser.cpp
@@ -35,7 +35,7 @@
 #include "mlxlink_reg_parser.h"
 #include <common/tools_utils.h>
 
-MlxlinkRegParser::MlxlinkRegParser() : RegAccessParser("", "", "", NULL, NULL, false, false)
+MlxlinkRegParser::MlxlinkRegParser() : RegAccessParser("", "", "", NULL, 0, false, false)
 {
     _mf = nullptr;
     _regLib = nullptr;

--- a/mlxreg/mlxreg_lib/mlxreg_lib.h
+++ b/mlxreg/mlxreg_lib/mlxreg_lib.h
@@ -72,7 +72,6 @@ public:
     AdbInstance* getAdbTable() { return _regAccessRootNode; };
     AdbInstance* get_current_node() { return _currentNode; };
     void set_current_node(string name) { _currentNode = findAdbNode(name); }
-    Adb& getAdb() { return *_adb; };
     /* * * * * * * *
      * library API *
      * * * * * * * */

--- a/mlxreg/mlxreg_lib/mlxreg_parser.cpp
+++ b/mlxreg/mlxreg_lib/mlxreg_parser.cpp
@@ -50,7 +50,6 @@ template<bool dynamic>
 _RegAccessParser_impl<dynamic>::_RegAccessParser_impl(string data,
                                                       string indexes,
                                                       string ops,
-                                                      Adb* adb,
                                                       AdbInstance* regNode,
                                                       std::vector<u_int32_t> buffer,
                                                       bool ignore_ro,
@@ -59,7 +58,6 @@ _RegAccessParser_impl<dynamic>::_RegAccessParser_impl(string data,
     _data = data;
     _indexes = indexes;
     _ops = ops;
-    _adb = adb;
     _regNode = regNode;
     _ignore_ro = ignore_ro;
     _full_path = full_path;
@@ -91,7 +89,6 @@ template<bool dynamic>
 _RegAccessParser_impl<dynamic>::_RegAccessParser_impl(string data,
                                                       string indexes,
                                                       string ops,
-                                                      Adb* adb,
                                                       AdbInstance* regNode,
                                                       u_int32_t len,
                                                       bool ignore_ro,
@@ -100,7 +97,6 @@ _RegAccessParser_impl<dynamic>::_RegAccessParser_impl(string data,
     _data = data;
     _indexes = indexes;
     _ops = ops;
-    _adb = adb;
     _regNode = regNode;
     _ignore_ro = ignore_ro;
     _full_path = full_path;
@@ -157,16 +153,15 @@ std::vector<u_int32_t> _RegAccessParser_impl<dynamic>::genBuffKnown()
     parse_register_params(_ops, ParamType::OP);
     parse_register_params(_data, ParamType::DATA);
 
-    _adb->traverse_layout(_regNode,
-                          "",
-                          0,
-                          (uint8_t*)&(_buffer[0]),
-                          _buffer.size() * sizeof(uint32_t),
-                          _RegAccessParser_impl<dynamic>::_on_traverse_update_buffer,
-                          (void*)this,
-                          false,
-                          false,
-                          _full_path);
+    _regNode->traverse_layout("",
+                              0,
+                              (uint8_t*)&(_buffer[0]),
+                              _buffer.size() * sizeof(uint32_t),
+                              _RegAccessParser_impl<dynamic>::_on_traverse_update_buffer,
+                              (void*)this,
+                              false,
+                              false,
+                              _full_path);
     if (_params_map.size() > 0)
     {
         string unfound_name = "";
@@ -510,16 +505,15 @@ typename _RegAccessParser_impl<dynamic>::AdbInstance* _RegAccessParser_impl<dyna
 {
     FieldSearchContext search_context = {name, size, offset, offsetSpecified, nullptr};
     uint32_t buffer_size = is_buffer_full ? _buffer.size() * sizeof(uint32_t) : _regNode->get_size() / 8;
-    _adb->traverse_layout(_regNode,
-                          "",
-                          0,
-                          (uint8_t*)&(_buffer[0]),
-                          buffer_size,
-                          _RegAccessParser_impl<dynamic>::on_traverse_get_field,
-                          (void*)&search_context,
-                          is_buffer_full,
-                          false,
-                          _full_path);
+    _regNode->traverse_layout("",
+                              0,
+                              (uint8_t*)&(_buffer[0]),
+                              buffer_size,
+                              _RegAccessParser_impl<dynamic>::on_traverse_get_field,
+                              (void*)&search_context,
+                              is_buffer_full,
+                              false,
+                              _full_path);
     if (search_context.instance)
     {
         return search_context.instance;

--- a/mlxreg/mlxreg_lib/mlxreg_parser.h
+++ b/mlxreg/mlxreg_lib/mlxreg_parser.h
@@ -61,9 +61,7 @@ template<bool dynamic = false>
 class _RegAccessParser_impl
 {
     // Type aliases based on dynamic template parameter
-    using Adb = _Adb_impl<dynamic, uint32_t>;
     using AdbInstance = _AdbInstance_impl<dynamic, uint32_t>;
-    using AdbCondition = _AdbCondition_impl<uint32_t>;
 
     struct FieldSearchContext
     {
@@ -86,7 +84,6 @@ public:
     _RegAccessParser_impl(string data,
                           string indexes,
                           string ops,
-                          Adb* adb,
                           AdbInstance* regNode,
                           std::vector<u_int32_t> buffer,
                           bool ignore_ro = false,
@@ -94,7 +91,6 @@ public:
     _RegAccessParser_impl(string data,
                           string indexes,
                           string ops,
-                          Adb* adb,
                           AdbInstance* regNode,
                           u_int32_t len,
                           bool ignore_ro = false,
@@ -111,7 +107,6 @@ protected:
     string _indexes;
     string _ops;
     u_int32_t _len;
-    Adb* _adb;
     AdbInstance* _regNode;
     parseMode _parseMode;
     string output_file;

--- a/mlxreg/mlxreg_sdk/prm_reg_sdk.cpp
+++ b/mlxreg/mlxreg_sdk/prm_reg_sdk.cpp
@@ -313,7 +313,7 @@ uint32_t PrmRegSdk::getNodeFields(AdbInstanceAdvLegacy* regNode,
     else
     {
         // Pass buffer so that we traverse only the right nodes
-        _mlxRegLib->getAdb().traverse_layout(regNode, "", 0, buffer, buffer_size, _getNodeFieldsCallback, &fields, buffer != nullptr, false);
+        regNode->traverse_layout("", 0, buffer, buffer_size, _getNodeFieldsCallback, &fields, buffer != nullptr, false);
     }
     return rc;
 }
@@ -843,7 +843,7 @@ int32_t PrmRegSdk::performRawRegRequest(void* buffer, const uint32_t size)
     {
         outBuffer = genarateBuffer(regNode, size);
 
-        _mlxRegLib->getAdb().traverse_layout(regNode, "", 0, nullptr, size, _on_traverse_get_fields, &fields_offsets, false, false);
+        regNode->traverse_layout("", 0, nullptr, size, _on_traverse_get_fields, &fields_offsets, false, false);
 
         for (auto field_offset : fields_offsets)
         {

--- a/mlxreg/mlxreg_ui.cpp
+++ b/mlxreg/mlxreg_ui.cpp
@@ -1158,8 +1158,7 @@ template<bool dynamic>
 void MlxRegUi::MlxRegUiImpl<dynamic>::printRegFields(AdbInstance* node)
 {
     _query_fields.clear();
-    _mlxRegLib->getAdb().traverse_layout(node, "", 0, nullptr, 0, QueryField::on_traverse, (void*)this, false, false,
-                                         _ui->_full_path);
+    node->traverse_layout("", 0, nullptr, 0, QueryField::on_traverse, (void*)this, false, false, _ui->_full_path);
     if (_ui->_advanced)
     {
         printQueryFieldsAdvanced(_query_fields, _ui->_field_name);
@@ -1260,8 +1259,8 @@ template<bool dynamic>
 void MlxRegUi::MlxRegUiImpl<dynamic>::printAdbContext(AdbInstance* node, const std::vector<u_int32_t>& buff)
 {
     _parsed_fields.clear();
-    _mlxRegLib->getAdb().traverse_layout(node, "", 0, (uint8_t*)&buff[0], buff.size() * sizeof(u_int32_t),
-                                         SentField::on_traverse, (void*)this, true, false, _ui->_full_path);
+    node->traverse_layout("", 0, (uint8_t*)&buff[0], buff.size() * sizeof(u_int32_t), SentField::on_traverse,
+                          (void*)this, true, false, _ui->_full_path);
     // Print the fields based on detailed flag
     if (_ui->_detailed)
     {
@@ -1368,8 +1367,8 @@ void MlxRegUi::MlxRegUiImpl<dynamic>::run()
                 regNode = _mlxRegLib->get_current_node();
             }
             typename MlxRegUiImpl<dynamic>::RegAccessParser parser(
-              _ui->_dataStr, _ui->_indexesStr, _ui->_opsStr, &_mlxRegLib->getAdb(), regNode,
-              _ui->_dataLen ? _ui->_dataLen : max_reg_size, false, _ui->_full_path);
+              _ui->_dataStr, _ui->_indexesStr, _ui->_opsStr, regNode, _ui->_dataLen ? _ui->_dataLen : max_reg_size,
+              false, _ui->_full_path);
             buff = parser.genBuff();
             if (!_ui->_gen_cmd_buffer_device_type.empty())
             {
@@ -1410,8 +1409,8 @@ void MlxRegUi::MlxRegUiImpl<dynamic>::run()
             }
             // Read current register data into buffer
             typename MlxRegUiImpl<dynamic>::RegAccessParser parserGet(
-              _ui->_dataStr, _ui->_indexesStr, _ui->_opsStr, &_mlxRegLib->getAdb(), regNode,
-              _ui->_dataLen ? _ui->_dataLen : max_reg_size, _ui->_ignore_ro, _ui->_full_path);
+              _ui->_dataStr, _ui->_indexesStr, _ui->_opsStr, regNode, _ui->_dataLen ? _ui->_dataLen : max_reg_size,
+              _ui->_ignore_ro, _ui->_full_path);
             buff = parserGet.genBuff();
             if (!_ui->_overwrite && _ui->_gen_cmd_buffer_device_type.empty())
             {
@@ -1426,8 +1425,7 @@ void MlxRegUi::MlxRegUiImpl<dynamic>::run()
             }
             // Update the register buffer with user inputs
             typename MlxRegUiImpl<dynamic>::RegAccessParser parser(_ui->_dataStr, _ui->_indexesStr, _ui->_opsStr,
-                                                                   &_mlxRegLib->getAdb(), regNode, buff,
-                                                                   _ui->_ignore_ro, _ui->_full_path);
+                                                                   regNode, buff, _ui->_ignore_ro, _ui->_full_path);
             buff = parser.genBuff();
             if (_ui->_output_file != "")
             {

--- a/mlxreg/mlxreg_ui.h
+++ b/mlxreg/mlxreg_ui.h
@@ -80,7 +80,6 @@ private:
         using MlxRegLib = _MlxRegLib_impl<dynamic>;
         using RegAccessParser = _RegAccessParser_impl<dynamic>;
         using AdbInstance = typename MlxRegLib::AdbInstance;
-        using Adb = typename MlxRegLib::Adb;
 
         struct FieldBase
         {

--- a/mstdump/crd_lib/crdump.c
+++ b/mstdump/crd_lib/crdump.c
@@ -134,11 +134,6 @@ static int crd_count_double_word(IN mfile* mf,
                                  IN u_int8_t with_sp2);
 
 /*
-   Fill addresses at dword_arr
- */
-static int crd_fill_address(IN crd_ctxt_t* context, OUT crd_dword_t* dword_arr);
-
-/*
    Read a line from csv file
  */
 static int crd_read_line(IN FILE* fd, OUT char* tmp);
@@ -290,22 +285,6 @@ int crd_init(OUT crd_ctxt_t** context,
 Cleanup:
     crd_free(*context);
     return rc;
-}
-
-int crd_get_addr_list(IN crd_ctxt_t* context, OUT crd_dword_t* dword_arr)
-{
-    int rc;
-
-    CRD_CHECK_NULL(context);
-    CRD_CHECK_NULL(dword_arr);
-
-    rc = crd_fill_address(context, dword_arr);
-    if (rc)
-    {
-        return rc;
-    }
-
-    return CRD_OK;
 }
 
 int crd_dump_data(IN crd_ctxt_t* context, OUT crd_dword_t* dword_arr, IN crd_callback_t func)
@@ -886,33 +865,6 @@ static int crd_count_double_word(IN mfile* mf,
         }
     }
 
-    return CRD_OK;
-}
-
-static int crd_fill_address(IN crd_ctxt_t* context, OUT crd_dword_t* dword_arr)
-{
-    u_int32_t i = 0;
-    u_int32_t j = 0;
-    int total = 0;
-
-    for (i = 0; i < context->block_count; i++)
-    {
-        for (j = 0; j < context->blocks[i].len; j++)
-        {
-            // CRD_UNKOWN, CRD_EMPTY
-            if (!context->is_full && strcmp(context->blocks[i].enable_addr, CRD_EMPTY))
-            {
-                break;
-            }
-            if ((u_int32_t)total >= context->number_of_dwords)
-            {
-                CRD_DEBUG("value exceeded, something wrong in calculation!");
-                return CRD_EXCEED_VALUE;
-            }
-            dword_arr[total].addr = context->blocks[i].addr + (j * 4);
-            total += 1;
-        }
-    }
     return CRD_OK;
 }
 

--- a/mstdump/crd_lib/crdump.h
+++ b/mstdump/crd_lib/crdump.h
@@ -112,13 +112,6 @@ extern "C"
     CRD_DLL_EXPORT int crd_get_dword_num(IN crd_ctxt_t* context, OUT u_int32_t* arr_size);
 
     /*
-       Store all addresses are dword_arr array
-     */
-    CRD_DLL_EXPORT int crd_get_addr_list(IN crd_ctxt_t* context,
-                                         OUT crd_dword_t* dword_arr); // caller well allocate the array and addresses
-                                                                      // will be filled.
-
-    /*
        Store all addresses and data in dword_arr, if func is not null, it will be called on each dword
      */
     CRD_DLL_EXPORT int crd_dump_data(IN crd_ctxt_t* context,


### PR DESCRIPTION
port MFT 4.37.0 [adb_parser][hca_capabilities][mlxlink][mlxreg][mstdump][common]

Description

MFT Commit: ec44ef93aba9554cf4bc7276ce76e053d47885f5
[adb_parser][mlxreg] fix ref to null Adb object

Description:
The root cause was that traverse_layout was used from a null object. this worked because the function doesn't realy use Adb object members. It was move to the more natural place for it, AdbInstance, this caused some more required refactors

1) Move traverse_layout (+ _trvrs_* helpers) from Adb onto AdbInstance; call sites use instance->traverse_layout(...).
2) Add ExceptionHolder::raiseException overloads (with/without addedMsg; optional raise_warnings); remove Adb::raiseException and AdbParser::raiseException — call ExceptionHolder directly from adb_parser.cpp / adb_xml_parser.cpp.
3) Rfactor raiseException
    a) rename to handle_exception
    b) make the function handle the error location part.
4) Replace a few manual insert/throw blocks with raiseException where behavior matches.
5) RegAccessParser: drop unused Adb* _adb member and ctor argument; update mlxreg_ui + mlxlink default ctor. Remove unused MlxRegLib::getAdb().

MSTFlint port needed: yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 4860711
------------------------------------------------------------
MFT Commit: 521bc358e072ba431b6e2ce69caeffba64a3d235
[mlxlink][SPC6] show eye from the slrg_all_lanes_5nm

Description:
This is done as a mitigation for SPC6 since the destructiveness of the regular flow

MSTFlint port needed: yes
Tested OS:
Tested devices: SPC6
Tested flows:

Known gaps (with RM ticket):

Issue: 4956707
------------------------------------------------------------
MFT Commit: d3a5daf1da9a003f5fd45a20547a04d5ed5dd547
[mstdump] clean code

Description:
1) remove dead code
2) remove redundant pass over all addresses

MSTFlint port needed:  yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 4975743
------------------------------------------------------------
MFT Commit: fe2619a4a973d8b688effcec4deea4f0c8951c5a
[a-me] replace_all: linear-time rewrite to fix adb_parse O(n*k) slowdown

Description:
replace_all did repeated in-place std::string::replace, shifting the tail
on every match (O(n*k)). AdbParser::descXmlToNative calls it per node and
field, so gilboa's multi-MB descr= attributes (2.45 MB, ~25k "\;") made
adb.Adb() and every a-me script that builds an Adb pathologically slow.
Rewrite as a single forward-pass rebuild that swaps the result back;
observable behavior is unchanged.

MSTFlint port needed: No
Tested OS: linux
Tested devices: N/A
Tested flows: adb.Adb() on gilboa.adb 20.5s -> 9.1s (warm cache);
              200k-case fuzz confirms output identical to prior impl.

Known gaps (with RM ticket): None

Issue: 5027924
------------------------------------------------------------
MFT Commit: 7f98ed85c1a74523bcd6109417380b600c9f6497
[a-me] use a convention for all adb_parser errors/warnings

MSTFlint port needed: Yes
Tested OS: linux
Tested devices: N/A (offline library change)
Tested flows: N/A (error-message formatting refactor)
Known gaps (with RM ticket): None

Description: Route all adb_parser error/warning location strings through
one formatter. Promote appendLocationSuffix to a public static
ExceptionHolder method and convert the 5 hand-built strings in
adb_xml_parser.cpp to the shared ", in file: \"X\" line: N" format
(dropping the ad-hoc "column:" field).

Issue: 5011920

