### PR TITLE
[VR] [kernel] Fix PCI VSEC address-space fallback

### DIFF
--- a/kernel/mst_main.c
+++ b/kernel/mst_main.c
@@ -344,13 +344,13 @@ static void swap_pci_address_space(int* address_space)
     {
         case AS_ICMD_EXT:
             *address_space = AS_PCI_ICMD;
-            fallthrough;
+            break;
 
         case AS_ND_CRSPACE:
             fallthrough;
         case AS_CR_SPACE:
             *address_space = AS_PCI_CRSPACE;
-            fallthrough;
+            break;
 
         case AS_ICMD:
             *address_space = AS_PCI_ALL_ICMD;


### PR DESCRIPTION
## Summary
VR backport of #1935.

- stop `swap_pci_address_space()` from falling through after mapping `AS_ICMD_EXT` and `AS_CR_SPACE`
- keep the intentional `AS_ND_CRSPACE` to `AS_CR_SPACE` grouping
- make CR-space retries use `AS_PCI_CRSPACE` (`0x102`) instead of incorrectly continuing to `AS_PCI_ALL_ICMD` (`0x103`)

## Root cause
The incorrect fallthrough made `mstflint_access` retry a failed CX9 CR-space read in address space `0x103`. The device rejected that access with `ADDRESS_OUT_OF_RANGE`, causing `mstflint -d <BDF> v` to stall.

Redmine: https://redmine.mellanox.com/issues/5265661

## Test plan
- [x] Build and load the patched 4.35 module on Linux aarch64
- [x] Run `mstflint -d 0005:01:00.0 v` on ConnectX-9 (`vera-c2-06`)
- [x] Verification completed successfully in 400 seconds with exit code 0
- [x] No new kernel errors were emitted during verification
