### PR TITLE
mstvpd: reject any misplaced or unknown option

### DIFF
--- a/small_utils/vpd.c
+++ b/small_utils/vpd.c
@@ -195,6 +195,12 @@ char const* get_opt_pos(const char* option_suspect, int enforce_option_with_args
     return strstr(OPTSTR, suspect_to_search);
 }
 
+// Returns 1 if the arg looks like an option, i.e. anything but "-" (stdin) and "--" (keywords separator)
+int is_option_like(const char* arg)
+{
+    return arg[0] == '-' && arg[1] != '\0' && strcmp(arg, "--") != 0;
+}
+
 int verify_command_layout(int argc, char const** argv)
 {
     if (argc < 2)
@@ -217,7 +223,7 @@ int verify_command_layout(int argc, char const** argv)
     // i is file argument or at the end of argv
     for (i = i + 1; i < argc; i++)
     {
-        if (get_opt_pos(argv[i], 0))
+        if (is_option_like(argv[i]))
         {
             return 0;
         }


### PR DESCRIPTION
verify_command_layout() only treated two-character "-x" tokens as options, so a bad option like --O@SY3 passed the check. FreeBSD's getopt() stops at the first non-option, so the token was consumed as a VPD keyword and mstvpd printed nothing and exited 0. glibc permutes arguments and rejects it, so only FreeBSD was affected.

Reject any argument starting with '-' other than "-" and "--" once the option section has ended.