### PR TITLE
[mlxlink][SPC6] Use per-lane PCIe eye flow

### DIFF
--- a/mlxlink/modules/mlxlink_commander.cpp
+++ b/mlxlink/modules/mlxlink_commander.cpp
@@ -4226,7 +4226,7 @@ void MlxlinkCommander::showEye()
             showEyeTitle += " (PCIe)";
         }
         setPrintTitle(_eyeOpeningInfoCmd, showEyeTitle, EYE_OPENING_INFO_LAST);
-        if (_devID == DeviceSpectrum6)
+        if (_devID == DeviceSpectrum6 && !_userInput._pcie)
         {
             prepareSpc6EyeInfo(numOfLanesToUse);
         }


### PR DESCRIPTION
Keep the Spectrum-6 all-lanes SLRG flow limited to network ports so PCIe reports Initial FOM and Last FOM through the regular 5nm path.

Ports MFT commit 623d6e8e67.