### PR TITLE
segmentation falut due to uninitilized iostream

### DIFF
--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -109,7 +109,7 @@ mstconfig_DEPENDENCIES = \
 
 mstconfig_LDADD = $(mstconfig_DEPENDENCIES) ${LDL}
 
-mstconfig_LDFLAGS = -static -Wl,--gc-sections
+mstconfig_LDFLAGS = -static
 
 if DISABLE_XML2
 AM_CXXFLAGS += -DDISABLE_XML2


### PR DESCRIPTION
Description:
prvious commit to mstconfig makefile added a linker flag --gc-sections in attempt to fix a dependency issue. this was not the correct approch and later proven not required. adding the flag caused the linker to discard sections it consider unreachable, that for some reason on freebsd include the iostream. iostream was declaired but not initilized and when using cout it caused a seg falut.

tested on both linux and freebds that they still compile after we remove this linker flags