### PR TITLE
[build] Fix FreeBSD build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -764,12 +764,17 @@ AM_CONDITIONAL([USE_LOCAL_INIPARSER], [test "$INIPARSER_SYSTEM_AVAILABLE" = no])
 AS_IF([test "x$INIPARSER_SYSTEM_AVAILABLE" = "xyes" ], [
     CXXFLAGS="$CXXFLAGS -DHAVE_INI_PARSER"])
 
-PKG_CHECK_MODULES([JSON], [jsoncpp], [JSON_SYSTEM_AVAILABLE="yes"],[
-    JSON_SYSTEM_AVAILABLE="no"
-    JSON_CFLAGS='-I$(top_srcdir)/ext_libs/json'
-    AC_SUBST(JSON_CFLAGS)
-    JSON_LIBS='$(top_builddir)/ext_libs/json/libjson.la'
-    AC_SUBST(JSON_LIBS)])
+# mtcr uses ceilf, so every program needs -lm. Without this the FreeBSD build fails.
+AC_SEARCH_LIBS([ceilf], [m])
+
+# Always use the jsoncpp copy in ext_libs/json. The tools are linked -static and
+# no package declares a jsoncpp dependency, so linking a system libjsoncpp would
+# leave a runtime dependency nothing installs.
+JSON_SYSTEM_AVAILABLE="no"
+JSON_CFLAGS='-I$(top_srcdir)/ext_libs/json'
+AC_SUBST(JSON_CFLAGS)
+JSON_LIBS='$(top_builddir)/ext_libs/json/libjson.la'
+AC_SUBST(JSON_LIBS)
 AM_CONDITIONAL([USE_LOCAL_JSON], [test "$JSON_SYSTEM_AVAILABLE" = no])
 
 AC_SEARCH_LIBS([mupCreateVar], [muparser], [MUPARSER_SYSTEM_AVAILABLE="yes"],[

--- a/efuse/Makefile.am
+++ b/efuse/Makefile.am
@@ -56,9 +56,8 @@ mstefuse_DEPENDENCIES = \
     $(top_builddir)/common/libcommon.la \
     $(top_builddir)/mft_core/mft_core_utils/operating_system_api/lib_os_api.la \
     $(top_builddir)/mft_core/mft_core_utils/logger/liblogger.la \
-    $(top_builddir)/mft_core/mft_core_utils/mft_exceptions/libmftexceptions.la \
-    $(JSON_LIBS)
+    $(top_builddir)/mft_core/mft_core_utils/mft_exceptions/libmftexceptions.la
 
-mstefuse_LDADD = $(mstefuse_DEPENDENCIES) -lm ${LDL}
+mstefuse_LDADD = $(mstefuse_DEPENDENCIES) $(JSON_LIBS) -lm ${LDL}
 
 mstefuse_LDFLAGS = -static

--- a/mlxconfig/Makefile.am
+++ b/mlxconfig/Makefile.am
@@ -82,11 +82,10 @@ libmlxcfg_la_DEPENDENCIES = \
     $(top_builddir)/dev_mgt/libdev_mgt.la \
     $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
     $(top_builddir)/tools_res_mgmt/libtools_res_mgmt.la \
-    $(JSON_LIBS) \
     $(MUPARSER_LIBS) \
     $(SQLITE_LIBS)
 
-libmlxcfg_la_LIBADD = $(libmlxcfg_la_DEPENDENCIES) ${LDL}
+libmlxcfg_la_LIBADD = $(libmlxcfg_la_DEPENDENCIES) $(JSON_LIBS) ${LDL}
 
 mstconfig_DEPENDENCIES = \
     libmlxcfg.la \

--- a/mlxfwupdate/Makefile.am
+++ b/mlxfwupdate/Makefile.am
@@ -109,7 +109,6 @@ mstfwmanager_DEPENDENCIES = \
     $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
     $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la \
     $(top_builddir)/common/libcommon.la \
-    $(JSON_LIBS) \
     $(INIPARSER_LIBS) \
     $(MUPARSER_LIBS) \
     $(SQLITE_LIBS)
@@ -135,5 +134,5 @@ mstfwmanager_CXXFLAGS += -DENABLE_DPA
 mstfwmanager_DEPENDENCIES += $(top_builddir)/mlxdpa/libmstdpa.a
 endif
 
-mstfwmanager_LDADD = $(mstfwmanager_DEPENDENCIES) $(LDADD_mstfwmanager)
+mstfwmanager_LDADD = $(mstfwmanager_DEPENDENCIES) $(JSON_LIBS) $(LDADD_mstfwmanager)
 mstfwmanager_LDFLAGS = -static

--- a/mlxlink/Makefile.am
+++ b/mlxlink/Makefile.am
@@ -68,9 +68,8 @@ mstlink_DEPENDENCIES = \
     $(top_builddir)/reg_access/libreg_access.la \
     $(top_builddir)/mft_core/mft_core_utils/operating_system_api/lib_os_api.la \
     $(top_builddir)/mft_core/mft_core_utils/logger/liblogger.la \
-    $(top_builddir)/mft_core/mft_core_utils/mft_exceptions/libmftexceptions.la \
-    $(JSON_LIBS)
+    $(top_builddir)/mft_core/mft_core_utils/mft_exceptions/libmftexceptions.la
 
-mstlink_LDADD = $(mstlink_DEPENDENCIES) $(liblzma_LIBS) ${LDL} $(expat_LIBS)
+mstlink_LDADD = $(mstlink_DEPENDENCIES) $(JSON_LIBS) $(liblzma_LIBS) ${LDL} $(expat_LIBS)
 
 mstlink_LDFLAGS = -static

--- a/mlxtokengenerator/Makefile.am
+++ b/mlxtokengenerator/Makefile.am
@@ -67,7 +67,6 @@ msttokengenerator_DEPENDENCIES = \
 							    $(top_builddir)/dev_mgt/libdev_mgt.la \
                                 $(top_builddir)/fw_comps_mgr/libfw_comps_mgr.la \
                                 $(SQLITE_LIBS) \
-                                $(JSON_LIBS) \
                                 $(top_builddir)/${MTCR_CONF_DIR}/libmtcr_ul.la
 
 if ENABLE_DPA
@@ -86,7 +85,7 @@ msttokengenerator_DEPENDENCIES += \
     $(top_builddir)/ext_libs/minixz/libminixz.la
 endif
 
-msttokengenerator_LDADD = $(msttokengenerator_DEPENDENCIES) ${LDL}
+msttokengenerator_LDADD = $(msttokengenerator_DEPENDENCIES) $(JSON_LIBS) ${LDL}
 
 if DISABLE_XML2
 AM_CXXFLAGS += -DDISABLE_XML2

--- a/mtcr_freebsd/Makefile.am
+++ b/mtcr_freebsd/Makefile.am
@@ -70,6 +70,10 @@ if ENABLE_INBAND
 libmtcr_ul_la_SOURCES += $(top_srcdir)/mtcr_ul/mtcr_ib_ofed.c
 endif
 
+libmtcr_ul_la_DEPENDENCIES = $(top_builddir)/mft_core/device/device_info/libdevice_info.la
+
+libmtcr_ul_la_LIBADD = $(libmtcr_ul_la_DEPENDENCIES)
+
 libraryincludedir=$(includedir)/mstflint
 
 libraryinclude_HEADERS = \


### PR DESCRIPTION
Description:
Three separate FreeBSD link failures.

66b2ca1a switched jsoncpp detection to PKG_CHECK_MODULES, which on FreeBSD yields JSON_LIBS="-L/usr/local/lib -ljsoncpp". Five Makefile.am files listed $(JSON_LIBS) in *_DEPENDENCIES, which automake emits as make prerequisites, so make looked for a file named -L/usr/local/lib. Move $(JSON_LIBS) into _LIBADD/_LDADD, leaving link order unchanged. Also drop the jsoncpp probe and always use the copy in ext_libs/json: the probe searched for a symbol named JSON so it never succeeded, and the tools link -static with no package declaring a jsoncpp dependency.

mtcr_freebsd did not link libdevice_info, so mtcr_ul_icmd_cif.c left resolve_functional_device_id and the get_property_as_* helpers undefined. mtcr_ul/Makefile.am already links it for Linux.

With libdevice_info linked in, device_properties_api.cpp then needs ceilf from libm. It arrives through mtcr, a convenience library, and those drop -l flags from their LIBADD, so -lm has to reach every final link line.

Tested OS: Linux (x86_64), FreeBSD
Tested flows: compilation on freebsd setup

Issue: 5239232