### PR TITLE
[dev_mgt][mlxfwops][mtcr_ul][vfio] report why a device failed to open…

### DIFF
--- a/dev_mgt/tools_dev_types.c
+++ b/dev_mgt/tools_dev_types.c
@@ -713,7 +713,8 @@ int dm_get_device_id(mfile* mf, dm_dev_id_t* ptr_dm_dev_id, u_int32_t* ptr_hw_de
     return_value = dm_get_device_id_inner(mf, ptr_dm_dev_id, ptr_hw_dev_id, ptr_hw_rev);
     if (return_value == CRSPACE_READ_ERROR)
     {
-        printf("FATAL - crspace read (0x%x) failed: %s\n", DEVID_ADDR, strerror(errno));
+        int err = errno;
+        DBG_PRINTF("Failed to read the device ID from CR-space%s%s\n", err ? ": " : "", err ? strerror(err) : "");
         return GET_DEV_ID_ERROR;
     }
     else if (return_value == CHECK_PTR_DEV_ID)

--- a/include/mtcr_ul/mtcr.h
+++ b/include/mtcr_ul/mtcr.h
@@ -117,6 +117,8 @@ mfile* mopend(const char* name, DType dtype);
 
 mfile* mopen_adv(const char* name, MType mtype);
 
+const char* mtcr_get_last_err(void);
+
 /*
  * Close Mellanox driver
  * req. descriptor

--- a/mlxfwops/lib/fw_ops.cpp
+++ b/mlxfwops/lib/fw_ops.cpp
@@ -933,8 +933,17 @@ const char* file_handle_type_to_str(fw_hndl_type_t type)
 bool FwOperations::IsDeviceSupported(fw_ops_params_t& fwParams)
 {
     mfile* mf = mopen_adv(fwParams.mstHndl, (MType)(MST_DEFAULT | MST_LINKX_CHIP));
+    int openErrno = errno;
     if (!mf)
     {
+        const char* openErr = openErrno ? strerror(openErrno) : "";
+#if !defined(__WIN__) && !defined(__FreeBSD__)
+        if (mtcr_get_last_err()[0])
+        {
+            openErr = mtcr_get_last_err();
+        }
+#endif
+        WriteToErrBuff(fwParams.errBuff, openErr, fwParams.errBuffSize);
         return false;
     }
 
@@ -1748,7 +1757,7 @@ bool FwOperations::FwSwReset()
     return true;
 }
 
-void FwOperations::WriteToErrBuff(char* errBuff, char* errStr, int bufSize)
+void FwOperations::WriteToErrBuff(char* errBuff, const char* errStr, int bufSize)
 {
     if (bufSize > 0)
     {

--- a/mlxfwops/lib/fw_ops.h
+++ b/mlxfwops/lib/fw_ops.h
@@ -769,7 +769,7 @@ private:
      * @param[in] errBuff - pointer to dist error buffer
      * @param[in] errStr - pointer to source string
      * @param[in] bufSize - size of error buffer */
-    static void WriteToErrBuff(char* errBuff, char* errStr, int bufSize);
+    static void WriteToErrBuff(char* errBuff, const char* errStr, int bufSize);
 
     // Methods
     void BackUpFwParams(fw_ops_params_t& fwParams);

--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -121,6 +121,24 @@
 #include "vfio_driver_access/VFIODriverAccessWrapperC.h"
 #endif
 
+static __thread char mtcr_last_err[256] = {0};
+
+const char* mtcr_get_last_err(void)
+{
+    return mtcr_last_err;
+}
+
+#ifdef ENABLE_VFIO
+static void mtcr_set_last_err(const char* err)
+{
+    if (err && err[0])
+    {
+        strncpy(mtcr_last_err, err, sizeof(mtcr_last_err) - 1);
+        mtcr_last_err[sizeof(mtcr_last_err) - 1] = '\0';
+    }
+}
+#endif
+
 #ifdef ENABLE_NVML
 #include "nvml_lib/nvml_c_wrapper.h"
 #endif
@@ -2229,6 +2247,7 @@ static int mtcr_vfio_device_open(mfile* mf, const char* name, unsigned domain, u
 
     if (GetStartOffsets(domain, bus, dev, func, &mf->fd, &mf->vsec_addr, &mf->address_region_addr) != 0)
     {
+        mtcr_set_last_err(GetVFIOLastError());
         return -1;
     }
 
@@ -4029,6 +4048,7 @@ mfile* mopen_ul_int(const char* name, u_int32_t adv_opt)
     int err;
     int rc;
 
+    mtcr_last_err[0] = '\0';
     if (geteuid() != 0)
     {
         errno = EACCES;

--- a/vfio_driver_access/VFIODriverAccess.cpp
+++ b/vfio_driver_access/VFIODriverAccess.cpp
@@ -203,9 +203,18 @@ void VFIODriverAccess::bindDeviceToVfioPciDriver(const std::string& dbdf)
         throw std::runtime_error(std::string("Failed to open new_id file: ") + VFIO_PCI_DRIVER_NEW_ID_PATH);
     }
 
+    errno = 0;
     new_id_file << "15b3 " + deviceId << std::endl;
     if (!new_id_file) {
-        throw std::runtime_error(std::string("Failed to write to ") + VFIO_PCI_DRIVER_NEW_ID_PATH);
+        int writeErrno = errno ? errno : EIO;
+        if (writeErrno != EEXIST) {
+            throw std::runtime_error(std::string("Failed to write to ") + VFIO_PCI_DRIVER_NEW_ID_PATH + ": " +
+                                     strerror(writeErrno));
+        }
+        if (!isDeviceBoundToVfioPci(dbdf)) {
+            throw std::runtime_error(std::string("PCI ID is registered with vfio-pci, but device ") + dbdf +
+                                     " is not bound to vfio-pci");
+        }
     }
 
     DBG_PRINTF("Device bound to vfio-pci successfully: %s\n", VFIO_PCI_DRIVER_NEW_ID_PATH);

--- a/vfio_driver_access/VFIODriverAccessWrapperC.cpp
+++ b/vfio_driver_access/VFIODriverAccessWrapperC.cpp
@@ -33,11 +33,20 @@
 #include "VFIODriverAccessWrapperC.h"
 #include "VFIODriverAccess.h"
 #include <string>
+#include <cstring>
 #include <iomanip>
 #include <sstream>
 
+static thread_local char vfioLastError[256] = {0};
+
+const char* GetVFIOLastError(void)
+{
+    return vfioLastError;
+}
+
 int GetStartOffsets(unsigned domain, unsigned bus, unsigned dev, unsigned func, int* deviceFD, uint64_t* vsecOffset, uint64_t* addressRegionOffset)
 {
+    vfioLastError[0] = '\0';
     try
     {
         std::ostringstream oss;
@@ -49,6 +58,8 @@ int GetStartOffsets(unsigned domain, unsigned bus, unsigned dev, unsigned func, 
     }
     catch(const std::exception& e)
     {
+        strncpy(vfioLastError, e.what(), sizeof(vfioLastError) - 1);
+        vfioLastError[sizeof(vfioLastError) - 1] = '\0';
         return -1;
     }
     return 0;

--- a/vfio_driver_access/VFIODriverAccessWrapperC.h
+++ b/vfio_driver_access/VFIODriverAccessWrapperC.h
@@ -49,6 +49,7 @@ int GetStartOffsets(unsigned domain, unsigned bus,
 bool CheckifKernelLockdownIsEnabled();
 bool CheckifVfioPciDriverIsLoaded();
 int CloseVFIODevices(int deviceFD);
+const char* GetVFIOLastError(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
… instead of a raw FATAL

Running a tool on a vfio- address printed "FATAL - crspace read (0xf0014) failed: ..." to stdout rather than the clean -E- error the equivalent MFT tool returns, and a failed device open often reported no reason at all.

- dev_mgt: a failed device ID read is now an MFT_DEBUG-gated diagnostic on stderr, which is the existing convention in mtcr_ul, leaving the tool's -E- message as the only user-visible error. Four call sites ignore the return value, so the diagnostic is kept rather than dropped.
- mlxfwops: IsDeviceSupported reported nothing at all when mopen_adv failed. It now reports the reason the transport gives, falling back to strerror(errno), and never reports errno 0 as the reason "Success".
- mtcr_ul: a failed mopen conveys only NULL and errno, which cannot express a transport-specific reason, so the reason is kept for the caller to report.
- vfio_driver_access: writing an already-registered PCI ID to new_id fails with EEXIST, which is not itself an error; the ID is accepted and the device's driver binding verified instead. This also replaces the misleading "Failed to write to .../new_id" message with the actual reason.

Verified on a ConnectX-6 Dx bound to vfio-pci (RHEL 8.3, kernel 6.17.0-rc2+, built with --enable-vfio):
- mstflint -d vfio-<bdf> q full on a device whose PCI ID is registered but which is not bound: two FATAL lines on stdout before, none after, and stderr now names the real reason instead of the new_id write failure.
- mstflint -d vfio-<bdf> q full on a healthy device: exit 0 and byte-identical output to the unmodified build.
- mstflint -d <bdf> q on a non-VFIO device that cannot be opened: the reason was empty before and is now reported.

Issue: 5243673