### PR TITLE
Fix/mdevices info leak

### DIFF
--- a/adb_parser/adb_instance.cpp
+++ b/adb_parser/adb_instance.cpp
@@ -1676,12 +1676,12 @@ LayoutItemAttrsMap::iterator::iterator(LayoutItemAttrsMap& container,
 
 LayoutItemAttrsMap::iterator::reference LayoutItemAttrsMap::iterator::operator*() const
 {
-    return (reference)(*_current);
+    return *_current;
 }
 
 LayoutItemAttrsMap::iterator::pointer LayoutItemAttrsMap::iterator::operator->()
 {
-    return (pointer)(&(*_current));
+    return &(*_current);
 }
 
 void LayoutItemAttrsMap::iterator::advance_internal()

--- a/adb_parser/adb_instance.h
+++ b/adb_parser/adb_instance.h
@@ -73,10 +73,10 @@ public:
     class iterator
     {
     public:
-        using value_type = pair<string, string>;
+        using value_type = pair<const string, string>;
         using difference_type = std::ptrdiff_t;
-        using pointer = pair<string, string>*;
-        using reference = pair<string, string>&;
+        using pointer = value_type*;
+        using reference = value_type&;
         using iterator_category = bidirectional_iterator_tag;
 
         explicit iterator(LayoutItemAttrsMap& container, AttrsMap::iterator current, bool past_layout_specific = false);

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -971,9 +971,9 @@ bool Flash::get_attr(ext_flash_attr_t& attr)
     if (_attr.type_str != NULL)
     {
         // we don't print the flash type in old devices
-        int type_str_len = strlen(_attr.type_str);
-        attr.type_str = strncpy(new char[type_str_len + 1], _attr.type_str, type_str_len);
-        attr.type_str[type_str_len] = '\0';
+        size_t type_str_len = strlen(_attr.type_str);
+        attr.type_str = strcpy(new char[type_str_len + 1], _attr.type_str);
+
     }
     attr.size = _attr.size;
     attr.sector_size = _attr.sector_size;

--- a/mlxfwops/lib/fs3_ops.cpp
+++ b/mlxfwops/lib/fs3_ops.cpp
@@ -32,6 +32,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <algorithm>
 #include <vector>
@@ -352,15 +353,17 @@ bool Fs3Operations::GetImageInfo(u_int8_t* buff)
         struct tools_open_image_info tools_image_info;
         memset(&tools_image_info, 0, sizeof(tools_image_info));
         tools_open_image_info_unpack(&tools_image_info, buff);
-        strncpy(_fs3ImgInfo.ext_info.name, tools_image_info.name, strlen(tools_image_info.name));
-        strncpy(_fs3ImgInfo.ext_info.description, tools_image_info.description, strlen(tools_image_info.description));
-        strncpy(_fs3ImgInfo.ext_info.prs_name, tools_image_info.prs_name, strlen(tools_image_info.prs_name));
+        snprintf(_fs3ImgInfo.ext_info.name, sizeof(_fs3ImgInfo.ext_info.name), "%s", tools_image_info.name);
+        snprintf(_fs3ImgInfo.ext_info.description, sizeof(_fs3ImgInfo.ext_info.description), "%s",
+                 tools_image_info.description);
+        snprintf(_fs3ImgInfo.ext_info.prs_name, sizeof(_fs3ImgInfo.ext_info.prs_name), "%s", tools_image_info.prs_name);
     }
     else if (image_info.minor_version == 3)
     {
-        strncpy(_fs3ImgInfo.ext_info.name, image_info.name, strlen(image_info.name));
-        strncpy(_fs3ImgInfo.ext_info.description, image_info.description, strlen(image_info.description));
-        strncpy(_fs3ImgInfo.ext_info.prs_name, image_info.prs_name, strlen(image_info.prs_name));
+        snprintf(_fs3ImgInfo.ext_info.name, sizeof(_fs3ImgInfo.ext_info.name), "%s", image_info.name);
+        snprintf(_fs3ImgInfo.ext_info.description, sizeof(_fs3ImgInfo.ext_info.description), "%s",
+                 image_info.description);
+        snprintf(_fs3ImgInfo.ext_info.prs_name, sizeof(_fs3ImgInfo.ext_info.prs_name), "%s", image_info.prs_name);
     }
 
     _fs3ImgInfo.ext_info.mcc_en = image_info.mcc_en;

--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -4537,7 +4537,13 @@ bool fromFileToArray(string& fileName, vector<u_int8_t>& outputArray, unsigned i
         fclose(pFile);
         return false;
     }
-    fread(data, sizeof(char), input_length, pFile);
+    size_t rc = fread(data, sizeof(char), input_length, pFile);
+    if (rc != input_length)
+    {
+        delete[] data;
+        fclose(pFile);
+        return false;
+    }
     fclose(pFile);
     outputArray.resize(input_length / 2);
     for (size_t i = 0; i < input_length; i += 2)

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -329,14 +329,14 @@ bool FsCtrlOperations::FsIntQuery()
         extractFwVersion(_fwImgInfo.ext_info.roms_info.rom_info[i].exp_rom_ver, fwQuery.roms[i].version);
     }
 
-    strncpy(_fsCtrlImgInfo.name, fwQuery.name, NAME_LEN);
-    strncpy(_fsCtrlImgInfo.description, fwQuery.description, DESCRIPTION_LEN);
-    (strncpy(_fsCtrlImgInfo.deviceVsd, fwQuery.deviceVsd, sizeof(_fsCtrlImgInfo.deviceVsd)));
+    snprintf(_fsCtrlImgInfo.name, sizeof(_fsCtrlImgInfo.name), "%s", fwQuery.name);
+    snprintf(_fsCtrlImgInfo.description, sizeof(_fsCtrlImgInfo.description), "%s", fwQuery.description);
+    snprintf(_fsCtrlImgInfo.deviceVsd, sizeof(_fsCtrlImgInfo.deviceVsd), "%s", fwQuery.deviceVsd);
     if (FwType() == FIT_FS3)
     {
         memcpy(_fwImgInfo.ext_info.vsd, fwQuery.deviceVsd, VSD_LEN);
     }
-    (strncpy(_fsCtrlImgInfo.image_vsd, fwQuery.imageVsd, sizeof(_fsCtrlImgInfo.image_vsd)));
+    snprintf(_fsCtrlImgInfo.image_vsd, sizeof(_fsCtrlImgInfo.image_vsd), "%s", fwQuery.imageVsd);
 
     bool mpir_reg_supported = false;
     rc = isRegisterValidAccordingToMcamReg(mf, REG_ID_MPIR, &mpir_reg_supported);

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -868,21 +868,22 @@ void FwOperations::BackUpFwParams(fw_ops_params_t& fwParams)
     _fwParams.cx3FwAccess = fwParams.cx3FwAccess;
     _fwParams.errBuff = (char*)NULL;
     _fwParams.errBuffSize = 0;
-    _fwParams.fileHndl =
-      (fwParams.hndlType == FHT_FW_FILE && fwParams.fileHndl) ? strncpy((char*)(new char[(strlen(fwParams.fileHndl) + 1)]), fwParams.fileHndl, strlen(fwParams.fileHndl) + 1) : (char*)NULL;
+    _fwParams.fileHndl = (fwParams.hndlType == FHT_FW_FILE && fwParams.fileHndl) ?
+                           strcpy((char*)(new char[(strlen(fwParams.fileHndl) + 1)]), fwParams.fileHndl) :
+                           (char*)NULL;
     // no support for flash params
     _fwParams.flashParams = (flash_params_t*)NULL;
     _fwParams.forceLock = fwParams.forceLock;
     _fwParams.ignoreCacheRep = fwParams.ignoreCacheRep;
-    _fwParams.mstHndl =
-      (fwParams.hndlType == FHT_MST_DEV && fwParams.mstHndl) ? strncpy((char*)(new char[(strlen(fwParams.mstHndl) + 1)]), fwParams.mstHndl, strlen(fwParams.mstHndl) + 1) : (char*)NULL;
+    _fwParams.mstHndl = (fwParams.hndlType == FHT_MST_DEV && fwParams.mstHndl) ?
+                          strcpy((char*)(new char[(strlen(fwParams.mstHndl) + 1)]), fwParams.mstHndl) :
+                          (char*)NULL;
     _fwParams.noFlashVerify = fwParams.noFlashVerify;
     _fwParams.numOfBanks = fwParams.numOfBanks;
-    _fwParams.psid = fwParams.psid ? strncpy((char*)(new char[(strlen(fwParams.psid) + 1)]), fwParams.psid, strlen(fwParams.psid) + 1) : (char*)NULL;
+    _fwParams.psid =
+      fwParams.psid ? strcpy((char*)(new char[(strlen(fwParams.psid) + 1)]), fwParams.psid) : (char*)NULL;
     _fwParams.readOnly = fwParams.readOnly;
     _fwParams.shortErrors = fwParams.shortErrors;
-    _fwParams.uefiExtra = fwParams.uefiExtra;
-    _fwParams.uefiHndl = fwParams.uefiHndl;
     _fwParams.isCableFw = fwParams.isCableFw;
     _fwParams.ignoreCrcCheck = fwParams.ignoreCrcCheck;
 }

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -884,6 +884,8 @@ void FwOperations::BackUpFwParams(fw_ops_params_t& fwParams)
       fwParams.psid ? strcpy((char*)(new char[(strlen(fwParams.psid) + 1)]), fwParams.psid) : (char*)NULL;
     _fwParams.readOnly = fwParams.readOnly;
     _fwParams.shortErrors = fwParams.shortErrors;
+    _fwParams.uefiExtra = fwParams.uefiExtra;
+    _fwParams.uefiHndl = fwParams.uefiHndl;
     _fwParams.isCableFw = fwParams.isCableFw;
     _fwParams.ignoreCrcCheck = fwParams.ignoreCrcCheck;
 }

--- a/mlxfwupdate/image_access.cpp
+++ b/mlxfwupdate/image_access.cpp
@@ -760,8 +760,7 @@ void ImageAccess::parse_image_info_data(u_int8_t* image_info_data, PsidQueryItem
     fw_ver[0] = image_info.FW_VERSION.MAJOR;
     fw_ver[1] = image_info.FW_VERSION.MINOR;
     fw_ver[2] = image_info.FW_VERSION.SUBMINOR;
-    (strncpy(fw_branch, image_info.vsd, BRANCH_LEN));
-    fw_branch[BRANCH_LEN] = (char)0;
+    snprintf(fw_branch, sizeof(fw_branch), "%.*s", BRANCH_LEN, image_info.vsd);
     ImgVersion imgv;
     imgv.setVersion("FW", FW_VER_SIZE, fw_ver, fw_branch);
     query_item.imgVers.push_back(imgv);

--- a/mlxfwupdate/mlnx_dev.cpp
+++ b/mlxfwupdate/mlnx_dev.cpp
@@ -911,8 +911,7 @@ bool MlnxDev::InitDevFWParams(FwOperations::fw_ops_params_t& devFwParams)
         _log += _errMsg;
         return false;
     }
-    memset(devFwParams.mstHndl, 0, length);
-    strncpy(devFwParams.mstHndl, deviceName, length - 1);
+    memcpy(devFwParams.mstHndl, deviceName, length);
     devFwParams.forceLock = false;
     devFwParams.readOnly = false;
     devFwParams.numOfBanks = -1;

--- a/mst_utils/mdevices_info.c
+++ b/mst_utils/mdevices_info.c
@@ -498,7 +498,7 @@ void print_pci_info(dev_info* dev, int domain_needed, mfile* mf, int net_width)
     if (CheckifVfioPciDriverIsLoaded())
     {
         char vfio_dev[32];
-        snprintf(vfio_dev, sizeof(vfio_dev), "vfio-%s", dbdf);
+        snprintf(vfio_dev, sizeof(vfio_dev), "vfio-%.26s", dbdf);
         printf("%-18s", vfio_dev);
     }
     else

--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -103,8 +103,10 @@ dev_info* mdevices_info(int mask, int* len)
         mfile* mf = mopen(dev_info_all[counter].dev_name);
         if (!mf)
         {
+            int dev_count = *len;
             *len = 0;
             free(dev_info_new);
+            mdevices_info_destroy(dev_info_all, dev_count);
             return NULL;
         }
         if (is_pcie_switch_device(mf) && !mf->functional_vsec_supp)


### PR DESCRIPTION
## Summary
- Fix a resource leak in `mdevices_info()` when `mopen()` fails while filtering devices without VSEC support.
- On the error path, free `dev_info_all` via `mdevices_info_destroy()` before returning `NULL`.
- Coverity: RESOURCE_LEAK / CID 871786 (`leaked_storage` on `dev_info_all`).
