### PR TITLE
[mlxdpa] Fix remove_all bit endianness in DpaAppRemoveMetadata

### DIFF
--- a/mlxdpa/dpaAppRemoval.cpp
+++ b/mlxdpa/dpaAppRemoval.cpp
@@ -49,9 +49,7 @@ vector<u_int8_t> DpaAppRemoveMetadata::Serialize()
 {
     vector<u_int8_t> serializedData(GetSize());
 
-    CPUTOn(_dpaAppUUID, sizeof(_dpaAppUUID) / 4);
     memcpy(serializedData.data(), _dpaAppUUID, DPA_APP_UUID_SIZE);
-    CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
     memcpy(serializedData.data() + DPA_APP_UUID_SIZE, _keypairUUID, KEY_PAIR_UUID_SIZE);
     serializedData[REMOVE_ALL_OFFSET] |= (_removeAll ? 1 : 0);
 
@@ -64,5 +62,8 @@ void DpaAppRemoveMetadata::Deserialize(vector<u_int8_t> buf)
     CPUTOn(_dpaAppUUID, sizeof(_dpaAppUUID) / 4);
     memcpy(_keypairUUID, buf.data() + DPA_APP_UUID_SIZE, KEY_PAIR_UUID_SIZE);
     CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
-    _removeAll = buf[REMOVE_ALL_OFFSET] & 1;
+    u_int32_t removeAllDword;
+    memcpy(&removeAllDword, buf.data() + REMOVE_ALL_OFFSET, sizeof(removeAllDword));
+    CPUTOn(&removeAllDword, 1);
+    _removeAll = removeAllDword & 1;
 }

--- a/mlxdpa/mlxdpa.cpp
+++ b/mlxdpa/mlxdpa.cpp
@@ -854,10 +854,11 @@ vector<CertContainerItem> MlxDpa::GetCertContainer(CertContainerType type)
  
      const string X = SINGLE_APP_DPA_FINGERPRINT;
  
-     DpaAppRemoveMetadata dpaAppRemovalMetadata(_dpaAppUUID, _keypairUUID, _removeAllDpaApps);
-     vector<u_int8_t> serializedMetadata = dpaAppRemovalMetadata.Serialize();
-     DpaAppStructHeader headerDpaAppRemovalMetadata(_priority, DpaAppStructHeader::StructType::DPA_APP_REMOVE_METADATA,
-                                                    serializedMetadata.size());
+    DpaAppRemoveMetadata dpaAppRemovalMetadata(_dpaAppUUID, _keypairUUID, _removeAllDpaApps);
+    vector<u_int8_t> serializedMetadata = dpaAppRemovalMetadata.Serialize();
+    CPUTOn(serializedMetadata.data(), serializedMetadata.size() / 4);
+    DpaAppStructHeader headerDpaAppRemovalMetadata(_priority, DpaAppStructHeader::StructType::DPA_APP_REMOVE_METADATA,
+                                                   serializedMetadata.size());
      vector<u_int8_t> headerDpaAppRemovalMetadataByteStream = CreateHeaderDataStream(headerDpaAppRemovalMetadata);
  
      serializedContainer.insert(end(serializedContainer), begin(X), end(X));


### PR DESCRIPTION
The remove_all flag dword was not converted to big-endian before being written to the container, causing it to be placed at byte offset 32 (the MSB of the dword) instead of byte offset 35 (the LSB, as required by the big-endian bitfield convention used throughout mlxdpa containers).

Fix Serialize() to apply CPUTOn on the flag dword after setting it, and fix Deserialize() to read from offset REMOVE_ALL_OFFSET+3 (the LSB of the big-endian dword), consistent with how the cert container handles its remove_all flag via CertContainerItem::Serialize(toBigEndian=true).