### PR TITLE
[resourcedump] Fix typo during driver error

### DIFF
--- a/resourcetools/resourcedump_lib/cresourcedump/CResourceDump.py
+++ b/resourcetools/resourcedump_lib/cresourcedump/CResourceDump.py
@@ -69,7 +69,7 @@ class CResourceDump:
             return ctypes.CDLL(str(installer_lib_path), *args)
 
     MEM_MODE_NOT_SUPPORTED = 0x105
-    MEM_MODE_NOT_SUPPORTED_ERROR = b"Mem Mode is not supported, unsopported OS or device, or the driver is down, or the driver's version is not supported."
+    MEM_MODE_NOT_SUPPORTED_ERROR = b"Mem Mode is not supported, unsupported OS or device, or the driver is down, or the driver's version is not supported."
     _mem_mode_blocked = False
 
     def is_ofed_up():

--- a/resourcetools/resourcedump_lib/src/common/resource_dump_error_handling.cpp
+++ b/resourcetools/resourcedump_lib/src/common/resource_dump_error_handling.cpp
@@ -73,7 +73,7 @@ namespace mft
 
             case Reason::MEM_MODE_NOT_SUPPORTED:
                 message =
-              "Mem Mode is not supported, unsopported OS or device, or the driver is down, or the driver's version is not supported.";
+              "Mem Mode is not supported, unsupported OS or device, or the driver is down, or the driver's version is not supported.";
                 break;
 
             case Reason::SEND_REG_ACCESS_FAILED:


### PR DESCRIPTION
## Summary
- Fix typo in MEM mode not-supported error message (`unsopported` → `unsupported`) in C++ and Python bindings.

## MFT ports
- MFT Commit: a77f8080f3949ca537b5ef1388a07fd14eb28394 — [resourcedump] Fix typo during driver error
- MFT Commit: cf78cf0933550221dedf234c44e488c090a13f0d — [resourcedump] use rdma-core version check after ofed_info deprecation

## Test plan
- [ ] Build mstflint (`make -j`)
- [ ] Trigger MEM mode not-supported path and verify error string spelling