### PR TITLE
[icmd] Changing ICMD busy bit timeout to 40 seconds

### DIFF
--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -58,7 +58,7 @@
 
 /* _DEBUG_MODE   // un-comment this to enable debug prints */
 
-#define ICMD_DEFAULT_TIMEOUT 10000
+#define ICMD_DEFAULT_TIMEOUT 40000
 #define STAT_CFG_NOT_DONE_ADDR_CIB 0xb0004
 #define STAT_CFG_NOT_DONE_ADDR_CX4 0xb0004
 #define STAT_CFG_NOT_DONE_ADDR_SW_IB 0x80010


### PR DESCRIPTION
Description: after commit no. 1390791 created a degredation, increasing the icmd busy bit timeout to 40 seconds. before the change of the 10 seconds, the timeout was 5120 iteration and each iteration has a 2-8ms sleep, so the max time was ~40 seconds.

mstflint port needed: yes
Tested OS: linux

Known gaps (with RM ticket): n/a

Issue: 5147856