### PR TITLE
[efuse] Add SPC6 CPO per-OE fuse reads

### DIFF
--- a/efuse/efuse.cpp
+++ b/efuse/efuse.cpp
@@ -143,7 +143,9 @@ struct FuseReading
     std::string rail_name;
     std::string die_label;
     bool fuse_mismatch;
+    bool is_raw; // true: value is raw fuse bits (print as hex); false: voltage_mv (print as mV)
     double voltage_mv;
+    uint32_t raw_value;
 };
 
 // Device-neutral view of the MRFV fields this tool consumes. The HCA and switch PRM
@@ -191,7 +193,7 @@ static const char* cvb_rail_name(int voltage_type)
 }
 #endif // EFUSE_CVB_ENABLED
 
-static void decode_raw_and_value(const MrfvEntry& mrfv, const std::string& rail, int inst, std::vector<FuseReading>& readings)
+static void decode_raw_and_value(const MrfvEntry& mrfv, const std::string& rail, int inst, const std::string& die_label, bool allow_raw, std::vector<FuseReading>& readings)
 {
     uint8_t value_valid = mrfv.value_valid;
     uint32_t value_base_raw = mrfv.value_base;
@@ -211,13 +213,21 @@ static void decode_raw_and_value(const MrfvEntry& mrfv, const std::string& rail,
 
     if (value_valid != 1)
     {
+        // value_valid qualifies only value_base/value_exponent, which encode a physical quantity.
+        // Identity fuses have none (SPC6 CPO per-OE fuses 17-24), so they report value_valid == 0
+        // while raw_fuses stays valid: report the raw bits, masked to raw_fuses_highest_bit + 1
+        // above. For voltage fuses the raw bits carry no meaning without base/exponent, so skip.
+        if (allow_raw)
+        {
+            readings.push_back({rail, die_label, false, true, 0.0, raw_fuses});
+        }
         return;
     }
 
     int32_t base = sign_extend_26bit(value_base_raw);
     int32_t exponent = sign_extend_6bit(value_exponent_raw);
     double voltage_mv = base * pow(10.0, exponent) * 1000.0;
-    readings.push_back({rail, instance_label(inst), false, voltage_mv});
+    readings.push_back({rail, die_label, false, false, voltage_mv, 0});
 }
 
 #ifdef EFUSE_CVB_ENABLED
@@ -233,7 +243,7 @@ static void decode_cvb(const MrfvEntry& mrfv, const std::string& rail, int inst,
     }
     // Per PRM, MRFV CVB layout reports cvb_voltage directly in mV (unlike the
     // RAW_AND_VALUE layout, which encodes base * 10^exponent volts and is converted to mV above).
-    readings.push_back({rail, instance_label(inst), false, static_cast<double>(mrfv.cvb_voltage)});
+    readings.push_back({rail, instance_label(inst), false, false, static_cast<double>(mrfv.cvb_voltage), 0});
 }
 #endif // EFUSE_CVB_ENABLED
 
@@ -241,12 +251,19 @@ static void decode_cvb(const MrfvEntry& mrfv, const std::string& rail, int inst,
 // [CVB-DISABLED] To restore the CVB layout, re-add the `bool is_cvb, int voltage_type` parameters,
 // set `mrfv.data.MRFV_CVB_ext.voltage_type` before the query, and gate each layout's copy on
 // `is_cvb` - `data` is a union and only the layout selected by fuse_id is unpacked.
-static reg_access_status_t query_mrfv_switch(mfile* mf, int fuse_id, int inst, MrfvEntry& entry)
+static reg_access_status_t query_mrfv_switch(mfile* mf, int fuse_id, int inst, int module_index, MrfvEntry& entry)
 {
     struct reg_access_switch_MRFV_ext mrfv;
     memset(&mrfv, 0, sizeof(mrfv));
     mrfv.fuse_id = static_cast<u_int8_t>(fuse_id);
     mrfv.instance_id = static_cast<u_int8_t>(inst);
+    // Per-OE fuses (SPC6 CPO) address the Optical Engine via <module_index_msb, module_index>.
+    if (module_index >= 0)
+    {
+        mrfv.module_index_valid = 1;
+        mrfv.module_index = static_cast<u_int8_t>(module_index & 0xFF);
+        mrfv.module_index_msb = static_cast<u_int8_t>((module_index >> 8) & 0xFF);
+    }
 
     reg_access_status_t rc = reg_access_mrfv_switch(mf, REG_ACCESS_METHOD_GET, &mrfv);
     if (rc != ME_OK)
@@ -274,12 +291,19 @@ static reg_access_status_t query_mrfv_switch(mfile* mf, int fuse_id, int inst, M
 
 // Query MRFV through the HCA PRM database and flatten the reading into `entry`.
 // [CVB-DISABLED] See query_mrfv_switch for how to restore the CVB layout.
-static reg_access_status_t query_mrfv_hca(mfile* mf, int fuse_id, int inst, MrfvEntry& entry)
+static reg_access_status_t query_mrfv_hca(mfile* mf, int fuse_id, int inst, int module_index, MrfvEntry& entry)
 {
     struct reg_access_hca_MRFV_ext mrfv;
     memset(&mrfv, 0, sizeof(mrfv));
     mrfv.fuse_id = static_cast<u_int8_t>(fuse_id);
     mrfv.instance_id = static_cast<u_int8_t>(inst);
+    // Per-OE fuses (SPC6 CPO) address the Optical Engine via <module_index_msb, module_index>.
+    if (module_index >= 0)
+    {
+        mrfv.module_index_valid = 1;
+        mrfv.module_index = static_cast<u_int8_t>(module_index & 0xFF);
+        mrfv.module_index_msb = static_cast<u_int8_t>((module_index >> 8) & 0xFF);
+    }
 
     reg_access_status_t rc = reg_access_mrfv(mf, REG_ACCESS_METHOD_GET, &mrfv);
     if (rc != ME_OK)
@@ -314,14 +338,14 @@ static bool uses_switch_mrfv_layout(dm_dev_id_t dev_type)
 // Query one MRFV reading and append the decoded value to `readings`.
 // [CVB-DISABLED] Only the RAW_AND_VALUE layout is active. To restore the CVB layout,
 // re-add `bool is_cvb, int voltage_type` parameters and the `#if 0` branches below.
-static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fuse, int inst, std::vector<FuseReading>& readings)
+static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fuse, int inst, int module_index, const std::string& die_label, std::vector<FuseReading>& readings)
 {
     MrfvEntry mrfv;
     memset(&mrfv, 0, sizeof(mrfv));
 
-    LOG.Debug("Querying fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst));
+    LOG.Debug("Querying fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) + " module_index=" + std::to_string(module_index));
 
-    reg_access_status_t rc = uses_switch_mrfv_layout(dev_type) ? query_mrfv_switch(mf, fuse.fuse_id, inst, mrfv) : query_mrfv_hca(mf, fuse.fuse_id, inst, mrfv);
+    reg_access_status_t rc = uses_switch_mrfv_layout(dev_type) ? query_mrfv_switch(mf, fuse.fuse_id, inst, module_index, mrfv) : query_mrfv_hca(mf, fuse.fuse_id, inst, module_index, mrfv);
 
     if (rc != ME_OK)
     {
@@ -345,7 +369,7 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
 
     if (fuse_mismatch == 1)
     {
-        readings.push_back({rail, instance_label(inst), true, 0.0});
+        readings.push_back({rail, die_label, true, false, 0.0, 0});
         return;
     }
     else if (fuse_mismatch != 0)
@@ -356,7 +380,7 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
 
     // [CVB-DISABLED] This unconditional call replaces the is_cvb ? decode_cvb : decode_raw_and_value
     // dispatch in the EFUSE_CVB_ENABLED block below. Restore the branch when re-enabling CVB.
-    decode_raw_and_value(mrfv, rail, inst, readings);
+    decode_raw_and_value(mrfv, rail, inst, die_label, fuse.per_oe, readings);
 #ifdef EFUSE_CVB_ENABLED
     if (is_cvb)
     {
@@ -364,28 +388,106 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
     }
     else
     {
-        decode_raw_and_value(mrfv, rail, inst, readings);
+        decode_raw_and_value(mrfv, rail, inst, die_label, fuse.per_oe, readings);
     }
 #endif // EFUSE_CVB_ENABLED
 }
 
-static std::vector<FuseReading> read_fuse_values(mfile* mf, dm_dev_id_t dev_type, const DeviceConfig& config)
+// Resolve the Optical Engine index range for per-OE fuses. Per-OE fuses only exist on SPC6 CPO,
+// so gate on MGIR.cpo_indication: on non-CPO systems (cpo_indication == 0) the per-OE fuses are
+// skipped cleanly (oe_enabled stays false). A register read failure only costs the per-OE fuses,
+// so warn and leave oe_enabled false rather than failing the whole run.
+static void resolve_oe_range(mfile* mf, bool& oe_enabled, int& oe_base, int& oe_count)
 {
-    std::vector<FuseReading> readings;
+    oe_enabled = false;
+    oe_base = 0;
+    oe_count = 0;
 
+    struct reg_access_hca_mgir_ext mgir;
+    memset(&mgir, 0, sizeof(mgir));
+    reg_access_status_t rc = reg_access_mgir(mf, REG_ACCESS_METHOD_GET, &mgir);
+    if (rc != ME_OK)
+    {
+        fprintf(stderr, "-W- Failed to read MGIR register (rc=%d). Skipping per-Optical-Engine fuses.\n", rc);
+        return;
+    }
+    LOG.Debug("MGIR cpo_indication=" + std::to_string(mgir.hw_info.cpo_indication));
+    if (mgir.hw_info.cpo_indication == 0)
+    {
+        LOG.Debug("MGIR.cpo_indication == 0 (non-CPO): skipping per-OE fuses");
+        return;
+    }
+
+    // The OE range comes from the switch MGPIR layout (hw_info.oe_count_local,
+    // hw_metadata.oe_base_index_local).
+    struct reg_access_switch_mgpir_ext mgpir;
+    memset(&mgpir, 0, sizeof(mgpir));
+    // The OE fields are scoped to the ASIC (chip/package) rather than to a slot, so slot_index
+    // only has to name the main board (0), as in dev_mgt/therm_fw.c.
+    mgpir.hw_info.slot_index = 0;
+    rc = reg_access_mgpir_switch_ext(mf, REG_ACCESS_METHOD_GET, &mgpir);
+    if (rc != ME_OK)
+    {
+        fprintf(stderr, "-W- Failed to read MGPIR register (rc=%d). Skipping per-Optical-Engine fuses.\n", rc);
+        return;
+    }
+
+    oe_base = mgpir.hw_metadata.oe_base_index_local;
+    oe_count = mgpir.hw_info.oe_count_local;
+    oe_enabled = (oe_count > 0);
+    LOG.Debug("MGPIR oe_base_index_local=" + std::to_string(oe_base) + " oe_count_local=" + std::to_string(oe_count));
+}
+
+static bool read_fuse_values(mfile* mf, dm_dev_id_t dev_type, const DeviceConfig& config, std::vector<FuseReading>& readings, std::string& error)
+{
     LOG.Debug(std::string("device_type=") + dm_dev_type2str(dev_type) + " using MRFV layout: " + (uses_switch_mrfv_layout(dev_type) ? "switch" : "hca"));
+
+    // Resolve the OE range once, only if the matched device has any per-OE fuse.
+    bool has_per_oe = std::any_of(config.fuses.begin(), config.fuses.end(), [](const FuseConfig& f) { return f.per_oe; });
+    bool oe_enabled = false;
+    int oe_base = 0;
+    int oe_count = 0;
+    if (has_per_oe)
+    {
+        // per_oe enumerates Optical Engines using the switch MGPIR OE fields
+        // (hw_metadata.oe_base_index_local, hw_info.oe_count_local). The NIC/HCA MGPIR layout
+        // (reg_access_mgpir / tools_mgpir) does not expose these OE fields, so per_oe is only
+        // supported on switch devices. Fail clearly instead of reading OE data that isn't there.
+        if (!uses_switch_mrfv_layout(dev_type))
+        {
+            error = "per_oe fuses require the switch MGPIR Optical Engine fields, which are not available on non-switch devices";
+            return false;
+        }
+        resolve_oe_range(mf, oe_enabled, oe_base, oe_count);
+    }
 
     // [CVB-DISABLED] Only the RAW_AND_VALUE layout is active. To restore the CVB layout,
     // dispatch on `fuse.fuse_id == 0` and iterate `fuse.voltage_types` per PRM.
     for (const auto& fuse : config.fuses)
     {
-        for (int inst : fuse.instance_ids)
+        if (fuse.per_oe)
         {
-            query_one_fuse(mf, dev_type, fuse, inst, readings);
+            if (!oe_enabled)
+            {
+                // non-CPO or no OEs: skip per-OE fuses cleanly
+                LOG.Debug("Skipping per-OE fuse_id=" + std::to_string(fuse.fuse_id) + " (" + fuse.name + "): no Optical Engines reported (oe_count=" + std::to_string(oe_count) + ")");
+                continue;
+            }
+            for (int i = oe_base; i < oe_base + oe_count; i++)
+            {
+                query_one_fuse(mf, dev_type, fuse, 0, i, "oe[" + std::to_string(i) + "]", readings);
+            }
+        }
+        else
+        {
+            for (int inst : fuse.instance_ids)
+            {
+                query_one_fuse(mf, dev_type, fuse, inst, -1, instance_label(inst), readings);
+            }
         }
     }
 
-    return readings;
+    return true;
 }
 
 static void print_fuse_readings(dm_dev_id_t dev_type, u_int32_t hw_dev_id, u_int32_t chip_rev, const std::string& part_number, const std::vector<FuseReading>& readings)
@@ -399,17 +501,21 @@ static void print_fuse_readings(dm_dev_id_t dev_type, u_int32_t hw_dev_id, u_int
 
     if (readings.empty())
     {
-        printf("\nNo fuse voltage readings available.\n");
+        printf("\nNo fuse readings available.\n");
         return;
     }
 
-    printf("\nFuse Voltage Readings:\n");
-    printf("  %-16s%-16s%s\n", "RAIL", "DIE", "VOLTAGE");
+    printf("\nFuse Readings:\n");
+    printf("  %-16s%-16s%s\n", "RAIL", "DIE", "VALUE");
     for (const auto& r : readings)
     {
         if (r.fuse_mismatch)
         {
             printf("  %-16s%-16sFuse mismatch detected\n", r.rail_name.c_str(), r.die_label.c_str());
+        }
+        else if (r.is_raw)
+        {
+            printf("  %-16s%-16s0x%X\n", r.rail_name.c_str(), r.die_label.c_str(), r.raw_value);
         }
         else
         {
@@ -530,7 +636,13 @@ int EfuseTool::Run()
             goto cleanup;
         }
 
-        std::vector<FuseReading> readings = read_fuse_values(mf, dev_type, device_config);
+        std::vector<FuseReading> readings;
+        std::string read_error;
+        if (!read_fuse_values(mf, dev_type, device_config, readings, read_error))
+        {
+            fprintf(stderr, "-E- %s\n", read_error.c_str());
+            goto cleanup;
+        }
         print_fuse_readings(dev_type, hw_dev_id, chip_rev, part_number, readings);
         ret = 0;
     }

--- a/efuse/efuse_config.cpp
+++ b/efuse/efuse_config.cpp
@@ -196,6 +196,40 @@ static bool parse_fuse_entry(const Json::Value& fuse_node,
     }
 #endif // EFUSE_CVB_ENABLED
 
+    // per_oe (optional): read the fuse per Optical Engine. The tool resolves the OE range from
+    // MGPIR at runtime and addresses each OE via the MRFV module_index fields. It reads a single
+    // fuse template per OE, so instance_ids must be [0], and it is mutually exclusive with the
+    // CVB voltage_types layout (fuse_id == 0).
+    if (fuse_node.isMember("per_oe"))
+    {
+        const Json::Value& per_oe_node = fuse_node["per_oe"];
+        if (!per_oe_node.isBool())
+        {
+            error = "JSON config format error: " + path + ".per_oe must be a boolean";
+            return false;
+        }
+        fuse.per_oe = per_oe_node.asBool();
+    }
+
+    if (fuse.per_oe)
+    {
+        if (fuse.fuse_id == 0)
+        {
+            error = "JSON config format error: " + path + ".per_oe is not allowed with fuse_id == 0 (CVB layout)";
+            return false;
+        }
+        if (fuse_node.isMember("voltage_types"))
+        {
+            error = "JSON config format error: " + path + ".per_oe is mutually exclusive with voltage_types";
+            return false;
+        }
+        if (fuse.instance_ids.size() != 1 || fuse.instance_ids[0] != 0)
+        {
+            error = "JSON config format error: " + path + ".per_oe requires instance_ids to be [0]";
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/efuse/efuse_config.h
+++ b/efuse/efuse_config.h
@@ -42,6 +42,10 @@ struct FuseConfig
     std::string name;
     std::vector<int> instance_ids;
     std::vector<int> voltage_types; // required iff fuse_id == 0 (CVB layout)
+    // When true, iterate the device's Optical Engine range (from MGPIR) and address each OE via
+    // the MRFV module_index fields (SPC6 CPO). Mutually exclusive with voltage_types; requires
+    // instance_ids == [0].
+    bool per_oe = false;
 };
 
 struct DeviceConfig

--- a/efuse/efuse_dbs/efuse_config.json
+++ b/efuse/efuse_dbs/efuse_config.json
@@ -10,7 +10,16 @@
             "fuses": [
                 {"fuse_id": 11, "name": "vdd", "instance_ids": [0, 1, 2, 3, 4, 5, 6, 7, 8]},
                 {"fuse_id": 12, "name": "pl_avdd", "instance_ids": [1, 2, 3, 4, 5, 6, 7, 8]},
-                {"fuse_id": 13, "name": "pl_dvdd", "instance_ids": [1, 2, 3, 4, 5, 6, 7, 8]}
+                {"fuse_id": 13, "name": "pl_dvdd", "instance_ids": [1, 2, 3, 4, 5, 6, 7, 8]},
+                {"fuse_id": 15, "name": "opt_fuse_rev", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 17, "name": "opt_lot_code_0", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 18, "name": "opt_lot_code_1", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 19, "name": "opt_ops_reserved", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 20, "name": "opt_vendor_code", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 21, "name": "opt_wafer_id", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 22, "name": "opt_x_coordinate", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 23, "name": "opt_y_coordinate", "instance_ids": [0], "per_oe": true},
+                {"fuse_id": 24, "name": "opt_fab_code", "instance_ids": [0], "per_oe": true}
             ]
         },
         {


### PR DESCRIPTION
Description:
Add per-Optical-Engine fuse reads on SPC6 CPO. A new per_oe flag in efuse_config.json makes the tool resolve the OE range from MGPIR and read the fuse once per OE via MRFV module_index, gated on MGIR.cpo_indication so non-CPO systems skip it. Fuses with value_valid 0 (15, 17-24) are rendered as masked raw hex, and the third output column is renamed VOLTAGE -> VALUE.

Ported from MFT.