### PR TITLE
[pldmlib] fix FD_UUID display and vendor string construction

### DIFF
--- a/pldmgen/pldm.cpp
+++ b/pldmgen/pldm.cpp
@@ -88,6 +88,66 @@
      return comparisonStamp;
  }
  
+ void PLDM::ParseCommonRecordFields(const Json::Value& deviceRecord,
+                                    vector<u_int8_t>& appliedComponents,
+                                    vector<PLDMDescriptor>& descriptors)
+ {
+     for (unsigned int j = 0; j < deviceRecord[COMPONENTS_STR].size(); j++)
+     {
+         bool componentFound = false;
+         string componentName = deviceRecord[COMPONENTS_STR][j].asString();
+         for (unsigned int k = 0; k < _components.size(); k++)
+         {
+             if (_components[k]._name == componentName)
+             {
+                 appliedComponents[k / 8] |= (1 << (k % 8));
+                 componentFound = true;
+             }
+         }
+         if (!componentFound)
+         {
+             throw PLDMException("Component %s was not found in the defined "
+                                 "components list",
+                                 componentName.c_str());
+         }
+     }
+
+     for (unsigned int j = 0; j < deviceRecord[DESCRIPTORS_STR].size(); j++)
+     {
+         for (Json::ValueConstIterator itr = deviceRecord[DESCRIPTORS_STR][j].begin();
+              itr != deviceRecord[DESCRIPTORS_STR][j].end();
+              itr++)
+         {
+             string type = itr.key().asString();
+             string val = deviceRecord[DESCRIPTORS_STR][j][type].asString();
+
+             if (val == "DEFAULT_VALUE")
+             {
+                 if (!PLDMDescriptor::IsDefaultValue(type))
+                 {
+                     throw PLDMException("The descriptor type '%s' cannot have 'DEFAULT_VALUE' as its value.",
+                                         type.c_str());
+                 }
+                 val = PLDMDescriptor::GetDefaultValue(type);
+             }
+
+             descriptors.push_back(PLDMDescriptor(type, val));
+         }
+     }
+ }
+
+ PLDMDeviceRecord PLDM::ParseDeviceRecord(const Json::Value& deviceRecord)
+ {
+     vector<u_int8_t> appliedComponents(_componentBitmapLength / 8);
+     vector<PLDMDescriptor> descriptors;
+     ParseCommonRecordFields(deviceRecord, appliedComponents, descriptors);
+
+     return PLDMDeviceRecord(GetStringFromJson(deviceRecord, SET_VERSION_STR),
+                             GetStringFromJson(deviceRecord, DEVICERECORD_OPTION_STR),
+                             appliedComponents,
+                             descriptors);
+ }
+
  PLDM::PLDM(const string& cookBook, bool recovery)
  {
      Json::Value root, componentsJSON, deviceRecordsJSON;
@@ -175,61 +235,7 @@
      deviceRecordsJSON = root[DEVICERECORDS_STR];
      for (unsigned int i = 0; i < deviceRecordsJSON.size(); i++)
      {
-         vector<u_int8_t> appliedComponents(_componentBitmapLength / 8);
-         vector<PLDMDescriptor> descriptors;
- 
-         // parse applied components
-         for (unsigned int j = 0; j < deviceRecordsJSON[i][COMPONENTS_STR].size(); j++)
-         {
-             bool componentFound = false;
-             string componentName = deviceRecordsJSON[i][COMPONENTS_STR][j].asString();
-             for (unsigned int k = 0; k < _components.size(); k++)
-             {
-                 if (_components[k]._name == componentName)
-                 {
-                     appliedComponents[k / 8] |= (1 << (k % 8));
-                     componentFound = true;
-                 }
-             }
-             if (!componentFound)
-             {
-                 throw PLDMException("Component %s was not found in the defined "
-                                     "components list",
-                                     componentName.c_str());
-             }
-         }
- 
-         // parse descriptors
-         for (unsigned int j = 0; j < deviceRecordsJSON[i][DESCRIPTORS_STR].size(); j++)
-         {
-             for (Json::ValueIterator itr = deviceRecordsJSON[i][DESCRIPTORS_STR][j].begin();
-                  itr != deviceRecordsJSON[i][DESCRIPTORS_STR][j].end();
-                  itr++)
-             {
-                 string type = itr.key().asString();
-                 string val = deviceRecordsJSON[i][DESCRIPTORS_STR][j][type].asString();
- 
-                 // if default value is set, use the default value
-                 if (val == "DEFAULT_VALUE")
-                 {
-                     if (!PLDMDescriptor::IsDefaultValue(type))
-                     {
-                         throw PLDMException("The descriptor type '%s' cannot have 'DEFAULT_VALUE' as its value.",
-                                             type.c_str());
-                     }
-                     string default_value = PLDMDescriptor::GetDefaultValue(type);
-                     val = default_value;
-                 }
- 
-                 descriptors.push_back(PLDMDescriptor(type, val));
-             }
-         }
- 
-         PLDMDeviceRecord deviceRecord(GetStringFromJson(deviceRecordsJSON[i], SET_VERSION_STR),
-                                       GetStringFromJson(deviceRecordsJSON[i], DEVICERECORD_OPTION_STR),
-                                       appliedComponents,
-                                       descriptors);
-         _deviceRecords.push_back(deviceRecord);
+         _deviceRecords.push_back(ParseDeviceRecord(deviceRecordsJSON[i]));
      }
      if (!_deviceRecords.size())
      {

--- a/pldmgen/pldm.h
+++ b/pldmgen/pldm.h
@@ -46,6 +46,10 @@
 
  
  private:
+     void ParseCommonRecordFields(const Json::Value& deviceRecord,
+                                  std::vector<u_int8_t>& appliedComponents,
+                                  std::vector<PLDMDescriptor>& descriptors);
+     PLDMDeviceRecord ParseDeviceRecord(const Json::Value& deviceRecord);
      static std::string FindComponentNameByIdentifier(const std::string& identifier, const Json::Value& components);
      static std::string
        AddComponent(const std::string& identifier, int& componentCounter, Json::Value& components, bool reuseComponents);

--- a/pldmlib/pldm_record_descriptor.cpp
+++ b/pldmlib/pldm_record_descriptor.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <algorithm>
 #include <vector>
+#include <cstring>
 
 #include "pldm_buff.h"
 #include "pldm_record_descriptor.h"
@@ -55,14 +56,17 @@ bool PldmRecordDescriptor::extractVendorDefined()
         std::string descriptorName((char*)vendoreDefinedPtr + 1, prefixlen);
         vendoreDefinedPtr++;
         vendoreDefinedPtr += prefixlen;
+        u_int16_t dataLen = (descriptorLength > (u_int16_t)(2 + prefixlen)) ? descriptorLength - 2 - prefixlen : 0;
         if (descriptorName == "PSID")
         {
-            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
+            size_t actualLen = strnlen(reinterpret_cast<const char*>(vendoreDefinedPtr), dataLen);
+            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr), actualLen);
             vendorDefinedType = VendorDefinedType::PSID;
         }
         else if (descriptorName == "recovery")
         {
-            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr));
+            size_t actualLen = strnlen(reinterpret_cast<const char*>(vendoreDefinedPtr), dataLen);
+            vendorDefinedStringValue = std::string(reinterpret_cast<const char*>(vendoreDefinedPtr), actualLen);
             vendorDefinedType = VendorDefinedType::RECOVERY;
         }
         else if (descriptorName == "APSKU")
@@ -201,8 +205,13 @@ void PldmRecordDescriptor::printFormatted() const
             printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "IANA Enterprise ID:", descriptorData[1], descriptorData[0]);
             break;
         case FD_UUID:
-            printf("%-*s%s\n", LABEL_WIDTH, "FD UUID:", descriptorData);
+        {
+            const u_int8_t* d = descriptorData;
+            printf("%-*s0x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x\n", LABEL_WIDTH,
+                   "FD UUID:", d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11], d[12], d[13],
+                   d[14], d[15]);
             break;
+        }
         case PnP_Vendor_ID:
             printf("%-*s0x%02x%02x\n", LABEL_WIDTH, "PnP Vendor ID:", descriptorData[1], descriptorData[0]);
             break;


### PR DESCRIPTION
Description:
FD_UUID was printed via %s on raw bytes instead of as a hex string. Vendor-defined string descriptors (PSID, recovery) were constructed using the null-terminated std::string constructor; changed to use the descriptor length to bound the string instead of relying on a null terminator.

MSTFlint port needed: yes
Tested OS: linux
Tested devices: N/A
Tested flows: flint -i <pkg> --package_info q

Known gaps (with RM ticket):

Issue: 5171760