### PR TITLE
cherry pick - [mtcr] Expose only BF4 network controller PCI ID 0xa2df

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -107,11 +107,7 @@ LIST_HEAD(mst_devices);
 #define BLUEFIELD_DPU_AUX_PCI_ID 49873
 #define BLUEFIELD3_PCI_ID 41692
 #define BLUEFIELD3_RMA_PCI_ID 541
-#define BLUEFIELD4_CRYPTO_ENABLED_PCI_ID     41693
-#define BLUEFIELD4_CRYPTO_DISABLED_PCI_ID    41694
 #define BLUEFIELD4_NETWORK_CONTROLLER_PCI_ID 41695
-#define BLUEFIELD4_MANAGMENT_INTERFACE_PCI_ID 49878
-#define BLUEFIELD4_PCI_ID 41695
 #define SWITCHIB_PCI_ID 52000
 #define SWITCHIB2_PCI_ID 53000
 #define QUANTUM_PCI_ID 54000
@@ -222,10 +218,7 @@ static struct pci_device_id supported_pci_devices[] = {{PCI_DEVICE(MST_MELLANOX_
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD_DPU_AUX_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD3_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD3_RMA_PCI_ID)},
-                                                       {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD4_CRYPTO_ENABLED_PCI_ID)},
-                                                       {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD4_CRYPTO_DISABLED_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD4_NETWORK_CONTROLLER_PCI_ID)},
-                                                       {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, BLUEFIELD4_MANAGMENT_INTERFACE_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, SWITCHIB_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, SWITCHIB2_PCI_ID)},
                                                        {PCI_DEVICE(MST_MELLANOX_PCI_VENDOR, QUANTUM_PCI_ID)},

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -3273,10 +3273,7 @@ static long supported_dev_ids[] = {0x1003, /* Connect-X3 */
                                    0xa2d2, /* MT416842 Family BlueField integrated ConnectX-5 network controller */
                                    0xa2d6, /* MT42822 Family BlueField2 integrated ConnectX-6DX network controller */
                                    0xa2dc, /* MT43244 Family BlueField3 integrated ConnectX-7 network controller */
-                                   0xa2dd, // BF4 Family BlueField4 Crypto Enabled
-                                   0xa2de, // BF4 Family BlueField4 Crypto Disabled
                                    0xa2df, // BF4 Family BlueField4 Network Controller
-                                   0xc2d6, // BF4 Family BlueField4 Management Interface
                                    0xcf70, /* Spectrum3 */
                                    0xcf80, /* Spectrum4 */
                                    0xcf82, /* Spectrum5 */


### PR DESCRIPTION
Remove BF4 Crypto Enabled (0xa2dd), Crypto Disabled (0xa2de) and SoC Management Interface (0xc2d6) from the MST supported-device lists so mstdevices_info no longer shows the BF4 SoC Management Interface. Only the BF4 network controller (0xa2df) is exposed as an MST device, aligning mstflint with MFT behavior.

Ports MFT commit d0cd0748a7 (userspace supported_dev_ids in mtcr_ul_com.c and kernel supported_pci_devices in mst_main.c).

Issue: 5124649