### PR TITLE
flint | enhance retries mechanism

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -293,14 +293,14 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
 {
     static bool env_vars_evaluated = false;
     static bool erase_verification_enable = false;
-    static int retries_num = 0;
+    static int retries_num = DEFAULT_WRITE_RETRIES;
     int rc = 0;
 
     if (!env_vars_evaluated)
     {
         erase_verification_enable = getenv("MFLASH_ERASE_VERIFY") ? true : false;
         const char* retries_num_str = getenv("MFLASH_WRITE_RETRIES");
-        retries_num = retries_num_str ? atoi(retries_num_str) : 0;
+        retries_num = retries_num_str ? atoi(retries_num_str) : DEFAULT_WRITE_RETRIES;
         env_vars_evaluated = true;
     }
     u_int8_t* p = (u_int8_t*)data;
@@ -422,27 +422,41 @@ int write_chunks(mflash* mfl, u_int32_t addr, u_int32_t len, u_int8_t* data)
                     CHECK_RC(rc);
                     /* Verify data */
                     bool verify_pass = true;
+                    bool erase_miss = false;
                     for (i = 0; i < data_size; i++)
                     {
-                        if (verify_buffer[i] != block_data[i + prefix_pad_size])
+                        u_int8_t want = block_data[i + prefix_pad_size];
+                        u_int8_t got = verify_buffer[i];
+                        if (got != want)
                         {
-                            verify_pass = false;
-                            FLASH_DPRINTF(("Write verification failed. Address 0x%08x - expected:0x%02x actual: 0x%02x\n", addr + i, block_data[i + prefix_pad_size], verify_buffer[i]));
-
-                            if (retries_counter >= retries_num)
+                            if (verify_pass) // log only the first mismatched byte
                             {
-                                return MFE_VERIFY_ERROR;
+                                FLASH_DPRINTF(
+                                  ("Write verification failed. Address 0x%08x - expected:0x%02x actual: 0x%02x\n",
+                                   addr + i, want, got));
                             }
-                            else
+                            verify_pass = false;
+                            if ((got & want) != want)
                             {
+                                erase_miss = true;
                                 break;
                             }
                         }
                     }
                     if (!verify_pass)
                     {
+                        if (erase_miss)
+                        {
+                            FLASH_DPRINTF(("Failure is due to erase miss -> skip write-only retries\n"));
+                            return MFE_ERASE_ERROR;
+                        }
+                        if (retries_counter >= retries_num)
+                        {
+                            FLASH_DPRINTF(("Write verification failed after %d retries\n", retries_counter));
+                            return MFE_VERIFY_ERROR;
+                        }
                         retries_counter++;
-                        FLASH_DPRINTF(("Retry number %d\n", retries_counter));
+                        FLASH_DPRINTF(("Write retry number %d\n", retries_counter));
                         continue;
                     }
                 }

--- a/mflash/mflash.h
+++ b/mflash/mflash.h
@@ -116,11 +116,31 @@ EXTERN_C_START
             fflush(stdout);                             \
         }                                               \
     } while (0)
+
+#define FLASH_DPRINTF(args)                          \
+    do                                               \
+    {                                                \
+        char* reacDebug = getenv("MFT_FLASH_DEBUG"); \
+        if (reacDebug != NULL)                       \
+        {                                            \
+            printf("\33[2K\r");                      \
+            printf("[MFT_FLASH_DEBUG]: -D- ");       \
+            printf args;                             \
+            fflush(stdout);                          \
+        }                                            \
+    } while (0)
+
 #else
 #define FLASH_ACCESS_DPRINTF(...)
 #endif
 
 #define MAX_FLASH_FREQ 90 // MHz
+
+// overridable by the MFLASH_WRITE_RETRIES env var.
+#define DEFAULT_WRITE_RETRIES 3
+
+// overridable by the MFLASH_ERASE_RETRIES env var.
+#define DEFAULT_ERASE_RETRIES 3
 
 #define MAX_NUM_OF_CYCLES 15
 #define MIN_NUM_OF_CYCLES 1

--- a/mflash/mflash_dev_capability.h
+++ b/mflash/mflash_dev_capability.h
@@ -44,20 +44,7 @@
 
 #include "mflash_pack_layer.h"
 
-#ifndef UEFI_BUILD
-#define FLASH_DPRINTF(args)                          \
-    do                                               \
-    {                                                \
-        char* reacDebug = getenv("MFT_FLASH_DEBUG"); \
-        if (reacDebug != NULL)                       \
-        {                                            \
-            printf("\33[2K\r");                      \
-            printf("[MFT_FLASH_DEBUG]: -D- ");       \
-            printf args;                             \
-            fflush(stdout);                          \
-        }                                            \
-    } while (0)
-#else
+#ifdef UEFI_BUILD
 #define FLASH_DPRINTF(...)
 #endif
 

--- a/mlxfwops/lib/flint_io.cpp
+++ b/mlxfwops/lib/flint_io.cpp
@@ -465,6 +465,8 @@ bool Flash::open_com_checks(const char* device, int rc, bool force_lock)
         return errmsg("Failed getting flash attributes for device %s: %s", device, mf_err2str(rc));
     }
     _curr_sector_size = _attr.sector_size;
+    // The mirror describes a sector on whatever device was open before - never carry it across.
+    _sector_mirror_valid = false;
 
     rc = mf_set_opt(_mfl, MFO_NO_VERIFY, _no_flash_verify ? 1 : 0);
     if (rc != MFE_OK)
@@ -528,6 +530,7 @@ bool Flash::open(uefi_Dev_t* uefi_dev, uefi_dev_extra_t* uefi_extra, bool force_
 ////////////////////////////////////////////////////////////////////////
 void Flash::close()
 {
+    _sector_mirror_valid = false;
     if (!_mfl)
     {
         return;
@@ -689,11 +692,28 @@ bool Flash::erase_sector_phy(u_int32_t phy_addr)
     NATIVE_PHY_ADDR_FUNC(erase_sector, (phy_addr));
 }
 
+// Number of re-erase attempts allowed when a write fails because the sector wasn't properly
+// erased (see #5099855). Shared by the plain-write and the read-modify-write paths.
+static int get_reerase_retries()
+{
+    static bool evaluated = false;
+    static int retries = DEFAULT_ERASE_RETRIES;
+
+    if (!evaluated)
+    {
+        const char* retries_str = getenv("MFLASH_ERASE_RETRIES");
+        retries = retries_str ? atoi(retries_str) : DEFAULT_ERASE_RETRIES;
+        evaluated = true;
+    }
+    return retries;
+}
+
 ////////////////////////////////////////////////////////////////////////
 bool Flash::write(u_int32_t addr, void* data, int cnt, bool noerase)
 {
     // FIX:
     noerase = _no_erase || noerase;
+    _erase_needed = false;
 
     if (!_mfl)
     {
@@ -746,8 +766,14 @@ bool Flash::write(u_int32_t addr, void* data, int cnt, bool noerase)
                 _curr_sector = sector;
                 if (!erase_sector(_curr_sector))
                 {
+                    mf_release_persistent_lock(_mfl);
                     return false;
                 }
+                // Arm the mirror for the newly opened sector (erase_sector() invalidated it).
+                // Erased flash reads as 0xff, so that is the correct initial content.
+                _sector_mirror.assign(sect_size, 0xff);
+                _sector_mirror_addr = _curr_sector;
+                _sector_mirror_valid = true;
             }
         }
 
@@ -759,13 +785,77 @@ bool Flash::write(u_int32_t addr, void* data, int cnt, bool noerase)
         // Actual write:
         u_int32_t phys_addr = cont2phys(chunk_addr);
         // printf("-D- write: addr = %#x, phys_addr = %#x\n", chunk_addr, phys_addr);
-        mft_signal_set_handling(1);
-        if (_cputUtilizationApplied)
+        // On an erase miss we re-erase the sector and replay it whole from _sector_mirror, which
+        // holds everything written into it since we erased it - including chunks written by
+        // earlier write() calls into the same sector (one 64KB sector spans 16 Flash::TRANS-sized
+        // calls). This gives the plain-write path the same erase-retry as write_sector_with_erase()
+        // without paying for its pre-read: the replayed bytes come from the caller's data, never
+        // from a read-back of flash that has just misbehaved.
+        // noerase callers (the read-modify-write path) do their own retrying and we do not own
+        // their erase, so we must not erase underneath them.
+        bool can_reerase = !noerase && _sector_mirror_valid && _sector_mirror_addr == _curr_sector;
+        int reerase_retries = can_reerase ? get_reerase_retries() : 0;
+        u_int32_t chunk_offs_in_sector = chunk_addr - _curr_sector;
+
+        for (int reerase_attempt = 0;; reerase_attempt++)
         {
-            mf_set_cpu_utilization(_mfl, _cpuPercent);
+            mft_signal_set_handling(1);
+            if (_cputUtilizationApplied)
+            {
+                mf_set_cpu_utilization(_mfl, _cpuPercent);
+            }
+            if (reerase_attempt == 0)
+            {
+                rc = mf_write(_mfl, phys_addr, chunk_size, p);
+            }
+            else
+            {
+                // Replay the whole sector - this chunk was merged into the mirror below
+                rc = mf_write(_mfl, cont2phys(_curr_sector), _sector_mirror.size(), &_sector_mirror[0]);
+            }
+            _erase_needed = (rc == MFE_ERASE_ERROR);
+            deal_with_signal(_mfl);
+
+            if (rc == MFE_OK)
+            {
+                if (reerase_attempt > 0)
+                {
+                    FLASH_DPRINTF(("Write succeeded after %d re-erase attempts\n", reerase_attempt));
+                }
+                break;
+            }
+
+            // Only an erase miss is recoverable by re-erasing - any other failure is returned as-is
+            if (!_erase_needed)
+            {
+                FLASH_DPRINTF(("Write failed but not an erase failure - skipping re-erase\n"));
+                break;
+            }
+            if (reerase_attempt >= reerase_retries)
+            {
+                FLASH_DPRINTF(("Write failed, re-erase attempts exhausted (%d)\n", reerase_retries));
+                break;
+            }
+
+            FLASH_DPRINTF(("Write failed on erase miss, re-erase attempt %d\n", reerase_attempt + 1));
+            memcpy(&_sector_mirror[chunk_offs_in_sector], p, chunk_size);
+            if (!erase_sector(_curr_sector))
+            {
+                FLASH_DPRINTF(("Erase sector failed\n"));
+                mf_release_persistent_lock(_mfl);
+                return false;
+            }
+            // erase_sector() invalidates the mirror - the replay is exactly what it holds
+            _sector_mirror_valid = true;
         }
-        rc = mf_write(_mfl, phys_addr, chunk_size, p);
-        deal_with_signal(_mfl);
+
+        // Record this chunk at its offset in the sector, so a retry on any later chunk of the same
+        // sector can replay all of it. can_reerase already means "the mirror tracks _curr_sector and
+        // we own its erase" - the same condition that makes recording meaningful.
+        if (can_reerase && rc == MFE_OK)
+        {
+            memcpy(&_sector_mirror[chunk_offs_in_sector], p, chunk_size);
+        }
 
         if (rc != MFE_OK)
         {
@@ -853,8 +943,50 @@ bool Flash::write_sector_with_erase(u_int32_t addr, void* data, int cnt)
 
     memcpy(&buff[word_in_sector], data, cnt);
 
-    // no need to erase twice noerase=true
-    return write(sector, &buff[0], sector_size, true);
+    // We only re-erase when a read-back confirms the un-erased signature (a bit that must be 1 is still 0)
+    static bool reerase_retries_evaluated = false;
+    int reerase_retries = get_reerase_retries();
+    if (reerase_retries <= 0)
+    {
+        // no need to erase twice noerase=true
+        return write(sector, &buff[0], sector_size, true);
+    }
+
+    for (int reerase_attempt = 0; reerase_attempt <= reerase_retries; reerase_attempt++)
+    {
+        if (write(sector, &buff[0], sector_size, true))
+        {
+            if (reerase_attempt > 0)
+            {
+                FLASH_DPRINTF(("Write succeeded after %d re-erase attempts\n", reerase_attempt));
+            }
+            return true;
+        }
+
+        if (reerase_attempt == reerase_retries)
+        {
+            FLASH_DPRINTF(("Write failed, re-erase attempts exhausted (%d)\n", reerase_retries));
+            return false;
+        }
+        FLASH_DPRINTF(("Write failed, re-erase attempt %d\n", reerase_attempt));
+
+        // Re-erase only when the write failed because the sector wasn't erased. write() sets
+        // _erase_needed from mf_write's rc, so we act on it directly - no need to re-read the sector
+        // (a re-read is unreliable on SPC6 after a bad write). Any other failure can't be fixed by
+        // re-erasing, so return it as-is.
+        if (!_erase_needed)
+        {
+            FLASH_DPRINTF(("Write failed but not an erase failure - skipping re-erase\n"));
+            return false;
+        }
+
+        if (!erase_sector(sector))
+        {
+            FLASH_DPRINTF(("Erase sector failed\n"));
+            return false;
+        }
+    }
+    return false; // unreachable
 }
 
 bool Flash::write_with_erase(u_int32_t addr, void* data, int cnt)
@@ -884,6 +1016,10 @@ bool Flash::erase_sector(u_int32_t addr)
 {
     int rc;
     u_int32_t phys_addr = cont2phys(addr);
+    // Any erase invalidates the sector mirror. Callers outside write() (the flint erase subcommand,
+    // the FS2 config wipe) can blank a sector that _curr_sector still points at, and replaying a
+    // stale mirror would restore data that was deliberately erased. write() re-arms it explicitly.
+    _sector_mirror_valid = false;
     mft_signal_set_handling(1);
     if (_flash_working_mode == Flash::Fwm_4KB)
     {
@@ -1770,6 +1906,9 @@ bool Flash::set_flash_working_mode(int mode)
     {
         return errmsg("Changing Flash IO working mode not supported.");
     }
+    // The sector size and the _curr_sector masking below both change here, so the mirror's size
+    // and base address can no longer be trusted - drop it.
+    _sector_mirror_valid = false;
     // Verification Hook
     if (_attr.support_sub_and_sector)
     {

--- a/mlxfwops/lib/flint_io.h
+++ b/mlxfwops/lib/flint_io.h
@@ -59,6 +59,7 @@
 #endif
 
 #include <string>
+#include <vector>
 
 // external flash attr struct
 
@@ -400,7 +401,10 @@ public:
         _cr_space_locked(0),
         _flash_working_mode(FBase::Fwm_Default),
         _cputUtilizationApplied(false),
-        _cpuPercent(-1)
+        _cpuPercent(-1),
+        _erase_needed(false),
+        _sector_mirror_addr(0),
+        _sector_mirror_valid(false)
     {
         memset(&_attr, 0, sizeof(_attr));
     }
@@ -569,6 +573,16 @@ protected:
     int _flash_working_mode;
     bool _cputUtilizationApplied;
     int _cpuPercent;
+    bool _erase_needed;
+
+    // In-memory mirror of everything written into the currently open sector (_curr_sector) since
+    // write() erased it. Filled from the caller's data only - never read back from flash, which is
+    // unreliable right after a bad write. Lets an erase-miss retry re-erase the sector and replay
+    // it whole, including chunks written by earlier write() calls into the same sector.
+    // Any erase outside write() invalidates it (see Flash::erase_sector).
+    std::vector<u_int8_t> _sector_mirror;
+    u_int32_t _sector_mirror_addr;
+    bool _sector_mirror_valid;
 };
 
 #endif

--- a/mlxfwops/lib/fs4_ops.cpp
+++ b/mlxfwops/lib/fs4_ops.cpp
@@ -2441,6 +2441,24 @@ bool Fs4Operations::DoAfterBurnJobs(const u_int32_t magic_pattern[], ExtBurnPara
     return true;
 }
 
+// The image is burnt with plain writes by default. Burning it through the read-modify-write path
+// instead routes every write via Flash::write_sector_with_erase, which retries a failed write by
+// re-erasing the sector and writing it again (MFLASH_ERASE_RETRIES). That costs a read of every
+// sector before writing it and erases in 4KB instead of 64KB sectors, so it is opt-in only.
+static bool burn_with_read_modify_write()
+{
+    static bool evaluated = false;
+    static bool enabled = false;
+
+    if (!evaluated)
+    {
+        const char* env = getenv("MFLASH_BURN_RMW");
+        enabled = env ? (strtoul(env, (char**)NULL, 0) != 0) : false;
+        evaluated = true;
+    }
+    return enabled;
+}
+
 bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& burnParams)
 {
     u_int8_t is_curr_image_on_second_partition;
@@ -2532,7 +2550,9 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
     //* Burn
     int alreadyWrittenSz = 0;
     //* Burn image without signature
-    DPRINTF(("Fs4Operations::burnEncryptedImage - Burning image without magic-pattern\n"));
+    bool readModifyWrite = burn_with_read_modify_write();
+    DPRINTF(("Fs4Operations::burnEncryptedImage - Burning image without magic-pattern (read-modify-write = %d)\n",
+             readModifyWrite));
     if (!writeImageEx(burnParams.progressFuncEx,
                       burnParams.progressUserData,
                       burnParams.progressFunc,
@@ -2540,7 +2560,7 @@ bool Fs4Operations::burnEncryptedImage(FwOperations* imageOps, ExtBurnParams& bu
                       imgBuff.data() + FS3_FW_SIGNATURE_SIZE,       // data
                       imgBuff.size() - FS3_FW_SIGNATURE_SIZE,       // size
                       true,                                         // phys addr
-                      false,
+                      readModifyWrite,
                       total_img_size,
                       alreadyWrittenSz))
     {


### PR DESCRIPTION
Description: modified the write retries mechanism to be defaulted to 3 retries (unless MFLASH_WRITE_RETRIES overrides it). 
Also added a erase retry mechanism - when write fails check if all bits that should be ones are indeed ones, if not - we won't be able to recover by doing only write retry - and we'll need to actually do a re-erase then re-write for the page we failed on. 
erase retry also gets 3 retries as default, unless MFLASH_ERASE_RETRIES overrides it