### PR TITLE
[build] Link the device-properties generator against libjson.la

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,7 +28,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-SUBDIRS = $(NVML_DIR) mft_core ext_libs $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser $(DPA) mlxfwops mlxconfig $(NVFWRESET_DIR) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump efuse ${ADABE_TOOLS} $(HCA_CAP_DIR) $(MSTFLINT_SDK_DIR) tracers resourcetools $(IBDUMP_DIR)
+SUBDIRS = $(NVML_DIR) ext_libs mft_core $(TOOLS_CRYPTO) tools_layouts common $(VFIO_DRIVER_DIR) ${MTCR_CONF_DIR} mtcr_py $(MAD_IFC) $(XZ_UTILS_DIR) reg_access cmdif dev_mgt pci_library mft_utils $(CABLE_ACCESS_DIR) tools_res_mgmt mvpd mflash fw_comps_mgr libmfa pldm_utils pldmlib cmdparser $(DPA) mlxfwops mlxconfig $(NVFWRESET_DIR) $(FW_MGR_TOOLS) $(PLDM_PKG_GEN) mlxtokengenerator flint small_utils mst_utils mstdump efuse ${ADABE_TOOLS} $(HCA_CAP_DIR) $(MSTFLINT_SDK_DIR) tracers resourcetools $(IBDUMP_DIR)
 
 DIST_SUBDIRS = tracers
 
@@ -63,8 +63,8 @@ if ENABLE_MSTFLINT_SDK
 # builds the convenience libs the SDK links (libmstreg_lib, libmlxreg_sdk,
 # libmodules_lib); mft_core builds the mft_core_utils and NVML libs.
 SDK_BUILD_SUBDIRS = \
-	mft_core \
 	ext_libs \
+	mft_core \
 	tools_layouts \
 	common \
 	$(VFIO_DRIVER_DIR) \

--- a/mft_core/device/device_info/Makefile.am
+++ b/mft_core/device/device_info/Makefile.am
@@ -51,24 +51,15 @@ libdevice_info_la_LIBADD = \
     $(top_builddir)/mft_core/mft_core_utils/logger/liblogger.la \
     $(top_builddir)/mft_core/mft_core_utils/mft_exceptions/libmftexceptions.la
 
-# Build-host code generator (not installed). Uses jsoncpp - system if
-# available, otherwise the vendored ext_libs/json fallback selected in
-# configure.ac. When using the vendored copy we compile its .cpp files
-# directly into the generator: the top-level SUBDIRS ordering builds
-# mft_core before ext_libs, so libjson.la is not yet available here.
 noinst_PROGRAMS = generate_device_properties
 generate_device_properties_CPPFLAGS = $(JSON_CFLAGS)
-if USE_LOCAL_JSON
-generate_device_properties_SOURCES = \
-    generate_device_properties.cpp \
-    $(top_srcdir)/ext_libs/json/json_reader.cpp \
-    $(top_srcdir)/ext_libs/json/json_value.cpp \
-    $(top_srcdir)/ext_libs/json/json_writer.cpp
-generate_device_properties_LDADD =
-else
 generate_device_properties_SOURCES = generate_device_properties.cpp
 generate_device_properties_LDADD = $(JSON_LIBS)
-endif
+generate_device_properties_DEPENDENCIES = $(JSON_LIBS)
+
+# Build libjson.la on demand, so `make -C mft_core` works before ext_libs is built.
+$(top_builddir)/ext_libs/json/libjson.la:
+	cd $(top_builddir)/ext_libs/json && $(MAKE) $(AM_MAKEFLAGS) libjson.la
 
 DEVICE_PROPS_GENERATOR = generate_device_properties$(EXEEXT)
 DEVICE_PROPS_JSON_DIR = $(srcdir)/json


### PR DESCRIPTION
Description:
generate_device_properties listed $(top_srcdir)/ext_libs/json/*.cpp in its sources, because ext_libs was built after mft_core. Together with the per-target CPPFLAGS this makes automake place the objects outside the directory and emit dependency includes rooted at $(top_builddir). config.status only expands $(DEPDIR) when it pre-creates those stubs, so the real ext_libs/json/.deps/generate_device_properties-json_*.Po files are never created and make fails with "No rule to make target". Automake 1.16 hides this with its am__depfiles_remade recovery rule, older versions do not.

Build ext_libs before mft_core in SUBDIRS, which ext_libs allows since it does not depend on mft_core, and link the generator against $(JSON_LIBS) instead of compiling the sources into it.

A rule builds libjson.la on demand so mft_core still builds on its own in a tree where ext_libs was never built. It needs an explicit _DEPENDENCIES, since automake cannot tell that the $(JSON_LIBS) substitution is a library and leaves the generated dependency list empty.

Tested OS: Linux (x86_64 build with CFLAGS='-Wimplicit-function-declaration -Werror=implicit-function-declaration');
Tested flows: full make, make -C mft_core on an unbuilt tree, make check in mft_core/device/device_info