### PR TITLE
[VR] mtcr_ul: support net interface device names

### DIFF
--- a/README
+++ b/README
@@ -101,7 +101,12 @@ MSTFLINT Package - Firmware Burning and Diagnostics Tools
        # Use mstvpd tool to dump the VPD of this device
        > mstvpd mlx5_0
 
-    c) PCI configuration access
+    c) The devices can be accessed by their network interface name using the
+       net- prefix. The interface is resolved to its PCI address through sysfs.
+       Example:
+       > mstflint -d net-enp2s0 q
+
+    d) PCI configuration access
        In examples a and b above, the device is accessed via PCI Memory Mapping.
        The device can also be accessed by PCI configuration cycles.
        PCI configuration access is slower and less safe than memory access --
@@ -120,7 +125,7 @@ MSTFLINT Package - Firmware Burning and Diagnostics Tools
 
        Note: Typically, you will need root privileges for hardware access
 
-	d) Accessing a multi-function device:
+	e) Accessing a multi-function device:
 
 	   In some configuration, the CA device identifies as a multi-function device on PCI. E.G.:
 	   > /sbin/lspci -d 15b3:
@@ -142,7 +147,7 @@ MSTFLINT Package - Firmware Burning and Diagnostics Tools
 	   > mstflint -d 07:00.0 q
 
 	   When the device driver is not loaded, all the functions can be accessed using configuration cycles, as
-	   described in sub section c) above. It is recommended to use function 0 for FW update or diagnostics, E.G.:
+	   described in sub section d) above. It is recommended to use function 0 for FW update or diagnostics, E.G.:
 	   > mstflint -d /proc/bus/pci/07/00.0 q
 
 ## Usage

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -141,6 +141,7 @@ typedef enum
 #define DBDF "%4.4x:%2.2x:%2.2x.%1.1x"
 #define DRIVER_CR_NAME "/dev/" DBDF "_mstcr"
 #define DRIVER_CONF_NAME "/dev/" DBDF "_mstconf"
+#define NET_DEV_PREFIX "net-"
 
 /* Forward decl*/
 static int get_inband_dev_from_pci(char* inband_dev, char* pci_dev);
@@ -2997,6 +2998,45 @@ int change_i2c_secondary_address(mfile* mf, DType dtype)
 }
 #endif /* ifdef ENABLE_MST_DEV_I2C */
 
+/* Network interface name to PCI address.
+ * Returns 0 on success with domain/bus/dev/func populated, -1 on failure.
+ */
+static int mtcr_resolve_net_device_pci(const char* name, unsigned* domain, unsigned* bus, unsigned* dev, unsigned* func)
+{
+    char mbuf[4048] = {0};
+    char pbuf[4048] = {0};
+    char* base;
+    int r, scnt;
+
+    r = snprintf(mbuf, sizeof(mbuf) - 1, "/sys/class/net/%s/device", name);
+    if ((r <= 0) || (r >= (int)sizeof(mbuf)))
+    {
+        fprintf(stderr, "Unable to print device name %s\n", name);
+        return -1;
+    }
+
+    r = readlink(mbuf, pbuf, sizeof(pbuf) - 1);
+    if (r < 0)
+    {
+        return -1;
+    }
+    pbuf[r] = '\0';
+
+    base = basename(pbuf);
+    if (!base)
+    {
+        return -1;
+    }
+
+    scnt = sscanf(base, "%x:%x:%x.%x", domain, bus, dev, func);
+    if (scnt != 4)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
 static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, unsigned* bus_p, unsigned* dev_p, unsigned* func_p)
 {
     unsigned my_domain = 0;
@@ -3138,6 +3178,13 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         {
             force_config = 1;
         }
+        goto name_parsed;
+    }
+
+    if (!strncmp(name, NET_DEV_PREFIX, strlen(NET_DEV_PREFIX)) &&
+        mtcr_resolve_net_device_pci(name + strlen(NET_DEV_PREFIX), &my_domain, &my_bus, &my_dev, &my_func) == 0)
+    {
+        force_config = 1;
         goto name_parsed;
     }
 


### PR DESCRIPTION
## Summary
- resolve `net-<interface>` device names through `/sys/class/net/<interface>/device`
- use PCI configuration access so tools continue working after the MST driver is unloaded
- document the network-interface device-name format

VR port of #1898. Ports MFT commit `18c4de8c905601098219c3d7af5c53f4aa64519e` (issue 5176907).

## Test plan
- [x] Build the VR branch from a clean checkout on Ubuntu 24.04
- [x] Run `make check`