### PR TITLE
[mtcr] Cache the device-properties catalog key on the mfile

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -50,6 +50,7 @@
 #include "mflash/mflash_types.h"
 #include "mtcr_ul/mtcr_ul_com.h"
 #include "mtcr_ul/mtcr_common.h"
+#include "mft_core/device/device_info/device_properties_api.h"
 #ifdef CABLES_SUPPORT
 #include "mtcr_ul/mtcr_cables.h"
 #endif
@@ -703,6 +704,19 @@ static int dm_get_device_id_inner(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int32
     return CHECK_PTR_DEV_ID;
 }
 
+/*
+ * Covers the paths that never reach read_device_id(): BlueField4 by PCI, LinkX,
+ * cables and MGIR. Only the two codes below guarantee *ptr_hw_dev_id was
+ * written. mf->rev_id, not *ptr_hw_rev, which is always 0 on the CR-space path.
+ */
+static void update_functional_device_id(mfile* mf, int return_value, const u_int32_t* ptr_hw_dev_id)
+{
+    if (return_value == GET_DEV_ID_SUCCESS || return_value == CHECK_PTR_DEV_ID)
+    {
+        mf->functional_device_id = resolve_functional_device_id(*ptr_hw_dev_id, mf->rev_id, mf->pci_device_id);
+    }
+}
+
 /**
  * Returns 0 on success and 1 on failure.
  */
@@ -710,13 +724,21 @@ int dm_get_device_id(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int32_t* ptr_hw_de
 {
     int return_value = 1;
 
+    if (mf == NULL)
+    {
+        return MFE_ERROR;
+    }
+
     return_value = dm_get_device_id_inner(mf, ptr_dm_dev_id, ptr_hw_dev_id, ptr_hw_rev);
     if (return_value == CRSPACE_READ_ERROR)
     {
         printf("FATAL - crspace read (0x%x) failed: %s\n", DEVID_ADDR, strerror(errno));
         return GET_DEV_ID_ERROR;
     }
-    else if (return_value == CHECK_PTR_DEV_ID)
+
+    update_functional_device_id(mf, return_value, ptr_hw_dev_id);
+
+    if (return_value == CHECK_PTR_DEV_ID)
     {
         if (*ptr_dm_dev_id == DeviceUnknown)
         {
@@ -738,7 +760,13 @@ int dm_get_device_id_without_prints(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int
 {
     int return_value = 1;
 
+    if (mf == NULL)
+    {
+        return MFE_ERROR;
+    }
+
     return_value = dm_get_device_id_inner(mf, ptr_dm_dev_id, ptr_hw_dev_id, ptr_hw_rev);
+    update_functional_device_id(mf, return_value, ptr_hw_dev_id);
     if (return_value == CHECK_PTR_DEV_ID)
     {
         if (*ptr_dm_dev_id == DeviceUnknown)

--- a/include/mtcr_ul/mtcr_mf.h
+++ b/include/mtcr_ul/mtcr_mf.h
@@ -60,6 +60,8 @@ struct mfile_t {
     u_int16_t     hw_dev_id;
     u_int16_t     pci_device_id;
     u_int16_t     rev_id;
+    /* Key into the device-properties catalog, resolved once at device open. */
+    u_int32_t     functional_device_id;
     MType         tp; /*  type of driver */
     MType         orig_tp;
     MType         res_tp; /*  Will be used with HCR if need */

--- a/mtcr_freebsd/mtcr_ul.c
+++ b/mtcr_freebsd/mtcr_ul.c
@@ -53,6 +53,7 @@
 #include "common/tools_time.h"
 #include <stdlib.h>
 #include "tools_dev_types.h"
+#include "mft_core/device/device_info/device_properties_api.h"
 
 #include <unistd.h>
 
@@ -195,11 +196,16 @@ int read_device_id(mfile* mf, u_int32_t* device_id)
 
     unsigned hw_id_address = mf->cr_space_offset + HW_ID_ADDR;
 
-    mf->rev_id = EXTRACT(*device_id, 16, 4);
-    *device_id = (*device_id & 0xffff);
-    mf->hw_dev_id = (*device_id & 0xffff);
+    int rc = mread4(mf, hw_id_address, device_id);
 
-    return mread4(mf, hw_id_address, device_id);
+    /* Derive after the read: these used to run before mread4() and so read the
+     * caller's uninitialized stack. *device_id stays raw because
+     * mtcr_check_signature() compares the full 32-bit word. */
+    mf->rev_id = EXTRACT(*device_id, 16, 4);
+    mf->hw_dev_id = (*device_id & 0xffff);
+    mf->functional_device_id = resolve_functional_device_id(mf->hw_dev_id, mf->rev_id, mf->pci_device_id);
+
+    return rc;
 }
 
 int mtcr_check_signature(mfile* mf)

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -117,6 +117,7 @@
 #include "fwctrl_ioctl.h"
 #include "kernel/mst.h"
 #include "tools_dev_types.h"
+#include "mft_core/device/device_info/device_properties_api.h"
 #ifdef ENABLE_VFIO
 #include "vfio_driver_access/VFIODriverAccessWrapperC.h"
 #endif
@@ -5466,6 +5467,7 @@ int read_device_id(mfile* mf, u_int32_t* device_id)
     {
         *device_id = nvml_get_device_id(mf->nvml_device);
         mf->hw_dev_id = (*device_id & 0xffff);
+        mf->functional_device_id = resolve_functional_device_id(mf->hw_dev_id, mf->rev_id, mf->pci_device_id);
         return 4;
     }
 #endif
@@ -5490,6 +5492,7 @@ int read_device_id(mfile* mf, u_int32_t* device_id)
     }
     
     mf->hw_dev_id = (*device_id & 0xffff);
+    mf->functional_device_id = resolve_functional_device_id(mf->hw_dev_id, mf->rev_id, mf->pci_device_id);
     DBG_PRINTF("MTCR:read_device_id: mf->hw_dev_id:0x%x\n", mf->hw_dev_id);
     return rc;
 }

--- a/mtcr_ul/mtcr_ul_icmd_cif.c
+++ b/mtcr_ul/mtcr_ul_icmd_cif.c
@@ -981,40 +981,13 @@ int icmd_send_command_enhanced(mfile* mf, IN int opcode, INOUT void* data, IN in
     }
 }
 
-/*
- * Resolve the functional device id that keys the device-properties catalog, and
- * reject the devices whose iCMD addresses cannot be looked up there: an id that
- * is missing from the catalog would leave every address at 0 and fail later on
- * a CR access at address 0.
- *
- * The catalog describes the iCMD registers only for the devices that have an
- * iCMD gateway, so the semaphore address doubles as the presence test. It is
- * read with the string accessor because get_property_as_* returns 0 both for a
- * missing property and for a legitimate zero.
- */
-static int icmd_get_catalog_device_id(mfile* mf, u_int32_t hw_id, u_int32_t* ptr_device_id)
-{
-    u_int32_t device_id = resolve_functional_device_id(hw_id, mf->rev_id, mf->pci_device_id);
-
-    if (get_property_as_cstring(device_id, PROP_SEMAPHORE_ADDRESS)[0] == '\0')
-    {
-        DBG_PRINTF("icmd: device id 0x%x has no iCMD properties in the device catalog.\n", device_id);
-        return ME_ICMD_NOT_SUPPORTED;
-    }
-
-    *ptr_device_id = device_id;
-    return ME_OK;
-}
-
 static int icmd_init_cr(mfile* mf)
 {
     int icmd_ver;
-    int prop_rc = ME_OK;
     u_int32_t hcr_address;
     u_int32_t cmd_ptr_addr;
     u_int32_t reg = 0x0;
     u_int32_t hw_id = 0x0;
-    u_int32_t device_id = 0x0;
     mf->icmd.syndrome = 0;
 
 #ifndef __FreeBSD__
@@ -1066,21 +1039,31 @@ static int icmd_init_cr(mfile* mf)
             break;
 
         default:
-            prop_rc = icmd_get_catalog_device_id(mf, hw_id, &device_id);
-            if (prop_rc != ME_OK)
+        {
+            u_int32_t did = mf->functional_device_id;
+            if (is_cable(did) || (is_linkx(did) && (did != ArcusESddv && !is_retimer(did))))
             {
-                return prop_rc;
+                DBG_PRINTF("icmd_init_cr: ICMD not supported for device type.\n");
+                return ME_ICMD_NOT_SUPPORTED;
             }
-            cmd_ptr_addr = get_property_as_uint(device_id, PROP_CMD_PTR_ADDRESS);
+            /* get_property_as_* returns 0 for a missing entry, which would leave
+               every address at 0 and fail later on a CR access at address 0. */
+            if (get_property_as_cstring(did, PROP_DEVICE_NAME)[0] == '\0')
+            {
+                DBG_PRINTF("icmd: device id 0x%x not in property catalog.\n", did);
+                return ME_ICMD_NOT_SUPPORTED;
+            }
+            cmd_ptr_addr = get_property_as_uint(did, PROP_CMD_PTR_ADDRESS);
             /* hcr_address is the "version address" */
-            hcr_address = get_property_as_uint(device_id, PROP_VERSION_ADDRESS);
-            mf->icmd.cmd_ptr_bitlen = get_property_as_int(device_id, PROP_CMD_PTR_BITLEN);
-            mf->icmd.version_bit_offset = get_property_as_int(device_id, PROP_VERSION_BIT_OFFSET);
-            mf->icmd.version_bitlen = get_property_as_int(device_id, PROP_VERSION_BITLEN);
-            mf->icmd.semaphore_addr = get_property_as_int(device_id, PROP_SEMAPHORE_ADDRESS);
-            mf->icmd.static_cfg_not_done_addr = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
-            mf->icmd.static_cfg_not_done_offs = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_OFFSET);
+            hcr_address = get_property_as_uint(did, PROP_VERSION_ADDRESS);
+            mf->icmd.cmd_ptr_bitlen = get_property_as_int(did, PROP_CMD_PTR_BITLEN);
+            mf->icmd.version_bit_offset = get_property_as_int(did, PROP_VERSION_BIT_OFFSET);
+            mf->icmd.version_bitlen = get_property_as_int(did, PROP_VERSION_BITLEN);
+            mf->icmd.semaphore_addr = get_property_as_int(did, PROP_SEMAPHORE_ADDRESS);
+            mf->icmd.static_cfg_not_done_addr = get_property_as_int(did, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
+            mf->icmd.static_cfg_not_done_offs = get_property_as_int(did, PROP_STATIC_CFG_NOT_DONE_OFFSET);
             break;
+        }
     }
     mf->icmd.max_cmd_size = ICMD_MAX_CMD_SIZE;
     icmd_ver = get_version(mf, hcr_address);
@@ -1122,9 +1105,7 @@ static int icmd_init_cr(mfile* mf)
 
 static int icmd_init_vcr_crspace_addr(mfile* mf)
 {
-    int rc = ME_OK;
     u_int32_t hw_id = 0x0;
-    u_int32_t device_id = 0x0;
 
     /* get device specific addresses */
     if (read_device_id(mf, &hw_id) != 4)
@@ -1147,14 +1128,24 @@ static int icmd_init_vcr_crspace_addr(mfile* mf)
             break;
 
         default:
-            rc = icmd_get_catalog_device_id(mf, hw_id, &device_id);
-            if (rc != ME_OK)
+        {
+            u_int32_t did = mf->functional_device_id;
+            if (is_cable(did) || ((is_linkx(did) || is_retimer(did)) && did != ArcusESddv))
             {
-                return rc;
+                DBG_PRINTF("icmd_init_vcr_crspace: not supported for this device.\n");
+                return ME_ICMD_NOT_SUPPORTED;
             }
-            mf->icmd.static_cfg_not_done_addr = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
-            mf->icmd.static_cfg_not_done_offs = get_property_as_int(device_id, PROP_STATIC_CFG_NOT_DONE_OFFSET);
+            /* MFT does not check this. Without it a device that is missing from
+               the catalog is accepted with the address left at 0. */
+            if (get_property_as_cstring(did, PROP_DEVICE_NAME)[0] == '\0')
+            {
+                DBG_PRINTF("icmd: device id 0x%x not in property catalog.\n", did);
+                return ME_ICMD_NOT_SUPPORTED;
+            }
+            mf->icmd.static_cfg_not_done_addr = get_property_as_int(did, PROP_STATIC_CFG_NOT_DONE_ADDRESS);
+            mf->icmd.static_cfg_not_done_offs = get_property_as_int(did, PROP_STATIC_CFG_NOT_DONE_OFFSET);
             break;
+        }
     }
     return ME_OK;
 }


### PR DESCRIPTION
Description:
Resolve the catalog key once, when the device identity is established, and cache it as mf->functional_device_id, instead of re-deriving it on every lookup. It is set in read_device_id() on Linux and FreeBSD and in the two dm_get_device_id() wrappers, which cover the paths that never reach read_device_id(). icmd_get_catalog_device_id() now reads the field and loses its redundant hw_id parameter.

The FreeBSD read_device_id() derived rev_id and hw_dev_id from the caller's uninitialized stack, since those ran before the mread4() that fills the word; they now run after it. *device_id stays raw because mtcr_check_signature() compares the full 32-bit word.
