### PR TITLE
[mtcr] Fix BlueField4 detection over fwctl

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -595,9 +595,9 @@ static int dm_get_device_id_inner(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int32
     int rc;
     u_int32_t dev_flags;
 
-    if (mf->pci_device_id == DeviceBlueField4_HwId)
+    if (is_bluefield4_pci_device(mf->pci_device_id))
     {
-        *ptr_hw_dev_id = mf->pci_device_id;
+        *ptr_hw_dev_id = DeviceBlueField4_HwId;
         *ptr_hw_rev = 0;
         *ptr_dm_dev_id = DeviceBlueField4;
         return CHECK_PTR_DEV_ID;

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -4390,7 +4390,7 @@ int init_dev_info_ul(mfile* mf, const char* dev_name, unsigned domain, unsigned 
     }
     if (mf->dinfo && is_bluefield4_pci_device(mf->dinfo->pci.dev_id))
     {
-        mf->pci_device_id = DeviceBlueField4_HwId;
+        mf->pci_device_id = mf->dinfo->pci.dev_id;
     }
     
 cleanup:
@@ -5480,8 +5480,7 @@ int read_device_id(mfile* mf, u_int32_t* device_id)
     // For Bluefield4 device, the HW device ID is 0x224, but need to check the PCI device ID
     if (mf->dinfo && is_bluefield4_pci_device(mf->dinfo->pci.dev_id))
     {
-        // Use the HW device ID for JSON
-        mf->pci_device_id = DeviceBlueField4_HwId;
+        mf->pci_device_id = mf->dinfo->pci.dev_id;
     }
     
     mf->hw_dev_id = (*device_id & 0xffff);


### PR DESCRIPTION
Description:
BF4 and CX9 both report hw_dev_id 0x224, so BF4 is disambiguated by PCI id. The mf->pci_device_id convention was inconsistent (fwctl stored the real PCI id, mopen stored the 0x220 sentinel), so the check missed BF4 over fwctl. Always store the real PCI id and detect via
is_bluefield4_pci_device().

Tested OS: Linux
Tested devices: BlueField4
Tested flows:
 sudo modprobe mlx5_core
 dmesg | grep mlx5
 mstconfig -d /dev/fwctl/fwctlXX show_system_conf

Known gaps (with RM ticket): n/a

Issue: n/a