### PR TITLE
[mflash][BF4] Fix OCR flash access

### DIFF
--- a/mflash/mflash.c
+++ b/mflash/mflash.c
@@ -3454,6 +3454,12 @@ int mf_opend_int(mflash** pmfl, void* access_dev, int num_of_banks, flash_params
         u_int32_t chip_rev;
         rc = dm_get_device_id((*pmfl)->mf, &((*pmfl)->dm_dev_id), &dev_id, &chip_rev);
         CHECK_RC(rc);
+
+        /* BlueField4 uses ConnectX9 flash parameters. */
+        if ((*pmfl)->dm_dev_id == DeviceBlueField4)
+        {
+            (*pmfl)->dm_dev_id = DeviceConnectX9;
+        }
     }
     else if (access_type == MFAT_UEFI)
     {


### PR DESCRIPTION
## Summary
- Treat BlueField-4 as ConnectX-9 when selecting flash parameters for MFILE/OCR access.
- Port the verified internal MFT fix `1acf3bd7c8b` as explicitly requested by that commit.
- Track the work in [mstflint issue 5242114](https://redmine.nvidia.com/issues/5242114) and upstream issue 4740511.

## Test plan
- [x] Build current `master_devel` successfully with autotools on the aarch64 `MFT-sv-strata-02` host.
- [x] Run `mstflint -d 000d:41:00.0 -ocr hw query` on BF4 and verify RC 0.
- [x] Verify the query reports HwDevId 548 and a 64 MiB IS25LPxxx flash.