### PR TITLE
[mtcr] Support PCI domain larger than 16 bits

### DIFF
--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -214,9 +214,9 @@ int hot_reset(mfile* mf, int in_parallel,
               int domain_2, int bus_2,
               int device_2, int function_2);
 
-void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func);
+void set_fwctl_dev(char* fwctl_dev, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func);
 
-void open_fwctl_dev(mfile* mf, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func);
+void open_fwctl_dev(mfile* mf, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func);
 
 #ifdef __cplusplus
 }

--- a/include/mtcr_ul/mtcr_com_defs.h
+++ b/include/mtcr_ul/mtcr_com_defs.h
@@ -118,6 +118,8 @@ typedef long long int64_t;
 #endif /* ifdef __WIN__ */
 
 #define DEV_NAME_SZ 512
+/* "dddddddd:bb:dd.f" - the PCI domain is 32 bits, so up to 8 hex digits. */
+#define PCI_DBDF_STR_SZ 20
 #define MAX_PAGES_SIZE 8
 #define SMP_SEMAPHOE_LOCK_CMD 0xff53
 #define ADDRESS_OUT_OF_RANGE 0x3 /* syndrome_code value */
@@ -396,7 +398,7 @@ typedef enum
 typedef struct vf_info_t
 {
     char dev_name[512];
-    u_int16_t domain;
+    u_int32_t domain;
     u_int8_t bus;
     u_int8_t dev;
     u_int8_t func;
@@ -414,7 +416,7 @@ typedef struct dev_info_t
     {
         struct
         {
-            u_int16_t domain;
+            u_int32_t domain;
             u_int8_t bus;
             u_int8_t dev;
             u_int8_t func;

--- a/mst_utils/mdevices_info.c
+++ b/mst_utils/mdevices_info.c
@@ -56,6 +56,10 @@
 #define BUF_MAX 4096
 #define MAX_NET_DEVS_DISPLAY 5
 #define MAX_PCI_INFO_LENGTH 16384
+#define MST_WIDTH_UL_MODE 9
+#define MST_WIDTH_KERNEL_MODE 30
+#define PCI_WIDTH_WITH_DOMAIN 16
+#define PCI_WIDTH_NO_DOMAIN 10
 
 #ifdef __FreeBSD__
 mfile* mopen_ul(const char* name)
@@ -311,6 +315,18 @@ int get_max_net_column_width(dev_info* devs, int len)
     return max_width + 1; // +1 for space
 }
 
+/* Single source for the PCI address text, so the column width and the printed
+ * value can never disagree. Returns the length written, as snprintf does. */
+static int format_pci_addr(char* buf, size_t size, const dev_info* dev, int domain_needed)
+{
+    if (domain_needed)
+    {
+        return snprintf(buf, size, "%04x:%02x:%02x.%x", dev->pci.domain, dev->pci.bus, dev->pci.dev, dev->pci.func);
+    }
+
+    return snprintf(buf, size, "%02x:%02x.%x", dev->pci.bus, dev->pci.dev, dev->pci.func);
+}
+
 void find_all_fwctl_devices(dev_info* devs, int dev_count)
 {
 #ifdef __linux__
@@ -318,7 +334,7 @@ void find_all_fwctl_devices(dev_info* devs, int dev_count)
     struct dirent* ent;
     char device_path[PATH_MAX];
     char absolute_device_path[PATH_MAX];
-    char pci_addr[32];
+    char pci_addr[PCI_DBDF_STR_SZ];
     int i;
     int idx;
 
@@ -373,7 +389,7 @@ void find_all_fwctl_devices(dev_info* devs, int dev_count)
         {
             unsigned int domain, bus, dev, func;
             // Parse PCI address (format: DDDD:BB:DD.F)
-            if (sscanf(pci_name, "%x:%x:%x.%x", &domain, &bus, &dev, &func) == 4)
+            if (sscanf(pci_name, "%8x:%x:%x.%x", &domain, &bus, &dev, &func) == 4)
             {
                 snprintf(pci_addr, sizeof(pci_addr), "%04x:%02x:%02x.%x", domain, bus, dev, func);
                 // printf("find_all_fwctl_devices: Extracted PCI address: %s\n", pci_addr);
@@ -382,8 +398,8 @@ void find_all_fwctl_devices(dev_info* devs, int dev_count)
                 {
                     if (devs[i].type == MDEVS_TAVOR_CR)
                     {
-                        char dev_pci_addr[32];
-                        snprintf(dev_pci_addr, sizeof(dev_pci_addr), "%04x:%02x:%02x.%x", devs[i].pci.domain, devs[i].pci.bus, devs[i].pci.dev, devs[i].pci.func);
+                        char dev_pci_addr[PCI_DBDF_STR_SZ];
+                        format_pci_addr(dev_pci_addr, sizeof(dev_pci_addr), &devs[i], 1);
 
                         if (strcmp(dev_pci_addr, pci_addr) == 0)
                         {
@@ -429,22 +445,45 @@ void find_fwctl_device(dev_info* dev)
     find_all_fwctl_devices(dev, 1);
 }
 
-void print_pci_info(dev_info* dev, int domain_needed, mfile* mf, int net_width)
+/* Calculate the PCI column width. A domain wider than 4 hex digits overflows the
+ * legacy fixed column, so grow it to the widest domain actually present; the
+ * legacy widths are the floor, keeping single-domain output byte-identical. */
+static int get_pci_column_width(dev_info* devs, int len, int domain_needed)
 {
-    char dbdf[MAX_PCI_INFO_LENGTH] = {0};
+    char dbdf[PCI_DBDF_STR_SZ];
+    int max_width = PCI_WIDTH_WITH_DOMAIN;
+    int i;
+
+    if (!domain_needed)
+    {
+        return PCI_WIDTH_NO_DOMAIN;
+    }
+
+    for (i = 0; i < len; i++)
+    {
+        if (devs[i].type != MDEVS_TAVOR_CR)
+        {
+            continue;
+        }
+
+        int width = format_pci_addr(dbdf, sizeof(dbdf), &devs[i], 1) + 1; /* +1 for space */
+        if (width > max_width)
+        {
+            max_width = width;
+        }
+    }
+
+    return max_width;
+}
+
+void print_pci_info(dev_info* dev, int domain_needed, mfile* mf, int pci_width, int net_width)
+{
+    char dbdf[PCI_DBDF_STR_SZ] = {0};
     char fmt[MAX_PCI_INFO_LENGTH] = {0};
 
     /* Add PCI info */
-    if (domain_needed)
-    {
-        sprintf(dbdf, "%04x:%02x:%02x.%x", dev->pci.domain, dev->pci.bus, dev->pci.dev, dev->pci.func);
-        printf("%-16s", dbdf);
-    }
-    else
-    {
-        sprintf(dbdf, "%02x:%02x.%x", dev->pci.bus, dev->pci.dev, dev->pci.func);
-        printf("%-10s", dbdf);
-    }
+    format_pci_addr(dbdf, sizeof(dbdf), dev, domain_needed);
+    printf("%-*s", pci_width, dbdf);
 
     int hasIB = fmt_ib_dev(dev, fmt);
     // Initialize the net_buf for seperating the net devices from the rdma bond device prints
@@ -639,91 +678,30 @@ int main(int argc, char** argv)
 #ifndef __FreeBSD__
         ul_mode = devs[0].ul_mode;
 #endif
+        int mst_width = ul_mode ? MST_WIDTH_UL_MODE : MST_WIDTH_KERNEL_MODE;
+        int pci_width = get_pci_column_width(devs, len, domain_needed);
         int net_width = 0;
         if (verbose)
         {
             // Calculate dynamic NET column width
             net_width = get_max_net_column_width(devs, len);
-            if (domain_needed)
-            {
-                if (ul_mode)
-                {
-                    printf("%-24s%-9s%-16s%-16s%-*s%-6s%-18s%-25s%-12s\n",
-                           "DEVICE_TYPE",
-                           "MST",
-                           "PCI",
-                           "RDMA",
-                           net_width,
-                           "NET",
-                           "NUMA",
+            printf("%-24s%-*s%-*s%-16s%-*s%-6s%-18s%-25s%-12s\n",
+                   "DEVICE_TYPE",
+                   mst_width,
+                   "MST",
+                   pci_width,
+                   "PCI",
+                   "RDMA",
+                   net_width,
+                   "NET",
+                   "NUMA",
 #ifdef ENABLE_VFIO
-                           "VFIO",
+                   "VFIO",
 #else
-                           "",
+                   "",
 #endif
-                           "FWCTL",
-                           "STATE");
-                }
-                else
-                {
-                    printf("%-24s%-30s%-16s%-16s%-*s%-6s%-18s%-25s%-12s\n",
-                           "DEVICE_TYPE",
-                           "MST",
-                           "PCI",
-                           "RDMA",
-                           net_width,
-                           "NET",
-                           "NUMA",
-#ifdef ENABLE_VFIO
-                           "VFIO",
-#else
-                           "",
-#endif
-                           "FWCTL",
-                           "STATE");
-                }
-                /* printf("%-30s%-16s%-16s%-8s%-20s\n", "---", "-----------", "---", "----", "---"); */
-            }
-            else
-            {
-                if (ul_mode)
-                {
-                    printf("%-24s%-9s%-10s%-16s%-*s%-6s%-18s%-25s%-12s\n",
-                           "DEVICE_TYPE",
-                           "MST",
-                           "PCI",
-                           "RDMA",
-                           net_width,
-                           "NET",
-                           "NUMA",
-#ifdef ENABLE_VFIO
-                           "VFIO",
-#else
-                           "",
-#endif
-                           "FWCTL",
-                           "STATE");
-                }
-                else
-                {
-                    printf("%-24s%-30s%-10s%-16s%-*s%-6s%-18s%-25s%-12s\n",
-                           "DEVICE_TYPE",
-                           "MST",
-                           "PCI",
-                           "RDMA",
-                           net_width,
-                           "NET",
-                           "NUMA",
-#ifdef ENABLE_VFIO
-                           "VFIO",
-#else
-                           "",
-#endif
-                           "FWCTL",
-                           "STATE");
-                }
-                /* printf("%-30s%-16s%-10s%-8s%-20s\n", "---", "-----------", "---", "----", "---"); */
-            }
+                   "FWCTL",
+                   "STATE");
         }
 
         /* dev_lst = devs; */
@@ -772,19 +750,19 @@ int main(int argc, char** argv)
                         printf("%-24s", dev_type);
                         if (ul_mode)
                         {
-                            printf("%-9s", "NA");
+                            printf("%-*s", mst_width, "NA");
                         }
                         else
                         {
-                            printf("%-30s", devs[i].pci.conf_dev);
+                            printf("%-*s", mst_width, devs[i].pci.conf_dev);
                         }
-                        print_pci_info(&devs[i], domain_needed, mf, net_width);
+                        print_pci_info(&devs[i], domain_needed, mf, pci_width, net_width);
                     }
                     if (cr_exist)
                     {
                         printf("%-24s", dev_type);
-                        printf("%-30s", devs[i].pci.cr_dev);
-                        print_pci_info(&devs[i], domain_needed, mf, net_width);
+                        printf("%-*s", mst_width, devs[i].pci.cr_dev);
+                        print_pci_info(&devs[i], domain_needed, mf, pci_width, net_width);
                     }
                 }
                 else
@@ -797,32 +775,32 @@ int main(int argc, char** argv)
                         {
                             if (verbose)
                             {
-                                printf("%-9s", "NA");
+                                printf("%-*s", mst_width, "NA");
                             }
                             else
                             {
-                                printf("%-9s", devs[i].pci.cr_dev);
+                                printf("%-*s", mst_width, devs[i].pci.cr_dev);
                             }
                         }
                         else
                         {
-                            printf("%-30s", devs[i].pci.conf_dev);
+                            printf("%-*s", mst_width, devs[i].pci.conf_dev);
                         }
                     }
                     if (cr_exist)
                     {
                         if (conf_exist)
                         {
-                            print_pci_info(&devs[i], domain_needed, mf, net_width);
+                            print_pci_info(&devs[i], domain_needed, mf, pci_width, net_width);
                             printf("\n");
                         }
                         printf("%-24s", dev_type);
-                        printf("%-30s", devs[i].pci.cr_dev);
+                        printf("%-*s", mst_width, devs[i].pci.cr_dev);
                     }
 
                     if (verbose)
                     {
-                        print_pci_info(&devs[i], domain_needed, mf, net_width);
+                        print_pci_info(&devs[i], domain_needed, mf, pci_width, net_width);
                     }
                 }
                 printf("\n");

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -3297,7 +3297,7 @@ int is_zombiefish_device(mfile* mf)
     }
 }
 
-void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
+void set_fwctl_dev(char* fwctl_dev, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
 {
     (void)fwctl_dev;
     (void)domain;
@@ -3306,7 +3306,7 @@ void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev
     (void)func;
 }
 
-void open_fwctl_dev(mfile* mf, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
+void open_fwctl_dev(mfile* mf, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
 {
     (void)mf;
     (void)domain;

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -268,15 +268,15 @@ cl_clean_up:
 
 static int _extract_dbdf_from_full_name(const char* name, unsigned* domain, unsigned* bus, unsigned* dev, unsigned* func)
 {
-    if (sscanf(name, "/sys/bus/pci/devices/%4x:%2x:%2x.%d/resource0", domain, bus, dev, func) == 4)
+    if (sscanf(name, "/sys/bus/pci/devices/%8x:%2x:%2x.%d/resource0", domain, bus, dev, func) == 4)
     {
         return 0;
     }
-    else if (sscanf(name, "/sys/bus/pci/devices/%4x:%2x:%2x.%d/config", domain, bus, dev, func) == 4)
+    else if (sscanf(name, "/sys/bus/pci/devices/%8x:%2x:%2x.%d/config", domain, bus, dev, func) == 4)
     {
         return 0;
     }
-    else if (sscanf(name, "/proc/bus/pci/%4x:%2x/%2x.%d", domain, bus, dev, func) == 4)
+    else if (sscanf(name, "/proc/bus/pci/%8x:%2x/%2x.%d", domain, bus, dev, func) == 4)
     {
         return 0;
     }
@@ -1589,13 +1589,13 @@ int mtcr_pciconf_set_addr_space(mfile* mf, u_int16_t space)
     return ME_OK;
 }
 
-void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
+void set_fwctl_dev(char* fwctl_dev, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
 {
     DIR          * dir;
     struct dirent* ent;
     char           link_path[PATH_MAX];
     char           resolved_path[PATH_MAX];
-    char           dbdf[32];
+    char           dbdf[PCI_DBDF_STR_SZ];
     unsigned int   d, b, dv, f;
 
     if (!fwctl_dev) {
@@ -1627,7 +1627,7 @@ void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev
             continue;
         }
 
-        if (sscanf(pci_name, "%x:%x:%x.%x", &d, &b, &dv, &f) != 4) {
+        if (sscanf(pci_name, "%8x:%x:%x.%x", &d, &b, &dv, &f) != 4) {
             continue;
         }
 
@@ -1640,7 +1640,7 @@ void set_fwctl_dev(char* fwctl_dev, u_int16_t domain, u_int8_t bus, u_int8_t dev
     closedir(dir);
 }
 
-void open_fwctl_dev(mfile* mf, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
+void open_fwctl_dev(mfile* mf, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func)
 {
     DIR          * dir;
     struct dirent* ent;
@@ -1669,7 +1669,7 @@ void open_fwctl_dev(mfile* mf, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_i
             continue;
         }
 
-        if (sscanf(pci_name, "%x:%x:%x.%x", &d, &b, &dv, &f) != 4) {
+        if (sscanf(pci_name, "%8x:%x:%x.%x", &d, &b, &dv, &f) != 4) {
             continue;
         }
 
@@ -3059,7 +3059,7 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
 #ifdef ENABLE_VFIO
     if (is_vfio)
     {
-        scnt = sscanf(name, "vfio-%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
+        scnt = sscanf(name, "vfio-%8x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
         if (scnt != 4)
         {
             my_domain = 0;
@@ -3079,7 +3079,7 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
 
     if (CheckifKernelLockdownIsEnabled() && CheckifVfioPciDriverIsLoaded())
     {
-        scnt = sscanf(name, "%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
+        scnt = sscanf(name, "%8x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
         if (scnt != 4)
         {
             my_domain = 0;
@@ -3142,7 +3142,7 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         {
             goto parse_error;
         }
-        scnt = sscanf(base, "%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
+        scnt = sscanf(base, "%8x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
         if (scnt != 4)
         {
             goto parse_error;
@@ -3161,7 +3161,7 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         goto name_parsed;
     }
 
-    scnt = sscanf(name, "%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
+    scnt = sscanf(name, "%8x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
     if (scnt == 4)
     {
         force_config = check_force_config(my_domain, my_bus, my_dev, my_func);
@@ -3175,7 +3175,7 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         goto name_parsed;
     }
 
-    scnt = sscanf(name, "pciconf-%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
+    scnt = sscanf(name, "pciconf-%8x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
     if (scnt == 4)
     {
         force_config = 1;
@@ -3498,7 +3498,7 @@ cleanup_dir_opened:
     return ndevs;
 }
 
-static int read_pci_config_header(u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, u_int8_t data[0x40])
+static int read_pci_config_header(u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, u_int8_t data[0x40])
 {
     char proc_dev[64];
 
@@ -3542,7 +3542,7 @@ int check_force_config(unsigned my_domain, unsigned my_bus, unsigned my_dev, uns
 #define IB_INF "infiniband:"
 #define ETH_INF "net:"
 
-static char** get_ib_net_devs(int domain, int bus, int dev, int func, int ib_eth_)
+static char** get_ib_net_devs(unsigned int domain, int bus, int dev, int func, int ib_eth_)
 {
     char** ib_net_devs = NULL;
     int i;
@@ -3630,7 +3630,7 @@ mem_error:
     return NULL;
 }
 
-static int get_vf_devs(int domain, int bus, int dev, int func, char* buf, int len)
+static int get_vf_devs(unsigned int domain, int bus, int dev, int func, char* buf, int len)
 {
     int count = 0;
     DIR* physfndir;
@@ -3668,7 +3668,7 @@ static int get_vf_devs(int domain, int bus, int dev, int func, char* buf, int le
 
 #define VIRTFN_LINK_NAME_SIZE 128
 #define VIRTFN_PATH_SIZE 128
-static void read_vf_info(vf_info* virtfn_info, u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, char* virtfn)
+static void read_vf_info(vf_info* virtfn_info, u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, char* virtfn)
 {
     char linkname[VIRTFN_LINK_NAME_SIZE];
     char virtfn_path[VIRTFN_PATH_SIZE];
@@ -3702,7 +3702,7 @@ static void read_vf_info(vf_info* virtfn_info, u_int16_t domain, u_int8_t bus, u
     virtfn_info->net_devs = get_ib_net_devs(vf_domain, vf_bus, vf_dev, vf_func, 0);
 }
 
-vf_info* get_vf_info(u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, u_int16_t* len)
+vf_info* get_vf_info(u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, u_int16_t* len)
 {
     int vf_count = 0;
     char* vf_devs = NULL;
@@ -3759,7 +3759,7 @@ vf_info* get_vf_info(u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func
     return vf_arr;
 }
 
-static void get_numa_node(u_int16_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, char* data)
+static void get_numa_node(u_int32_t domain, u_int8_t bus, u_int8_t dev, u_int8_t func, char* data)
 {
     char numa_path[64];
     int c;
@@ -3835,10 +3835,10 @@ dev_info* mdevices_info_v_ul(int mask, int* len, int verbosity)
     dev_name = devs;
     for (i = 0; i < rc; i++)
     {
-        int domain = 0;
-        int bus = 0;
-        int dev = 0;
-        int func = 0;
+        unsigned int domain = 0;
+        unsigned int bus = 0;
+        unsigned int dev = 0;
+        unsigned int func = 0;
 
         dev_info_arr[i].ul_mode = 1;
         dev_info_arr[i].type = (Mdevs)MDEVS_TAVOR_CR;
@@ -3850,7 +3850,7 @@ dev_info* mdevices_info_v_ul(int mask, int* len, int verbosity)
         strncpy(dev_info_arr[i].pci.cr_dev, dev_name, sizeof(dev_info_arr[i].pci.cr_dev) - 1);
 
         /* update dbdf */
-        if (sscanf(dev_name, "%x:%x:%x.%x", &domain, &bus, &dev, &func) != 4)
+        if (sscanf(dev_name, "%8x:%x:%x.%x", &domain, &bus, &dev, &func) != 4)
         {
             rc = -1;
             len = 0;
@@ -5149,7 +5149,7 @@ int mvpd_read4_ul_int(mfile* mf, unsigned int offset, u_int8_t value[4])
     {
         return mst_driver_vpd_read4(mf, offset, value);
     }
-    u_int16_t domain = (mf->dinfo)->pci.domain;
+    u_int32_t domain = (mf->dinfo)->pci.domain;
     u_int8_t bus = (mf->dinfo)->pci.bus;
     u_int8_t dev = (mf->dinfo)->pci.dev;
     u_int8_t func = (mf->dinfo)->pci.func;


### PR DESCRIPTION
Description:
The PCI domain was stored as 16 bits and parsed with a 4-hex-digit bound, so a device above 0xFFFF (e.g. 20000:70:00.0) was missed or aliased onto one sharing the low 16 bits. Reported as issue #925.

- Widen dev_info.pci.domain and vf_info.domain to u_int32_t, and the domain parameters that carry them.
- Fix the three %4x DBDF conversions in _extract_dbdf_from_full_name; the remaining DBDF sscanf sites already parsed into unsigned, and are bounded to %8x so the input cannot overflow the field.
- mstdevices_info sizes the PCI column to the widest domain present, instead of the fixed 16-character column a wide domain overflowed. The legacy width is the floor, so output is unchanged when every domain fits in 4 digits.

The struct does not grow, but the mtcr headers change: binaries linking libmtcr_ul directly must be recompiled.

Ported from MFT.

Tested OS: Linux (x86_64 build), FreeBSD (signatures only) Tested devices: ConnectX-7, ConnectX-8, ConnectX-9 - all on domain 0 Tested flows: full tree build; mstdevices_info, -v and -vv output byte-identical before and after

Known gaps (with RM ticket): no >16-bit-domain hardware available, so the wide-domain path is not exercised on a device. mstfwreset's Python DBDF regexes and nvfwreset's HotResetManager substr parsing still assume a 4-digit domain; not touched here.