### PR TITLE
[mlxdpa] Fix remove_all bit endianness in DpaAppRemoveMetadata

### DIFF
--- a/mlxdpa/dpaAppRemoval.cpp
+++ b/mlxdpa/dpaAppRemoval.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2024 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED
+ * Copyright (c) 2013-2026 NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -54,6 +54,7 @@ vector<u_int8_t> DpaAppRemoveMetadata::Serialize()
     CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
     memcpy(serializedData.data() + DPA_APP_UUID_SIZE, _keypairUUID, KEY_PAIR_UUID_SIZE);
     serializedData[REMOVE_ALL_OFFSET] |= (_removeAll ? 1 : 0);
+    CPUTOn(serializedData.data() + REMOVE_ALL_OFFSET, 1);
 
     return serializedData;
 }
@@ -64,5 +65,8 @@ void DpaAppRemoveMetadata::Deserialize(vector<u_int8_t> buf)
     CPUTOn(_dpaAppUUID, sizeof(_dpaAppUUID) / 4);
     memcpy(_keypairUUID, buf.data() + DPA_APP_UUID_SIZE, KEY_PAIR_UUID_SIZE);
     CPUTOn(_keypairUUID, sizeof(_keypairUUID) / 4);
-    _removeAll = buf[REMOVE_ALL_OFFSET] & 1;
+    u_int32_t removeAllDword = 0;
+    memcpy(&removeAllDword, buf.data() + REMOVE_ALL_OFFSET, sizeof(removeAllDword));
+    CPUTOn(&removeAllDword, 1);
+    _removeAll = removeAllDword & 1;
 }


### PR DESCRIPTION
The remove_all flag dword was not converted to big-endian before being written to the container, causing it to be placed at byte offset 32 (the MSB of the dword) instead of byte offset 35 (the LSB, as required by the big-endian bitfield at spec offset 0x20).

Added CPUTOn on the remove_all dword in Serialize() and updated Deserialize() to use memcpy + CPUTOn for a proper big-endian read. No change to mlxdpa.cpp (UUID conversion remains inside Serialize on this branch).

Tested: created remove_all DPA app removal container and verified the flag is at file byte offset 59. FW developer confirmed the fix.

Issue: #5249472