### PR TITLE
[flint] Present MGIR board_ga in query output

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -5028,6 +5028,11 @@ FlintStatus QuerySubCommand::printInfo(const fw_info_t& fwInfo, bool fullQuery)
         printf("INI revision:          0x%x\n", fwInfo.fs3_info.ini_file_version);
     }
 
+    if (fwInfo.fs3_info.board_ga_valid)
+    {
+        printf("Board Geo Address:     BOARD %x\n", fwInfo.fs3_info.board_ga);
+    }
+
     if (fwInfo.fs3_info.geo_address_valid)
     {
         printf("Geographical Address:  ASIC %x\n", fwInfo.fs3_info.geo_address);

--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -2050,6 +2050,16 @@ bool FwCompsMgr::queryFwInfo(fwInfoT* query, bool next_boot_fw_ver)
         }
     }
 
+    query->board_ga_valid = false;
+    bool is_board_ga_supported = false;
+    rc = isCapabilitySupportedAccordingToMcamReg(_mf, MCAM_CAP_MGIR_HW_INFO_BOARD_GA,
+                                                 dm_dev_is_mcam_dword_swap_needed(dm_device_id), &is_board_ga_supported);
+    if (rc == ME_OK && is_board_ga_supported)
+    {
+        query->board_ga_valid = true;
+        query->board_ga = mgir.hw_info.board_ga;
+    }
+
     return true;
 }
 unsigned char* FwCompsMgr::getLastErrMsg()

--- a/fw_comps_mgr/fw_comps_mgr.h
+++ b/fw_comps_mgr/fw_comps_mgr.h
@@ -140,6 +140,8 @@ typedef struct
     u_int32_t ini_file_version;
     u_int8_t geo_address;
     bool geo_address_valid;
+    u_int8_t board_ga;
+    bool board_ga_valid;
     uint8_t independent_module;
     uint8_t pci_switch_only_mode;
     uint8_t pci_switch_only_mode_valid;

--- a/mlxfwops/lib/fsctrl_ops.cpp
+++ b/mlxfwops/lib/fsctrl_ops.cpp
@@ -238,6 +238,8 @@ bool FsCtrlOperations::FsIntQuery()
     _fsCtrlImgInfo.ini_file_version = fwQuery.ini_file_version;
     _fsCtrlImgInfo.geo_address = fwQuery.geo_address;
     _fsCtrlImgInfo.geo_address_valid = fwQuery.geo_address_valid;
+    _fsCtrlImgInfo.board_ga = fwQuery.board_ga;
+    _fsCtrlImgInfo.board_ga_valid = fwQuery.board_ga_valid;
     _fsCtrlImgInfo.independent_module = fwQuery.independent_module;
     std::vector<FwComponent> compsMap;
     if (!_fwCompsAccess->getFwComponents(compsMap, false))

--- a/mlxfwops/lib/mlxfwops_com.h
+++ b/mlxfwops/lib/mlxfwops_com.h
@@ -536,6 +536,8 @@ typedef struct fs3_info_ext
     u_int32_t ini_file_version;
     u_int8_t geo_address;
     bool geo_address_valid;
+    u_int8_t board_ga;
+    bool board_ga_valid;
     bool socket_direct;
     bool aux_card_connected;
     bool is_aux_card_connected_valid;

--- a/reg_access/mcam_capabilities.h
+++ b/reg_access/mcam_capabilities.h
@@ -49,6 +49,7 @@ static const unsigned int REG_GROUP_LEN = 0x80;
 typedef enum
 {
     MCAM_CAP_MGIR_PCI_SWITCH_ONLY_MODE = 74, // If set, MGIR.hw_info.pci_switch_only_mode is supported [NIC_only]
+    MCAM_CAP_MGIR_HW_INFO_BOARD_GA = 93,     // If set, MGIR.hw_info.board_ga is supported
 
     MCAM_CAP_MAX // for validation
 } mcam_capability_t;


### PR DESCRIPTION
Description:
Add a "Board Geo Address" line to flint query, printed just above the existing "Geographical Address" line. The value comes from the new 6-bit MGIR.hw_info.board_ga field and is displayed only when MCAM bit 93 reports it as supported, so devices with older FW are unaffected.

Plumbing follows the existing ga/geo_address path: FwCompsMgr::queryFwInfo reads the field under the MCAM gate into fwInfoT, FsCtrlOperations copies it into fs3_info_t, and flint renders it.

MFT Commit: ac008542101ac27132863b8cc13fb90c7da3f85b

Issue: 5155941