### PR TITLE
mft_sdk | fix module-info DDM valid bit reported when no module is plugged

### DIFF
--- a/mft_sdk/mft_sdk_telemetry.cpp
+++ b/mft_sdk/mft_sdk_telemetry.cpp
@@ -850,9 +850,14 @@ void MftSdk::setFwVersionFromJson(const Json::Value& moduleInfoJson, MstModuleIn
 
 void MftSdk::setPowerAndCdrInfoFromJson(const Json::Value& moduleInfoJson, MstModuleInfo* moduleInfo)
 {
-    moduleInfo->powerAndCdrInfo.digitalDiagnosticMonitoring =
-      getJsonStringValue(moduleInfoJson, FIELD_DIGITAL_DIAGNOSTIC_MONITORING) == "Yes";
-    mstQuerySetBit(moduleInfo->header, TELEMETRY_MODULE_INFO_DIGITAL_DIAGNOSTIC_MONITORING);
+    // Mark DDM valid only when mlxlink actually reported it (no module plugged
+    // -> field absent -> bit stays clear), like every other module field.
+    const std::string ddmValue = getJsonStringValue(moduleInfoJson, FIELD_DIGITAL_DIAGNOSTIC_MONITORING);
+    if (ddmValue != NA_FIELD_VALUE && !ddmValue.empty())
+    {
+        moduleInfo->powerAndCdrInfo.digitalDiagnosticMonitoring = ddmValue == "Yes";
+        mstQuerySetBit(moduleInfo->header, TELEMETRY_MODULE_INFO_DIGITAL_DIAGNOSTIC_MONITORING);
+    }
     extractAndSetStringField(moduleInfoJson, FIELD_POWER_CLASS, moduleInfo->powerAndCdrInfo.powerClass,
                              MODULE_INFO_MAX_LENGTH, moduleInfo->header, TELEMETRY_MODULE_INFO_POWER_CLASS);
     extractAndSetStringField(moduleInfoJson, FIELD_MAX_POWER, moduleInfo->powerAndCdrInfo.maxPower,


### PR DESCRIPTION
## Summary
Mark the digital diagnostic monitoring (DDM) field of module-info valid only when mlxlink actually reported it.

Previously the valid bit was set unconditionally, so with no module plugged (field absent from mlxlink output) the DDM field was still reported as valid. This aligns DDM with the `NA_FIELD_VALUE`/empty gating used by every other module-info field.

Port of internal MFT change [1454965](https://git-nbu.nvidia.com/r/c/tools/mft/+/1454965) (Id5e8b6d762b9eecb5c125f6633a937bb86e66696). The Python-binding fixes in that change (`_py_to_c` map, `MstStatus` code 16 name) do not apply here since `mft_sdk_py` is not part of mstflint, and `mft_sdk_errors.h` already uses the canonical `MST_ERROR_FAILED_TO_SET_I2C_SECONDARY` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)