### PR TITLE
[mtcr_ul] accept any RDMA device name, not just mthca/mlx4_/mlx5_

### DIFF
--- a/mtcr_ul/mtcr_ul_com.c
+++ b/mtcr_ul/mtcr_ul_com.c
@@ -3010,13 +3010,52 @@ int change_i2c_secondary_address(mfile* mf, DType dtype)
 }
 #endif /* ifdef ENABLE_MST_DEV_I2C */
 
+// RDMA device name to PCI address
+// Returns 0 on success with domain/bus/dev/func populated, -1 on failure.
+// RDMA name could be any name, user can set it using "rdma dev set <rdma_name> <new_name>"
+static int mtcr_resolve_rdma_device_pci(const char* name, unsigned* domain, unsigned* bus, unsigned* dev, unsigned* func)
+{
+    char mbuf[4048] = {0};
+    char pbuf[4048] = {0};
+    char* base;
+    int r, scnt;
+
+    r = snprintf(mbuf, sizeof(mbuf) - 1, "/sys/class/infiniband/%s/device", name);
+    if ((r <= 0) || (r >= (int)sizeof(mbuf)))
+    {
+        return -1;
+    }
+
+    r = readlink(mbuf, pbuf, sizeof(pbuf) - 1);
+    if (r < 0)
+    {
+        DBG_PRINTF("Unable to read link %s: %s\n", mbuf, strerror(errno));
+        return -1;
+    }
+    pbuf[r] = '\0';
+
+    base = basename(pbuf);
+    if (!base)
+    {
+        return -1;
+    }
+
+    scnt = sscanf(base, "%8x:%x:%x.%x", domain, bus, dev, func);
+    if (scnt != 4)
+    {
+        return -1;
+    }
+
+    return 0;
+}
+
 static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, unsigned* bus_p, unsigned* dev_p, unsigned* func_p)
 {
     unsigned my_domain = 0;
     unsigned my_bus;
     unsigned my_dev;
     unsigned my_func;
-    int scnt, r;
+    int scnt;
     int force_config = 0;
     char config[] = "/config";
     char resource0[] = "/resource0";
@@ -3115,45 +3154,6 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         return MST_PCICONF;
     }
 
-    if ((sscanf(name, "mthca%x", &tmp) == 1) || (sscanf(name, "mlx4_%x", &tmp) == 1) || (sscanf(name, "mlx5_%x", &tmp) == 1))
-    {
-        char mbuf[4048] = {0};
-        char pbuf[4048] = {0};
-        char* base;
-
-        r = snprintf(mbuf, sizeof(mbuf) - 1, "/sys/class/infiniband/%s/device", name);
-        if ((r <= 0) || (r >= (int)sizeof mbuf))
-        {
-            fprintf(stderr, "Unable to print device name %s\n", name);
-            goto parse_error;
-        }
-
-        r = readlink(mbuf, pbuf, sizeof(pbuf) - 1);
-        if (r < 0)
-        {
-            perror("read link");
-            fprintf(stderr, "Unable to read link %s\n", mbuf);
-            return MST_ERROR;
-        }
-        pbuf[r] = '\0';
-
-        base = basename(pbuf);
-        if (!base)
-        {
-            goto parse_error;
-        }
-        scnt = sscanf(base, "%x:%x:%x.%x", &my_domain, &my_bus, &my_dev, &my_func);
-        if (scnt != 4)
-        {
-            goto parse_error;
-        }
-        if (sscanf(name, "mlx5_%x", &tmp) == 1)
-        {
-            force_config = 1;
-        }
-        goto name_parsed;
-    }
-
     scnt = sscanf(name, "%x:%x.%x", &my_bus, &my_dev, &my_func);
     if (scnt == 3)
     {
@@ -3182,7 +3182,12 @@ static MType mtcr_parse_name(const char* name, int* force, unsigned* domain_p, u
         goto name_parsed;
     }
 
-parse_error:
+    if (mtcr_resolve_rdma_device_pci(name, &my_domain, &my_bus, &my_dev, &my_func) == 0)
+    {
+        force_config = 1;
+        goto name_parsed;
+    }
+
     fprintf(stderr, "Unable to parse device name %s\n", name);
     errno = EINVAL;
     return MST_ERROR;


### PR DESCRIPTION
Description:
mtcr only resolved RDMA device names matching mthca*, mlx4_* or mlx5_*, so a device carrying any other name was rejected with "Unable to parse device name". That includes the persistent names rdma-core assigns by default (ibp*/rocep*, from 60-rdma-persistent-naming.rules) and any name set with "rdma dev set <dev> name <new>".

The prefix test is replaced by a lookup of /sys/class/infiniband/<name>/device, tried after every other form has failed, so any RDMA device resolves by name while unrelated names still report the parse error.

Port of MFT commit 6119e8487e (issue 4870166), which fixed this in MFT only; it was marked "MSTFlint port needed: No", but mstflint carries the same prefix test and is what the reporter hit. The resolver here matches MFT's current mtcr_ul, where the "%8x" domain width arrived after that commit, in dfec7a5af9 "[mtcr] Support PCI domain larger than 16 bits".

Two deliberate differences. The failed-lookup diagnostic is MFT_DEBUG-gated where MFT prints perror plus a message unconditionally. MFT's resolver is the last name form tried there too, so it also reaches this path for every unparseable name; gating is a deliberate reduction of that output, so that a mistyped device name does not gain two extra lines. The flows below show a bad name produces byte-identical output to the unmodified build. Second, a resolved RDMA name always sets force_config, as it does in MFT, whereas the removed test set it only for mlx5_*; mthca* and mlx4_* names therefore move from BAR mmap to PCI config cycles.

Tested OS: Linux (RHEL 8.3, kernel 4.18.0-240)
Tested devices: RoCE (Ethernet link layer) RDMA device at 05:00.0, ConnectX-6 Dx Tested flows: compared against an unmodified master (a2b9858) build made on the same host in the same run with identical flags. mstmcra reads the device ID over CR-space through the same mtcr name parsing every tool uses.
  rdma dev set mlx5_0 name rocep5s0f0    # the ticket's name form
  mstmcra rocep5s0f0 0xf0014             # master: "Unable to parse device name"
                                         # this commit: 0x00000212
  rdma dev set rocep5s0f0 name rdma_0    # arbitrary admin-set name
  mstmcra rdma_0 0xf0014                 # master: rejected; commit: 0x00000212
  mstmcra mlx5_0 0xf0014                 # 0x00000212 on both - no regression
  mstmcra 05:00.0 0xf0014                # 0x00000212 on both
  mstmcra pciconf-05:00.0 0xf0014        # 0x00000212 on both
  mstmcra nosuchdev 0xf0014              # identical output on both
  MFT_DEBUG=1 mstmcra nosuchdev 0xf0014  # adds "Unable to read link ..."
mstlink, the tool named in the ticket, was built separately with
--enable-adb-generic-tools and run against a fake /sys/class/infiniband entry
pointing at a non-Mellanox BDF, which separates a parse failure from a device
rejection. No MFT and no mst driver were present, so resolution used PCI config
cycles only:
  mstlink -d rocep5s0f0   # master: "Unable to parse device name", EINVAL
                          # this commit: parses, then ENOTSUP from that device
  mstlink -d mlx5_0       # ENOTSUP on both - no regression
  mstlink -d nosuchdev    # identical output on both

Known gaps (with RM ticket): none needing a ticket, but three coverage limits. mstlink was not seen opening a real adapter by its rocep* name - the name being accepted and a real adapter answering are each shown above, but not together. mthca* and mlx4_* were not exercised after the force_config change, for want of that hardware. And only a manual "rdma dev set" was tested, not a host where udev assigns rocep* at boot, which is the reporter's configuration. Issue: 5230965