### PR TITLE
flint: don't fclose a NULL FILE* when the dc output can't be opened [4.35.0 VR]

### DIFF
--- a/flint/subcommands.cpp
+++ b/flint/subcommands.cpp
@@ -1418,7 +1418,6 @@ bool SubCommand::dumpFile(const char* confFile, std::vector<u_int8_t>& data, con
         if (out == NULL)
         {
             reportErr(true, OPEN_WRITE_FILE_ERROR, confFile, strerror(errno));
-            fclose(out);
             return false;
         }
     }


### PR DESCRIPTION
Backport of #1938 to `mstflint_4_35_0_VR`. `SubCommand::dumpFile()` is byte-identical between `master_devel` and this branch, so the patch and its verification apply unchanged.

### Problem

`mstflint ... dc <path>` terminates with SIGSEGV instead of reporting an error whenever the destination cannot be opened for write. Reproduced on FreeBSD 16.0-CURRENT (rc=139) and on Linux/glibc (core dumped), with and without a device:

```
$ mstflint -i fw.bin dc /nonexistent_dir/x.ini
Segmentation fault (core dumped)
```

A writable destination works normally, so the trigger is solely a destination that cannot be opened.

### Root cause

`SubCommand::dumpFile()` closes `out` inside the `out == NULL` branch, which is only reached after `fopen()` has already failed:

```c++
out = fopen(confFile, "w");

if (out == NULL)
{
    reportErr(true, OPEN_WRITE_FILE_ERROR, confFile, strerror(errno));
    fclose(out);      // closes a NULL FILE*
    return false;
}
```

`fclose(NULL)` dereferences the handle and faults on both FreeBSD libc and glibc. The error text is lost with it: `reportErr()` writes to stdout, which is fully buffered under a pipe, and the process never reaches a flush, so the tool appears to die silently.

The line arrived with the port of e3e83834 ("[Coverity] 852507 - Resource leak"). In the MFT source the same Coverity fix went to the `data.empty()` early return, where `out` was a valid open handle; mstflint's `dumpFile()` had no such early return, so the line landed in the one branch where the handle is guaranteed to be NULL.

### Fix

Drop the call. There is nothing to close when `fopen()` has failed, and no success path changes behaviour.

### Verification

Controlled before/after build from the same tree and toolchain (mstflint-4.38.0-1.10.g7d2e5b2):

- before: `dc` into an unopenable path -> Segmentation fault (core dumped)
- after: rc=1 with `-E- Can not open file /nonexistent_dir/x.ini for write: No such file or directory.`
- after, writable destination: rc=0 and the produced INI is byte-identical to the pre-patch output
