### PR TITLE
[sdk][test] Fall back when the scratch root is not writable

### DIFF
--- a/mft_sdk/unit_tests/packaging/test_source_packages.py
+++ b/mft_sdk/unit_tests/packaging/test_source_packages.py
@@ -899,9 +899,10 @@ def main():
         return 1
 
     # /data/tmp, never the system temp dir: an SDK rpmbuild does not fit in /tmp.
+    # Test writability, not just existence -- /data/tmp is root-owned on some hosts.
     if workdir is None:
         root = os.environ.get("SDKV_TMP_ROOT", "/data/tmp")
-        if not os.path.isdir(root):
+        if not (os.path.isdir(root) and os.access(root, os.W_OK)):
             root = os.path.expanduser("~")
         workdir = os.path.join(root, "sdkv_source_pkg_test")
     if os.path.isdir(workdir):


### PR DESCRIPTION
Follow-up to #1829.

`test_source_packages.py` chose its workdir with `os.path.isdir(SDKV_TMP_ROOT)` but never checked writability. On a host where `/data/tmp` exists but is root-owned (several lab machines), the suite died with `PermissionError` instead of falling back to `$HOME`.

```python
-        if not os.path.isdir(root):
+        if not (os.path.isdir(root) and os.access(root, os.W_OK)):
             root = os.path.expanduser("~")
```

Verified against a deliberately root-owned `SDKV_TMP_ROOT`:

```
before: PermissionError: [Errno 13] Permission denied: '.../sdkv_source_pkg_test'
after:  Overall: ALL TESTS PASSED
```