### PR TITLE
[VR] Port BF4 OCR and 2184 GUID support

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1519,9 +1519,9 @@ bool SubCommand::extractValuesFromString(string valStr, u_int16_t values[2], str
     }
 
     // perform checks
-    if (tempValues[0] > 1024 || tempValues[1] > 1024)
+    if (tempValues[0] > 2184 || tempValues[1] > 2184)
     {
-        reportErr(true, "Invalid argument values for %s, values can't be larger than 1024.\n", origArg.c_str());
+        reportErr(true, "Invalid argument values for %s, values can't be larger than 2184.\n", origArg.c_str());
         return false;
     }
     values[0] = tempValues[0];

--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -3344,6 +3344,12 @@ int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params
         u_int32_t chip_rev;
         rc = dm_get_device_id((*pmfl)->mf, &((*pmfl)->dm_dev_id), &dev_id, &chip_rev);
         CHECK_RC(rc);
+
+        /* BlueField4 uses ConnectX9 flash parameters. */
+        if ((*pmfl)->dm_dev_id == DeviceBlueField4)
+        {
+            (*pmfl)->dm_dev_id = DeviceConnectX9;
+        }
     }
     else if (access_type == MFAT_UEFI)
     {


### PR DESCRIPTION
## Summary
- Backport the 2184 GUID-count limit required by Chameleon 5/6 verification.
- Map BlueField-4 to ConnectX-9 flash parameters so OCR hardware queries can open the device.
- Track the work in [MFT issue 5242110](https://redmine.nvidia.com/issues/5242110) and [mstflint issue 5242114](https://redmine.nvidia.com/issues/5242114).

## Test plan
- [x] Build the current `mstflint_4_35_0_VR` branch successfully with autotools on the aarch64 `MFT-sv-strata-02` host.
- [x] Verify `guids_num=2184` passes argument validation and reaches device opening.
- [x] Verify `guids_num=2185` is rejected with the 2184-limit message.
- [x] Verify BF4 `-ocr hw query` exits 0 and reports the 64 MiB IS25LPxxx flash.