### PR TITLE
[Virtual Module] Add vmdl support to mstflint

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -1127,3 +1127,14 @@ int dm_dev_is_mcam_dword_swap_needed(dm_dev_id_t type)
 {
     return dm_dev_is_hca(type) || dm_dev_is_retimer(type);
 }
+
+int dm_dev_is_vmdl(mfile* mf, dm_dev_id_t type, u_int8_t* ptr_vmdl_ind)
+{
+    if (type != DeviceSpectrum5 && type != DeviceSpectrum6)
+    {
+        *ptr_vmdl_ind = 0;
+        return MFE_OK;
+    }
+
+    return dm_is_cpo(mf, ptr_vmdl_ind);
+}

--- a/dev_mgt/tools_dev_types.h
+++ b/dev_mgt/tools_dev_types.h
@@ -363,6 +363,8 @@ extern "C"
     A predicate returning if the device needs dword swap for MCAM.mng_feature_cap_mask
     */
     int dm_dev_is_mcam_dword_swap_needed(dm_dev_id_t type);
+
+    int dm_dev_is_vmdl(mfile* mf, dm_dev_id_t type, u_int8_t* ptr_vmdl_ind);
 #ifdef __cplusplus
 } /* end of 'extern "C"' */
 #endif

--- a/mst_utils/cable_discovery.cpp
+++ b/mst_utils/cable_discovery.cpp
@@ -15,8 +15,17 @@
 #include "dev_mgt/tools_dev_types.h"
 #include "reg_access/reg_access.h"
 #include "tools_layouts/reg_access_hca_layouts.h"
+#include "tools_layouts/reg_access_switch_layouts.h"
 #include "mft_utils/mft_sig_handler.h"
 #include "tools_layouts/reg_access_switch_layouts.h"
+
+#ifdef ENABLE_MST_DEV_I2C
+#define VMDL_PORT_OFFSET 0xb4
+#define VMDL_PORT_TENS_MASK 0x0000000F
+#define VMDL_PORT_ONES_MASK 0x00000F00
+#define VMDL_PORT_ONES_SHIFT 8
+#endif
+#define VMDL_DEV_ID 0x80
 
 
 const std::string TOOL_NAME = "mstcable_discovery";
@@ -109,6 +118,59 @@ void CreateCableDeviceFile(const std::string& cable_name)
     mstDeviceFile.close();
 }
 
+#ifdef ENABLE_MST_DEV_I2C
+int discoverVmdlOnI2c(unsigned int& cable_count) {
+    dev_info   * devs = NULL;
+    int          device_count = 0;
+    int          port = 0;
+    u_int32_t    port_dword = 0;
+    mfile      * cable_mf = NULL;
+
+    // Read directory directly since raw i2c devices are not shown in m_devices_ul
+    DIR        * d = opendir("/dev");
+    struct dirent* dir;
+    while ((dir = readdir(d)) != NULL)
+    {
+        if (dir->d_name[0] == '.')
+        {
+            continue;
+        }
+        if (!strstr(dir->d_name, "i2c-"))
+        {
+            continue;
+        }
+    
+        port = 0;
+        port_dword = 0;
+        std::string base_cable_name = std::string(dir->d_name) + "_" + VMDL_DEVICE_STR + std::to_string(port);
+        cable_mf = mopen_adv(base_cable_name.c_str(), (MType)(MST_DEFAULT | MST_CABLE));
+        if (!cable_mf)
+        {
+            continue;
+        }
+        u_int32_t hw_dev_id = 0;
+        dm_dev_id_t dm_dev_id = DeviceUnknown;
+        get_cable_id(cable_mf, &hw_dev_id, &dm_dev_id);
+        if (hw_dev_id != VMDL_DEV_ID)
+        {
+            mclose(cable_mf);
+            continue;
+        }
+        if (mcables_read4(cable_mf, VMDL_PORT_OFFSET, &port_dword) != 4)
+        {
+            mclose(cable_mf);
+            continue;
+        }
+        port = ((port_dword & VMDL_PORT_TENS_MASK) * 10) + ((port_dword & VMDL_PORT_ONES_MASK) >> VMDL_PORT_ONES_SHIFT);
+        mclose(cable_mf);
+        std::string cable_name = std::string(dir->d_name) + "_" + VMDL_DEVICE_STR + std::to_string(port);
+        CreateCableDeviceFile(cable_name);
+        cable_count++;
+    }
+    return 0;
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     dev_info   * devs = NULL;
@@ -120,6 +182,9 @@ int main(int argc, char* argv[])
     unsigned int cable_count = 0;
 
     bool filterSecondary = false;
+#ifdef ENABLE_MST_DEV_I2C
+    bool discoverVmdlOverI2c = false;
+#endif
 
     for (int argIdx = 1; argIdx < argc; argIdx++)
     {
@@ -128,10 +193,20 @@ int main(int argc, char* argv[])
         {
             filterSecondary = true;
         }
+#ifdef ENABLE_MST_DEV_I2C
+        else if (arg == "--discover_vmdl_on_i2c")
+        {
+            discoverVmdlOverI2c = 1;
+        }
+#endif
         else
         {
             std::cout << "Invalid argument: " << arg << std::endl;
-            std::cout << "Usage: " << TOOL_NAME << " [--filter_secondary]" << std::endl;
+            std::cout << "Usage: " << TOOL_NAME << " [--filter_secondary]";
+#ifdef ENABLE_MST_DEV_I2C
+            std::cout << " [--discover_vmdl_on_i2c]";
+#endif
+            std::cout << std::endl;
             return 1;
         }
     }
@@ -213,6 +288,22 @@ int main(int argc, char* argv[])
         else if (dm_dev_is_switch(devid_type) && !dm_is_gpu(devid_type))
         {
             num_ports = dm_get_hw_ports_num(devid_type);
+
+            u_int8_t is_vmdl_device = 0;
+            const char *device_str = CABLE_DEVICE_STR;
+            dm_dev_is_vmdl(mf, devid_type, &is_vmdl_device);  // On failure assume not vmdl device
+            if (is_vmdl_device)
+            {
+                device_str = VMDL_DEVICE_STR;
+
+                struct reg_access_switch_mgpir_ext mgpir;
+                memset(&mgpir, 0, sizeof(mgpir));
+                reg_access_status_t mgpir_rc = reg_access_mgpir_switch_ext(mf, REG_ACCESS_METHOD_GET, &mgpir);
+                if (!mgpir_rc)
+                {
+                    num_ports = mgpir.hw_info.num_of_modules;
+                }
+            }
             for (int port = 0; port < num_ports && !mft_signal_is_fired(); port++)
             {
                 if (filterSecondary)
@@ -223,17 +314,25 @@ int main(int argc, char* argv[])
                         continue;
                     }
                 }
-                std::string cable_name = std::string(devs[i].dev_name) + "_" + CABLE_DEVICE_STR + std::to_string(port);
+                std::string cable_name = std::string(devs[i].dev_name) + "_" + device_str + std::to_string(port);
                 mfile     * cable_mf = mopen_adv(cable_name.c_str(), (MType)(MST_DEFAULT | MST_CABLE));
                 if (!cable_mf)
                 {
                     continue;
                 }
-                else
+                if (is_vmdl_device)
                 {
-                    CreateCableDeviceFile(cable_name);
-                    cable_count++;
+                    u_int32_t hw_dev_id = 0;
+                    dm_dev_id_t dm_dev_id = DeviceUnknown;
+                    get_cable_id(cable_mf, &hw_dev_id, &dm_dev_id);
+                    if (hw_dev_id != VMDL_DEV_ID)
+                    {
+                        cable_name = std::string(devs[i].dev_name) + "_" + CABLE_DEVICE_STR + std::to_string(port);
+                    }
                 }
+
+                CreateCableDeviceFile(cable_name);
+                cable_count++;
     
                 mclose(cable_mf);
             }
@@ -242,6 +341,12 @@ int main(int argc, char* argv[])
     }
 
     free(devs);
+#ifdef ENABLE_MST_DEV_I2C
+    if (discoverVmdlOverI2c)
+    {
+        discoverVmdlOnI2c(cable_count);
+    }
+#endif
 
     if (mft_signal_is_fired())
     {

--- a/mst_utils/mdevices_info.c
+++ b/mst_utils/mdevices_info.c
@@ -847,6 +847,25 @@ int main(int argc, char** argv)
         printf("\n");
     }
 
+    int vmdl_found = 0;
+    for (i = 0; i < len; i++)
+    {
+        if (devs[i].dev_name && (strstr(devs[i].dev_name, "vmdl_") != NULL))
+        {
+            if (vmdl_found == 0)
+            {
+                printf("\nVirtual module devices:\n");
+                printf("---------------\n");
+                vmdl_found = 1;
+            }
+            printf("%s\n", devs[i].dev_name);
+        }
+    }
+    if (vmdl_found)
+    {
+        printf("\n");
+    }
+
     rc = 0;
 cleanup:
     if (devs)

--- a/mtcr_ul/mtcr_cables.c
+++ b/mtcr_ul/mtcr_cables.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <dlfcn.h>
+#include <errno.h>
 #include <stdbool.h>
 #include "mtcr_cables.h"
 #include "mtcr_int_defs.h"
@@ -131,6 +132,52 @@ int cable_access_reg_rw(mfile    * mf,
     return 0;
 }
 
+#ifdef ENABLE_MST_DEV_I2C
+int cable_access_mtusb_rw(mfile* mf, u_int8_t page_num, u_int8_t page_off, u_int8_t size, u_int32_t* data, rw_op_t _rw)
+{
+    unsigned char i2c_secondary = ((cable_ctx*)(mf->cable_ctx))->i2c_addr;
+    u_int8_t addr_width = 1;
+
+    int rc = 0;
+    /* write page selector */
+
+    unsigned int page_sel = 0x7f;
+    int num_of_retries = NUM_OF_WRITE_PAGE_RETRIES;
+    do
+    {
+        rc = mwrite_i2cblock(mf, i2c_secondary, addr_width, page_sel, &page_num, 1);
+        num_of_retries -= 1;
+    } while ((rc != 1) && (num_of_retries > 0));
+
+    if (1 != rc)
+    {
+        DBG_PRINTF("Failed to write page_sel. rc=%d,  page_num=%d\n", rc, page_num);
+        return MCABLES_MTUSB_FAILED;
+    }
+    if (WRITE_OP == _rw)
+    {
+        rc = mwrite_i2cblock(mf, i2c_secondary, addr_width, page_off, data, size);
+        if (size != rc)
+        {
+            DBG_PRINTF("Failed to write block, rc=%d\n", rc);
+            return MCABLES_MTUSB_FAILED;
+        }
+    }
+    else if (READ_OP == _rw)
+    {
+        rc = mread_i2cblock(mf, i2c_secondary, addr_width, page_off, data, size);
+        if (size != rc)
+        {
+            DBG_PRINTF("Failed to read block, rc=%d, %s\n", rc, strerror(errno));
+            DBG_PRINTF("page_off=0x%x, size=0x%x\n", page_off, size);
+            return MCABLES_MTUSB_FAILED;
+        }
+    }
+
+    return 0;
+}
+#endif /* ENABLE_MST_DEV_I2C */
+
 int cable_access_rw(mfile* mf, u_int32_t addr, u_int32_t len, u_int32_t* data, rw_op_t _rw)
 {
     MCABLES_ERROR ret = MCABLES_OK;
@@ -176,7 +223,18 @@ int cable_access_rw(mfile* mf, u_int32_t addr, u_int32_t len, u_int32_t* data, r
                 goto cleanup;
             }
             break;
-
+#ifdef ENABLE_MST_DEV_I2C
+        case MLXCABLES_MTUSB_ACCESS:
+            {
+                if (cable_access_mtusb_rw(mf, (u_int8_t)(page_num + page_i), (u_int8_t)(device_addr + addr_i),
+                                          (u_int8_t)tmp_size, data + i / 4, _rw))
+                {
+                    ret = MCABLES_MTUSB_FAILED;
+                    goto cleanup;
+                }
+            }
+            break;
+#endif /* ENABLE_MST_DEV_I2C */
         default:
             break;
         }
@@ -218,7 +276,18 @@ int mcables_open(mfile* mf, int port)
     memset(cbl, 0, sizeof(cable_ctx));
     cbl->port = port;
     cbl->src_tp = mf->tp;
-    cbl->cable_access = MLXCABLES_REG_ACCESS;
+    switch (mf->tp)
+    {
+#ifdef ENABLE_MST_DEV_I2C
+        case MST_USB_DIMAX:
+        case MST_DEV_I2C:
+            cbl->cable_access = MLXCABLES_MTUSB_ACCESS;
+            break;
+#endif
+        default:
+            cbl->cable_access = MLXCABLES_REG_ACCESS;
+            break;
+    }
     cbl->i2c_addr = CABLE_I2C_DEVICE_ADDR;
     mf->tp = MST_CABLE;
     switch_access_funcs(mf);

--- a/mtcr_ul/mtcr_cables.h
+++ b/mtcr_ul/mtcr_cables.h
@@ -11,6 +11,7 @@ extern "C"
 #include "dev_mgt/tools_dev_types.h"
 
 #define CABLE_DEVICE_STR "_cable_"
+#define VMDL_DEVICE_STR "_vmdl_"
 
 typedef enum {
     MCABLES_OK = 0,
@@ -32,6 +33,9 @@ typedef enum {
 
 typedef enum {
     MLXCABLES_REG_ACCESS = 1,
+#ifdef ENABLE_MST_DEV_I2C
+    MLXCABLES_MTUSB_ACCESS
+#endif /* ENABLE_MST_DEV_I2C */
 } cable_access_type_t;
 
 #define MCABLES_INTERNAL_ERROR_MSG_SIZE 256

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -2292,6 +2292,14 @@ bool is_cable_device(const char* name)
     {
         return false;
     }
+    if (strlen(name) < sizeof(VMDL_DEVICE_STR))
+    {
+        return false;
+    }
+    if (strstr(name, VMDL_DEVICE_STR) != NULL)
+    {
+        return true;
+    }
     if (strlen(name) < sizeof(CABLE_DEVICE_STR))
     {
         return false;
@@ -2306,12 +2314,18 @@ bool is_cable_device(const char* name)
 int get_cable_port(const char* name)
 {
 #ifdef CABLES_SUPPORT
-    char* cable_name_ptr = strstr(name, CABLE_DEVICE_STR);
+    const char* dev_str = CABLE_DEVICE_STR;
+    char* cable_name_ptr = strstr(name, dev_str);
+    if (!cable_name_ptr)
+    {
+        dev_str = VMDL_DEVICE_STR;
+        cable_name_ptr = strstr(name, dev_str);
+    }
 
     if (cable_name_ptr)
     {
         char* endptr;
-        int port = strtol(cable_name_ptr + (sizeof(CABLE_DEVICE_STR) - 1), &endptr, 10);
+        int port = strtol(cable_name_ptr + strlen(dev_str), &endptr, 10);
         if ((*endptr != '\0') || (port < 0))
         {
             DBG_PRINTF("Invalid cable port: %s\n", name);
@@ -2799,6 +2813,8 @@ void safe_free(mfile** pmf)
 
 static int mtcr_i2c_open(mfile* mf, const char* name)
 {
+    char name_buf[512];
+    memset(name_buf, 0, sizeof(name_buf));
     ul_ctx_t* ctx = mf->ul_ctx;
 
     mf->tp = MST_DEV_I2C;
@@ -2811,6 +2827,14 @@ static int mtcr_i2c_open(mfile* mf, const char* name)
     ctx->mread4_block = (f_mread4_block)mtcr_i2c_mread_chunks;
     ctx->mwrite4_block = (f_mwrite4_block)mtcr_i2c_mwrite_chunks;
 
+    if (is_cable_device(mf->dev_name))
+    {
+        snprintf(name_buf, sizeof(name_buf), "/dev/%s", name);
+        char *p = strchr(name_buf, '_');
+        *p = '\0';
+        name = name_buf;
+    }
+
     if ((mf->fd = open(name, O_RDWR | O_SYNC)) < 0)
     {
         safe_free(&mf);
@@ -2819,7 +2843,7 @@ static int mtcr_i2c_open(mfile* mf, const char* name)
     }
 
     /* Support functional devices from secure generation (CX7, Quantum2 and above) */
-    if (change_i2c_secondary_address(mf, mf->dtype))
+    if (!is_cable_device(mf->dev_name) && !change_i2c_secondary_address(mf, mf->dtype))
     {
         DBG_PRINTF("mtcr_i2c_open: failed to determine i2c secondary address\n");
         return -1;
@@ -3090,8 +3114,9 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
     }
 
 #ifdef ENABLE_MST_DEV_I2C
-    if (strstr(name, "/dev/i2c"))
+    if (strstr(name, "/dev/i2c") || strstr(name, "i2c-"))
     {
+        *force = 0;
         return MST_DEV_I2C;
     }
 #endif
@@ -3515,7 +3540,7 @@ int mdevices_v_ul(char* buf, int len, int mask, int verbosity)
                     continue;
                 }
 
-                if (strstr(mstflint_entry->d_name, "cable_") != NULL)
+                if (strstr(mstflint_entry->d_name, "cable_") != NULL || strstr(mstflint_entry->d_name, "vmdl_") != NULL)
                 {
                     int sz = strlen(mstflint_entry->d_name);
                     int rsz = sz + 1; /* dev name size + place for Null char */
@@ -3882,6 +3907,22 @@ dev_info* mdevices_info_v_ul(int mask, int* len, int verbosity)
     dev_name = devs;
     for (i = 0; i < rc; i++)
     {
+        // Divergence from MFT since here we can have non PCI devices in UL
+        unsigned _domain = 0, _bus = 0, _dev = 0, _func = 0;
+        int _force = 0;
+
+        MType type = mtcr_parse_name(dev_name, &_force, &_domain, &_bus, &_dev, &_func);
+
+#ifdef ENABLE_MST_DEV_I2C
+        if (type == MST_DEV_I2C)
+        {
+            dev_info_arr[i].ul_mode = 1;
+            dev_info_arr[i].type = (Mdevs)MDEVS_DEV_I2C;
+            strncpy(dev_info_arr[i].dev_name, dev_name, sizeof(dev_info_arr[i].dev_name) - 1);
+            goto next;
+        }
+#endif
+
         unsigned int domain = 0;
         unsigned int bus = 0;
         unsigned int dev = 0;
@@ -4168,13 +4209,26 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
     if (return_mf)
     {
 #ifdef CABLES_SUPPORT
+#ifdef ENABLE_MST_DEV_I2C
+        if (dev_type == MST_DEV_I2C && is_cable_device(name))
+        {
+            int cable_port = get_cable_port(name);
+            rc = mcables_open(mf, cable_port);
+            if (rc)
+            {
+                goto open_failed;
+            }
+        }
+        return mf;
+#else
         if (!is_cable_device(name))
         {
             return mf;
         }
+#endif /* ENABLE_MST_DEV_I2C */
 #else
         return mf;
-#endif
+#endif /* CABLES_SUPPORT */
     }
 
     if (dev_type == MST_ERROR)


### PR DESCRIPTION
Description:
 - Use existing mstcable_discovery flow
 - Create _vmdl_ devices
 - Also add mtusb flow to mtcr_cables, even though for vmdl it's embedded i2c
 - Add cable discovery to vmdls on embedded i2c
 - Adapt mread, mopen functions so that i2c cables work

Tested flows:
 - mstcable_discovery
 - mstmcra
 - mstdevices_info
