### PR TITLE
mlxprivhost | Report failing host in multi host configuration

### DIFF
--- a/mlxconfig/mstprivhost.py
+++ b/mlxconfig/mstprivhost.py
@@ -369,10 +369,14 @@ class PrivilegeMgr(object):
         exit_code = 0
         if self._isARM:
             for host in range(self._total_hosts):
+                rc = 0
                 if self._requested_level == self.RESTRICT:
-                    exit_code = self.setRestrictConf(host)
+                    rc = self.setRestrictConf(host)
                 elif self._requested_level == self.PRIVILEGE:
-                    exit_code = self.setPrivilegeConf(host)
+                    rc = self.setPrivilegeConf(host)
+                if rc:
+                    error("Failed to configure host %d", host)
+                    exit_code = rc
                 self._disable_out = True
         else:
             error("Operation is not permitted (refer to the DPU user manual)")


### PR DESCRIPTION
Description:
Fixed an issue in mlxprivhost where failures on non first hosts in a multi host configuration were not reported. The tool now prints an error for the failed host and preserves the correct exit status.