### PR TITLE
[resourcedump] use rdma-core version check after ofed_info deprecation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -63,8 +63,9 @@ AC_COMPILE_IFELSE(
 OS=$(uname -s)
 KERNEL_VER=`uname -r | egrep -E -o '[[0-9]]+\.[[0-9]]+' | head -1`
 OFED_VER=`ofed_info -s | egrep -E -o '[[0-9]]+\.[[0-9]]+' | head -1`
-OFED_EXIST=`ofed_info -s`
-OFED_NOT_EXIST="ofed_info: command not found"
+MIN_OFED_VER="5.6"
+MIN_RDMA_CORE_VER="2607"
+RDMA_CORE_VER=`{ rpm -q rdma-core --queryformat '%{VERSION}\n' 2>/dev/null; dpkg-query -W -f='${Version}\n' rdma-core 2>/dev/null; } | egrep -E -o '^[[0-9]]+' | head -1`
 MTCR_CONF_DIR=""
 LDL=""
 LDFLAGS="$LDFLAGS -lstdc++"
@@ -77,10 +78,11 @@ default_en_mstflint_sdk="no"
 OFED_VERSION_CHK=0
 KERNEL_BUILD_CHK=0
 
-if test "x$OFED_EXIST" != "x$OFED_NOT_EXIST"; then
-    if test $(echo $OFED_VER 5.6 | tr " " "\n" | sort -V | tail -n 1) == $OFED_VER ; then
-        OFED_VERSION_CHK=1
-    fi
+if test -n "$OFED_VER" && test $(echo $OFED_VER $MIN_OFED_VER | tr " " "\n" | sort -V | tail -n 1) == "$OFED_VER" ; then
+    OFED_VERSION_CHK=1
+fi
+if test -n "$RDMA_CORE_VER" && test $(echo $RDMA_CORE_VER $MIN_RDMA_CORE_VER | tr " " "\n" | sort -V | tail -n 1) == "$RDMA_CORE_VER" ; then
+    OFED_VERSION_CHK=1
 fi
 
 AM_CONDITIONAL(OFED_BUILD,[test ${OFED_VERSION_CHK} = 1])

--- a/resourcetools/resourcedump_lib/cresourcedump/CResourceDump.py
+++ b/resourcetools/resourcedump_lib/cresourcedump/CResourceDump.py
@@ -42,8 +42,21 @@
 import sys
 import ctypes
 import platform
+import subprocess
 from pathlib import Path
 from . import cresourcedump_types
+
+
+def exec_command(cmd_list):
+    process = subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = process.communicate()
+    if stderr and isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8")
+    if stdout and isinstance(stdout, bytes):
+        stdout = stdout.decode("utf-8")
+    if process.returncode != 0:
+        raise RuntimeError("Command '%s' has failed with error:\n%s" % (cmd_list, stderr))
+    return stdout.strip()
 
 
 class CResourceDump:
@@ -54,6 +67,38 @@ class CResourceDump:
         except BaseException:
             # print("Openning: {}".format(installer_lib_path))
             return ctypes.CDLL(str(installer_lib_path), *args)
+
+    MEM_MODE_NOT_SUPPORTED = 0x105
+    MEM_MODE_NOT_SUPPORTED_ERROR = b"Mem Mode is not supported, unsopported OS or device, or the driver is down, or the driver's version is not supported."
+    _mem_mode_blocked = False
+
+    def is_ofed_up():
+        try:
+            exec_command(["/etc/init.d/openibd", "status"])
+        except FileNotFoundError:
+            return False
+        except RuntimeError:
+            return False
+        return True
+
+    def c_create_resource_dump(device_attributes, *args):
+        if device_attributes.rdma_name and not CResourceDump.is_ofed_up():
+            CResourceDump._mem_mode_blocked = True
+            return CResourceDump.MEM_MODE_NOT_SUPPORTED
+        CResourceDump._mem_mode_blocked = False
+        return CResourceDump._c_create_resource_dump(device_attributes, *args)
+
+    def c_dump_resource_to_file(device_attributes, *args):
+        if device_attributes.rdma_name and not CResourceDump.is_ofed_up():
+            CResourceDump._mem_mode_blocked = True
+            return CResourceDump.MEM_MODE_NOT_SUPPORTED
+        CResourceDump._mem_mode_blocked = False
+        return CResourceDump._c_dump_resource_to_file(device_attributes, *args)
+
+    def c_get_resource_dump_error():
+        if CResourceDump._mem_mode_blocked:
+            return CResourceDump.MEM_MODE_NOT_SUPPORTED_ERROR
+        return CResourceDump._c_get_resource_dump_error()
 
     try:
         c_resource_dump_sdk = None
@@ -73,9 +118,9 @@ class CResourceDump:
         print("Error: Failed loading shared-library - {0}. Exiting...".format(ose))
         sys.exit(1)
 
-    c_create_resource_dump = c_resource_dump_sdk.create_resource_dump
-    c_create_resource_dump.restype = ctypes.c_uint16
-    c_create_resource_dump.argtypes = [
+    _c_create_resource_dump = c_resource_dump_sdk.create_resource_dump
+    _c_create_resource_dump.restype = ctypes.c_uint16
+    _c_create_resource_dump.argtypes = [
         cresourcedump_types.c_device_attributes,
         cresourcedump_types.c_dump_request,
         ctypes.POINTER(cresourcedump_types.c_resource_dump_data),
@@ -88,9 +133,9 @@ class CResourceDump:
         cresourcedump_types.c_resource_dump_data
     ]
 
-    c_dump_resource_to_file = c_resource_dump_sdk.dump_resource_to_file
-    c_dump_resource_to_file.restype = ctypes.c_uint16
-    c_dump_resource_to_file.argtypes = [
+    _c_dump_resource_to_file = c_resource_dump_sdk.dump_resource_to_file
+    _c_dump_resource_to_file.restype = ctypes.c_uint16
+    _c_dump_resource_to_file.argtypes = [
         cresourcedump_types.c_device_attributes,
         cresourcedump_types.c_dump_request,
         ctypes.c_uint32,
@@ -98,6 +143,6 @@ class CResourceDump:
         ctypes.c_uint8
     ]
 
-    c_get_resource_dump_error = c_resource_dump_sdk.get_resource_dump_error
-    c_get_resource_dump_error.restype = ctypes.c_char_p
-    c_get_resource_dump_error.argtypes = []
+    _c_get_resource_dump_error = c_resource_dump_sdk.get_resource_dump_error
+    _c_get_resource_dump_error.restype = ctypes.c_char_p
+    _c_get_resource_dump_error.argtypes = []


### PR DESCRIPTION
## Summary

After `ofed_info` deprecation, the MEM-mode ("mlx5 SDK") eligibility was gated only on the presence of `doca-ofed`, so doca-host setups (without doca-ofed) were incorrectly blocked from MEM mode. This aligns mstflint with the MFT change by:

- **`configure.ac`**: replace the `OFED_EXIST` (`ofed_info` presence) evaluation with an OFED **and** rdma-core version check. `OFED_VERSION_CHK` is now set when OFED >= 5.6 **or** rdma-core >= 2607 (detected via `rpm` / `dpkg-query`). This still drives `OFED_BUILD` / `ENABLE_RDMEM` (`default_en_rdmem`).
- **`resourcetools/resourcedump_lib/cresourcedump/CResourceDump.py`**: add a runtime `is_ofed_up()` check (via `/etc/init.d/openibd status`). The ctypes SDK entry points `c_create_resource_dump` / `c_dump_resource_to_file` are wrapped so that when a MEM-mode request is made (`rdma_name` set) and OFED is down, they short-circuit and `c_get_resource_dump_error` returns the `MEM_MODE_NOT_SUPPORTED` message. Non-MEM (register-access) dumps still delegate to the real SDK, so they keep working when OFED is down.

## Test plan

- [ ] `./autogen.sh && ./configure --enable-adb-generic-tools --disable-inband && make -j` (passes locally)
- [ ] Verify MEM-mode dump on a doca-host setup with rdma-core >= 2607 (no doca-ofed)
- [ ] Verify MEM-mode dump is cleanly rejected when the driver is down
- [ ] Verify normal (non-`--mem`) dump still works when OFED is down

MFT Commit: cf78cf0933550221dedf234c44e488c090a13f0d