### PR TITLE
mtcr_ul: use explicit compatibility symlink path

### DIFF
--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -77,4 +77,4 @@ libraryinclude_HEADERS = $(top_srcdir)/include/mtcr_ul/mtcr.h  $(top_srcdir)/inc
 
 install-exec-hook:
 	rm -f $(DESTDIR)$(pkglibdir)/libmtcr_ul.so* $(DESTDIR)$(pkglibdir)/libmtcr_ul.la
-	ln -snf mstflint/libmtcr_ul.a $(DESTDIR)$(libdir)/
+	ln -snf mstflint/libmtcr_ul.a $(DESTDIR)$(libdir)/libmtcr_ul.a


### PR DESCRIPTION
Avoid relying on ln to infer the installed link name from a directory target, which fails during CTyunOS RPM installation. Naming libmtcr_ul.a directly preserves the resulting layout across platforms.

Issue: 5220927