### PR TITLE
mstfwreset | vfio | tool is broken

### DIFF
--- a/common/python_wrapper.sh
+++ b/common/python_wrapper.sh
@@ -22,6 +22,12 @@ export PYTHONPATH
 export MSTFLINT_LIB_DIR=$mlibdir
 export LD_LIBRARY_PATH=$mlibdir
 export MSTFLINT_BIN_DIR=$mbindir
+# Ensure co-installed sibling tools (mstmcra, mstconfig, flint, ...) are found
+# when the tool shells out to them, even under a minimal PATH (e.g. sudo, which
+# resets PATH to secure_path and drops $mbindir such as /usr/local/bin).
+# Append (not prepend) so PATH precedence is unchanged wherever the tool already
+# resolves; this only adds a fallback location when $mbindir is missing from PATH.
+export PATH=$PATH:$mbindir
 PYTHON_EXEC=`find /usr/bin /bin/ /usr/local/bin -iname 'python*' 2>&1 | grep -e='*python[0-9,.]*' | sort -d | head -n 1`
 which python3 >/dev/null 2>&1
 if test $? -eq 0 ; then

--- a/mtcr_py/Makefile.am
+++ b/mtcr_py/Makefile.am
@@ -34,7 +34,22 @@ mtcr_pylibdir = $(libdir)/mstflint/python_tools/
 
 mtcr_pylib_DATA = cmtcr.so
 dist_mtcr_pylib_DATA = mtcr.py
+
+# With --enable-vfio, libmtcr_ul.a absorbs vfio_driver_access -> libcommon
+# (tools_json.cpp), which references jsoncpp symbols (Json::parseFromStream,
+# Json::Value::asString, ...). cmtcr.so must therefore also link jsoncpp,
+# otherwise it fails to dlopen at runtime with "undefined symbol: _ZN4Json...".
+if ENABLE_VFIO
+if USE_LOCAL_JSON
+CMTCR_JSON_LIBS = $(top_builddir)/ext_libs/json/.libs/libjson.a
+else
+CMTCR_JSON_LIBS = -ljsoncpp
+endif
+else
+CMTCR_JSON_LIBS =
+endif
+
 cmtcr.so:
-	$(CC) -g -Wall -pthread -shared ${CFLAGS} ${LDFLAGS} -o cmtcr.so -Wl,--whole-archive $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a -Wl,--no-whole-archive -lstdc++
+	$(CC) -g -Wall -pthread -shared ${CFLAGS} ${LDFLAGS} -o cmtcr.so -Wl,--whole-archive $(top_builddir)/${MTCR_CONF_DIR}/.libs/libmtcr_ul.a -Wl,--no-whole-archive $(CMTCR_JSON_LIBS) -lstdc++
 
 CLEANFILES = cmtcr.so


### PR DESCRIPTION
Description: Two issues broke mstfwreset on VFIO-enabled builds:

1. cmtcr.so failed to dlopen with "undefined symbol: _ZN4Json..." with --enable-vfio, libmtcr_ul.a pulls in tools_json.cpp (via vfio_driver_access -> libcommon), which references jsoncpp, but cmtcr.so never linked it. Link libjson/-ljsoncpp into cmtcr.so when ENABLE_VFIO.

2. mstfwreset reported "mstmcra: command not found" when run under sudo, whose reset PATH drops $mbindir (e.g. /usr/local/bin). The python wrapper exported MSTFLINT_BIN_DIR but never added it to PATH. Append $mbindir to PATH so sibling tools are found.