### PR TITLE
[mlxlink][bugfix] Fix driver-down error message

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -103,7 +103,6 @@ void MlxlinkCommander::updatePortInfo()
 
     labelToLocalPort();
     validatePortType(_userInput._portType);
-    updateSwControlStatus();
     updateNvlinkModeBStatus();
     updateCpoStatus();
     if (!_userInput._pcie)
@@ -111,6 +110,7 @@ void MlxlinkCommander::updatePortInfo()
         checkValidFW();
     }
 
+    updateSwControlStatus();
     updateBonusPortStatus();
 
     if (!(_mf->tp == MST_PCICONF && (dm_is_gpu(static_cast<dm_dev_id_t>(_devID)))))


### PR DESCRIPTION
Validate firmware and driver access before querying software-controlled module status so inaccessible devices return the actionable driver-up error.

Ports MFT change 1454813.
Issue: 5096658
Issue: 5103757