### PR TITLE
[efuse] Report fuse mismatch instead of skipping the reading

### DIFF
--- a/efuse/efuse.cpp
+++ b/efuse/efuse.cpp
@@ -353,12 +353,6 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
         return;
     }
 
-    if (mrfv.v != 1)
-    {
-        MFT_LOG_DEBUG(nvtoolslogger::Layer::EFUSE, ("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) + " v=" + std::to_string(mrfv.v) + " (not valid). Skipping this fuse reading.").c_str());
-        return;
-    }
-
     // [CVB-DISABLED] was: is_cvb ? cvb_rail_name(voltage_type) : fuse.name;
     std::string rail = fuse.name;
 
@@ -367,6 +361,8 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
     // so we fall back to fm. Gate on the bit if older NICs ever need explicit support.
     uint8_t fuse_mismatch = (mrfv.fm_sel == 1) ? mrfv.fm2 : mrfv.fm;
 
+    MFT_LOG_DEBUG(nvtoolslogger::Layer::EFUSE, ("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) + " v=" + std::to_string(mrfv.v) + " fm=" + std::to_string(mrfv.fm) + " fm2=" + std::to_string(mrfv.fm2) + " fm_sel=" + std::to_string(mrfv.fm_sel) + " fuse_mismatch=" + std::to_string(fuse_mismatch)).c_str());
+
     if (fuse_mismatch == 1)
     {
         readings.push_back({rail, die_label, true, false, 0.0, 0});
@@ -374,7 +370,15 @@ static void query_one_fuse(mfile* mf, dm_dev_id_t dev_type, const FuseConfig& fu
     }
     else if (fuse_mismatch != 0)
     {
-        MFT_LOG_DEBUG(nvtoolslogger::Layer::EFUSE, ("fuse_id=" + std::to_string(fuse.fuse_id) + " instance_id=" + std::to_string(inst) + " unexpected fm=" + std::to_string(mrfv.fm) + " fm_sel=" + std::to_string(mrfv.fm_sel)).c_str());
+        MFT_LOG_DEBUG(nvtoolslogger::Layer::EFUSE, ("Reserved fuse_mismatch=" + std::to_string(fuse_mismatch) + ". Skipping this fuse reading.").c_str());
+        return;
+    }
+
+    // Checked after the mismatch fields: per PRM, v is Reserved (0) when the fuse_id-related
+    // mismatch field is 1, so a v gate placed first would swallow every mismatch.
+    if (mrfv.v != 1)
+    {
+        MFT_LOG_DEBUG(nvtoolslogger::Layer::EFUSE, "Fuse reading is not supported for this system. Skipping this fuse reading.");
         return;
     }
 


### PR DESCRIPTION
Ports the MFT change (gerrit 1495901, Change-Id
Ic1afa4e946ec7b485e82fe05f923caabaa12f065) so the two trees stay diffable.

The MRFV reading was gated on v == 1 before the fuse mismatch fields were examined. Per PRM, v is Reserved (0) whenever the fuse_id-related mismatch field (fm or fm2, per fm_sel) is 1, so every mismatch was dropped by the v gate and the "Fuse mismatch detected" row could never be printed. The same applied to an invalid instance_id, which the PRM also reports as fm = 1.

The mismatch fields are now evaluated first, and the v gate runs afterwards so that it only rejects readings the device does not support. A debug line reporting v/fm/fm2/fm_sel/fuse_mismatch was added, and the reserved fuse_mismatch branch now says so instead of re-printing the raw fields.

Tested OS: Linux (x86_64)
Tested devices: N/A (offline)
Tested flows: compile only. The mismatch path was not exercised on hardware - it needs a device reporting fm = 1.