### PR TITLE
[mstfwreset] install rp_pio_dpc_block.py

### DIFF
--- a/small_utils/mlxfwresetlib/Makefile.am
+++ b/small_utils/mlxfwresetlib/Makefile.am
@@ -32,5 +32,5 @@
 
 
 docdir = $(libdir)/mstflint/python_tools/mstfwreset/mlxfwresetlib
-dist_doc_DATA = __init__.py mlxfwreset_mlnxdriver.py mlxfwreset_status_checker.py mlxfwreset_utils.py logger.py mcra.py mlnx_peripheral_components.py pci_device.py cmd_reg_mfrl.py drivers_safety_check.py cmd_reg_mroq.py cmd_reg_mpcir.py cmd_reg_mcam.py cmd_reg_mrsi.py gpu_drivers_safety_check.py hot_reset.py
+dist_doc_DATA = __init__.py mlxfwreset_mlnxdriver.py mlxfwreset_status_checker.py mlxfwreset_utils.py logger.py mcra.py mlnx_peripheral_components.py pci_device.py cmd_reg_mfrl.py drivers_safety_check.py cmd_reg_mroq.py cmd_reg_mpcir.py cmd_reg_mcam.py cmd_reg_mrsi.py gpu_drivers_safety_check.py hot_reset.py rp_pio_dpc_block.py
 


### PR DESCRIPTION
rp_pio_dpc_block.py was missing from dist_doc_DATA, so it never got installed alongside the rest of mlxfwresetlib. mstfwreset.py imports it under a bare "except ImportError: pass", leaving
apply_rp_pio_dpc_restrictions set to None -- the RP PIO DPC check was silently skipped on every installed build, and only worked when running from the source tree.

Issue: 5216559