### PR TITLE
[mlxreg] bugfix - the tool crashes on an empty register

### DIFF
--- a/adb_parser/adb_instance.cpp
+++ b/adb_parser/adb_instance.cpp
@@ -1421,7 +1421,7 @@ bool _AdbInstance_impl<e, O>::isConditionalNode()
 template<bool e, typename O>
 bool _AdbInstance_impl<e, O>::containsDynamicArray()
 {
-    if (!isNode())
+    if (!isNode() || subItems.empty())
     {
         return false;
     }


### PR DESCRIPTION
Port of mft commit `282640d66bd2815ac6ebd94f7f26f59d5a48ef34` (Issue 5233551),
the `mft_4_35_0_vr` counterpart of the fix.

mlxreg crashed when accessing a register whose external layout has no fields,
such as MN2NS. `_AdbInstance_impl::containsDynamicArray()` called
`subItems.back()` on an empty `subItems` vector; the guard now also returns
false for nodes with no sub-items.

MFT Commit: 282640d66bd2815ac6ebd94f7f26f59d5a48ef34

Tested flows (on the mft side):
- MN2NS get no longer crashes, offline and on device
- MN2NS show_reg exits successfully, with and without --advanced
- PAOS get and set on device unchanged
- Dynamic-array registers produce unchanged buffers (PAOS, MCDA, MGIR)