### PR TITLE
[mstflint][VR][cables] block FW Update/Query on Secondary cables

### DIFF
--- a/cable_access/cable_access.cpp
+++ b/cable_access/cable_access.cpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <vector>
 #include <sstream>
-
+#include <stdexcept>
 #include "cable_access.h"
 #include "mtcr_cables.h"
 #include "mtcr_ul/mtcr_ul_com.h"
@@ -97,6 +97,32 @@ int send_pmaos(mfile* mf, int state, bool verbose)
     }
     mf->tp = tmp_tp;
     switch_access_funcs(mf);
+    return ret;
+}
+
+int is_secondary(mfile* mf, bool* isSecondary)
+{
+    MCABLES_ERROR ret = MCABLES_OK;
+
+    cable_ctx* ctx = (cable_ctx*)(mf->cable_ctx);
+    if (!ctx)
+    {
+        return MCABLES_ACCESS_ERROR;
+    }
+    MType tmp_tp = mf->tp;
+    mf->tp = ctx->src_tp;
+    switch_access_funcs(mf);
+    struct reg_access_switch_pmaos_reg_ext pmaos;
+    memset(&pmaos, 0, sizeof(pmaos));
+    pmaos.module = ctx->port;
+    if (reg_access_pmaos(mf, REG_ACCESS_METHOD_GET, &pmaos))
+    {
+        printf("-E- Failed to get the module state from the cable\n");
+        ret = MCABLES_REG_FAILED;
+    }
+    mf->tp = tmp_tp;
+    switch_access_funcs(mf);
+    *isSecondary = (pmaos.secondary != 0);
     return ret;
 }
 
@@ -329,5 +355,15 @@ bool cableAccess::resetCable()
         return resetCableModule(false);
     }
     return false;
+}
+
+bool cableAccess::isSecondary()
+{
+    bool isSecondary = false;
+    if (is_secondary(_mf, &isSecondary) != MCABLES_OK)
+    {
+        throw std::runtime_error("Failed to get the module state from the cable");
+    }
+    return isSecondary;
 }
 

--- a/cable_access/cable_access.h
+++ b/cable_access/cable_access.h
@@ -288,6 +288,7 @@
     string getLastErrMsg();
     void setBurnFlow(bool isBurnFlow);
     bool resetCable();
+    bool isSecondary();
  
  private:
     bool resetCableModule(bool verbose);

--- a/cable_access/cdb_cable_access.cpp
+++ b/cable_access/cdb_cable_access.cpp
@@ -571,6 +571,10 @@ void FWManagementCdbAccess::Init(vector<u_int8_t> password)
         vector<u_int8_t> data(sizeof(fwMngfeatures), 0);
 
         CmisCdbAccess::Init();
+        if (_cableAccess.isSecondary())
+        {
+            throw CmisCdbAccessException("Firmware management is not supported on secondary cables, please use primary cable.");
+        }
         if (!password.empty())
         {
             EnterPassword(password);


### PR DESCRIPTION
Description: Although secondary cables can be discovered and used for basic flows, FW management via CDB commands is not supported on them. Blocking this usage from CDB Cables Commander and adding approptiate error message