### PR TITLE
mstvpd: close the device handle before exit

### DIFF
--- a/small_utils/vpd.c
+++ b/small_utils/vpd.c
@@ -336,10 +336,12 @@ int main(int argc, char** argv)
         rc = mvpd_get_vpd_size(mf, &mvpd_len);
         if (rc != 0)
         {
+            mclose(mf);
             fprintf(stderr, "-E- Failed to get VPD size from %s!\n", name);
             return MVPD_ERR;
         }
         rc = mvpd_get_raw_vpd(mf, (u_int8_t*)d, mvpd_len);
+        mclose(mf);
         if (rc)
         {
             fprintf(stderr, "-E- Failed to read VPD from %s!\n", name);


### PR DESCRIPTION
mopen() was never paired with mclose(), so every mstvpd run leaked the mfile and its dev_info allocations.

Harmless in a release build, but the ASAN-instrumented package exits non-zero on the LeakSanitizer report (9058 bytes in 8 allocations, direct leak in mopen_ul_int), which fails the mstvpd regression cases that check the return code.

mf is unused after the raw read, so one mclose() after it plus one on the size-failure path covers every exit -- the same pattern as mread.c / mcra.c / mget_temp.c.
