### PR TITLE
[sdk][test] Stop the harness manufacturing SDK failures from its own plumbing

### DIFF
--- a/mft_sdk/unit_tests/build/test_configure_compiler_warning.py
+++ b/mft_sdk/unit_tests/build/test_configure_compiler_warning.py
@@ -31,6 +31,7 @@ from __future__ import print_function
 import os
 import re
 import shutil
+import socket
 import subprocess
 import sys
 
@@ -119,7 +120,13 @@ def main():
     root = os.environ.get("SDKV_TMP_ROOT", "/data/tmp")
     if not (os.path.isdir(root) and os.access(root, os.W_OK)):
         root = os.path.expanduser("~")
-    work = os.path.join(root, "sdkv_configure_warning_test")
+    # Namespaced by host+pid, because the fallback root above is $HOME and
+    # $HOME (/labhome/<user>) is ONE NFS export shared by every lab machine.
+    # With machines tested in parallel, a fixed name means two hosts rmtree
+    # each other's tree mid-build ("Stale file handle"). This suite is
+    # per-machine by design; the name just has to say so.
+    work = os.path.join(root, "sdkv_configure_warning_test_{}_{}".format(
+        socket.gethostname().split(".")[0], os.getpid()))
     shutil.rmtree(work, ignore_errors=True)
 
     cc = os.environ.get("CC") or "gcc"

--- a/mft_sdk/unit_tests/mlxreg/test_full_path.py
+++ b/mft_sdk/unit_tests/mlxreg/test_full_path.py
@@ -421,13 +421,15 @@ class MlxregFullPathCliRunner(object):
         if full_path:
             cmd += " --full_path"
         cmd = "echo '{}' | sudo su".format(cmd)
+        # merge_stderr=False: parse_show_reg() takes everything before the
+        # first '|' as a field name, so any stderr text becomes a phantom field.
         self.success, self.output = CommandRunner.run(
             cmd, "Running {} --show_reg {} {}on {}".format(
                 MFT_SDK_REG_TOOL,
                 register_name,
                 "--full_path " if full_path else "",
                 self.device),
-            verbose)
+            verbose, merge_stderr=False)
         return self.success
 
     def get_field_names(self):

--- a/mft_sdk/unit_tests/mlxreg/test_metadata.py
+++ b/mft_sdk/unit_tests/mlxreg/test_metadata.py
@@ -128,8 +128,12 @@ class MlxregCliRunner(object):
         # names the SDK metadata uses (e.g. fw_info.major).
         cmd = self._base_cmd() + " --show_reg {} --full_path".format(register_name)
         cmd = "echo '{}' | sudo su".format(cmd)
+        # merge_stderr=False: get_fields() parses this as a pipe table, so a
+        # diagnostic on the tool's stderr would corrupt a row and be reported
+        # as an SDK field mismatch.
         self.success, self.output = CommandRunner.run(
-            cmd, "Running {} --show_reg {} on {}".format(MFT_SDK_REG_TOOL, register_name, self.device), verbose)
+            cmd, "Running {} --show_reg {} on {}".format(MFT_SDK_REG_TOOL, register_name, self.device), verbose,
+            merge_stderr=False)
         return self.success
 
     def get_fields(self):

--- a/mft_sdk/unit_tests/packaging/test_build_flags.py
+++ b/mft_sdk/unit_tests/packaging/test_build_flags.py
@@ -94,8 +94,36 @@ def _run(cmd, desc="", verbose=False, timeout=None):
 
 
 def _pkg_type():
-    return "deb" if os.path.exists("/usr/bin/dpkg") and not os.path.exists("/usr/bin/rpm") \
-        else ("rpm" if os.path.exists("/usr/bin/rpm") else "deb")
+    """Which packaging this DISTRO uses -- not merely which tools are present.
+
+    The old test was `dpkg and not rpm -> deb`, which misreads any Debian
+    machine that happens to have /usr/bin/rpm installed (a perfectly normal
+    thing: rpm2cpio, or a cross-inspection tool). apps-124-002 (Ubuntu 24.04,
+    aarch64) has both, was classified rpm, and then hunted for
+    mstflint-sdk-*.rpm in an aarch64 cache holding only a .deb -- 3 red
+    "variant package not in cache" rows for a machine whose deb was right
+    there. The sibling apps-124-003 (Debian 13, no rpm binary) passed the same
+    suite, which is the asymmetry that gave it away.
+
+    Ask /etc/os-release first; fall back to dpkg OWNING its own binary (true
+    only on a real dpkg distro), and only then to bare tool presence.
+    """
+    try:
+        with open("/etc/os-release") as fh:
+            osr = fh.read().lower()
+        ids = " ".join(l.split("=", 1)[1].strip().strip('"')
+                       for l in osr.splitlines() if l.startswith(("id=", "id_like=")))
+        if any(d in ids for d in ("debian", "ubuntu")):
+            return "deb"
+        if any(d in ids for d in ("rhel", "fedora", "centos", "suse", "mariner", "azurelinux")):
+            return "rpm"
+    except Exception:  # noqa: BLE001 - fall through to the probes below
+        pass
+    # dpkg owning its own binary is true only where dpkg is the system manager.
+    if os.path.exists("/usr/bin/dpkg") and subprocess.call(
+            "dpkg -S /usr/bin/dpkg >/dev/null 2>&1", shell=True) == 0:
+        return "deb"
+    return "rpm" if os.path.exists("/usr/bin/rpm") else "deb"
 
 
 def _arch():

--- a/mft_sdk/unit_tests/packaging/test_source_packages.py
+++ b/mft_sdk/unit_tests/packaging/test_source_packages.py
@@ -47,6 +47,7 @@ Env:
 
 from __future__ import print_function
 import os
+import socket
 import platform
 import re
 import shutil
@@ -904,7 +905,11 @@ def main():
         root = os.environ.get("SDKV_TMP_ROOT", "/data/tmp")
         if not (os.path.isdir(root) and os.access(root, os.W_OK)):
             root = os.path.expanduser("~")
-        workdir = os.path.join(root, "sdkv_source_pkg_test")
+        # Host+pid namespaced: the fallback root is $HOME, one NFS export
+        # shared by the whole fleet, so a fixed name lets two machines running
+        # this suite in parallel rmtree each other's tree mid-build.
+        workdir = os.path.join(root, "sdkv_source_pkg_test_{}_{}".format(
+            socket.gethostname().split(".")[0], os.getpid()))
     if os.path.isdir(workdir):
         shutil.rmtree(workdir)
     os.makedirs(workdir)

--- a/mft_sdk/unit_tests/utils.py
+++ b/mft_sdk/unit_tests/utils.py
@@ -463,11 +463,24 @@ class CommandRunner(object):
     """Handles execution of shell commands."""
 
     @staticmethod
-    def run(cmd, description, verbose=True):
+    def run(cmd, description, verbose=True, merge_stderr=True):
         """Run a command and return (success, output).
 
         When BaseConfig.VERBOSE is True, output is streamed in real-time
         and errors are shown even for quiet (verbose=False) commands.
+
+        merge_stderr=False keeps the command's stderr OUT of the returned
+        text. Pass it whenever the output is going to be machine-parsed.
+
+        Why this matters: the default 2>&1 merge means any diagnostic the
+        reference tool writes to stderr is spliced into the stdout we parse
+        as a table -- and because the tool's stdout is a block-buffered pipe
+        while stderr is unbuffered, it lands in the MIDDLE of a row. A
+        Bullseye-coverage-instrumented mlxreg_ext (COVFILE unset) did exactly
+        that on 2026-08-06 and split one row of `--show_reg --full_path` in
+        two, which the parsers then read as an SDK field mismatch: 15 red
+        rows across apps-174 and apps-08-03 blaming the SDK for a message
+        printed by the oracle. The SDK output was correct throughout.
         """
         show_header = verbose or BaseConfig.VERBOSE
         if show_header and description:
@@ -479,7 +492,8 @@ class CommandRunner(object):
         if BaseConfig.VERBOSE:
             # Stream output line-by-line in real-time while capturing it
             process = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                cmd, shell=True, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL)
             output_lines = []
             for line in iter(process.stdout.readline, b''):
                 decoded = line.decode('utf-8', errors='replace')
@@ -490,7 +504,8 @@ class CommandRunner(object):
             output = ''.join(output_lines)
         else:
             process = subprocess.Popen(
-                cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+                cmd, shell=True, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT if merge_stderr else subprocess.DEVNULL)
             output, _ = process.communicate()
             output = output.decode('utf-8', errors='replace')
         success = process.returncode == 0


### PR DESCRIPTION
Four bugs in mft_sdk/unit_tests/ that reported the SDK as broken when it was
not. Found triaging the 2026-08-06 SDK-Verify run: 18 of its 50 failures were
these, and the SDK output was correct in every one.

1. utils.py merged the reference CLI's stderr into the stdout it parses as a
   table (stderr=subprocess.STDOUT). apps-174 and apps-08-03 had a
   Bullseye-coverage-instrumented mlxreg_ext installed; with COVFILE unset it
   writes an error to stderr on every invocation, and because the tool's
   stdout is a block-buffered pipe while stderr is unbuffered, that text
   landed in the MIDDLE of a --show_reg row. test_metadata.py then dropped
   both halves (<5 columns) and reported "SDK-only fields (1):
   dev_info.dev_branch_tag[8]"; test_full_path.py took the orphan as a field
   name and invented fields "24" and "BullseyeCoverage". 15 red rows blaming
   the SDK for a message printed by the oracle. CommandRunner.run gains
   merge_stderr (default True, unchanged for the ~100 other call sites) and
   the two mlxreg oracle sites pass False. Control on apps-174: dropping
   stderr yields exactly the 122 field rows the SDK reported.

2. test_build_flags.py::_pkg_type asked "does /usr/bin/rpm exist" rather than
   what the distro is, so any Debian machine that also has rpm installed was
   classified rpm. apps-124-002 (Ubuntu 24.04, aarch64, has both) then hunted
   for mstflint-sdk-*.rpm in an aarch64 cache holding only a .deb: 3 rows of
   "variant package not in cache" for a machine whose deb was present. Its
   sibling apps-124-003 (Debian 13, no rpm binary) passed the identical
   suite, which is the asymmetry that exposed it. Now reads /etc/os-release
   ID/ID_LIKE first, then dpkg owning its own binary, then tool presence.
   Verified live: apps-124-002 rpm->deb, apps-124-003 and apps-127 unchanged.

3+4. test_configure_compiler_warning.py and test_source_packages.py rmtree'd
   fixed-name scratch dirs whose fallback root is $HOME -- one NFS export
   shared by the whole fleet -- so two machines running them concurrently
   deleted each other's tree mid-build. Namespaced by hostname+pid, matching
   the idiom hca_caps/test_hca_caps_validation.py already uses. Both suites
   are documented per-machine; this only makes that true under parallelism.

