### PR TITLE
[mstflint] No rule to make target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser mlxfwops mlxconfig $(NVFWRESET_DIR) $(DPA) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump efuse ${ADABE_TOOLS} tracers resourcetools
+SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser $(DPA) mlxfwops mlxconfig $(NVFWRESET_DIR) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump efuse ${ADABE_TOOLS} tracers resourcetools
 
 DIST_SUBDIRS = tracers
 

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -95,11 +95,7 @@ mstconfig_DEPENDENCIES = \
     $(top_builddir)/mlxfwops/lib/libmlxfwops.a \
     $(top_builddir)/pldmlib/libpldm.la \
     $(top_builddir)/pldm_utils/libpldm_utils.la \
-    $(top_builddir)/libmfa/libmfa.la \
-    $(top_builddir)/xz_utils/libxz_utils.la \
-    $(top_builddir)/ext_libs/minixz/libminixz.la \
     $(top_builddir)/mflash/libmflash.la \
-    $(top_builddir)/tools_crypto/libtools_crypto.a \
     $(top_builddir)/mft_utils/libmftutils.la \
     $(top_builddir)/cmdif/libcmdif.la \
     $(top_builddir)/reg_access/libreg_access.la \
@@ -136,6 +132,17 @@ mstconfig_LDADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 libmlxcfg_la_LIBADD += $(top_builddir)/mlxsign_lib/libmlxsign.la $(openssl_LIBS)
 else
 AM_CXXFLAGS += -DNO_OPEN_SSL
+endif
+
+if ENABLE_FWMGR
+mstconfig_DEPENDENCIES += \
+    $(top_builddir)/libmfa/libmfa.la \
+    $(top_builddir)/xz_utils/libxz_utils.la \
+    $(top_builddir)/ext_libs/minixz/libminixz.la
+endif
+
+if ENABLE_CS
+mstconfig_DEPENDENCIES += $(top_builddir)/tools_crypto/libtools_crypto.a
 endif
 
 if ENABLE_DPA


### PR DESCRIPTION
Description:
Makefile.am: reorder SUBDIRS to fix build dependency ordering. mlxconfig/Makefile.am: guard libmfa/xz_utils/minixz under ENABLE_FWMGR and tools_crypto under ENABLE_CS to fix missing target build errors.

MSTFlint port needed:
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: 5174151