### PR TITLE
Error message fixing (partial backport for 4.35.0 VR)

### DIFF
--- a/fw_comps_mgr/fw_comps_mgr.cpp
+++ b/fw_comps_mgr/fw_comps_mgr.cpp
@@ -793,7 +793,11 @@ bool FwCompsMgr::controlFsm(fsm_command_t          command,
     if ((expectedState != FSMST_NA) && (_lastFsmCtrl.control_state != expectedState)) {
         DPRINTF(("controlFsm : control_state FW %s expected %s\n", StateNames[_lastFsmCtrl.control_state],
                  StateNames[expectedState]));
-        _lastError = FWCOMPS_MCC_UNEXPECTED_STATE;
+        if (_lastFsmCtrl.error_code) {
+            _lastError = mccErrTrans(_lastFsmCtrl.error_code);
+        } else {
+            _lastError = FWCOMPS_MCC_UNEXPECTED_STATE;
+        }
         return false;
     }
 
@@ -1468,7 +1472,6 @@ bool FwCompsMgr::IsCfgComponentType(FwComponent::comps_ids_t type)
 
 bool FwCompsMgr::burnComponents(FwComponent& comp, ProgressCallBackAdvSt* progressFuncAdv)
 {
-    unsigned i = 0;
     const u_int8_t LOCK_FW_UPDATE = 0x2;
     const u_int8_t LOCK_HOST_CFG = 0x3;
     FwComponent::comps_ids_t component = comp.getType();

--- a/mlxfwupdate/mlxfwmanager.cpp
+++ b/mlxfwupdate/mlxfwmanager.cpp
@@ -160,7 +160,7 @@ void updateSingleDevice(int device_index,
         }
         else
         {
-            result.error_message = "Fail : " + dev->getLastErrMsg();
+            result.error_message = dev->getLastErrMsg();
             result.rc = rc0;
         }
         return;
@@ -200,7 +200,7 @@ void updateSingleDevice(int device_index,
         }
         else
         {
-            result.error_message = "Fail : " + dev->getLastErrMsg();
+            result.error_message = dev->getLastErrMsg();
         }
     }
 }


### PR DESCRIPTION
Backport of the non-fwctl parts of upstream commit 75e6e33255dd ("Error message fixing") to mstflint_4_35_0_VR:

- fw_comps_mgr: translate the FSM's error_code via mccErrTrans() when available instead of always reporting a generic FWCOMPS_MCC_UNEXPECTED_STATE, and drop an unused local variable.
- mlxfwupdate: drop the redundant "Fail : " prefix from result.error_message, since callers already label it as a failure.

The rest of 75e6e33255dd depends on the fwctl device-access feature (_useFwctl / openFwctlDev / fwctl_fd), which does not exist on this branch, so it is intentionally not included here.

Original-commit: https://github.com/Mellanox/mstflint/commit/75e6e33255dda8512f434f3ce401bf8853cc1b87