### PR TITLE
[mtcr] [bugfix] fix resource leak in mdevices_info

### DIFF
--- a/mtcr_ul/mtcr_ul.c
+++ b/mtcr_ul/mtcr_ul.c
@@ -95,7 +95,19 @@ dev_info* mdevices_info(int mask, int* len)
     int counter, new_length = 0;
 
     dev_info* dev_info_all = mdevices_info_ul(mask, len);
+    if (!dev_info_all || !*len)
+    {
+        return dev_info_all;
+    }
+
     dev_info* dev_info_new = (dev_info*)malloc(sizeof(dev_info) * *len);
+    if (!dev_info_new)
+    {
+        mdevices_info_destroy(dev_info_all, *len);
+        *len = 0;
+        errno = ENOMEM;
+        return NULL;
+    }
 
     // Remove devices without VSEC supported.
     for (counter = 0; counter < *len; counter++)


### PR DESCRIPTION
Ported from MFT commit 822fdcbb2e.

`mdevices_info` never checked the allocation of the filtered device array, so on failure it leaked the list returned by `mdevices_info_ul` and then dereferenced a NULL pointer.

Return early on an empty or failed device list, and release the original list when the allocation fails.

Found by Coverity (871786). Issue: 5241231