### PR TITLE
[efuse] Add -fPIC to fix PIE hardened link

### DIFF
--- a/efuse/Makefile.am
+++ b/efuse/Makefile.am
@@ -36,7 +36,8 @@ AM_CPPFLAGS = \
     -I$(srcdir) \
     -I$(top_srcdir) \
     -I$(top_srcdir)/${MTCR_CONF_DIR} \
-    -I$(top_srcdir)/include/mtcr_ul
+    -I$(top_srcdir)/include/mtcr_ul \
+    $(COMPILER_FPIC)
 
 AM_CPPFLAGS += $(JSON_CFLAGS)
 


### PR DESCRIPTION
Description:
efuse/Makefile.am was missing $(COMPILER_FPIC) in AM_CPPFLAGS, so efuse.cpp/efuse_config.cpp compiled without -fPIC. Linking with the redhat-hardened-ld spec (which forces -pie) then failed with "relocation R_X86_64_32 ... can not be used when making a PIE object". Add $(COMPILER_FPIC) to match every other tool Makefile.am.

Tested OS: Linux
Tested devices: n/a
Tested flows: CXXFLAGS="-Wl,-z -Wl,relro -specs=/usr/lib/rpm/redhat/redhat-hardened-ld" ./configure && make

Known gaps (with RM ticket): n/a

Issue: 5161416