### PR TITLE
[mtcr] Read iCMD register addresses from the device properties API

### DIFF
--- a/mft_core/mft_core_utils/mft_exceptions/Makefile.am
+++ b/mft_core/mft_core_utils/mft_exceptions/Makefile.am
@@ -39,4 +39,7 @@ noinst_LTLIBRARIES = libmftexceptions.la
 libmftexceptions_la_SOURCES = MftGeneralException.h MftGeneralException.cpp DevicePropertyNotFoundException.h
 
 libmftexceptions_la_DEPENDENCIES = ../operating_system_api/lib_os_api.la
-libmftexceptions_la_LIBADD = $(LIBSTD_CPP_SO) $(libmftexceptions_la_DEPENDENCIES)
+# lib_os_api stays in _DEPENDENCIES for build ordering only. Embedding it here
+# too would place its objects in both libmftexceptions.a and liblogger.a, and a
+# convenience library that pulls in both then ends up with duplicate symbols.
+libmftexceptions_la_LIBADD = $(LIBSTD_CPP_SO)

--- a/mtcr_ul/Makefile.am
+++ b/mtcr_ul/Makefile.am
@@ -47,7 +47,7 @@ libmtcr_ul_la_SOURCES = mtcr_ul.c mtcr_ib.h  mtcr_int_defs.h\
 			fwctrl.c fwctrl.h fwctrl_ioctl.h \
 			mtcr_gpu.c mtcr_gpu.h
 libmtcr_ul_la_CFLAGS = -W -Wall -g -MP -MD -fPIC -DMTCR_API="" -DMST_UL
-libmtcr_ul_la_DEPENDENCIES = 
+libmtcr_ul_la_DEPENDENCIES = $(top_builddir)/mft_core/device/device_info/libdevice_info.la
 
 if ENABLE_INBAND
 libmtcr_ul_la_SOURCES += mtcr_ib_ofed.c

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -47,6 +47,7 @@
 #include "mtcr_ib_res_mgt.h"
 #endif
 #include "tools_dev_types.h"
+#include "mft_core/device/device_info/device_properties_api.h"
 
 #include "mtcr_mem_ops.h"
 #include "mtcr_ul_com.h"
@@ -59,56 +60,21 @@
 /* _DEBUG_MODE   // un-comment this to enable debug prints */
 
 #define ICMD_DEFAULT_TIMEOUT 10000
+/* Kept for the devices that are not described by the device-properties
+   catalog: ConnectIB and the Amos gearbox. Every other device takes these
+   values from the catalog. */
 #define STAT_CFG_NOT_DONE_ADDR_CIB 0xb0004
-#define STAT_CFG_NOT_DONE_ADDR_CX4 0xb0004
-#define STAT_CFG_NOT_DONE_ADDR_SW_IB 0x80010
-#define STAT_CFG_NOT_DONE_ADDR_QUANTUM 0x100010
-#define STAT_CFG_NOT_DONE_ADDR_CX5 0xb5e04
 #define STAT_CFG_NOT_DONE_ADDR_CX6 0xb5f04
-#define STAT_CFG_NOT_DONE_ADDR_CX7 0xb5f04
-#define STAT_CFG_NOT_DONE_ADDR_CX8 656132
-#define STAT_CFG_NOT_DONE_ADDR_GPU 0x3100010
 #define STAT_CFG_NOT_DONE_BITOFF_CIB 31
-#define STAT_CFG_NOT_DONE_BITOFF_CX4 31
-#define STAT_CFG_NOT_DONE_BITOFF_SW_IB 0
 #define STAT_CFG_NOT_DONE_BITOFF_CX5 31
-#define STAT_CFG_NOT_DONE_BITOFF_CX7 31
-#define SEMAPHORE_ADDR_CIB 0xe27f8   /* sem62 */
-#define SEMAPHORE_ADDR_CX4 0xe250c   /* sem67 bit31 is the semaphore bit here (only one semaphore in this dword) */
-#define SEMAPHORE_ADDR_SW_IB 0xa24f8 /* sem 62 */
-#define SEMAPHORE_ADDR_QUANTUM 0xa68f8
-#define SEMAPHORE_ADDR_QUANTUM2 0xa52f8
-#define SEMAPHORE_ADDR_QUANTUM3 0xa52f8 /* 0x25b */
-#define SEMAPHORE_ADDR_NVLINK6_SWITCH 0x1550f8 /* 0x278 */
-#define SEMAPHORE_ADDR_GB100 0xa52f8
-#define SEMAPHORE_ADDR_CX5 0xe74e0
-#define SEMAPHORE_ADDR_CX7 0xe5660
-#define SEMAPHORE_ADDR_CX8 358016
-#define SEMAPHORE_ADDR_GPU 0x308F4F8
-#define SEMAPHORE_ADDR_GR100 0x30938F8
+#define SEMAPHORE_ADDR_CIB 0xe27f8 /* sem62 */
+#define SEMAPHORE_ADDR_CX4 0xe250c /* sem67 bit31 is the semaphore bit here (only one semaphore in this dword) */
 #define HCR_ADDR_CIB 0x0
-#define HCR_ADDR_CX4 HCR_ADDR_CIB
-#define HCR_ADDR_CX5 HCR_ADDR_CIB
-#define HCR_ADDR_CX7 HCR_ADDR_CIB
-#define HCR_ADDR_SW_IB 0x80000
-#define HCR_ADDR_QUANTUM 0x100000
-#define HCR_ADDR_GPU 0x3100044
 #define ICMD_VERSION_BITOFF 24
-#define ICMD_VERSION_BITOFF_GPU 0
 #define ICMD_VERSION_BITLEN 8
-#define ICMD_VERSION_BITLEN_CX8 4
 #define CMD_PTR_ADDR_CIB 0x0
-#define CMD_PTR_ADDR_SW_IB 0x80000
-#define CMD_PTR_ADDR_QUANTUM 0x100000
-#define CMD_PTR_ADDR_CX4 CMD_PTR_ADDR_CIB
-#define CMD_PTR_ADDR_CX5 CMD_PTR_ADDR_CIB
-#define CMD_PTR_ADDR_CX7 CMD_PTR_ADDR_CIB
-#define CMD_PTR_ADDR_CX8 27262976
-#define CMD_PTR_ADDR_GPU 0x3100000
 #define CMD_PTR_BITOFF 0
 #define CMD_PTR_BITLEN 24
-#define CMD_PTR_BITLEN_CX8 28
-#define CMD_PTR_BITLEN_GPU 32
 #define CTRL_OFFSET 0x3fc
 #define BUSY_BITOFF 0
 #define BUSY_BITLEN 1
@@ -290,41 +256,12 @@ enum
 
 /***********************************************
  *
- *  get correct addresses for : STAT_CCFG_NOT_DONE_ADDR, SEMAPHORE_ADDR, HCR_ADDR, CMD_PTR_ADDR
- *  according to Hw devid
+ *  STAT_CCFG_NOT_DONE_ADDR, SEMAPHORE_ADDR, HCR_ADDR and CMD_PTR_ADDR are read
+ *  from the device-properties catalog. Only the two devices that are absent
+ *  from it are still matched by HW devid here.
  */
 
-#define HW_ID_ADDR 0xf0014
 #define CIB_HW_ID 511
-#define CX4_HW_ID 521
-#define CX4LX_HW_ID 523
-#define CX5_HW_ID 525
-#define CX6_HW_ID 527
-#define CX6DX_HW_ID 530
-#define CX6LX_HW_ID 534
-#define CX7_HW_ID 536
-#define CX8_HW_ID 542
-#define CX9_HW_ID 548
-#define CX8_PURE_PCIE_SWITCH_HW_ID 546
-#define CX9_PURE_PCIE_SWITCH_HW_ID 552
-#define BF_HW_ID 529
-#define BF2_HW_ID 532
-#define BF3_HW_ID 540
-#define BF4_HW_ID 544
-#define SW_IB_HW_ID 583
-#define SW_EN_HW_ID 585
-#define SW_IB2_HW_ID 587
-#define QUANTUM_HW_ID 589
-#define SPECTRUM2_HW_ID 590
-#define SPECTRUM3_HW_ID 592
-#define QUANTUM2_HW_ID 599
-#define QUANTUM3_HW_ID 603 /* 0x25b */
-#define NVLINK6_SWITCH_HW_ID 632 /* 0x278 */
-#define GB100_HW_ID 0x2900
-#define GR100_HW_ID 0x3000
-#define SPECTRUM4_HW_ID 596
-#define SPECTRUM5_HW_ID 624
-#define SPECTRUM6_HW_ID 628
 #define AMOS_GBOX_HW_ID 594
 
 /***** GLOBALS *****/
@@ -1044,13 +981,40 @@ int icmd_send_command_enhanced(mfile* mf, IN int opcode, INOUT void* data, IN in
     }
 }
 
+/*
+ * Resolve the functional device id that keys the device-properties catalog, and
+ * reject the devices whose iCMD addresses cannot be looked up there: an id that
+ * is missing from the catalog would leave every address at 0 and fail later on
+ * a CR access at address 0.
+ *
+ * The catalog describes the iCMD registers only for the devices that have an
+ * iCMD gateway, so the semaphore address doubles as the presence test. It is
+ * read with the string accessor because get_property_as_* returns 0 both for a
+ * missing property and for a legitimate zero.
+ */
+static int icmd_get_catalog_device_id(mfile* mf, u_int32_t hw_id, u_int32_t* ptr_device_id)
+{
+    u_int32_t device_id = resolve_functional_device_id(hw_id, mf->rev_id, mf->pci_device_id);
+
+    if (get_property_as_cstring(device_id, PROP_SEMAPHORE_ADDRESS)[0] == '\0')
+    {
+        DBG_PRINTF("icmd: device id 0x%x has no iCMD properties in the device catalog.\n", device_id);
+        return ME_ICMD_NOT_SUPPORTED;
+    }
+
+    *ptr_device_id = device_id;
+    return ME_OK;
+}
+
 static int icmd_init_cr(mfile* mf)
 {
     int icmd_ver;
+    int prop_rc = ME_OK;
     u_int32_t hcr_address;
     u_int32_t cmd_ptr_addr;
     u_int32_t reg = 0x0;
     u_int32_t hw_id = 0x0;
+    u_int32_t device_id = 0x0;
     mf->icmd.syndrome = 0;
 
 #ifndef __FreeBSD__
@@ -1064,130 +1028,17 @@ static int icmd_init_cr(mfile* mf)
         return ME_ICMD_NOT_SUPPORTED;
     }
 
-    mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN;
-    mf->icmd.version_bit_offset = ICMD_VERSION_BITOFF;
     switch (hw_id & 0xffff)
     {
+        /* ConnectIB is not described by the device-properties catalog. */
         case (CIB_HW_ID):
             cmd_ptr_addr = CMD_PTR_ADDR_CIB;
             hcr_address = HCR_ADDR_CIB;
+            mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN;
+            mf->icmd.version_bit_offset = ICMD_VERSION_BITOFF;
             mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CIB;
             mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
             mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
-
-        case (CX4LX_HW_ID):
-        case (CX4_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX4;
-            hcr_address = HCR_ADDR_CX4;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
-
-        case (CX5_HW_ID):
-        case (BF_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX5;
-            hcr_address = HCR_ADDR_CX5;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
-
-        case (SW_IB_HW_ID):
-        case (SW_EN_HW_ID):
-        case (SW_IB2_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_SW_IB;
-            hcr_address = HCR_ADDR_SW_IB;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (QUANTUM_HW_ID):
-        case (SPECTRUM2_HW_ID):
-        case (SPECTRUM3_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
-            hcr_address = HCR_ADDR_QUANTUM;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (QUANTUM2_HW_ID):
-        case (SPECTRUM4_HW_ID):
-        case (SPECTRUM5_HW_ID):
-        case (SPECTRUM6_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_QUANTUM;
-            hcr_address = HCR_ADDR_QUANTUM;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_QUANTUM2;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (QUANTUM3_HW_ID):
-            cmd_ptr_addr = 0x200000;
-            hcr_address = 0x200000;
-            mf->icmd.semaphore_addr = 0x1550f8;
-            mf->icmd.static_cfg_not_done_addr = 0x200010;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (NVLINK6_SWITCH_HW_ID):
-            cmd_ptr_addr = 0x200000;
-            mf->icmd.cmd_ptr_bitlen = 24;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_NVLINK6_SWITCH;
-            mf->icmd.static_cfg_not_done_addr = 0x200010;
-            mf->icmd.static_cfg_not_done_offs = 0;
-            mf->icmd.version_bit_offset = 24;
-            mf->icmd.version_bitlen = 8;
-            hcr_address = 0x200000;
-            break;
-
-        case (GB100_HW_ID):
-        case (GR100_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_GPU;
-            hcr_address = HCR_ADDR_GPU;
-            mf->icmd.semaphore_addr = hw_id == GR100_HW_ID ? SEMAPHORE_ADDR_GR100 : SEMAPHORE_ADDR_GPU;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_GPU;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN_GPU;
-            mf->icmd.version_bit_offset = ICMD_VERSION_BITOFF_GPU;
-            break;
-
-        case (CX6_HW_ID):
-        case (CX6DX_HW_ID):
-        case (CX6LX_HW_ID):
-        case (BF2_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX5;
-            hcr_address = HCR_ADDR_CX5;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5;
-            break;
-
-        case (CX7_HW_ID):
-        case (BF3_HW_ID):
-        case (BF4_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX7;
-            hcr_address = HCR_ADDR_CX7;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX7;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX7;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
-            break;
-
-        case (CX8_HW_ID):
-        case (CX9_HW_ID):
-        case (CX8_PURE_PCIE_SWITCH_HW_ID):
-        case (CX9_PURE_PCIE_SWITCH_HW_ID):
-            cmd_ptr_addr = CMD_PTR_ADDR_CX8;
-            mf->icmd.cmd_ptr_bitlen = CMD_PTR_BITLEN_CX8;
-            mf->icmd.semaphore_addr = SEMAPHORE_ADDR_CX8;
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX8;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
-            mf->icmd.version_bit_offset = CMD_PTR_BITLEN_CX8;
-            mf->icmd.version_bitlen = ICMD_VERSION_BITLEN_CX8;
-            hcr_address = CMD_PTR_ADDR_CX8; /* hcr_address is "version address" */
             break;
 
         case (AMOS_GBOX_HW_ID):
@@ -1215,7 +1066,21 @@ static int icmd_init_cr(mfile* mf)
             break;
 
         default:
-            return ME_ICMD_NOT_SUPPORTED;
+            prop_rc = icmd_get_catalog_device_id(mf, hw_id, &device_id);
+            if (prop_rc != ME_OK)
+            {
+                return prop_rc;
+            }
+            cmd_ptr_addr = get_property_as_uint(device_id, PROP_CMD_PTR_ADDRESS);
+            /* hcr_address is the "version address" */
+            hcr_address = get_property_as_uint(device_id, PROP_VERSION_ADDRESS);
+            mf->icmd.cmd_ptr_bitlen = get_property_as_int(device_id, PROP_CMD_PTR_BITLEN);
+            mf->icmd.version_bit_offset = get_property_as_int(device_id, PROP_VERSION_BIT_OFFSET);
+            mf->icmd.version_bitlen = get_property_as_int(device_id, PROP_VERSION_BITLEN);
+            mf->icmd.semaphore_addr = get_property_as_int(device_id, PROP_SEMAPHORE_ADDRESS);
+            mf->icmd.static_cfg_not_done_addr = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
+            mf->icmd.static_cfg_not_done_offs = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_OFFSET);
+            break;
     }
     mf->icmd.max_cmd_size = ICMD_MAX_CMD_SIZE;
     icmd_ver = get_version(mf, hcr_address);
@@ -1257,7 +1122,9 @@ static int icmd_init_cr(mfile* mf)
 
 static int icmd_init_vcr_crspace_addr(mfile* mf)
 {
+    int rc = ME_OK;
     u_int32_t hw_id = 0x0;
+    u_int32_t device_id = 0x0;
 
     /* get device specific addresses */
     if (read_device_id(mf, &hw_id) != 4)
@@ -1267,70 +1134,27 @@ static int icmd_init_vcr_crspace_addr(mfile* mf)
 
     switch (hw_id & 0xffff)
     {
+        /* ConnectIB is not described by the device-properties catalog. */
         case (CIB_HW_ID):
             mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CIB;
             mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
             break;
 
-        case (CX4LX_HW_ID):
-        case (CX4_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX4;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
-
-        case (CX5_HW_ID):
-        case (BF_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX5;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CIB;
-            break;
-
-        case (SW_IB_HW_ID):
-        case (SW_EN_HW_ID):
-        case (SW_IB2_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_SW_IB;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (QUANTUM_HW_ID):
-        case (SPECTRUM2_HW_ID):
-        case (SPECTRUM3_HW_ID):
-        case (QUANTUM2_HW_ID):
-        case (QUANTUM3_HW_ID):
-        case (NVLINK6_SWITCH_HW_ID):
-        case (GB100_HW_ID):
-        case (SPECTRUM4_HW_ID):
-        case (SPECTRUM5_HW_ID):
-        case (SPECTRUM6_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_QUANTUM;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_SW_IB;
-            break;
-
-        case (CX6_HW_ID):
-        case (CX6DX_HW_ID):
-        case (CX6LX_HW_ID):
-        case (BF2_HW_ID):
-        case (BF3_HW_ID):
-        case (CX7_HW_ID):
-        case (BF4_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5; /* same bit offset as CX5 */
-            break;
-
-        case (CX8_HW_ID):
-        case (CX8_PURE_PCIE_SWITCH_HW_ID):
-        case (CX9_HW_ID):
-        case (CX9_PURE_PCIE_SWITCH_HW_ID):
-            mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX8;
-            mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX7;
-            break;
-
+        /* The gearbox reuses the CX6 address, it has no catalog entry of its own. */
         case (AMOS_GBOX_HW_ID):
             mf->icmd.static_cfg_not_done_addr = STAT_CFG_NOT_DONE_ADDR_CX6;
             mf->icmd.static_cfg_not_done_offs = STAT_CFG_NOT_DONE_BITOFF_CX5; /* same bit offset as CX5 */
             break;
 
         default:
-            return ME_ICMD_NOT_SUPPORTED;
+            rc = icmd_get_catalog_device_id(mf, hw_id, &device_id);
+            if (rc != ME_OK)
+            {
+                return rc;
+            }
+            mf->icmd.static_cfg_not_done_addr = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
+            mf->icmd.static_cfg_not_done_offs = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_OFFSET);
+            break;
     }
     return ME_OK;
 }


### PR DESCRIPTION
Description:
Both iCMD init paths matched the HW device id in a switch to pick the command-pointer, version, semaphore and static-cfg-not-done addresses. Those values are already in the device properties catalog, so read them from there and drop the per-device defines. ConnectIB and the Amos gearbox keep explicit cases: the first has no catalog entry, the second discovers its gateway base at runtime.

All addresses match the old constants except Spectrum6, which was wrongly grouped with Quantum2. The catalog values are taken, matching MFT.

libmftexceptions no longer embeds lib_os_api: liblogger embeds it too, so libdevice_info ended up with two copies and libmtcr_ul failed to link.

Tested OS: Linux (x86_64 build)
Tested devices: n/a
Tested flows: n/a

Known gaps (with RM ticket): not exercised on hardware