### PR TITLE
[adb_parser] instance traverse, skip empty nodes

### DIFF
--- a/adb_parser/adb_parser.cpp
+++ b/adb_parser/adb_parser.cpp
@@ -1492,6 +1492,7 @@ void _Adb_impl<eval_expr, T_OFFSET>::traverse_layout(
             _trvrs_handle_enums(instance, element_path, element_offset_shift, buffer, func, context);
         }
         // Handle nodes with sub-items (structs/unions) - similar to field.subItems handling
+
         else if (instance->isNode() && !instance->subItems.empty())
         {
             // For unions, handle selected items (simplified version of _get_union_selected_items)
@@ -1548,7 +1549,7 @@ void _Adb_impl<eval_expr, T_OFFSET>::traverse_layout(
             }
         }
         // Handle leaf fields - similar to the final else clause in _parse_seg_field
-        else
+        else if (instance->isLeaf())
         {
             T_OFFSET field_offset = instance->offset + element_offset_shift;
             uint64_t value = 0;


### PR DESCRIPTION
Description:

Before the fix, nodes with zero fields were treated like fields. So the traversal tried to read from the buffer the size of the node which can be more than 32bit which is the maximal field size. That causes a segmentation fault, since the buffer handling functions doesn't build on that size.

MSTFlint port needed: Yes
Tested OS:
Tested devices:
Tested flows:

Known gaps (with RM ticket):

Issue: None

MFT Commit: 5211e10eec18c9eb60f0e23ccae6cfda61b82a92