### PR TITLE
mft_sdk | add per-port MstTelemetryContext to the telemetry SDK API

### DIFF
--- a/mft_sdk/mft_sdk_class.hpp
+++ b/mft_sdk/mft_sdk_class.hpp
@@ -39,6 +39,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include <mft_sdk/mft_sdk.h>
 #ifdef MFT_SDK_EXTERNAL
@@ -79,11 +80,15 @@ public:
     MstStatus getPRMRegisterField(MstPrmRegisterMap* registerMap, const char* fieldName, uint32_t* value);
 
     // mlxlink SDK functions
-    MstStatus getTelemetryOperationalInfo(MstTelemetryOperationalInfo* operationalInfo);
-    MstStatus getFecHistogram(MstFecHistogram* fecHistogram);
-    MstStatus getCountersInfo(MstCountersInfo* countersInfo);
-    MstStatus getCableDDMInfo(MstCableDDMInfo* cableDDMInfo);
-    MstStatus getModuleInfo(MstModuleInfo* moduleInfo);
+    MstStatus getTelemetryOperationalInfo(MstTelemetryOperationalInfo* operationalInfo,
+                                          const MstTelemetryContext& context = MstTelemetryContext{0, ""});
+    MstStatus getFecHistogram(MstFecHistogram* fecHistogram,
+                              const MstTelemetryContext& context = MstTelemetryContext{0, ""});
+    MstStatus getCountersInfo(MstCountersInfo* countersInfo,
+                              const MstTelemetryContext& context = MstTelemetryContext{0, ""});
+    MstStatus getCableDDMInfo(MstCableDDMInfo* cableDDMInfo,
+                              const MstTelemetryContext& context = MstTelemetryContext{0, ""});
+    MstStatus getModuleInfo(MstModuleInfo* moduleInfo, const MstTelemetryContext& context = MstTelemetryContext{0, ""});
 
     // HCA capabilities SDK functions
     MstStatus getCapabilityTypesList(std::vector<std::string>& capabilityTypes);
@@ -127,7 +132,7 @@ private:
     MstStatus setErrorFromMlxregSDKError(int32_t errorCode);
 
     // mlxlink SDK private functions
-    MstStatus initMlxLinkSdk(MlxLinkInitMode initMode = MlxLinkInitMode::NONE);
+    MstStatus initMlxLinkSdk(MlxLinkInitMode initMode = MlxLinkInitMode::NONE, const std::string& port = "");
     void initMlxLinkSdkPortInfo();
     void initMlxLinkSdkUserInput(MlxLinkInitMode initMode);
     MstStatus extractOperationalInfoFromJson(MstTelemetryOperationalInfo* operationalInfo);
@@ -211,4 +216,8 @@ private:
     std::unique_ptr<HcaCapabilities> _hcaCapabilitiesSdkInstance;
     std::vector<mfile*> _mfiles;
     std::map<MlxLinkInitMode, bool> mlxlinkSdkInitialized;
+    // Currently bound mlxlink port label (empty => device default). Guards redundant re-binds.
+    std::string _currentMlxLinkPort;
+    // Tracks the per-port init flow (updatePortInfo()+showPddr()) already run for each (port, mode).
+    std::map<std::pair<std::string, MlxLinkInitMode>, bool> _portModeInitialized;
 };

--- a/mft_sdk/mft_sdk_telemetry.cpp
+++ b/mft_sdk/mft_sdk_telemetry.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <string.h>
+#include <cstddef>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -61,6 +62,66 @@ static void mstQuerySetBit(mstQueryHeader& header, uint8_t bitIndex)
 }
 
 using mft_core::MftGeneralException;
+
+namespace
+{
+
+// Reads the port label out of a caller-supplied telemetry context in an ABI-safe way.
+class TelemetryContextView
+{
+public:
+    explicit TelemetryContextView(const MstTelemetryContext& context) : _context(context) {}
+
+    std::string getPort() const
+    {
+        // Only read 'port' if the caller's struct is large enough to contain it
+        // (a smaller/older caller falls back to the device default port).
+        if (_context.size < offsetof(MstTelemetryContext_t, label_port) + sizeof(_context.label_port))
+        {
+            return std::string();
+        }
+        return std::string(_context.label_port, strnlen(_context.label_port, MST_TELEMETRY_PORT_MAX_LENGTH));
+    }
+
+private:
+    const MstTelemetryContext& _context;
+};
+
+// Validate a caller-supplied telemetry context. NULL means "use device defaults".
+// A non-NULL context must carry a plausible size header, which guards against
+// callers that forgot MST_TELEMETRY_CONTEXT_INIT and against future ABI drift.
+MstStatus validateTelemetryContext(const MstTelemetryContext* context)
+{
+    if (context == nullptr)
+    {
+        return MST_SUCCESS;
+    }
+    if (context->size < sizeof(unsigned int))
+    {
+        return MST_ERROR_INVALID_ARGUMENT;
+    }
+    return MST_SUCCESS;
+}
+
+// The device-defaults context, initialized once and shared.
+const MstTelemetryContext& defaultTelemetryContext()
+{
+    static const MstTelemetryContext defaults = []
+    {
+        MstTelemetryContext c;
+        MST_TELEMETRY_CONTEXT_INIT(&c);
+        return c;
+    }();
+    return defaults;
+}
+
+// NULL context => the shared default context (device defaults).
+const MstTelemetryContext& resolveTelemetryContext(const MstTelemetryContext* context)
+{
+    return context != nullptr ? *context : defaultTelemetryContext();
+}
+
+} // namespace
 
 static std::uint32_t parseUint32FromString(const std::string& value)
 {
@@ -164,7 +225,7 @@ void MftSdk::initMlxLinkSdkUserInput(MlxLinkInitMode initMode)
     }
 }
 
-MstStatus MftSdk::initMlxLinkSdk(MlxLinkInitMode initMode)
+MstStatus MftSdk::initMlxLinkSdk(MlxLinkInitMode initMode, const std::string& port)
 {
     clearError();
     try
@@ -176,11 +237,30 @@ MstStatus MftSdk::initMlxLinkSdk(MlxLinkInitMode initMode)
             _mfiles.push_back(_mstMlxLinkSdkInstance->_mf);
         }
 
+        // The user-input flags for a mode (e.g. cable/ddm/show_module) are set once per mode.
         if (!mlxlinkSdkInitialized[initMode])
         {
             initMlxLinkSdkUserInput(initMode);
-            initMlxLinkSdkPortInfo();
             mlxlinkSdkInitialized[initMode] = true;
+        }
+
+        // Re-bind the port only when it changes; handlePortStr parses the new port label.
+        // _currentMlxLinkPort starts empty, so the device-default port ("") never re-parses
+        // (handlePortStr would reject an empty label), matching the original default-port flow.
+        const bool portChanged = (port != _currentMlxLinkPort);
+        if (portChanged)
+        {
+            _mstMlxLinkSdkInstance->handlePortStr(port);
+            _currentMlxLinkPort = port;
+        }
+
+        // Run the per-port flow (updatePortInfo() + showPddr()) once per (port, mode), and re-run it
+        // whenever the port changes so per-port state stays fresh.
+        const auto key = std::make_pair(port, initMode);
+        if (portChanged || !_portModeInitialized[key])
+        {
+            initMlxLinkSdkPortInfo();
+            _portModeInitialized[key] = true;
         }
     }
     catch (const std::exception& e)
@@ -407,14 +487,15 @@ MstStatus MftSdk::extractOperationalInfoFromJson(MstTelemetryOperationalInfo* op
     return _lastError.status;
 }
 
-MstStatus MftSdk::getTelemetryOperationalInfo(MstTelemetryOperationalInfo* operationalInfo)
+MstStatus MftSdk::getTelemetryOperationalInfo(MstTelemetryOperationalInfo* operationalInfo,
+                                              const MstTelemetryContext& context)
 {
     if (!operationalInfo || operationalInfo->header.size < sizeof(mstQueryHeader))
     {
         return MST_ERROR_INVALID_ARGUMENT;
     }
 
-    if (initMlxLinkSdk(MlxLinkInitMode::OPERATIONAL_INFO) != MST_SUCCESS)
+    if (initMlxLinkSdk(MlxLinkInitMode::OPERATIONAL_INFO, TelemetryContextView(context).getPort()) != MST_SUCCESS)
     {
         return _lastError.status;
     }
@@ -457,14 +538,14 @@ MstStatus MftSdk::mlxlinkGetFecHistogram(MstFecHistogram* fecHistogram)
     return MST_SUCCESS;
 }
 
-MstStatus MftSdk::getFecHistogram(MstFecHistogram* fecHistogram)
+MstStatus MftSdk::getFecHistogram(MstFecHistogram* fecHistogram, const MstTelemetryContext& context)
 {
     if (!fecHistogram || fecHistogram->header.size < sizeof(mstQueryHeader))
     {
         return MST_ERROR_INVALID_ARGUMENT;
     }
 
-    if (initMlxLinkSdk() != MST_SUCCESS)
+    if (initMlxLinkSdk(MlxLinkInitMode::NONE, TelemetryContextView(context).getPort()) != MST_SUCCESS)
     {
         return _lastError.status;
     }
@@ -620,13 +701,13 @@ MstStatus MftSdk::extractCountersInfoFromJson(MstCountersInfo* countersInfo)
     return _lastError.status;
 }
 
-MstStatus MftSdk::getCountersInfo(MstCountersInfo* countersInfo)
+MstStatus MftSdk::getCountersInfo(MstCountersInfo* countersInfo, const MstTelemetryContext& context)
 {
     if (!countersInfo || countersInfo->header.size < sizeof(mstQueryHeader))
     {
         return MST_ERROR_INVALID_ARGUMENT;
     }
-    if (initMlxLinkSdk() != MST_SUCCESS)
+    if (initMlxLinkSdk(MlxLinkInitMode::NONE, TelemetryContextView(context).getPort()) != MST_SUCCESS)
     {
         return _lastError.status;
     }
@@ -757,13 +838,13 @@ MstStatus MftSdk::extractCableDDMInfoFrom(MstCableDDMInfo* cableDDMInfo)
     return MST_SUCCESS;
 }
 
-MstStatus MftSdk::getCableDDMInfo(MstCableDDMInfo* cableDDMInfo)
+MstStatus MftSdk::getCableDDMInfo(MstCableDDMInfo* cableDDMInfo, const MstTelemetryContext& context)
 {
     if (!cableDDMInfo || cableDDMInfo->header.size < sizeof(mstQueryHeader))
     {
         return MST_ERROR_INVALID_ARGUMENT;
     }
-    if (initMlxLinkSdk(MlxLinkInitMode::CABLE_DDM) != MST_SUCCESS)
+    if (initMlxLinkSdk(MlxLinkInitMode::CABLE_DDM, TelemetryContextView(context).getPort()) != MST_SUCCESS)
     {
         return _lastError.status;
     }
@@ -1153,14 +1234,14 @@ MstStatus MftSdk::extractModuleInfoFromJson(MstModuleInfo* moduleInfo)
     return MST_SUCCESS;
 }
 
-MstStatus MftSdk::getModuleInfo(MstModuleInfo* moduleInfo)
+MstStatus MftSdk::getModuleInfo(MstModuleInfo* moduleInfo, const MstTelemetryContext& context)
 {
     if (!moduleInfo || moduleInfo->header.size < sizeof(mstQueryHeader))
     {
         return MST_ERROR_INVALID_ARGUMENT;
     }
 
-    if (initMlxLinkSdk(MlxLinkInitMode::MODULE_INFO) != MST_SUCCESS)
+    if (initMlxLinkSdk(MlxLinkInitMode::MODULE_INFO, TelemetryContextView(context).getPort()) != MST_SUCCESS)
     {
         return _lastError.status;
     }
@@ -1181,59 +1262,61 @@ MstStatus MftSdk::getModuleInfo(MstModuleInfo* moduleInfo)
 // Pure C API functions:
 extern "C"
 {
-    MstStatus mstGetTelemetryOperationalInfo(MstDevice mstDevice, MstTelemetryOperationalInfo* operationalInfo)
+    MstStatus mstGetTelemetryOperationalInfo(MstDevice mstDevice,
+                                             const MstTelemetryContext* context,
+                                             MstTelemetryOperationalInfo* operationalInfo)
     {
-        if (!mstDevice)
+        if (!mstDevice || validateTelemetryContext(context) != MST_SUCCESS)
         {
             return MST_ERROR_INVALID_ARGUMENT;
         }
 
         MftSdk* instance = reinterpret_cast<MftSdk*>(mstDevice);
-        return instance->getTelemetryOperationalInfo(operationalInfo);
+        return instance->getTelemetryOperationalInfo(operationalInfo, resolveTelemetryContext(context));
     }
 
-    MstStatus mstGetFecHistogram(MstDevice mstDevice, MstFecHistogram* fecHistogram)
+    MstStatus mstGetFecHistogram(MstDevice mstDevice, const MstTelemetryContext* context, MstFecHistogram* fecHistogram)
     {
-        if (!mstDevice)
+        if (!mstDevice || validateTelemetryContext(context) != MST_SUCCESS)
         {
             return MST_ERROR_INVALID_ARGUMENT;
         }
 
         MftSdk* instance = reinterpret_cast<MftSdk*>(mstDevice);
-        return instance->getFecHistogram(fecHistogram);
+        return instance->getFecHistogram(fecHistogram, resolveTelemetryContext(context));
     }
 
-    MstStatus mstGetCountersInfo(MstDevice mstDevice, MstCountersInfo* countersInfo)
+    MstStatus mstGetCountersInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstCountersInfo* countersInfo)
     {
-        if (!mstDevice)
+        if (!mstDevice || validateTelemetryContext(context) != MST_SUCCESS)
         {
             return MST_ERROR_INVALID_ARGUMENT;
         }
 
         MftSdk* instance = reinterpret_cast<MftSdk*>(mstDevice);
-        return instance->getCountersInfo(countersInfo);
+        return instance->getCountersInfo(countersInfo, resolveTelemetryContext(context));
     }
 
-    MstStatus mstGetCableDDMInfo(MstDevice mstDevice, MstCableDDMInfo* cableDDMInfo)
+    MstStatus mstGetCableDDMInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstCableDDMInfo* cableDDMInfo)
     {
-        if (!mstDevice)
+        if (!mstDevice || validateTelemetryContext(context) != MST_SUCCESS)
         {
             return MST_ERROR_INVALID_ARGUMENT;
         }
 
         MftSdk* instance = reinterpret_cast<MftSdk*>(mstDevice);
-        return instance->getCableDDMInfo(cableDDMInfo);
+        return instance->getCableDDMInfo(cableDDMInfo, resolveTelemetryContext(context));
     }
 
-    MstStatus mstGetModuleInfo(MstDevice mstDevice, MstModuleInfo* moduleInfo)
+    MstStatus mstGetModuleInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstModuleInfo* moduleInfo)
     {
-        if (!mstDevice)
+        if (!mstDevice || validateTelemetryContext(context) != MST_SUCCESS)
         {
             return MST_ERROR_INVALID_ARGUMENT;
         }
 
         MftSdk* instance = reinterpret_cast<MftSdk*>(mstDevice);
-        return instance->getModuleInfo(moduleInfo);
+        return instance->getModuleInfo(moduleInfo, resolveTelemetryContext(context));
     }
 
 } // extern "C"

--- a/mft_sdk/mft_sdk_telemetry.h
+++ b/mft_sdk/mft_sdk_telemetry.h
@@ -49,43 +49,51 @@ extern "C"
      * @brief Gets the Telemetry Operational info of the device. Equivalent to Mlxlink's general query "Operating Info"
      * page.
      * @param mstDevice The MstDevice handle.
+     * @param context Context options (port and future flags), or NULL for the device defaults. Initialize with
+     * MST_TELEMETRY_CONTEXT_INIT.
      * @param operationalInfo The Telemetry Operational info struct to fill. Should be initialized with MST_QUERY_INIT.
      * @return The status of the operation.
      */
-    MstStatus mstGetTelemetryOperationalInfo(MstDevice mstDevice, MstTelemetryOperationalInfo* operationalInfo);
+    MstStatus mstGetTelemetryOperationalInfo(MstDevice mstDevice,
+                                             const MstTelemetryContext* context,
+                                             MstTelemetryOperationalInfo* operationalInfo);
 
     /**
      * @brief Gets the FEC histogram of the device. Equivalent to Mlxlink's "--show_histogram
      * --rx_fec_histogram" command.
      * @param mstDevice The MstDevice handle.
+     * @param context Context options, or NULL for the device defaults. Initialize with MST_TELEMETRY_CONTEXT_INIT.
      * @param fecHistogram The FEC histogram struct to fill.
      * @return The status of the operation.
      */
-    MstStatus mstGetFecHistogram(MstDevice mstDevice, MstFecHistogram* fecHistogram);
+    MstStatus mstGetFecHistogram(MstDevice mstDevice, const MstTelemetryContext* context, MstFecHistogram* fecHistogram);
 
     /**
      * @brief Gets the counters info of the device. Equivalent to Mlxlink's "show counters" command.
      * @param mstDevice The MstDevice handle.
+     * @param context Context options, or NULL for the device defaults. Initialize with MST_TELEMETRY_CONTEXT_INIT.
      * @param countersInfo The counters info struct to fill. should be initialized with MST_QUERY_INIT.
      * @return The status of the operation.
      */
-    MstStatus mstGetCountersInfo(MstDevice mstDevice, MstCountersInfo* countersInfo);
+    MstStatus mstGetCountersInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstCountersInfo* countersInfo);
 
     /**
      * @brief Gets the Cable DDM info of the device. Equivalent to Mlxlink's "--cable --ddm" command.
      * @param mstDevice The MstDevice handle.
+     * @param context Context options, or NULL for the device defaults. Initialize with MST_TELEMETRY_CONTEXT_INIT.
      * @param cableDDMInfo The Cable DDM info struct to fill. should be initialized with MST_QUERY_INIT.
      * @return The status of the operation.
      */
-    MstStatus mstGetCableDDMInfo(MstDevice mstDevice, MstCableDDMInfo* cableDDMInfo);
+    MstStatus mstGetCableDDMInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstCableDDMInfo* cableDDMInfo);
 
     /**
      * @brief Gets the Module info of the device. Equivalent to Mlxlink's "--show_module" command.
      * @param mstDevice The MstDevice handle.
+     * @param context Context options, or NULL for the device defaults. Initialize with MST_TELEMETRY_CONTEXT_INIT.
      * @param moduleInfo The Module info struct to fill. should be initialized with MST_QUERY_INIT.
      * @return The status of the operation.
      */
-    MstStatus mstGetModuleInfo(MstDevice mstDevice, MstModuleInfo* moduleInfo);
+    MstStatus mstGetModuleInfo(MstDevice mstDevice, const MstTelemetryContext* context, MstModuleInfo* moduleInfo);
 
 #ifdef __cplusplus
 }

--- a/mft_sdk/mft_sdk_telemetry_types.h
+++ b/mft_sdk/mft_sdk_telemetry_types.h
@@ -44,6 +44,43 @@
 #define MAX_NUM_OF_BINS 32
 #define MAX_NUM_OF_CHANNELS 8
 
+#define MST_TELEMETRY_PORT_MAX_LENGTH 32
+
+/**
+ * @brief Telemetry context options, passed by pointer to the SDK.
+ *
+ * @ref size MUST be the first member and MUST equal sizeof(MstTelemetryContext).
+ * It lets the SDK detect the ABI/version the caller compiled against: when this
+ * struct is extended with new fields, a newer SDK can tell how many fields an
+ * older (smaller) caller actually provided and never reads past the caller's
+ * struct. Always initialize with MST_TELEMETRY_CONTEXT_INIT() (which zeroes the
+ * struct and stamps @ref size); an empty @ref label_port selects the device
+ * default port. Pass NULL to a telemetry function to use the device defaults.
+ *
+ * @code
+ *   MstTelemetryContext context;
+ *   MST_TELEMETRY_CONTEXT_INIT(&context);
+ *   // optional: snprintf(context.label_port, sizeof(context.label_port), "1/1/1");
+ *   mstGetTelemetryOperationalInfo(dev, &context, &info);
+ * @endcode
+ */
+typedef struct MstTelemetryContext_t
+{
+    unsigned int size; /**< Must be first; set to sizeof(MstTelemetryContext) before use. */
+    char label_port[MST_TELEMETRY_PORT_MAX_LENGTH]; /**< Port label (e.g. "1/1/1"); empty string => device default. */
+} MstTelemetryContext;
+
+/**
+ * @brief Zero-initialize an MstTelemetryContext and stamp its size field.
+ * @param a Pointer to the MstTelemetryContext to initialize.
+ */
+#define MST_TELEMETRY_CONTEXT_INIT(a) \
+    do                                \
+    {                                 \
+        memset((a), 0, sizeof(*(a))); \
+        (a)->size = sizeof(*(a));     \
+    } while (0)
+
 // Telemetry Operational info capability bits:
 #define TELEMETRY_OP_INFO_STATE 0            // State of the device.
 #define TELEMETRY_OP_INFO_PHYSICAL_STATE 1   // Physical state of the device.


### PR DESCRIPTION
## What
Adds the per-port `MstTelemetryContext` as the 2nd arg of the five telemetry getters (`mstGetTelemetryOperationalInfo`, `mstGetFecHistogram`, `mstGetCountersInfo`, `mstGetCableDDMInfo`, `mstGetModuleInfo`), mirroring the MFT SDK. `NULL`/empty `label_port` selects the device default port.

## Why
The MFT test binary now calls the 3-arg context API, but the mstflint `.so` still exported the old 2-arg signatures — so `&context` was read as the output struct and every device telemetry test failed with `MST_ERROR_INVALID_ARGUMENT`/empty mask (mlxlink columns all-`N/A`). This realigns mstflint with the MFT public API.
