### PR TITLE
[mstflint][cable_discovery] secondary cables filtering

### DIFF
--- a/mst_utils/cable_discovery.cpp
+++ b/mst_utils/cable_discovery.cpp
@@ -13,6 +13,7 @@
 #include "dev_mgt/tools_dev_types.h"
 #include "reg_access/reg_access.h"
 #include "tools_layouts/reg_access_hca_layouts.h"
+#include "tools_layouts/reg_access_switch_layouts.h"
 
 
 const std::string TOOL_NAME = "mstcable_discovery";
@@ -40,6 +41,25 @@ int checkModule(mfile* mf, u_int32_t localPort)
     }
 
     return ret;
+}
+
+int isModuleSecondary(mfile* mf, u_int32_t module, bool* isSecondary)
+{
+    if (!mf || !isSecondary) {
+        return -1;
+    }
+
+    struct reg_access_switch_pmaos_reg_ext pmaos;
+    memset(&pmaos, 0, sizeof(pmaos));
+    pmaos.module = module;
+
+    reg_access_status_t rc = reg_access_pmaos(mf, REG_ACCESS_METHOD_GET, &pmaos);
+    if (rc) {
+        return -1;
+    }
+
+    *isSecondary = (pmaos.secondary != 0);
+    return 0;
 }
 
 void CreateDirectoryIfNotExist(const std::string& poNewDirectory)
@@ -75,11 +95,21 @@ int main(int argc, char* argv[])
     int          ul_mode = 0;
     unsigned int cable_count = 0;
 
-    if (argc > 1)
+    bool filterSecondary = false;
+
+    for (int argIdx = 1; argIdx < argc; argIdx++)
     {
-        std::cout << "Invalid argument: " << argv[1] << std::endl;
-        std::cout << "Usage: " << TOOL_NAME << std::endl;
-        return 1;
+        std::string arg = argv[argIdx];
+        if (arg == "--filter_secondary")
+        {
+            filterSecondary = true;
+        }
+        else
+        {
+            std::cout << "Invalid argument: " << arg << std::endl;
+            std::cout << "Usage: " << TOOL_NAME << " [--filter_secondary]" << std::endl;
+            return 1;
+        }
     }
 
     devs = mdevices_info_v(MDEVS_TAVOR, &device_count, 1);
@@ -121,6 +151,15 @@ int main(int argc, char* argv[])
             }
             else
             {
+                if (filterSecondary)
+                {
+                    bool isSecondary = false;
+                    if (isModuleSecondary(mf, (u_int32_t)num_ports, &isSecondary) == 0 && isSecondary)
+                    {
+                        mclose(mf);
+                        continue;
+                    }
+                }
                 std::string cable_name = std::string(devs[i].dev_name) + "_" + CABLE_DEVICE_STR + std::to_string(num_ports);
                 mfile* cable_mf = mopen_adv(cable_name.c_str(), (MType)(MST_DEFAULT | MST_CABLE));
                 if (cable_mf)
@@ -141,6 +180,14 @@ int main(int argc, char* argv[])
             num_ports = dm_get_hw_ports_num(devid_type);
             for (int port = 0; port < num_ports; port++)
             {
+                if (filterSecondary)
+                {
+                    bool isSecondary = false;
+                    if (isModuleSecondary(mf, (u_int32_t)port, &isSecondary) == 0 && isSecondary)
+                    {
+                        continue;
+                    }
+                }
                 std::string cable_name = std::string(devs[i].dev_name) + "_" + CABLE_DEVICE_STR + std::to_string(port);
                 mfile     * cable_mf = mopen_adv(cable_name.c_str(), (MType)(MST_DEFAULT | MST_CABLE));
                 if (!cable_mf)


### PR DESCRIPTION
Description: in the conf5 use case there are some secondary modules that are blocked for writing. Adding a new flag to filter those cables from the discovery command output, the flag is "--filter_secondary".

MSTFlint port needed: no
Tested OS: linux arm64,x86_64
Tested devices: orchid, qtm3
Tested flows: mstcable_discovery with and without --filter_secondary

Known gaps (with RM ticket): N/A

Issue: 5197801