### PR TITLE
[mlxreg] bugfix - the tool crashes on an empty register

### DIFF
--- a/adb_parser/adb_instance.cpp
+++ b/adb_parser/adb_instance.cpp
@@ -1424,7 +1424,7 @@ bool _AdbInstance_impl<e, O>::isConditionalNode()
 template<bool e, typename O>
 bool _AdbInstance_impl<e, O>::containsDynamicArray()
 {
-    if (!isNode())
+    if (!isNode() || subItems.empty())
     {
         return false;
     }


### PR DESCRIPTION
Port of mft commit `eef11c3d6a9de385d59bc8b83ed81f0605e72a6e` (Issue 5233551).

mlxreg crashed when accessing a register whose external layout has no fields,
such as MN2NS. `_AdbInstance_impl::containsDynamicArray()` called
`subItems.back()` on an empty `subItems` vector; the guard now also returns
false for nodes with no sub-items.

MFT Commit: eef11c3d6a9de385d59bc8b83ed81f0605e72a6e

Tested flows (on the mft side):
- MN2NS get no longer crashes, offline and on device
- MN2NS show_reg exits successfully, with and without --advanced
- PAOS get and set on device unchanged
- Dynamic-array registers produce unchanged buffers (PAOS, MCDA, MGIR)