### PR TITLE
mtcr_freebsd: keep the logger on libmtcr_ul's link line

### DIFF
--- a/mtcr_freebsd/Makefile.am
+++ b/mtcr_freebsd/Makefile.am
@@ -70,16 +70,15 @@ libmtcr_ul_la_CFLAGS = -W -Wall -g -MP -MD -fPIC -DMTCR_API="" -DMST_UL
 # This target compiles the shared mtcr_ul/*.c sources, which log on the MTCR
 # layer of the central NVIDIA Tools logger, so it needs the same dependency
 # the Linux libmtcr_ul has.
-libmtcr_ul_la_DEPENDENCIES = $(top_builddir)/mft_core/mft_core_utils/nvtoolslogger/libnvtoolslogger.la
-libmtcr_ul_la_LIBADD = $(libmtcr_ul_la_DEPENDENCIES) -lstdc++
-
 if ENABLE_INBAND
 libmtcr_ul_la_SOURCES += $(top_srcdir)/mtcr_ul/mtcr_ib_ofed.c
 endif
 
-libmtcr_ul_la_DEPENDENCIES = $(top_builddir)/mft_core/device/device_info/libdevice_info.la
+libmtcr_ul_la_DEPENDENCIES = \
+    $(top_builddir)/mft_core/device/device_info/libdevice_info.la \
+    $(top_builddir)/mft_core/mft_core_utils/nvtoolslogger/libnvtoolslogger.la
 
-libmtcr_ul_la_LIBADD = $(libmtcr_ul_la_DEPENDENCIES)
+libmtcr_ul_la_LIBADD = $(libmtcr_ul_la_DEPENDENCIES) -lstdc++
 
 libraryincludedir=$(includedir)/mstflint
 


### PR DESCRIPTION
The logger port added libmtcr_ul_la_DEPENDENCIES/LIBADD above the ENABLE_INBAND block, where the pre-existing libdevice_info assignments below overwrite them, so libnvtoolslogger.la never reached the link and mstconfig failed with "undefined symbol: mft_log_fmt". automake had been warning "multiply defined in condition TRUE" since the merge.

Merge the two into one assignment after the conditional.